### PR TITLE
fix(zendriver-mcp): make zendriver-interception dev-dep path-only

### DIFF
--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -56,8 +56,10 @@ insta      = { workspace = true }
 rmcp       = { workspace = true, features = ["client", "transport-child-process", "transport-streamable-http-client", "transport-streamable-http-client-reqwest"] }
 # `test-support` enables `InterceptHandle::for_tests`, which the lifecycle
 # close-cleanup unit test uses to populate `SessionState::rules` without
-# spinning up a real interception actor.
-zendriver-interception = { workspace = true, features = ["test-support"] }
+# spinning up a real interception actor. Path-only (no version) so `cargo
+# publish` strips this dev-dep from the published manifest — avoids
+# requiring the `test-support` feature on crates.io's `zendriver-interception`.
+zendriver-interception = { path = "../zendriver-interception", features = ["test-support"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- Switch `zendriver-mcp`'s `zendriver-interception` dev-dep to path-only (no version) so `cargo publish` strips it from the published manifest.
- Unblocks the `Publish` workflow, which was failing because crates.io's `zendriver-interception` 0.1.0 lacks the `test-support` feature the dev-dep was requesting.

## Test plan
- [x] `cargo publish --dry-run --locked --allow-dirty --manifest-path crates/zendriver-mcp/Cargo.toml` succeeds locally (verified pre-commit)
- [ ] CI green on this PR
- [ ] After merge: `Publish` workflow on main succeeds and uploads `zendriver-mcp v0.1.0`

Part of: `docs/superpowers/specs/2026-05-25-publish-version-automation-design.md` Phase 0.