### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "futures",
  "serde",
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.1.3", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.1.4", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.2" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.1.3" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.1.3" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.1.2" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.2" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.1.3" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.1.1" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.1.4" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.1.2" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.2] - 2026-06-01
+
+
 ## [0.1.1] - 2026-05-26
 
 

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.4] - 2026-06-01
+
+
 ## [0.1.3] - 2026-05-26
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,17 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-06-01
+
+### Added
+
+- Add BrowserContext skeleton
+- BrowserInner::dispose_browser_context
+- Drop for BrowserContext schedules dispose
+- Browser::create_browser_context[_with]
+- BrowserContext::new_tab[_at] threads browserContextId
+
+
 ### Added
 
 - `Browser::create_browser_context` and `Browser::create_browser_context_with(proxy_server, proxy_bypass_list)` — high-level wrappers around CDP `Target.createBrowserContext` for per-context proxy and storage isolation.

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-imperva`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `zendriver`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `zendriver-mcp`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>


## `zendriver`

<blockquote>

## [0.1.4] - 2026-06-01

### Added

- Add BrowserContext skeleton
- BrowserInner::dispose_browser_context
- Drop for BrowserContext schedules dispose
- Browser::create_browser_context[_with]
- BrowserContext::new_tab[_at] threads browserContextId


### Added

- `Browser::create_browser_context` and `Browser::create_browser_context_with(proxy_server, proxy_bypass_list)` — high-level wrappers around CDP `Target.createBrowserContext` for per-context proxy and storage isolation.
- `BrowserContext` RAII guard with `new_tab` / `new_tab_at` (threads `browserContextId` into `Target.createTarget`) and a `Drop` impl that schedules `Target.disposeBrowserContext` via the underlying connection.
- `examples/browser_context_isolation` demonstrating per-context proxy bindings against a rotating upstream.
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).