### PR TITLE
chore: release v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -3274,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-cloudflare"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.1.1", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.1.2", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.1" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.1.1" }
-zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.1.1" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.1.2" }
+zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.1.2" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.1.1" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.1" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.1.1" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.1.2" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-cloudflare/CHANGELOG.md
+++ b/crates/zendriver-cloudflare/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-05-25
+
+### Fixed
+
+- Repair stealth + cloudflare nightly tests against drift
+
+
 ### Changed
 
 - `CloudflareBypass::wait_for_clearance` now drives a unified poll loop

--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-cloudflare"
 description = "Cloudflare Turnstile bypass for zendriver"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.2] - 2026-05-25
+
+
 ## [0.1.1] - 2026-05-25
 
 ### Changed

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.2] - 2026-05-25
+
+### Fixed
+
+- Repair stealth + cloudflare nightly tests against drift
+
+
 ## [0.1.1] - 2026-05-25
 
 ### Changed

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.2] - 2026-05-25
+
+### Fixed
+
+- Repair stealth + cloudflare nightly tests against drift
+
+
 ## [0.1.1] - 2026-05-25
 
 ### Changed

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-cloudflare`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `zendriver-stealth`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `zendriver`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `zendriver-mcp`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-cloudflare`

<blockquote>

## [0.1.2] - 2026-05-25

### Fixed

- Repair stealth + cloudflare nightly tests against drift


### Changed

- `CloudflareBypass::wait_for_clearance` now drives a unified poll loop
  rather than an upfront iframe-detect + click + poll. Each tick fetches
  the `cf-turnstile-response` token, the challenge iframe bbox (shadow-DOM
  aware), and a challenge-marker flag in a single CDP round-trip. The
  click flow still fires when the interactive iframe mounts; the
  **invisible Turnstile** path — where Cloudflare populates the token
  with no iframe ever mounting — now resolves to `TokenAcquired` instead
  of `Err(NoChallenge)`. `NoChallenge` is now reserved for the case
  where the entire timeout window elapsed without any challenge marker on
  the page. Public surface unchanged.
</blockquote>

## `zendriver-stealth`

<blockquote>

## [0.1.2] - 2026-05-25

### Fixed

- Repair stealth + cloudflare nightly tests against drift
</blockquote>

## `zendriver`

<blockquote>

## [0.1.2] - 2026-05-25

### Fixed

- Repair stealth + cloudflare nightly tests against drift
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).