### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-cloudflare"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -3315,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "futures",
  "serde",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-transport"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.1.4", default-features = false }
-zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.2" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.1.3" }
-zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.1.3" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.1.2" }
+zendriver               = { path = "crates/zendriver", version = "0.2.0", default-features = false }
+zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.3" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.1.4" }
+zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.1.4" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.2.0" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.2" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.1.4" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.1.2" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.1.5" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.1.3" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-cloudflare/CHANGELOG.md
+++ b/crates/zendriver-cloudflare/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-06-02
+
+
 ## [0.1.3] - 2026-05-26
 
 ### Added

--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-cloudflare"
 description = "Cloudflare Turnstile bypass for zendriver"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.3] - 2026-06-02
+
+
 ## [0.1.2] - 2026-06-01
 
 

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.0] - 2026-06-02
+
+### Added
+
+- Full nodriver / zendriver-py parity — phases P-A…P-E ([#17](https://github.com/TurtIeSocks/zendriver-rs/pull/17))
+
+
 ## [0.1.2] - 2026-05-26
 
 

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.1.2"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.5] - 2026-06-02
+
+### Added
+
+- Full nodriver / zendriver-py parity — phases P-A…P-E ([#17](https://github.com/TurtIeSocks/zendriver-rs/pull/17))
+
+
 ## [0.1.4] - 2026-06-01
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.4] - 2026-06-02
+
+
 ## [0.1.3] - 2026-05-26
 
 

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-transport/CHANGELOG.md
+++ b/crates/zendriver-transport/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-06-02
+
+### Added
+
+- Full nodriver / zendriver-py parity — phases P-A…P-E ([#17](https://github.com/TurtIeSocks/zendriver-rs/pull/17))
+
+
 ### Added
 
 - `Connection::reconnect(ws)` / `Connection::redial(ws_url)` — restart the actor on a fresh socket while reusing the same `Connection` handle and broadcast event bus (raw event subscribers re-attach automatically), re-spawning with the original observer chain. `redial` re-applies the WebSocket size config. Pre-existing CDP `sessionId`s are stale after a reconnect.

--- a/crates/zendriver-transport/Cargo.toml
+++ b/crates/zendriver-transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-transport"
 description = "Internal: WebSocket + CDP routing actor for zendriver"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-02
+
+### Added
+
+- Full nodriver / zendriver-py parity — phases P-A…P-E ([#17](https://github.com/TurtIeSocks/zendriver-rs/pull/17))
+
+
 ### Added
 
 - `Browser::reconnect()` — re-establish a dropped connection to the same still-running Chrome process (re-dials the surviving `/devtools/browser/<id>` endpoint on the existing `Connection`, re-arms `Target.setAutoAttach{flatten:true}` so stealth re-injects, refreshes the tab registry). Scoped v1: existing `Tab`/`Frame`/`Element` handles are **invalidated** — re-acquire via `tabs()` (not `main_tab()`, which still returns the stale handle). Per-feature domain re-arm (`Network.enable`, `Fetch` rules, etc.) and transparent handle-preserving reconnect are deferred.

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.1.4"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-transport`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `zendriver-interception`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)
* `zendriver`: 0.1.4 -> 0.2.0 (⚠ API breaking changes)
* `zendriver-mcp`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `zendriver-cloudflare`: 0.1.3 -> 0.1.4
* `zendriver-imperva`: 0.1.2 -> 0.1.3
* `zendriver-stealth`: 0.1.3 -> 0.1.4

### ⚠ `zendriver-interception` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant Rule:ModifyResponse in /tmp/.tmpeNEkvb/zendriver-rs/crates/zendriver-interception/src/rule.rs:75
  variant Rule:ModifyResponse in /tmp/.tmpeNEkvb/zendriver-rs/crates/zendriver-interception/src/rule.rs:75
```

### ⚠ `zendriver` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Cookie.priority in /tmp/.tmpeNEkvb/zendriver-rs/crates/zendriver/src/cookies/mod.rs:138
  field Cookie.same_party in /tmp/.tmpeNEkvb/zendriver-rs/crates/zendriver/src/cookies/mod.rs:142
  field Cookie.source_scheme in /tmp/.tmpeNEkvb/zendriver-rs/crates/zendriver/src/cookies/mod.rs:146
  field Cookie.source_port in /tmp/.tmpeNEkvb/zendriver-rs/crates/zendriver/src/cookies/mod.rs:150
  field Cookie.partition_key in /tmp/.tmpeNEkvb/zendriver-rs/crates/zendriver/src/cookies/mod.rs:159
  field Cookie.priority in /tmp/.tmpeNEkvb/zendriver-rs/crates/zendriver/src/cookies/mod.rs:138
  field Cookie.same_party in /tmp/.tmpeNEkvb/zendriver-rs/crates/zendriver/src/cookies/mod.rs:142
  field Cookie.source_scheme in /tmp/.tmpeNEkvb/zendriver-rs/crates/zendriver/src/cookies/mod.rs:146
  field Cookie.source_port in /tmp/.tmpeNEkvb/zendriver-rs/crates/zendriver/src/cookies/mod.rs:150
  field Cookie.partition_key in /tmp/.tmpeNEkvb/zendriver-rs/crates/zendriver/src/cookies/mod.rs:159
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-transport`

<blockquote>

## [0.1.3] - 2026-06-02

### Added

- Full nodriver / zendriver-py parity — phases P-A…P-E ([#17](https://github.com/TurtIeSocks/zendriver-rs/pull/17))


### Added

- `Connection::reconnect(ws)` / `Connection::redial(ws_url)` — restart the actor on a fresh socket while reusing the same `Connection` handle and broadcast event bus (raw event subscribers re-attach automatically), re-spawning with the original observer chain. `redial` re-applies the WebSocket size config. Pre-existing CDP `sessionId`s are stale after a reconnect.
- Unexpected ws death (Chrome-sent Close frame, read error, stream end) now drains in-flight calls with a distinct `DISCONNECTED_CODE`, mapped by `Connection::call_raw` to `TransportError::Disconnected` — separate from the `SHUTDOWN_DRAIN_CODE`/`TransportError::Shutdown` used for a caller-requested `shutdown()`.
- `MockConnection::disconnect()` test helper to simulate an unexpected socket drop.
</blockquote>

## `zendriver-interception`

<blockquote>

## [0.2.0] - 2026-06-02

### Added

- Full nodriver / zendriver-py parity — phases P-A…P-E ([#17](https://github.com/TurtIeSocks/zendriver-rs/pull/17))
</blockquote>

## `zendriver`

<blockquote>

## [0.2.0] - 2026-06-02

### Added

- Full nodriver / zendriver-py parity — phases P-A…P-E ([#17](https://github.com/TurtIeSocks/zendriver-rs/pull/17))


### Added

- `Browser::reconnect()` — re-establish a dropped connection to the same still-running Chrome process (re-dials the surviving `/devtools/browser/<id>` endpoint on the existing `Connection`, re-arms `Target.setAutoAttach{flatten:true}` so stealth re-injects, refreshes the tab registry). Scoped v1: existing `Tab`/`Frame`/`Element` handles are **invalidated** — re-acquire via `tabs()` (not `main_tab()`, which still returns the stale handle). Per-feature domain re-arm (`Network.enable`, `Fetch` rules, etc.) and transparent handle-preserving reconnect are deferred.

### Changed

- An unexpected WebSocket drop (Chrome died / socket severed) now surfaces in-flight CDP calls as the new distinct `ZendriverError::Disconnected` variant, instead of the opaque shutdown error used for a clean `close()`. Long-running callers can now tell "connection lost" apart from "I closed it" and recover via `Browser::reconnect()`.
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.1.5] - 2026-06-02

### Added

- Full nodriver / zendriver-py parity — phases P-A…P-E ([#17](https://github.com/TurtIeSocks/zendriver-rs/pull/17))
</blockquote>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).