### PR TITLE
ci: add release-plz workflows in dry-run mode

### DIFF
--- a/.github/workflows/release-plz-pr.yml
+++ b/.github/workflows/release-plz-pr.yml
@@ -1,0 +1,39 @@
+name: Release PR (dry-run)
+
+# Phase-3 staging: workflow_dispatch only. Phase 4 flips to `on: push`.
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: release-plz-pr
+  cancel-in-progress: false
+
+jobs:
+  release-plz-pr:
+    name: Update release PR (dry-run)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: release-plz/action@v0.5.129
+        with:
+          command: release-pr
+          # `dry-run` means: compute the bumps + changelog and log them,
+          # but do not open or amend a PR. Safe to run repeatedly while
+          # iterating on the config.
+          # Once we're happy, Phase 4 removes this flag.
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz-release.yml
+++ b/.github/workflows/release-plz-release.yml
@@ -1,0 +1,44 @@
+name: Release (dry-run)
+
+# Phase-3 staging: workflow_dispatch only with --dry-run. Phase 4 flips
+# to `on: push` and removes --dry-run.
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      really_publish:
+        description: "If false (default), pass --dry-run to cargo publish. Leave false in Phase 3."
+        type: boolean
+        default: false
+
+concurrency:
+  group: release-plz-release
+  cancel-in-progress: false
+
+jobs:
+  release-plz-release:
+    name: Publish to crates.io (dry-run)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: release-plz/action@v0.5.129
+        with:
+          command: release
+          # Phase 3: always force --dry-run regardless of input. This
+          # makes `cargo publish` validate but skip the upload.
+          # cargo_publish_args is passed straight to `cargo publish`.
+          cargo_publish_args: ${{ inputs.really_publish && '' || '--dry-run' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `release-plz-pr.yml` and `release-plz-release.yml`, both gated on `workflow_dispatch` only.
- Existing `publish.yml` is untouched — it's still authoritative until Phase 5.
- Allows us to invoke `release-pr` manually and inspect logs to validate the config before flipping to `on: push`.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: manually trigger `Release PR (dry-run)` workflow, inspect logs for the computed bumps + changelog snippet (Task 3.5)

Phase 3 of: `docs/superpowers/plans/2026-05-25-publish-version-automation.md`.