### PR TITLE
ci: wire release-plz workflows to on:push trigger

### DIFF
--- a/.github/workflows/release-plz-pr.yml
+++ b/.github/workflows/release-plz-pr.yml
@@ -1,12 +1,15 @@
-name: Release PR (dry-run)
-
-# Phase-3 staging: workflow_dispatch only. Phase 4 flips to `on: push`.
+name: Release PR
 
 permissions:
   contents: write
   pull-requests: write
 
 on:
+  push:
+    branches: [main]
+    # Don't fire on the release PR's own merge commit (release-plz
+    # commits are titled "chore: release ..."); the release workflow
+    # picks that up instead.
   workflow_dispatch:
 
 concurrency:
@@ -15,7 +18,7 @@ concurrency:
 
 jobs:
   release-plz-pr:
-    name: Update release PR (dry-run)
+    name: Update release PR
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,10 +33,6 @@ jobs:
       - uses: release-plz/action@v0.5.129
         with:
           command: release-pr
-          # `dry-run` means: compute the bumps + changelog and log them,
-          # but do not open or amend a PR. Safe to run repeatedly while
-          # iterating on the config.
-          # Once we're happy, Phase 4 removes this flag.
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz-release.yml
+++ b/.github/workflows/release-plz-release.yml
@@ -1,18 +1,12 @@
-name: Release (dry-run)
-
-# Phase-3 staging: workflow_dispatch only with --dry-run. Phase 4 flips
-# to `on: push` and removes --dry-run.
+name: Release
 
 permissions:
   contents: write
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
-    inputs:
-      really_publish:
-        description: "If false (default), pass --dry-run to cargo publish. Leave false in Phase 3."
-        type: boolean
-        default: false
 
 concurrency:
   group: release-plz-release
@@ -20,7 +14,7 @@ concurrency:
 
 jobs:
   release-plz-release:
-    name: Publish to crates.io (dry-run)
+    name: Publish to crates.io
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,10 +29,6 @@ jobs:
       - uses: release-plz/action@v0.5.129
         with:
           command: release
-          # Phase 3: always force --dry-run regardless of input. This
-          # makes `cargo publish` validate but skip the upload.
-          # cargo_publish_args is passed straight to `cargo publish`.
-          cargo_publish_args: ${{ inputs.really_publish && '' || '--dry-run' }}
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- Flips `release-plz-pr.yml` and `release-plz-release.yml` from `workflow_dispatch` only to `on: push: branches: [main]`.
- Drops the `cargo_publish_args` invalid input from Phase 3 (release-plz's action doesn't accept it; correct param is `dry_run`).
- Existing `publish.yml` still runs in parallel — release-plz only opens a PR on its own; no double-publish risk yet.
- Phase 5 will delete `publish.yml` after the first release-plz PR (#8) successfully publishes.

## Test plan
- [ ] CI green
- [ ] After merge: release-plz amends PR #8 with the latest state (already open from Phase 3 dry-run trigger)

Phase 4 of: `docs/superpowers/plans/2026-05-25-publish-version-automation.md`.