### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3274,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-cloudflare"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fetcher"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dirs",
  "futures",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-transport"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver",               version = "0.1.0", default-features = false }
-zendriver-transport     = { path = "crates/zendriver-transport",     version = "0.1.0" }
-zendriver-stealth       = { path = "crates/zendriver-stealth",       version = "0.1.0" }
-zendriver-cloudflare    = { path = "crates/zendriver-cloudflare",    version = "0.1.0" }
-zendriver-interception  = { path = "crates/zendriver-interception",  version = "0.1.0" }
-zendriver-fetcher       = { path = "crates/zendriver-fetcher",       version = "0.1.0" }
-zendriver-mcp           = { path = "crates/zendriver-mcp",           version = "0.1.0" }
+zendriver               = { path = "crates/zendriver", version = "0.1.1", default-features = false }
+zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.1" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.1.1" }
+zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.1.1" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.1.1" }
+zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.1" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.1.1" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-cloudflare/CHANGELOG.md
+++ b/crates/zendriver-cloudflare/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this crate documented here. Format: [Keep a
+Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
+
+## [0.1.1] - 2026-05-25
+
+### Changed
+
+- Split workspace.package.version into per-crate versions ([#5](https://github.com/TurtIeSocks/zendriver-rs/pull/5))
+

--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-cloudflare"
 description = "Cloudflare Turnstile bypass for zendriver"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fetcher/CHANGELOG.md
+++ b/crates/zendriver-fetcher/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this crate documented here. Format: [Keep a
+Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
+
+## [0.1.1] - 2026-05-25
+
+### Changed
+
+- Split workspace.package.version into per-crate versions ([#5](https://github.com/TurtIeSocks/zendriver-rs/pull/5))
+

--- a/crates/zendriver-fetcher/Cargo.toml
+++ b/crates/zendriver-fetcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fetcher"
 description = "Chrome binary downloader for zendriver"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this crate documented here. Format: [Keep a
+Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
+
+## [0.1.1] - 2026-05-25
+
+### Changed
+
+- Split workspace.package.version into per-crate versions ([#5](https://github.com/TurtIeSocks/zendriver-rs/pull/5))
+
+### Fixed
+
+- Clean expectations + interception rules on browser_close
+

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this crate documented here. Format: [Keep a
+Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
+
+## [0.1.1] - 2026-05-25
+
+### Changed
+
+- Split workspace.package.version into per-crate versions ([#5](https://github.com/TurtIeSocks/zendriver-rs/pull/5))
+

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this crate documented here. Format: [Keep a
+Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
+
+## [0.1.1] - 2026-05-25
+
+### Changed
+
+- Split workspace.package.version into per-crate versions ([#5](https://github.com/TurtIeSocks/zendriver-rs/pull/5))
+

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-transport/CHANGELOG.md
+++ b/crates/zendriver-transport/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this crate documented here. Format: [Keep a
+Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
+
+## [0.1.1] - 2026-05-25
+
+### Changed
+
+- Split workspace.package.version into per-crate versions ([#5](https://github.com/TurtIeSocks/zendriver-rs/pull/5))
+

--- a/crates/zendriver-transport/Cargo.toml
+++ b/crates/zendriver-transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-transport"
 description = "Internal: WebSocket + CDP routing actor for zendriver"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this crate documented here. Format: [Keep a
+Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
+
+## [0.1.1] - 2026-05-25
+
+### Changed
+
+- Split workspace.package.version into per-crate versions ([#5](https://github.com/TurtIeSocks/zendriver-rs/pull/5))
+

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-transport`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `zendriver-interception`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `zendriver-cloudflare`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `zendriver-fetcher`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `zendriver-stealth`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `zendriver`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `zendriver-mcp`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-transport`

<blockquote>

## [0.1.1] - 2026-05-25

### Changed

- Split workspace.package.version into per-crate versions ([#5](https://github.com/TurtIeSocks/zendriver-rs/pull/5))
</blockquote>

## `zendriver-interception`

<blockquote>

## [0.1.1] - 2026-05-25

### Changed

- Split workspace.package.version into per-crate versions ([#5](https://github.com/TurtIeSocks/zendriver-rs/pull/5))

### Fixed

- Clean expectations + interception rules on browser_close
</blockquote>

## `zendriver-cloudflare`

<blockquote>

## [0.1.1] - 2026-05-25

### Changed

- Split workspace.package.version into per-crate versions ([#5](https://github.com/TurtIeSocks/zendriver-rs/pull/5))
</blockquote>

## `zendriver-fetcher`

<blockquote>

## [0.1.1] - 2026-05-25

### Changed

- Split workspace.package.version into per-crate versions ([#5](https://github.com/TurtIeSocks/zendriver-rs/pull/5))
</blockquote>

## `zendriver-stealth`

<blockquote>

## [0.1.1] - 2026-05-25

### Changed

- Split workspace.package.version into per-crate versions ([#5](https://github.com/TurtIeSocks/zendriver-rs/pull/5))
</blockquote>

## `zendriver`

<blockquote>

## [0.1.1] - 2026-05-25

### Changed

- Split workspace.package.version into per-crate versions ([#5](https://github.com/TurtIeSocks/zendriver-rs/pull/5))
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.1.1] - 2026-05-25

### Changed

- Split workspace.package.version into per-crate versions ([#5](https://github.com/TurtIeSocks/zendriver-rs/pull/5))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).