### PR TITLE
chore(release): add release-plz config

### DIFF
--- a/release-plz-changelog.toml
+++ b/release-plz-changelog.toml
@@ -1,0 +1,43 @@
+# release-plz changelog template — extends git-cliff config.
+# Docs: https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this crate documented here. Format: [Keep a
+Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
+
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | upper_first | trim }}\
+            {% if commit.breaking %} **(BREAKING)**{% endif %}\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+    { message = "^feat", group = "Added" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Changed" },
+    { message = "^docs", skip = true },
+    { message = "^test", skip = true },
+    { message = "^ci", skip = true },
+    { message = "^chore", skip = true },
+    { message = "^style", skip = true },
+]
+filter_commits = true
+tag_pattern = "v[0-9].*"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,36 @@
+# release-plz workspace configuration.
+# Docs: https://release-plz.ieni.dev/docs/config
+
+[workspace]
+# Run cargo-semver-checks before bumping. Catches API breaks that
+# conventional commits forgot to mark with `!`.
+semver_check = true
+
+# Generate per-crate CHANGELOG.md. The top-level CHANGELOG.md stays
+# human-curated (release-plz does not touch the workspace root).
+changelog_update = true
+
+# Open a GitHub Release for each published crate version, with the
+# changelog snippet as the release body.
+git_release_enable = true
+
+# Use conventional commits for bump magnitude inference. The template
+# below also drives the generated CHANGELOG entries.
+changelog_config = "release-plz-changelog.toml"
+
+# Don't release a crate just because its files changed — require a
+# conventional commit that maps to a bump (fix/feat/BREAKING). This is
+# the safer default; flip to `true` per-crate if we lose releases.
+# release_always = false  # ← default
+
+# Don't skip the cargo-publish verify step.
+publish_no_verify = false
+
+# Disable changelog generation for purely-internal crates? — none here,
+# all 7 are public.
+
+# zendriver-mcp is a binary crate. release-plz still publishes it so
+# `cargo install zendriver-mcp` works.
+[[package]]
+name = "zendriver-mcp"
+publish = true


### PR DESCRIPTION
## Summary
- Adds `release-plz.toml` and `release-plz-changelog.toml` at workspace root.
- Configures per-crate CHANGELOG generation, semver checks, and conventional-commit bumps.
- No workflows yet — Phase 3 of the migration adds those.

Spec: [`docs/superpowers/specs/2026-05-25-publish-version-automation-design.md`](docs/superpowers/specs/2026-05-25-publish-version-automation-design.md)

## Test plan
- [x] TOML syntactically valid
- [ ] CI green (no functional change expected)

Phase 2 of: `docs/superpowers/plans/2026-05-25-publish-version-automation.md`. Task 2.4 (RELEASE_PLZ_TOKEN secret) is a separate manual step blocking Phase 3.