### PR TITLE
ci: auto-merge release-plz release PRs

### DIFF
--- a/.github/workflows/release-plz-pr.yml
+++ b/.github/workflows/release-plz-pr.yml
@@ -31,8 +31,33 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - uses: release-plz/action@v0.5.129
+        id: release-plz
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      # Auto-merge the release PR so publishing stays hands-off: the
+      # merge pushes "chore: release ..." to main, which triggers
+      # release-plz-release.yml to publish to crates.io.
+      #
+      # GH_TOKEN is the PAT, not GITHUB_TOKEN — a GITHUB_TOKEN-authored
+      # push would NOT trigger the release workflow (GitHub's anti-
+      # recursion rule). The PAT-authored merge does.
+      #
+      # `gh pr merge --auto` queues the merge behind required status
+      # checks when branch protection defines them. main is currently
+      # unprotected (no required checks), and GitHub refuses to *enable*
+      # auto-merge on an already-mergeable PR — so the `|| gh pr merge`
+      # fallback merges immediately. Add branch protection with required
+      # checks later and the --auto path will gate on green CI with no
+      # further changes here.
+      - name: Auto-merge the release PR
+        if: ${{ steps.release-plz.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          PR_NUMBER: ${{ fromJSON(steps.release-plz.outputs.pr).number }}
+        run: |
+          gh pr merge --auto --merge "$PR_NUMBER" \
+            || gh pr merge --merge "$PR_NUMBER"


### PR DESCRIPTION
## What

Auto-merge the `chore: release` PRs that release-plz opens, so cutting a release is hands-off: merge → push to `main` → `release-plz-release.yml` publishes to crates.io.

## How

New step in `release-plz-pr.yml`, after the `release-pr` step:

```yaml
- name: Auto-merge the release PR
  if: ${{ steps.release-plz.outputs.prs_created == 'true' }}
  env:
    GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
    PR_NUMBER: ${{ fromJSON(steps.release-plz.outputs.pr).number }}
  run: |
    gh pr merge --auto --merge "$PR_NUMBER" \
      || gh pr merge --merge "$PR_NUMBER"
```

## Decisions

- **PAT (`RELEASE_PLZ_TOKEN`), not `GITHUB_TOKEN`** — a `GITHUB_TOKEN`-authored merge push would not trigger `release-plz-release.yml` (GitHub's anti-recursion rule). The PAT-authored merge does, so the publish chain runs.
- **`--auto … || direct merge`** — `--auto` queues behind required status checks *when branch protection defines them*. `main` is currently unprotected, and GitHub refuses to *enable* auto-merge on an already-mergeable PR, so the fallback merges immediately. Add branch protection with required checks later and the `--auto` path gates on green CI with no further edits here.
- **Guarded on `prs_created`** — only fires when a release PR actually exists. Repo already has `delete_branch_on_merge`, so the `release-plz-*` branch auto-cleans.

## Caveats

- Takes effect once merged to `main` (push-triggered workflows run the default-branch version).
- Not retroactive: the currently-open #18 needs a one-time manual merge; release PRs after this lands auto-merge.
- Since `main` is unprotected, auto-merge does **not** wait for CI. Want CI to gate releases? Add branch protection with required status checks — the workflow already supports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)