### PR TITLE
feat(mcp): expand zendriver-mcp coverage 49 → 65 tools (near-full API parity)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# zendriver-rs — project instructions
+
+## Before every push (REQUIRED)
+
+CI fails the PR on formatting or lint regressions, so run these locally and fix
+**before** pushing — never push and rely on CI to catch them:
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --locked --fix --allow-dirty --allow-staged
+```
+
+Then confirm both gates pass exactly as CI runs them:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+```
+
+- `cargo fmt --all` first — the most common CI failure is unformatted code.
+- `clippy --fix` auto-applies machine-applicable lints; review the diff, then
+  hand-fix anything `--fix` couldn't (clippy CI uses `-D warnings`, so any
+  remaining warning is a hard failure).
+- Re-stage / amend after the fixes so the pushed commit is already clean.
+
+CI clippy runs on **default features**; if you touched feature-gated code
+(`interception` / `expect` / `cloudflare` / `imperva` / `fetcher`), also run
+`cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings`.
+
+## Schema snapshots (zendriver-mcp)
+
+After changing any MCP tool input/output type, regenerate + accept the `insta`
+JSON-schema snapshots and ensure none stay pending:
+
+```bash
+cargo test -p zendriver-mcp --test schema_snapshots --all-features --locked
+cargo insta accept --all
+```
+
+Commit the updated `crates/zendriver-mcp/tests/snapshots/*.snap` — the wire
+shape is reviewed.

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -21,10 +21,11 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [features]
-default = ["interception", "expect", "cloudflare", "fetcher"]
+default = ["interception", "expect", "cloudflare", "imperva", "fetcher"]
 interception = ["zendriver/interception", "dep:uuid"]
 expect       = ["zendriver/expect", "dep:uuid"]
 cloudflare   = ["zendriver/cloudflare"]
+imperva      = ["zendriver/imperva"]
 fetcher      = ["zendriver/fetcher"]
 integration-tests = []
 

--- a/crates/zendriver-mcp/src/server.rs
+++ b/crates/zendriver-mcp/src/server.rs
@@ -40,8 +40,8 @@ use crate::tools::imperva;
 #[cfg(feature = "interception")]
 use crate::tools::intercept;
 use crate::tools::{
-    actions, cookies, eval, find, frames, lifecycle, navigation, reads, snapshot, stealth, storage,
-    tabs,
+    actions, cookies, eval, find, frames, lifecycle, mouse, navigation, pdf, reads, scroll,
+    snapshot, stealth, storage, tabs, window,
 };
 
 /// rmcp handler carrying the per-session [`SessionState`].
@@ -603,6 +603,80 @@ impl ZendriverServer {
         storage::storage_clear(self.state.clone(), input)
             .await
             .map(Json)
+    }
+
+    // ---------- scroll / window / pdf / mouse (Tier 1 coverage) ----------
+
+    /// Scroll the page by a signed pixel distance.
+    #[tool(
+        name = "browser_scroll",
+        description = "Scroll the page by a signed pixel distance via `Input.synthesizeScrollGesture`. Intuitive axes: positive `dy` scrolls **down**, positive `dx` scrolls **right** (the tool negates internally for CDP). Optional `speed` (px/sec). Returns the resulting `{ scroll_x, scroll_y }` (and the trimmed HTML when `return_snapshot: true`). Use `browser_scroll_into_view` instead when you want to bring a specific element into view."
+    )]
+    pub async fn browser_scroll(
+        &self,
+        Parameters(input): Parameters<scroll::PageScrollInput>,
+    ) -> Result<Json<scroll::PageScrollOutput>, ErrorData> {
+        scroll::scroll(self.state.clone(), input).await.map(Json)
+    }
+
+    /// Read the current OS window bounds + state.
+    #[tool(
+        name = "browser_get_window",
+        description = "Read the current OS window bounds + state (`Browser.getWindowForTarget`). Returns `{ left?, top?, width?, height?, state }` in device-independent pixels; geometry fields are omitted for a minimized window. `state` is one of `normal` / `minimized` / `maximized` / `fullscreen`."
+    )]
+    pub async fn browser_get_window(
+        &self,
+        Parameters(_): Parameters<EmptyInput>,
+    ) -> Result<Json<window::WindowBoundsDto>, ErrorData> {
+        window::get_window(self.state.clone()).await.map(Json)
+    }
+
+    /// Resize / reposition / change the state of the OS window.
+    #[tool(
+        name = "browser_set_window",
+        description = "Resize, reposition, or change the state of the OS window hosting the current tab. `mode`: `size` (resize to `width`×`height`, both required), `bounds` (set any subset of `left`/`top`/`width`/`height`/`state`), `maximize`, `minimize`, or `fullscreen`. Returns the resulting bounds. Affects viewport size for screenshots + responsive layouts."
+    )]
+    pub async fn browser_set_window(
+        &self,
+        Parameters(input): Parameters<window::SetWindowInput>,
+    ) -> Result<Json<window::WindowBoundsDto>, ErrorData> {
+        window::set_window(self.state.clone(), input).await.map(Json)
+    }
+
+    /// Export the current page to PDF.
+    #[tool(
+        name = "browser_pdf",
+        description = "Export the current page to PDF (`Page.printToPDF`). All options optional: `landscape`, `print_background`, `scale`, `paper_width`/`paper_height` (inches), `margin_*` (inches), `page_ranges` (e.g. `\"1-3, 5\"`), `prefer_css_page_size`. When `save_path` is set the bytes are written to disk on the MCP host and `{ saved_path, byte_len }` is returned; otherwise the bytes are base64-inlined in `{ byte_len, base64 }` (blobs over 5 MiB require `save_path`)."
+    )]
+    pub async fn browser_pdf(
+        &self,
+        Parameters(input): Parameters<pdf::PdfInput>,
+    ) -> Result<Json<crate::tools::common::BlobOutput>, ErrorData> {
+        pdf::pdf(self.state.clone(), input).await.map(Json)
+    }
+
+    /// Capture an MHTML archive of the current page.
+    #[tool(
+        name = "browser_save_mhtml",
+        description = "Capture a single-file MHTML archive of the current page (`Page.captureSnapshot`) — HTML plus inlined subresources. When `save_path` is set the bytes are written to disk on the MCP host; otherwise base64-inlined (same `BlobOutput` shape as `browser_pdf`)."
+    )]
+    pub async fn browser_save_mhtml(
+        &self,
+        Parameters(input): Parameters<pdf::SaveMhtmlInput>,
+    ) -> Result<Json<crate::tools::common::BlobOutput>, ErrorData> {
+        pdf::save_mhtml(self.state.clone(), input).await.map(Json)
+    }
+
+    /// Dispatch a coordinate-anchored mouse action.
+    #[tool(
+        name = "browser_mouse",
+        description = "Dispatch a coordinate-anchored pointer action for canvas / drag-and-drop / map / game interactions not reachable via element-targeted tools. `action`: `move` (Bezier path to `x,y`), `click` (at `x,y`, with optional `button` / `click_count` / `modifiers`), or `drag` (press at `x,y`, drag to `to_x,to_y` over `steps`, release). Coordinates are viewport CSS pixels. Returns `{ ok }` (and trimmed HTML when `return_snapshot: true`)."
+    )]
+    pub async fn browser_mouse(
+        &self,
+        Parameters(input): Parameters<mouse::MouseInput>,
+    ) -> Result<Json<actions::ActionOutput>, ErrorData> {
+        mouse::mouse(self.state.clone(), input).await.map(Json)
     }
 }
 

--- a/crates/zendriver-mcp/src/server.rs
+++ b/crates/zendriver-mcp/src/server.rs
@@ -760,7 +760,7 @@ impl ZendriverServer {
     /// Register a one-shot expectation against the current tab.
     #[tool(
         name = "browser_expect_register",
-        description = "Register a one-shot expectation against the current tab. `kind` selects `request` / `response` / `dialog` / `download`. `matcher.url_substr` / `matcher.url_regex` filter request and response by URL (regex wins if both set; default matches every URL). `dialog` and `download` ignore matcher fields entirely. `pre_await_timeout_ms` (default 60_000 = 60s) is the inner timeout applied to the lib's `.timeout(d)` so the user has time to trigger the action between `_register` and `_await`. Returns `{ expectation_id }` — pass to `browser_expect_await` or `browser_expect_cancel`."
+        description = "Register a one-shot expectation against the current tab. `kind` selects `request` / `response` / `dialog` / `download`. `matcher.url_substr` / `matcher.url_regex` filter request and response by URL (regex wins if both set; default matches every URL). `dialog` and `download` ignore matcher fields entirely. `pre_await_timeout_ms` (default 60_000 = 60s) is the inner timeout applied to the lib's `.timeout(d)` so the user has time to trigger the action between `_register` and `_await`. Drive params (decided here because the matched handle is consumed by the spawned task): `dialog_action` (`accept`/`dismiss`, plus `dialog_prompt_text` for prompts) drives a matched dialog so the page's blocking call returns; `fetch_body: true` inlines the response body as `body_base64`; `save_to: <path>` copies a completed download to the MCP host. Returns `{ expectation_id }` — pass to `browser_expect_await` or `browser_expect_cancel`."
     )]
     pub async fn browser_expect_register(
         &self,
@@ -772,7 +772,7 @@ impl ZendriverServer {
     /// Wait for a previously-registered expectation to resolve.
     #[tool(
         name = "browser_expect_await",
-        description = "Wait for a previously-registered expectation to resolve. `timeout_ms` (default 30_000 = 30s) is the outer wait on the spawned task's matched-event channel. Returns `{ expectation_id, event }` where `event` is a JSON object whose shape depends on the expectation's `kind`: request/response carry `url` / `headers` / `method` or `status`; dialog carries `dialog_type` / `message` / `default_prompt`; download carries `suggested_filename` / `guid` / `download_dir`. Response bodies and download bytes are NOT fetched in v0 — agents that need them can poll via `browser_evaluate` or a future kind-specific tool."
+        description = "Wait for a previously-registered expectation to resolve. `timeout_ms` (default 30_000 = 30s) is the outer wait on the spawned task's matched-event channel. Returns `{ expectation_id, event }` where `event` is a JSON object whose shape depends on the expectation's `kind`: request/response carry `url` / `headers` / `method` or `status`; dialog carries `dialog_type` / `message` / `default_prompt` / `driven`; download carries `suggested_filename` / `guid` / `download_dir` / `saved_path`. When the expectation was registered with `fetch_body: true`, response events also carry `body_base64` + `body_len`. Dialog drive and download save are requested at register time (see `browser_expect_register`)."
     )]
     pub async fn browser_expect_await(
         &self,

--- a/crates/zendriver-mcp/src/server.rs
+++ b/crates/zendriver-mcp/src/server.rs
@@ -35,6 +35,8 @@ use crate::tools::common::EmptyInput;
 use crate::tools::expect;
 #[cfg(feature = "fetcher")]
 use crate::tools::fetcher;
+#[cfg(feature = "imperva")]
+use crate::tools::imperva;
 #[cfg(feature = "interception")]
 use crate::tools::intercept;
 use crate::tools::{
@@ -744,6 +746,29 @@ impl ZendriverServer {
     }
 }
 
+// ---------- imperva (gated) ----------------------------------------------
+//
+// Same split pattern as the cloudflare block — own impl block so the
+// `tool_router` macro can cfg-gate the whole thing.
+
+#[cfg(feature = "imperva")]
+#[tool_router(router = imperva_tool_router, vis = "pub")]
+impl ZendriverServer {
+    /// Drive the Imperva / Incapsula clearance flow on the current tab.
+    #[tool(
+        name = "browser_solve_imperva",
+        description = "Drive the Imperva / Incapsula clearance flow on the current tab. Detects the active surface (modern reese84 bot-management, legacy Incapsula, or CAPTCHA escalation) and polls every `poll_interval_ms` until one of four terminal states is reached, bounded by `timeout_ms` (default 30_000 = 30s): `token_acquired` (reese84 cookie captured — returned in `reese84`), `challenge_gone` (markers cleared without a token, e.g. legacy flow), `already_clear` (no surface present at call time — fast path), or `timeout` (deadline elapsed — not an error, retry or fall back). Set `with_interception: true` for the Fetch-domain fast-path. Errors on structural failures: CAPTCHA with no solver, CDP failure, or in-page JS exception. Requires stealth (on by default)."
+    )]
+    pub async fn browser_solve_imperva(
+        &self,
+        Parameters(input): Parameters<imperva::SolveImpervaInput>,
+    ) -> Result<Json<imperva::SolveImpervaOutput>, ErrorData> {
+        imperva::solve_imperva(self.state.clone(), input)
+            .await
+            .map(Json)
+    }
+}
+
 // ---------- fetcher (gated) ----------------------------------------------
 //
 // Same split pattern as the other gated blocks. `browser_install_chrome`
@@ -785,6 +810,8 @@ impl ZendriverServer {
         let router = router + Self::expect_tool_router();
         #[cfg(feature = "cloudflare")]
         let router = router + Self::cloudflare_tool_router();
+        #[cfg(feature = "imperva")]
+        let router = router + Self::imperva_tool_router();
         #[cfg(feature = "fetcher")]
         let router = router + Self::fetcher_tool_router();
         router

--- a/crates/zendriver-mcp/src/server.rs
+++ b/crates/zendriver-mcp/src/server.rs
@@ -697,7 +697,9 @@ impl ZendriverServer {
         &self,
         Parameters(input): Parameters<window::SetWindowInput>,
     ) -> Result<Json<window::WindowBoundsDto>, ErrorData> {
-        window::set_window(self.state.clone(), input).await.map(Json)
+        window::set_window(self.state.clone(), input)
+            .await
+            .map(Json)
     }
 
     /// Export the current page to PDF.
@@ -747,7 +749,9 @@ impl ZendriverServer {
         &self,
         Parameters(input): Parameters<actions::KeySequenceInput>,
     ) -> Result<Json<actions::ActionOutput>, ErrorData> {
-        actions::key_sequence(self.state.clone(), input).await.map(Json)
+        actions::key_sequence(self.state.clone(), input)
+            .await
+            .map(Json)
     }
 
     /// Download a URL through the page's own network context.
@@ -759,7 +763,9 @@ impl ZendriverServer {
         &self,
         Parameters(input): Parameters<download::DownloadInput>,
     ) -> Result<Json<download::DownloadOutput>, ErrorData> {
-        download::download(self.state.clone(), input).await.map(Json)
+        download::download(self.state.clone(), input)
+            .await
+            .map(Json)
     }
 
     /// Set the directory downloads are saved into.
@@ -799,7 +805,9 @@ impl ZendriverServer {
         &self,
         Parameters(input): Parameters<frames::FrameGotoInput>,
     ) -> Result<Json<actions::AckOutput>, ErrorData> {
-        frames::frame_goto(self.state.clone(), input).await.map(Json)
+        frames::frame_goto(self.state.clone(), input)
+            .await
+            .map(Json)
     }
 }
 

--- a/crates/zendriver-mcp/src/server.rs
+++ b/crates/zendriver-mcp/src/server.rs
@@ -311,13 +311,53 @@ impl ZendriverServer {
     /// Resolve a Selector and report selected state fields.
     #[tool(
         name = "browser_element_state",
-        description = "Inspect a single element's state. `include` picks which fields to populate (default `all`). `in_viewport` is reserved for v1 and always returns null. Missing-element returns `{ exists: false }` rather than an error."
+        description = "Inspect a single element's state. `include` picks which fields to populate (default `all`): `visible`/`enabled`, `bounding_box` (viewport) + `bounding_box_page` (page-absolute), `text`/`attrs`/`inner_html`/`outer_html`. `in_viewport` is reserved for v1 and always returns null. Missing-element returns `{ exists: false }` rather than an error."
     )]
     pub async fn browser_element_state(
         &self,
         Parameters(input): Parameters<reads::ElementStateInput>,
     ) -> Result<Json<reads::ElementState>, ErrorData> {
         reads::element_state(self.state.clone(), input)
+            .await
+            .map(Json)
+    }
+
+    /// Harvest anchor URLs (and optionally resource sources) from the page.
+    #[tool(
+        name = "browser_get_links",
+        description = "Collect all anchor (`<a href>`) URLs on the current page. `absolute: true` resolves relative hrefs against the page URL. `include_sources: true` also returns `src`/`href` of linked-resource elements (img, script, link, …) in `sources`. Useful for crawling / link extraction without writing JS."
+    )]
+    pub async fn browser_get_links(
+        &self,
+        Parameters(input): Parameters<reads::GetLinksInput>,
+    ) -> Result<Json<reads::GetLinksOutput>, ErrorData> {
+        reads::get_links(self.state.clone(), input).await.map(Json)
+    }
+
+    /// Search every frame's loaded resources for a URL substring.
+    #[tool(
+        name = "browser_search_resources",
+        description = "Search across every frame's loaded resource URLs (`Page.getResourceTree`) for a substring `query`. Returns `{ matches: [{ url, frame_id }] }`. Use to locate a script/XHR/asset by URL fragment, including inside iframes."
+    )]
+    pub async fn browser_search_resources(
+        &self,
+        Parameters(input): Parameters<reads::SearchResourcesInput>,
+    ) -> Result<Json<reads::SearchResourcesOutput>, ErrorData> {
+        reads::search_resources(self.state.clone(), input)
+            .await
+            .map(Json)
+    }
+
+    /// Click through Chrome's TLS interstitial on the current tab.
+    #[tool(
+        name = "browser_bypass_insecure_warning",
+        description = "Dismiss Chrome's \"Your connection is not private\" TLS interstitial on the current tab (types the `thisisunsafe` bypass). Use after navigating to a site with a self-signed / invalid certificate when you intend to proceed anyway."
+    )]
+    pub async fn browser_bypass_insecure_warning(
+        &self,
+        Parameters(input): Parameters<EmptyInput>,
+    ) -> Result<Json<actions::AckOutput>, ErrorData> {
+        navigation::bypass_insecure_warning(self.state.clone(), input)
             .await
             .map(Json)
     }
@@ -365,7 +405,7 @@ impl ZendriverServer {
     /// Focus an element + dispatch a single keystroke.
     #[tool(
         name = "browser_press",
-        description = "Focus an element + dispatch a single keystroke. `key` accepts a special-key name (Enter, Tab, Escape, Backspace, Delete, ArrowUp/Down/Left/Right, Space, Home, End, PageUp, PageDown, F1..F12, etc., case-insensitive) OR a single character (typed as `Key::Char`)."
+        description = "Focus an element + dispatch a single keystroke. `key` accepts a special-key name (Enter, Tab, Escape, Backspace, Delete, ArrowUp/Down/Left/Right, Space, Home, End, PageUp, PageDown, F1..F12, etc., case-insensitive) OR a single character (typed as `Key::Char`). `modifiers` (e.g. `[\"ctrl\"]`) holds modifier keys for a chord. For multi-step shortcuts use `browser_key_sequence`."
     )]
     pub async fn browser_press(
         &self,
@@ -377,7 +417,7 @@ impl ZendriverServer {
     /// Set an element's `value` directly + fire `input`/`change` events.
     #[tool(
         name = "browser_set_value",
-        description = "Set an element's `value` directly + fire bubbled `input` and `change` events. Faster than `browser_type` when keystroke realism doesn't matter, but still routes through the event handlers React-style controlled inputs listen on."
+        description = "Set an element's `value` directly + fire bubbled `input` and `change` events. Faster than `browser_type` when keystroke realism doesn't matter, but still routes through the event handlers React-style controlled inputs listen on. Set `mode: text` to write `textContent` instead of `.value` (for non-form elements)."
     )]
     pub async fn browser_set_value(
         &self,
@@ -391,7 +431,7 @@ impl ZendriverServer {
     /// Clear an element's `value` and fire a bubbled `input` event.
     #[tool(
         name = "browser_clear",
-        description = "Clear an element's `value` by assigning `''` and firing a bubbled `input` event. Omits `change` event + focus + Backspace sequence — for contenteditable / non-`<input>` clearing semantics, use `browser_type` with a leading select-all + Delete."
+        description = "Clear an element's `value` by assigning `''` and firing a bubbled `input` event (default `mode: value`). Set `mode: backspace` to instead focus + select-all + Backspace — emitting the real key events some inputs require."
     )]
     pub async fn browser_clear(
         &self,
@@ -443,7 +483,7 @@ impl ZendriverServer {
     /// Return the current page's HTML (trimmed by default).
     #[tool(
         name = "browser_html",
-        description = "Return the current page's HTML as a text content block. With `selector` set, returns that element's `innerHTML`. With `frame_id` set, returns that frame's `document.documentElement.outerHTML`. `selector` and `frame_id` are mutually exclusive — use the selector's own `frame_id` field to scope element lookup to a sub-frame. `trim: true` (default) strips `<script>` / `<style>` blocks and collapses whitespace."
+        description = "Return the current page's HTML as a text content block. With `selector` set, returns that element's `innerHTML` (or `outerHTML` when `outer: true`). With `frame_id` set, returns that frame's `document.documentElement.outerHTML`. `selector` and `frame_id` are mutually exclusive — use the selector's own `frame_id` field to scope element lookup to a sub-frame. `trim: true` (default) strips `<script>` / `<style>` blocks and collapses whitespace."
     )]
     pub async fn browser_html(
         &self,

--- a/crates/zendriver-mcp/src/server.rs
+++ b/crates/zendriver-mcp/src/server.rs
@@ -40,8 +40,8 @@ use crate::tools::imperva;
 #[cfg(feature = "interception")]
 use crate::tools::intercept;
 use crate::tools::{
-    actions, cookies, eval, find, frames, lifecycle, mouse, navigation, pdf, reads, scroll,
-    snapshot, stealth, storage, tabs, window,
+    actions, cookies, download, eval, find, frames, lifecycle, mouse, navigation, pdf, reads,
+    scroll, snapshot, stealth, storage, tabs, window,
 };
 
 /// rmcp handler carrying the per-session [`SessionState`].
@@ -146,10 +146,13 @@ impl ZendriverServer {
     }
 
     /// Reload the current tab.
-    #[tool(name = "browser_reload", description = "Reload the current tab.")]
+    #[tool(
+        name = "browser_reload",
+        description = "Reload the current tab. Set `ignore_cache: true` for a hard reload that bypasses the HTTP cache. `return_snapshot: true` includes the trimmed page HTML."
+    )]
     pub async fn browser_reload(
         &self,
-        Parameters(input): Parameters<navigation::HistoryInput>,
+        Parameters(input): Parameters<navigation::ReloadInput>,
     ) -> Result<Json<navigation::NavOutput>, ErrorData> {
         navigation::reload(self.state.clone(), input)
             .await
@@ -252,13 +255,27 @@ impl ZendriverServer {
     /// Configure the session's default stealth profile.
     #[tool(
         name = "browser_set_stealth_profile",
-        description = "Configure the session's default stealth profile. NOTE: takes effect on the NEXT `browser_open` call; does NOT re-fingerprint an already-open browser. Call `browser_close` + `browser_open` to apply live."
+        description = "Configure the session's default stealth profile + optional fine-grained fingerprint `overrides` (`platform` / `locale` / `timezone` / `memory_gb` / `cpu_count` / `chrome_version` / `user_agent` / `bypass_csp`). Overrides are layered onto the profile and most meaningful with a `spoof_*` profile. NOTE: takes effect on the NEXT `browser_open`; does NOT re-fingerprint an already-open browser. `overrides` replaces any previously-set overrides (omit to clear)."
     )]
     pub async fn browser_set_stealth_profile(
         &self,
         Parameters(input): Parameters<stealth::SetStealthProfileInput>,
     ) -> Result<Json<stealth::SetStealthProfileOutput>, ErrorData> {
         stealth::set_stealth_profile(self.state.clone(), input)
+            .await
+            .map(Json)
+    }
+
+    /// Override the current tab's User-Agent at runtime.
+    #[tool(
+        name = "browser_set_user_agent",
+        description = "Override the current tab's User-Agent at runtime (`Emulation.setUserAgentOverride`), with optional `accept_language` and `platform`. Last-write-wins and sends NO userAgentMetadata — under a Spoofed stealth profile this can clobber UA-Client-Hints coherence and INCREASE detectability. Prefer the stealth profile for stealth-sensitive tabs; use this for non-stealth tabs or a deliberate per-tab change."
+    )]
+    pub async fn browser_set_user_agent(
+        &self,
+        Parameters(input): Parameters<stealth::SetUserAgentInput>,
+    ) -> Result<Json<actions::AckOutput>, ErrorData> {
+        stealth::set_user_agent(self.state.clone(), input)
             .await
             .map(Json)
     }
@@ -677,6 +694,72 @@ impl ZendriverServer {
         Parameters(input): Parameters<mouse::MouseInput>,
     ) -> Result<Json<actions::ActionOutput>, ErrorData> {
         mouse::mouse(self.state.clone(), input).await.map(Json)
+    }
+
+    // ---------- keyboard chords / downloads / load waits (Tier 2) --------
+
+    /// Dispatch a mixed text / key-chord sequence into an element.
+    #[tool(
+        name = "browser_key_sequence",
+        description = "Focus an element and dispatch an ordered sequence of typed text and (chorded) key presses — the way to send shortcuts like Ctrl+A, Cmd+C, or Tab-between-fields in one call. Each step sets `text` (literal text) OR `key` (a special-key name or single char) with optional `modifiers` (`alt`/`ctrl`/`meta`/`shift`). Example: `[{\"key\":\"a\",\"modifiers\":[\"ctrl\"]},{\"text\":\"new value\"}]`."
+    )]
+    pub async fn browser_key_sequence(
+        &self,
+        Parameters(input): Parameters<actions::KeySequenceInput>,
+    ) -> Result<Json<actions::ActionOutput>, ErrorData> {
+        actions::key_sequence(self.state.clone(), input).await.map(Json)
+    }
+
+    /// Download a URL through the page's own network context.
+    #[tool(
+        name = "browser_download",
+        description = "Download `url` by fetching it from the page's own network context (cookies / referer / same-origin credentials) and saving it via Chrome's download behavior. Optional `filename` sets the saved name (else derived from the URL). Fire-and-forget: returns once the fetch is dispatched, NOT when the file lands — for await/save-to-path use `browser_expect_register { kind: download, save_to }`."
+    )]
+    pub async fn browser_download(
+        &self,
+        Parameters(input): Parameters<download::DownloadInput>,
+    ) -> Result<Json<download::DownloadOutput>, ErrorData> {
+        download::download(self.state.clone(), input).await.map(Json)
+    }
+
+    /// Set the directory downloads are saved into.
+    #[tool(
+        name = "browser_set_download_path",
+        description = "Set the directory (on the MCP host) Chrome saves downloads into for the current tab (`Browser.setDownloadBehavior`). Created if missing. Applies to subsequent `browser_download` calls and any in-page-triggered downloads."
+    )]
+    pub async fn browser_set_download_path(
+        &self,
+        Parameters(input): Parameters<download::SetDownloadPathInput>,
+    ) -> Result<Json<actions::AckOutput>, ErrorData> {
+        download::set_download_path(self.state.clone(), input)
+            .await
+            .map(Json)
+    }
+
+    /// Wait for a document-load milestone on the tab or a frame.
+    #[tool(
+        name = "browser_wait_for_load",
+        description = "Wait for a load milestone. With no args, waits for the tab's `load` event. `ready_state` (`interactive` / `complete`) waits for that `document.readyState`. `frame_id` waits for a specific frame's load instead (ignoring `ready_state`). Distinct from `browser_wait_for_idle`, which waits for network quiet."
+    )]
+    pub async fn browser_wait_for_load(
+        &self,
+        Parameters(input): Parameters<navigation::WaitForLoadInput>,
+    ) -> Result<Json<navigation::NavOutput>, ErrorData> {
+        navigation::wait_for_load(self.state.clone(), input)
+            .await
+            .map(Json)
+    }
+
+    /// Navigate a specific frame to a URL.
+    #[tool(
+        name = "browser_frame_goto",
+        description = "Navigate the frame identified by `frame_id` (from `browser_frame_list`) to `url`, then wait for its load. Works on the main frame of an out-of-process iframe; in-process child frames surface the lib's navigation error. For top-level navigation use `browser_goto`."
+    )]
+    pub async fn browser_frame_goto(
+        &self,
+        Parameters(input): Parameters<frames::FrameGotoInput>,
+    ) -> Result<Json<actions::AckOutput>, ErrorData> {
+        frames::frame_goto(self.state.clone(), input).await.map(Json)
     }
 }
 

--- a/crates/zendriver-mcp/src/state.rs
+++ b/crates/zendriver-mcp/src/state.rs
@@ -40,6 +40,57 @@ pub enum StealthProfileChoice {
     SpoofWindows,
 }
 
+/// Platform to spoof via a fine-grained stealth override.
+///
+/// Wire mirror of `zendriver::stealth::Platform`; kept here (platform-agnostic)
+/// so the override schema stays stable independent of host detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum StealthPlatformChoice {
+    /// Windows.
+    Win32,
+    /// macOS (Intel).
+    MacIntel,
+    /// Linux x86_64.
+    LinuxX86_64,
+}
+
+/// Fine-grained stealth fingerprint overrides layered onto the chosen
+/// [`StealthProfileChoice`] at the next `browser_open`.
+///
+/// Every field is optional — an unset field leaves the base profile's value
+/// in place. Most meaningful paired with a `spoof_*` profile; applying these
+/// to `native` overrides the auto-detected real fingerprint and can *reduce*
+/// stealth if the values disagree with the host.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct StealthOverrides {
+    /// Spoofed `navigator.platform` / UA platform token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platform: Option<StealthPlatformChoice>,
+    /// Spoofed locale (e.g. `"en-US"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
+    /// Spoofed timezone (IANA name, e.g. `"America/New_York"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
+    /// Spoofed `navigator.deviceMemory` in GiB.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_gb: Option<u32>,
+    /// Spoofed `navigator.hardwareConcurrency`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_count: Option<u32>,
+    /// Spoofed Chrome major version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chrome_version: Option<u32>,
+    /// Full User-Agent string override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_agent: Option<String>,
+    /// Toggle Content-Security-Policy bypass.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bypass_csp: Option<bool>,
+}
+
 /// State held for the duration of a single MCP session.
 ///
 /// `browser` is `None` until `browser_open` is called. `current_tab_id`
@@ -48,6 +99,7 @@ pub struct SessionState {
     pub browser: Option<Browser>,
     pub current_tab_id: Option<String>,
     pub stealth_profile_choice: StealthProfileChoice,
+    pub stealth_overrides: StealthOverrides,
 
     #[cfg(feature = "expect")]
     pub expectations: HashMap<ExpectationId, ExpectationHandle>,
@@ -96,6 +148,7 @@ impl SessionState {
             browser: None,
             current_tab_id: None,
             stealth_profile_choice: StealthProfileChoice::default(),
+            stealth_overrides: StealthOverrides::default(),
             #[cfg(feature = "expect")]
             expectations: HashMap::new(),
             #[cfg(feature = "interception")]

--- a/crates/zendriver-mcp/src/tools/actions.rs
+++ b/crates/zendriver-mcp/src/tools/actions.rs
@@ -425,25 +425,41 @@ pub async fn key_sequence(
 
 // ---------- browser_set_value --------------------------------------------
 
+/// Which property `browser_set_value` writes.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SetValueMode {
+    /// Set the element's `.value` property + fire `input`/`change` (form
+    /// fields). Default.
+    #[default]
+    Value,
+    /// Set the element's `textContent` (non-form elements like `<div>`).
+    Text,
+}
+
 /// Input for `browser_set_value`.
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SetValueInput {
     #[serde(flatten)]
     pub selector: Selector,
-    /// New value for the element's `.value` property.
+    /// New value / text for the element.
     pub value: String,
+    /// Whether `value` targets the `.value` property (form fields) or
+    /// `textContent` (other elements). Default `value`.
+    #[serde(default)]
+    pub mode: SetValueMode,
     /// When `true`, include the trimmed page HTML in the response.
     #[serde(default)]
     pub return_snapshot: bool,
 }
 
-/// Set an element's `value` directly + fire bubbled `input` + `change`
-/// events.
+/// Set an element's `value` (or `textContent`) directly.
 ///
-/// Faster than [`type_text`] when the caller doesn't care about
-/// keystroke-by-keystroke realism — bypasses keydown/keyup but still
-/// fires the events React-style controlled inputs listen on.
+/// `mode: value` (default) sets `.value` + fires bubbled `input`/`change`
+/// events (React-style controlled inputs). `mode: text` sets `textContent`
+/// for non-form elements. Faster than [`type_text`] when keystroke realism
+/// doesn't matter.
 pub async fn set_value(
     state: Arc<Mutex<SessionState>>,
     input: SetValueInput,
@@ -451,13 +467,27 @@ pub async fn set_value(
     let s = state.lock().await;
     let tab = current_tab(&s).await?;
     let el = resolve(&tab, &input.selector).await?;
-    el.set_value(&input.value)
-        .await
-        .map_err(|e| map_error(McpServerError::from(e)))?;
+    match input.mode {
+        SetValueMode::Value => el.set_value(&input.value).await,
+        SetValueMode::Text => el.set_text(&input.value).await,
+    }
+    .map_err(|e| map_error(McpServerError::from(e)))?;
     ok_with_snapshot(&tab, input.return_snapshot).await
 }
 
 // ---------- browser_clear ------------------------------------------------
+
+/// How `browser_clear` empties an element.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ClearMode {
+    /// Reset `.value` to empty + fire `input` (fast). Default.
+    #[default]
+    Value,
+    /// Focus + select-all + Backspace (emits real key events some inputs
+    /// require). Slower but more faithful to user behavior.
+    Backspace,
+}
 
 /// Input for `browser_clear`.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -465,12 +495,15 @@ pub async fn set_value(
 pub struct ClearInput {
     #[serde(flatten)]
     pub selector: Selector,
+    /// Clearing strategy. Default `value`.
+    #[serde(default)]
+    pub mode: ClearMode,
     /// When `true`, include the trimmed page HTML in the response.
     #[serde(default)]
     pub return_snapshot: bool,
 }
 
-/// Clear an element's `value` and fire a bubbled `input` event.
+/// Clear an element's value (directly, or by deleting keystroke-by-keystroke).
 pub async fn clear(
     state: Arc<Mutex<SessionState>>,
     input: ClearInput,
@@ -478,9 +511,11 @@ pub async fn clear(
     let s = state.lock().await;
     let tab = current_tab(&s).await?;
     let el = resolve(&tab, &input.selector).await?;
-    el.clear()
-        .await
-        .map_err(|e| map_error(McpServerError::from(e)))?;
+    match input.mode {
+        ClearMode::Value => el.clear().await,
+        ClearMode::Backspace => el.clear_by_deleting().await,
+    }
+    .map_err(|e| map_error(McpServerError::from(e)))?;
     ok_with_snapshot(&tab, input.return_snapshot).await
 }
 
@@ -675,6 +710,7 @@ mod tests {
             SetValueInput {
                 selector: css("input"),
                 value: "rust async".into(),
+                mode: SetValueMode::Value,
                 return_snapshot: false,
             },
         )
@@ -689,6 +725,7 @@ mod tests {
             fresh(),
             ClearInput {
                 selector: css("input"),
+                mode: ClearMode::Value,
                 return_snapshot: false,
             },
         )

--- a/crates/zendriver-mcp/src/tools/actions.rs
+++ b/crates/zendriver-mcp/src/tools/actions.rs
@@ -40,13 +40,13 @@ use rmcp::ErrorData;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
-use zendriver::{ClickOptions, Key, MouseButton, SpecialKey};
+use zendriver::{ClickOptions, Key, KeySequence, MouseButton, SpecialKey};
 
 use crate::errors::{McpServerError, map_error};
 use crate::selectors::Selector;
 use crate::snapshot::html_trim;
 use crate::state::SessionState;
-use crate::tools::common::current_tab;
+use crate::tools::common::{ModifierArg, current_tab, modifiers_to_bits};
 use crate::tools::find::resolve;
 
 // ---------- shared output ------------------------------------------------
@@ -314,6 +314,10 @@ pub struct PressInput {
     /// Named special key (e.g. "Enter", "Tab", "ArrowUp") OR a single
     /// character (e.g. "a"). Special-key names are case-insensitive.
     pub key: String,
+    /// Modifier keys to hold while pressing `key` (a chord, e.g.
+    /// `["ctrl"]` + `key: "a"` for select-all). Default none.
+    #[serde(default)]
+    pub modifiers: Vec<ModifierArg>,
     /// When `true`, include the trimmed page HTML in the response.
     #[serde(default)]
     pub return_snapshot: bool,
@@ -328,10 +332,92 @@ pub async fn press(
     input: PressInput,
 ) -> Result<ActionOutput, ErrorData> {
     let key = parse_key(&input.key)?;
+    let mods = modifiers_to_bits(&input.modifiers);
     let s = state.lock().await;
     let tab = current_tab(&s).await?;
     let el = resolve(&tab, &input.selector).await?;
-    el.press(key)
+    if mods.is_empty() {
+        el.press(key)
+            .await
+            .map_err(|e| map_error(McpServerError::from(e)))?;
+    } else {
+        el.press_with(key, mods)
+            .await
+            .map_err(|e| map_error(McpServerError::from(e)))?;
+    }
+    ok_with_snapshot(&tab, input.return_snapshot).await
+}
+
+// ---------- browser_key_sequence -----------------------------------------
+
+/// One step in a [`KeySequenceInput`]: either literal text or a key press
+/// (optionally a modifier chord). Exactly one of `text` / `key` must be set.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct KeyStep {
+    /// Literal text to type (grapheme-by-grapheme). Mutually exclusive with
+    /// `key`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// Key to press — a special-key name or single character (see
+    /// `browser_press`). Mutually exclusive with `text`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    /// Modifiers held while pressing `key` (ignored for `text`).
+    #[serde(default)]
+    pub modifiers: Vec<ModifierArg>,
+}
+
+/// Input for `browser_key_sequence`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct KeySequenceInput {
+    #[serde(flatten)]
+    pub selector: Selector,
+    /// Ordered steps to dispatch: a mix of typed text and (chorded) key
+    /// presses. Example: `[{ "key": "a", "modifiers": ["ctrl"] }, { "text":
+    /// "replacement" }]` selects-all then types over it.
+    pub sequence: Vec<KeyStep>,
+    /// When `true`, include the trimmed page HTML in the response.
+    #[serde(default)]
+    pub return_snapshot: bool,
+}
+
+/// Focus an element + dispatch a mixed text / key-chord sequence in order.
+pub async fn key_sequence(
+    state: Arc<Mutex<SessionState>>,
+    input: KeySequenceInput,
+) -> Result<ActionOutput, ErrorData> {
+    // Build the lib sequence up front so a bad key name fails before we touch
+    // the browser.
+    let mut seq = KeySequence::new();
+    for step in &input.sequence {
+        match (&step.text, &step.key) {
+            (Some(text), None) => seq = seq.text(text.clone()),
+            (None, Some(key_str)) => {
+                let key = parse_key(key_str)?;
+                let mods = modifiers_to_bits(&step.modifiers);
+                if mods.is_empty() {
+                    match key {
+                        Key::Special(sk) => seq = seq.key(sk),
+                        Key::Char(_) => seq = seq.chord(key, mods),
+                    }
+                } else {
+                    seq = seq.chord(key, mods);
+                }
+            }
+            _ => {
+                return Err(ErrorData::invalid_params(
+                    "each sequence step must set exactly one of `text` or `key`".to_string(),
+                    None,
+                ));
+            }
+        }
+    }
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    let el = resolve(&tab, &input.selector).await?;
+    el.type_keys(seq)
         .await
         .map_err(|e| map_error(McpServerError::from(e)))?;
     ok_with_snapshot(&tab, input.return_snapshot).await
@@ -573,6 +659,7 @@ mod tests {
             PressInput {
                 selector: css("input"),
                 key: "Enter".into(),
+                modifiers: Vec::new(),
                 return_snapshot: false,
             },
         )

--- a/crates/zendriver-mcp/src/tools/common.rs
+++ b/crates/zendriver-mcp/src/tools/common.rs
@@ -58,6 +58,29 @@ pub async fn current_tab(s: &SessionState) -> Result<zendriver::Tab, ErrorData> 
         .ok_or_else(|| map_error(McpServerError::NoCurrentTab))
 }
 
+/// Look up a [`zendriver::Frame`] on `tab` by id.
+///
+/// Surfaces [`ZendriverError::FrameNotFound`] through the standard error
+/// pipeline (which adds a `browser_frame_list` suggestion) when no frame
+/// matches. Shared by `eval`, `frames`, and `navigation`.
+pub async fn lookup_frame(
+    tab: &zendriver::Tab,
+    frame_id: &str,
+) -> Result<zendriver::Frame, ErrorData> {
+    let frames = tab
+        .frames()
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
+    frames
+        .into_iter()
+        .find(|f| f.id() == frame_id)
+        .ok_or_else(|| {
+            map_error(McpServerError::from(
+                zendriver::ZendriverError::FrameNotFound(frame_id.to_string()),
+            ))
+        })
+}
+
 /// Collect a trimmed snapshot of the current rendered HTML.
 ///
 /// Uses `document.documentElement.outerHTML` (rather than CDP's

--- a/crates/zendriver-mcp/src/tools/common.rs
+++ b/crates/zendriver-mcp/src/tools/common.rs
@@ -7,12 +7,21 @@
 //!   don't fight the borrow checker against `Browser::tabs(&self).await`'s
 //!   `Vec<Tab>`.
 
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use rmcp::ErrorData;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::errors::{McpServerError, map_error};
+use crate::snapshot::html_trim;
 use crate::state::SessionState;
+
+/// Maximum blob size (bytes) returned inline as base64 before the caller is
+/// required to pass a `save_path`. 5 MiB keeps a single tool result well
+/// under typical MCP transport limits; larger captures (full-page PDFs,
+/// downloads) must go to disk.
+const MAX_INLINE_BYTES: usize = 5 * 1024 * 1024;
 
 /// Placeholder input struct for tools with no arguments.
 ///
@@ -47,4 +56,104 @@ pub async fn current_tab(s: &SessionState) -> Result<zendriver::Tab, ErrorData> 
     tabs.into_iter()
         .find(|t| t.target_id() == id)
         .ok_or_else(|| map_error(McpServerError::NoCurrentTab))
+}
+
+/// Collect a trimmed snapshot of the current rendered HTML.
+///
+/// Uses `document.documentElement.outerHTML` (rather than CDP's
+/// `Page.captureSnapshot`) so the result reflects post-script DOM mutations,
+/// then drops `<script>` / `<style>` and collapses whitespace. Shared by the
+/// tools (`scroll`, `mouse`) whose `return_snapshot` flag wants the same
+/// shape `navigation` / `actions` produce.
+pub async fn page_snapshot(tab: &zendriver::Tab) -> Result<String, ErrorData> {
+    let html: String = tab
+        .evaluate_main("document.documentElement.outerHTML")
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
+    Ok(html_trim::trim(&html))
+}
+
+/// MCP-layer keyboard-modifier flag, mapped onto [`zendriver::KeyModifiers`].
+///
+/// Shared by coordinate-mouse clicks (`browser_mouse`) and keyboard chords
+/// (`browser_press` / `browser_key_sequence`).
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ModifierArg {
+    /// `Alt` (Option on macOS).
+    Alt,
+    /// `Control`.
+    Ctrl,
+    /// `Meta` (Command on macOS, Windows key on Windows).
+    Meta,
+    /// `Shift`.
+    Shift,
+}
+
+/// Fold a slice of [`ModifierArg`] into a [`zendriver::KeyModifiers`] bitset.
+#[must_use]
+pub fn modifiers_to_bits(mods: &[ModifierArg]) -> zendriver::KeyModifiers {
+    let mut bits = zendriver::KeyModifiers::empty();
+    for m in mods {
+        bits |= match m {
+            ModifierArg::Alt => zendriver::KeyModifiers::ALT,
+            ModifierArg::Ctrl => zendriver::KeyModifiers::CTRL,
+            ModifierArg::Meta => zendriver::KeyModifiers::META,
+            ModifierArg::Shift => zendriver::KeyModifiers::SHIFT,
+        };
+    }
+    bits
+}
+
+/// Structured result for tools that produce a binary blob (PDF, MHTML,
+/// downloaded file).
+///
+/// When the caller passes a `save_path`, the bytes are written to disk on the
+/// MCP server host and only `{ saved_path, byte_len }` is returned. Otherwise
+/// the bytes are base64-inlined in `base64` (subject to [`MAX_INLINE_BYTES`]).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct BlobOutput {
+    /// Absolute/!relative path the bytes were written to, when `save_path`
+    /// was supplied. Path is on the MCP server host, not the client machine.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub saved_path: Option<String>,
+    /// Size of the blob in bytes.
+    pub byte_len: usize,
+    /// Base64-encoded bytes. Populated only when no `save_path` was given and
+    /// the blob is within the inline size limit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base64: Option<String>,
+}
+
+/// Build a [`BlobOutput`] from raw bytes + an optional save path.
+///
+/// # Errors
+///
+/// - The file write fails (`save_path` set).
+/// - The blob exceeds [`MAX_INLINE_BYTES`] and no `save_path` was given (the
+///   error message directs the caller to set one).
+pub fn blob_output(bytes: &[u8], save_path: Option<String>) -> Result<BlobOutput, ErrorData> {
+    let byte_len = bytes.len();
+    if let Some(path) = save_path {
+        std::fs::write(&path, bytes)
+            .map_err(|e| map_error(McpServerError::from(zendriver::ZendriverError::from(e))))?;
+        return Ok(BlobOutput {
+            saved_path: Some(path),
+            byte_len,
+            base64: None,
+        });
+    }
+    if byte_len > MAX_INLINE_BYTES {
+        return Err(ErrorData::invalid_params(
+            format!(
+                "Blob is {byte_len} bytes, over the {MAX_INLINE_BYTES}-byte inline limit. Pass `save_path` to write it to disk on the MCP server host instead of inlining it."
+            ),
+            None,
+        ));
+    }
+    Ok(BlobOutput {
+        saved_path: None,
+        byte_len,
+        base64: Some(BASE64.encode(bytes)),
+    })
 }

--- a/crates/zendriver-mcp/src/tools/download.rs
+++ b/crates/zendriver-mcp/src/tools/download.rs
@@ -52,9 +52,12 @@ pub async fn download(
 ) -> Result<DownloadOutput, ErrorData> {
     let s = state.lock().await;
     let tab = current_tab(&s).await?;
-    tab.download_file(input.url.as_str(), input.filename.as_deref().map(PathBuf::from))
-        .await
-        .map_err(|e| map_error(McpServerError::from(e)))?;
+    tab.download_file(
+        input.url.as_str(),
+        input.filename.as_deref().map(PathBuf::from),
+    )
+    .await
+    .map_err(|e| map_error(McpServerError::from(e)))?;
     Ok(DownloadOutput {
         ok: true,
         url: input.url,

--- a/crates/zendriver-mcp/src/tools/download.rs
+++ b/crates/zendriver-mcp/src/tools/download.rs
@@ -1,0 +1,106 @@
+//! Direct-download tools — `browser_download`, `browser_set_download_path`.
+//!
+//! `browser_download` ports nodriver's page-driven fetch-and-save: it injects
+//! a main-world script that `fetch`es the URL through the page's own network
+//! context (cookies / referer / same-origin creds) and saves it via Chrome's
+//! download behavior. It is **fire-and-forget** — it returns once the fetch is
+//! dispatched, not when the file lands. For await/inspect/save-to-path
+//! semantics use `browser_expect_register { kind: download, save_to }`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use rmcp::ErrorData;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use crate::errors::{McpServerError, map_error};
+use crate::state::SessionState;
+use crate::tools::actions::AckOutput;
+use crate::tools::common::current_tab;
+
+/// Input for `browser_download`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct DownloadInput {
+    /// URL to fetch + save. Fetched from the page's own network context.
+    pub url: String,
+    /// Saved file name within the tab's download directory. When omitted, the
+    /// name is derived from the URL's last path segment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+}
+
+/// Output of `browser_download`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DownloadOutput {
+    /// Always `true` — the fetch was dispatched. The download itself runs
+    /// asynchronously in Chrome.
+    pub ok: bool,
+    /// Echoed source URL.
+    pub url: String,
+    /// Echoed target filename, when one was supplied.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+}
+
+/// Initiate a page-driven download of `url`.
+pub async fn download(
+    state: Arc<Mutex<SessionState>>,
+    input: DownloadInput,
+) -> Result<DownloadOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    tab.download_file(input.url.as_str(), input.filename.as_deref().map(PathBuf::from))
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
+    Ok(DownloadOutput {
+        ok: true,
+        url: input.url,
+        filename: input.filename,
+    })
+}
+
+/// Input for `browser_set_download_path`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SetDownloadPathInput {
+    /// Directory (on the MCP host) Chrome should save downloads into. Created
+    /// if it does not exist.
+    pub path: String,
+}
+
+/// Set the directory downloads are saved into for the current tab.
+pub async fn set_download_path(
+    state: Arc<Mutex<SessionState>>,
+    input: SetDownloadPathInput,
+) -> Result<AckOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    tab.set_download_path(PathBuf::from(&input.path))
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
+    Ok(AckOutput { ok: true })
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn download_with_no_browser_errors() {
+        let state = Arc::new(Mutex::new(SessionState::new()));
+        let err = download(
+            state,
+            DownloadInput {
+                url: "https://example.com/x.bin".into(),
+                filename: None,
+            },
+        )
+        .await
+        .expect_err("expected BrowserNotOpen");
+        assert!(err.message.contains("Browser not open"));
+    }
+}

--- a/crates/zendriver-mcp/src/tools/eval.rs
+++ b/crates/zendriver-mcp/src/tools/eval.rs
@@ -29,11 +29,10 @@ use rmcp::ErrorData;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
-use zendriver::{Frame, Tab, ZendriverError};
 
 use crate::errors::{McpServerError, map_error};
 use crate::state::SessionState;
-use crate::tools::common::current_tab;
+use crate::tools::common::{current_tab, lookup_frame};
 
 /// Input for `browser_evaluate` / `browser_evaluate_main`.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -113,23 +112,6 @@ pub async fn evaluate_main(
             .map_err(|e| map_error(McpServerError::from(e)))?
     };
     Ok(EvalOutput { value })
-}
-
-/// Look up a `Frame` on `tab` by id. Surfaces `FrameNotFound` through the
-/// standard error pipeline (with `browser_frame_list` suggestion).
-async fn lookup_frame(tab: &Tab, frame_id: &str) -> Result<Frame, ErrorData> {
-    let frames = tab
-        .frames()
-        .await
-        .map_err(|e| map_error(McpServerError::from(e)))?;
-    frames
-        .into_iter()
-        .find(|f| f.id() == frame_id)
-        .ok_or_else(|| {
-            map_error(McpServerError::from(ZendriverError::FrameNotFound(
-                frame_id.to_string(),
-            )))
-        })
 }
 
 #[cfg(test)]

--- a/crates/zendriver-mcp/src/tools/expect.rs
+++ b/crates/zendriver-mcp/src/tools/expect.rs
@@ -19,28 +19,40 @@
 //!   spawned task so the lib-level `.matched()` future is killed promptly
 //!   rather than left to time out on its own.
 //!
-//! ## Wire-shape mappers (`event_to_json`)
+//! ## Wire-shape mappers + drive
 //!
-//! Each kind has a small free fn that flattens its lib-side struct
+//! Each kind has a small async free fn that flattens its lib-side struct
 //! (`MatchedRequest` / `MatchedResponse` / `MatchedDialog` / `MatchedDownload`)
-//! into a `serde_json::Value`. Bodies (`MatchedResponse::body()`,
-//! `MatchedDownload::save_to(...)`) are NOT fetched in v0 — they require an
-//! extra round-trip and aren't part of the event itself. Dialog
-//! accept/dismiss is also not exposed; Chrome's default handling fires
-//! when the `MatchedDialog` is dropped at task end.
+//! into a `serde_json::Value` and, when asked, *drives* the matched object
+//! before it is dropped. The drive parameters live on
+//! `browser_expect_register` (not `_await`) because the spawned task owns the
+//! matched handle and several drive methods consume it (`accept` / `dismiss` /
+//! `save_to`); the decision must therefore be made at register time, before
+//! the triggering action runs:
+//!
+//! - **Dialog** — `dialog_action: accept|dismiss` (+ `dialog_prompt_text`)
+//!   drives the dialog so the page's blocking `alert/confirm/prompt` returns.
+//! - **Response** — `fetch_body: true` fetches the body and inlines it as
+//!   `body_base64` + `body_len`.
+//! - **Download** — `save_to: <path>` waits for completion and copies the file
+//!   to the MCP host, reporting `saved_path`.
 
 #![cfg(feature = "expect")]
 
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use rmcp::ErrorData;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::sync::{Mutex, oneshot};
 use zendriver::{
-    MatchedDialog, MatchedDownload, MatchedRequest, MatchedResponse, UrlMatcher, ZendriverError,
+    DialogType, MatchedDialog, MatchedDownload, MatchedRequest, MatchedResponse, UrlMatcher,
+    ZendriverError,
 };
 
 use crate::errors::{McpServerError, map_error};
@@ -74,6 +86,23 @@ impl ExpectKind {
             Self::Download => "download",
         }
     }
+}
+
+/// How to drive a matched JavaScript dialog (`kind: dialog` only).
+///
+/// Applied by the spawned task the instant the dialog opens — so the page's
+/// blocking `alert()` / `confirm()` / `prompt()` call returns promptly and
+/// the matched event carries the chosen action. Omitting `dialog_action`
+/// falls back to Chrome's default handling (the dialog is accepted when the
+/// matched handle is dropped at task end).
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DialogAction {
+    /// Accept the dialog. For a `prompt`, submit `dialog_prompt_text` (or the
+    /// dialog's default value when that is unset).
+    Accept,
+    /// Dismiss / cancel the dialog.
+    Dismiss,
 }
 
 /// URL match predicate for request/response expectations. Dialog and
@@ -134,6 +163,22 @@ pub struct RegisterInput {
     /// triggers the event between `register` and `await`.
     #[serde(default = "default_pre_timeout")]
     pub pre_await_timeout_ms: u64,
+    /// Dialog only: drive the matched dialog (`accept` / `dismiss`) instead
+    /// of leaving Chrome's default handling. Decided here, at register time,
+    /// because the matched dialog handle is consumed by the spawned task.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dialog_action: Option<DialogAction>,
+    /// Dialog only: prompt answer for `dialog_action: accept` on a `prompt`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dialog_prompt_text: Option<String>,
+    /// Response only: fetch the response body and include it (base64) in the
+    /// matched event as `body_base64` + `body_len`. One extra CDP round-trip.
+    #[serde(default)]
+    pub fetch_body: bool,
+    /// Download only: copy the completed download to this path on the MCP
+    /// host; the matched event reports it as `saved_path`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub save_to: Option<String>,
 }
 
 fn default_pre_timeout() -> u64 {
@@ -162,6 +207,12 @@ pub async fn register(
     let pre_await = Duration::from_millis(input.pre_await_timeout_ms);
     let matcher = input.matcher.unwrap_or_default().into_url_matcher()?;
     let kind = input.kind;
+    // Drive params, captured before the per-kind spawn moves them in. Each is
+    // meaningful for exactly one kind (see field docs); the others are unused.
+    let dialog_action = input.dialog_action;
+    let dialog_prompt = input.dialog_prompt_text;
+    let fetch_body = input.fetch_body;
+    let save_to = input.save_to;
 
     let tab = {
         let s = state.lock().await;
@@ -187,18 +238,20 @@ pub async fn register(
         ExpectKind::Response => {
             let exp = tab.expect_response(matcher).timeout(pre_await);
             tokio::spawn(async move {
-                let msg = exp
-                    .matched()
-                    .await
-                    .map(response_to_json)
-                    .map_err(err_to_str);
+                let msg = match exp.matched().await {
+                    Ok(m) => response_to_json(m, fetch_body).await,
+                    Err(e) => Err(err_to_str(e)),
+                };
                 let _ = tx.send(msg);
             })
         }
         ExpectKind::Dialog => {
             let exp = tab.expect_dialog().timeout(pre_await);
             tokio::spawn(async move {
-                let msg = exp.matched().await.map(dialog_to_json).map_err(err_to_str);
+                let msg = match exp.matched().await {
+                    Ok(m) => dialog_to_json(m, dialog_action, dialog_prompt).await,
+                    Err(e) => Err(err_to_str(e)),
+                };
                 let _ = tx.send(msg);
             })
         }
@@ -213,11 +266,10 @@ pub async fn register(
                 .map_err(|e| map_error(McpServerError::from(e)))?
                 .timeout(pre_await);
             tokio::spawn(async move {
-                let msg = exp
-                    .matched()
-                    .await
-                    .map(download_to_json)
-                    .map_err(err_to_str);
+                let msg = match exp.matched().await {
+                    Ok(m) => download_to_json(m, save_to).await,
+                    Err(e) => Err(err_to_str(e)),
+                };
                 let _ = tx.send(msg);
             })
         }
@@ -397,55 +449,101 @@ fn request_to_json(m: MatchedRequest) -> Value {
     })
 }
 
-/// Flatten a [`MatchedResponse`] to a wire JSON object.
+/// Flatten a [`MatchedResponse`] to a wire JSON object, optionally fetching
+/// the response body (base64) when `fetch_body` is set.
 ///
-/// Body is NOT fetched in v0 — `body()` is an async CDP round-trip and
-/// not part of the event itself.
-fn response_to_json(m: MatchedResponse) -> Value {
-    json!({
+/// `body()` is an async CDP round-trip, so it is opt-in: agents that only
+/// need status/headers skip it.
+async fn response_to_json(m: MatchedResponse, fetch_body: bool) -> Result<Value, String> {
+    let mut v = json!({
         "kind": "response",
         "url": m.url,
         "status": m.status,
         "status_text": m.status_text,
         "headers": m.headers,
         "request_id": m.request_id,
-    })
+    });
+    if fetch_body {
+        let bytes = m.body().await.map_err(err_to_str)?;
+        v["body_len"] = json!(bytes.len());
+        v["body_base64"] = json!(BASE64.encode(&bytes));
+    }
+    Ok(v)
 }
 
-/// Flatten a [`MatchedDialog`] to a wire JSON object.
+/// Render a [`DialogType`] as a stable lowercase wire string.
+fn dialog_type_str(d: &DialogType) -> &'static str {
+    match d {
+        DialogType::Alert => "alert",
+        DialogType::Beforeunload => "beforeunload",
+        DialogType::Confirm => "confirm",
+        DialogType::Prompt => "prompt",
+    }
+}
+
+/// Flatten a [`MatchedDialog`] to a wire JSON object, driving the dialog
+/// (`accept` / `dismiss`) when `action` is set.
 ///
-/// `dialog_type` is rendered as a lowercase string for stable wire output.
-/// `accept`/`dismiss` are NOT exposed in v0 — Chrome's default handling
-/// applies when the matched-dialog handle is dropped at task end.
-fn dialog_to_json(m: MatchedDialog) -> Value {
-    let kind = match m.dialog_type {
-        zendriver::DialogType::Alert => "alert",
-        zendriver::DialogType::Beforeunload => "beforeunload",
-        zendriver::DialogType::Confirm => "confirm",
-        zendriver::DialogType::Prompt => "prompt",
+/// Fields are captured by reference first so the handle stays intact for the
+/// consuming `accept`/`dismiss` call. With no `action`, the handle is dropped
+/// here and Chrome's default handling applies.
+async fn dialog_to_json(
+    m: MatchedDialog,
+    action: Option<DialogAction>,
+    prompt: Option<String>,
+) -> Result<Value, String> {
+    let dialog_type = dialog_type_str(&m.dialog_type);
+    let message = m.message.clone();
+    let default_prompt = m.default_prompt.clone();
+    let url = m.url.clone();
+    let driven = match action {
+        Some(DialogAction::Accept) => {
+            m.accept(prompt).await.map_err(err_to_str)?;
+            "accept"
+        }
+        Some(DialogAction::Dismiss) => {
+            m.dismiss().await.map_err(err_to_str)?;
+            "dismiss"
+        }
+        None => {
+            drop(m);
+            "default"
+        }
     };
-    json!({
+    Ok(json!({
         "kind": "dialog",
-        "dialog_type": kind,
-        "message": m.message,
-        "default_prompt": m.default_prompt,
-        "url": m.url,
-    })
+        "dialog_type": dialog_type,
+        "message": message,
+        "default_prompt": default_prompt,
+        "url": url,
+        "driven": driven,
+    }))
 }
 
-/// Flatten a [`MatchedDownload`] to a wire JSON object.
+/// Flatten a [`MatchedDownload`] to a wire JSON object, optionally copying the
+/// completed download to `save_to` on the MCP host.
 ///
-/// `path()` is not awaited here — the download is only `InProgress` at
-/// `Page.downloadWillBegin` time. Agents needing the on-disk path can call
-/// a future tool that polls completion + reads the file.
-fn download_to_json(m: MatchedDownload) -> Value {
-    json!({
+/// `MatchedDownload::save_to` waits for completion before copying, so the
+/// reported `saved_path` is a fully-written file.
+async fn download_to_json(m: MatchedDownload, save_to: Option<String>) -> Result<Value, String> {
+    let url = m.url.clone();
+    let suggested_filename = m.suggested_filename.clone();
+    let guid = m.guid.clone();
+    let download_dir = m.download_dir.to_string_lossy().into_owned();
+    let saved_path = if let Some(dest) = save_to {
+        m.save_to(PathBuf::from(&dest)).await.map_err(err_to_str)?;
+        Some(dest)
+    } else {
+        None
+    };
+    Ok(json!({
         "kind": "download",
-        "url": m.url,
-        "suggested_filename": m.suggested_filename,
-        "guid": m.guid,
-        "download_dir": m.download_dir.to_string_lossy(),
-    })
+        "url": url,
+        "suggested_filename": suggested_filename,
+        "guid": guid,
+        "download_dir": download_dir,
+        "saved_path": saved_path,
+    }))
 }
 
 #[cfg(test)]
@@ -540,6 +638,10 @@ mod tests {
                 kind: ExpectKind::Request,
                 matcher: None,
                 pre_await_timeout_ms: 1_000,
+                dialog_action: None,
+                dialog_prompt_text: None,
+                fetch_body: false,
+                save_to: None,
             },
         )
         .await

--- a/crates/zendriver-mcp/src/tools/frames.rs
+++ b/crates/zendriver-mcp/src/tools/frames.rs
@@ -8,12 +8,13 @@ use std::sync::Arc;
 
 use rmcp::ErrorData;
 use schemars::JsonSchema;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
 use crate::errors::{McpServerError, map_error};
 use crate::state::SessionState;
-use crate::tools::common::{EmptyInput, current_tab};
+use crate::tools::actions::AckOutput;
+use crate::tools::common::{EmptyInput, current_tab, lookup_frame};
 
 /// Per-frame projection returned by `browser_frame_list`.
 ///
@@ -74,6 +75,41 @@ pub async fn list(
         });
     }
     Ok(FrameListOutput { frames: out })
+}
+
+// ---------- browser_frame_goto -------------------------------------------
+
+/// Input for `browser_frame_goto`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct FrameGotoInput {
+    /// Target frame id (from `browser_frame_list`).
+    pub frame_id: String,
+    /// URL to navigate the frame to.
+    pub url: String,
+}
+
+/// Navigate a specific frame to a URL and wait for its load.
+///
+/// `Frame::goto` only drives same-document navigation on the main frame of an
+/// out-of-process iframe; for in-process child frames it surfaces the lib's
+/// error through the standard pipeline.
+pub async fn frame_goto(
+    state: Arc<Mutex<SessionState>>,
+    input: FrameGotoInput,
+) -> Result<AckOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    let frame = lookup_frame(&tab, &input.frame_id).await?;
+    frame
+        .goto(&input.url)
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
+    frame
+        .wait_for_load()
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
+    Ok(AckOutput { ok: true })
 }
 
 #[cfg(test)]

--- a/crates/zendriver-mcp/src/tools/imperva.rs
+++ b/crates/zendriver-mcp/src/tools/imperva.rs
@@ -1,0 +1,172 @@
+//! Imperva / Incapsula bypass tool — `browser_solve_imperva`. Gated behind
+//! the `imperva` feature.
+//!
+//! Mirrors [`tools/cloudflare.rs`][crate::tools::cloudflare]: the lib's
+//! [`ImpervaBypass::wait_for_clearance`] models its terminal state as
+//! `Result<ImpervaClearanceOutcome, ImpervaError>`. The MCP layer collapses
+//! the [`ImpervaError::Timeout`] arm into a non-error
+//! [`Outcome::Timeout`] — a deadline in a bot-management flow is a normal
+//! "didn't finish, retry or give up" signal, not a server error — and keeps
+//! every other `ImpervaError` (CAPTCHA-without-solver, CDP failure, JS error)
+//! as a real MCP error.
+//!
+//! Unlike Cloudflare's three states, Imperva reports a fourth —
+//! [`ImpervaClearanceOutcome::AlreadyClear`] (no surface present at call
+//! time, fast path) — surfaced as a distinct [`Outcome::AlreadyClear`] so an
+//! agent can skip redundant follow-up work.
+//!
+//! The lib's `on_captcha` solver hook is intentionally **not** wired over
+//! MCP (same class as the interception stream non-goal): a CAPTCHA surface
+//! without a registered solver surfaces as `ImpervaError::CaptchaRequired`,
+//! which becomes a real MCP error the agent must handle out-of-band.
+//!
+//! [`ImpervaBypass::wait_for_clearance`]: zendriver_imperva::ImpervaBypass::wait_for_clearance
+
+#![cfg(feature = "imperva")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rmcp::ErrorData;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use zendriver::{ImpervaClearanceOutcome, ImpervaError, ZendriverError};
+
+use crate::errors::{McpServerError, map_error};
+use crate::state::SessionState;
+use crate::tools::common::current_tab;
+
+/// Input for `browser_solve_imperva`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SolveImpervaInput {
+    /// Maximum total wait for a terminal outcome, in milliseconds. Default
+    /// 30_000 (30s). Maps to [`ImpervaBypass::timeout`].
+    ///
+    /// [`ImpervaBypass::timeout`]: zendriver_imperva::ImpervaBypass::timeout
+    #[serde(default = "default_timeout")]
+    pub timeout_ms: u64,
+    /// Override the bypass driver's internal poll cadence, in milliseconds.
+    /// Defaults to the lib's own default. Lowering speeds up detection at the
+    /// cost of more CDP `Runtime.evaluate` round-trips; raising is a safe
+    /// knob for slow / sandboxed environments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub poll_interval_ms: Option<u64>,
+    /// Enable the Fetch-domain interception fast-path
+    /// ([`ImpervaBypass::with_interception`]) for quicker reese84 capture on
+    /// modern surfaces. Default `false`.
+    ///
+    /// [`ImpervaBypass::with_interception`]: zendriver_imperva::ImpervaBypass::with_interception
+    #[serde(default)]
+    pub with_interception: bool,
+}
+
+fn default_timeout() -> u64 {
+    30_000
+}
+
+/// Terminal outcome of an Imperva bypass attempt.
+///
+/// `TokenAcquired` / `ChallengeGone` / `AlreadyClear` mirror the lib's
+/// [`ImpervaClearanceOutcome`] variants. `Timeout` is the MCP layer's
+/// collapse of [`ImpervaError::Timeout`] into the success channel — agents
+/// branch on `outcome` without try/catch around a timeout.
+#[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Outcome {
+    /// reese84 token acquired (value in [`SolveImpervaOutput::reese84`]).
+    TokenAcquired,
+    /// Body markers cleared without a reese84 token (e.g. legacy Incapsula
+    /// flow). `reese84` will be `None`.
+    ChallengeGone,
+    /// No Imperva surface was present at call time (fast path, no waiting).
+    /// `reese84` will be `None`.
+    AlreadyClear,
+    /// `timeout_ms` elapsed without reaching clearance. Not a hard error —
+    /// agents can retry or give up. `reese84` will be `None`.
+    Timeout,
+}
+
+/// Output of `browser_solve_imperva`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct SolveImpervaOutput {
+    /// Which terminal state the bypass reached.
+    pub outcome: Outcome,
+    /// reese84 cookie value. Populated only when `outcome == token_acquired`;
+    /// `None` for every other outcome.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reese84: Option<String>,
+}
+
+/// Drive the Imperva clearance flow on the current tab, returning the
+/// terminal outcome within `timeout_ms`.
+///
+/// See module-level docs for outcome semantics.
+pub async fn solve_imperva(
+    state: Arc<Mutex<SessionState>>,
+    input: SolveImpervaInput,
+) -> Result<SolveImpervaOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    // `tab.imperva()` borrows `tab` for the bypass's lifetime; the builder
+    // methods consume + return `self`, and `wait_for_clearance` consumes it,
+    // so the bypass lives only for the single await below.
+    let mut bypass = tab.imperva().timeout(Duration::from_millis(input.timeout_ms));
+    if let Some(p) = input.poll_interval_ms {
+        bypass = bypass.poll_interval(Duration::from_millis(p));
+    }
+    if input.with_interception {
+        bypass = bypass.with_interception();
+    }
+    match bypass.wait_for_clearance().await {
+        Ok(ImpervaClearanceOutcome::TokenAcquired { reese84, .. }) => Ok(SolveImpervaOutput {
+            outcome: Outcome::TokenAcquired,
+            reese84: Some(reese84),
+        }),
+        Ok(ImpervaClearanceOutcome::ChallengeGone) => Ok(SolveImpervaOutput {
+            outcome: Outcome::ChallengeGone,
+            reese84: None,
+        }),
+        Ok(ImpervaClearanceOutcome::AlreadyClear) => Ok(SolveImpervaOutput {
+            outcome: Outcome::AlreadyClear,
+            reese84: None,
+        }),
+        // Timeout collapses into the success channel — see module docs.
+        Err(ImpervaError::Timeout { .. }) => Ok(SolveImpervaOutput {
+            outcome: Outcome::Timeout,
+            reese84: None,
+        }),
+        // Everything else (CAPTCHA-without-solver, CDP failure, JS error) is a
+        // real error. Route through `From<ImpervaError> for ZendriverError` so
+        // the existing `map_error` knows how to format it.
+        Err(other) => Err(map_error(McpServerError::from(ZendriverError::from(other)))),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    //! No-browser unit coverage. The bypass flow itself needs a live Chrome +
+    //! an Imperva-protected page — exercised in the integration test gated
+    //! behind `integration-tests + imperva`. Here we cover the only branch
+    //! reachable without a browser: no browser open surfaces `BrowserNotOpen`.
+
+    use super::*;
+
+    #[tokio::test]
+    async fn solve_imperva_with_no_browser_errors() {
+        let state = Arc::new(Mutex::new(SessionState::new()));
+        let err = solve_imperva(
+            state,
+            SolveImpervaInput {
+                timeout_ms: 100,
+                poll_interval_ms: None,
+                with_interception: false,
+            },
+        )
+        .await
+        .expect_err("expected BrowserNotOpen");
+        assert!(err.message.contains("Browser not open"));
+    }
+}

--- a/crates/zendriver-mcp/src/tools/imperva.rs
+++ b/crates/zendriver-mcp/src/tools/imperva.rs
@@ -112,7 +112,9 @@ pub async fn solve_imperva(
     // `tab.imperva()` borrows `tab` for the bypass's lifetime; the builder
     // methods consume + return `self`, and `wait_for_clearance` consumes it,
     // so the bypass lives only for the single await below.
-    let mut bypass = tab.imperva().timeout(Duration::from_millis(input.timeout_ms));
+    let mut bypass = tab
+        .imperva()
+        .timeout(Duration::from_millis(input.timeout_ms));
     if let Some(p) = input.poll_interval_ms {
         bypass = bypass.poll_interval(Duration::from_millis(p));
     }

--- a/crates/zendriver-mcp/src/tools/intercept.rs
+++ b/crates/zendriver-mcp/src/tools/intercept.rs
@@ -41,7 +41,7 @@ use rmcp::ErrorData;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
-use zendriver::{RequestOverrides, ZendriverError};
+use zendriver::{RequestOverrides, ResponseInfo, ResponseOverrides, ZendriverError};
 
 use crate::errors::{McpServerError, map_error};
 use crate::state::{InterceptRuleHandle, RuleId, SessionState};
@@ -90,6 +90,19 @@ pub enum InterceptAction {
         /// `continueRequest.headers` is a full replacement, so the closure
         /// rebuilds the header list from the intercepted request and
         /// overlays these entries (case-insensitive on names).
+        #[serde(default)]
+        headers: BTreeMap<String, String>,
+    },
+    /// Continue the *response* with an overridden status and/or headers
+    /// (pauses at the response stage). Other fields are left at Chrome's
+    /// originals. The body is not rewritten — use `respond` to synthesize a
+    /// whole response instead.
+    ModifyResponse {
+        /// Override the HTTP status code. Omit to keep Chrome's original.
+        #[serde(default)]
+        status: Option<u16>,
+        /// Headers to merge over the response's originals (full-replacement
+        /// semantics, same as `modify_request`; case-insensitive names).
         #[serde(default)]
         headers: BTreeMap<String, String>,
     },
@@ -184,6 +197,28 @@ pub async fn add_rule(
                 .start();
             (h, "modify_request")
         }
+        InterceptAction::ModifyResponse { status, headers } => {
+            // Same `Arc`-capture pattern as `modify_request`; the closure runs
+            // on the actor task per matching response.
+            let overlay = Arc::new(headers);
+            let h = tab
+                .intercept()
+                .modify_response(input.pattern.clone(), move |resp: &ResponseInfo| {
+                    let headers = if overlay.is_empty() {
+                        None
+                    } else {
+                        Some(merge_header_list(&resp.headers, &overlay))
+                    };
+                    ResponseOverrides {
+                        status,
+                        headers,
+                        ..ResponseOverrides::default()
+                    }
+                })
+                .map_err(zendriver_err)?
+                .start();
+            (h, "modify_response")
+        }
     };
 
     let id: RuleId = uuid::Uuid::new_v4().to_string();
@@ -209,11 +244,25 @@ fn merge_headers(
     original: &[(String, String)],
     overlay: &BTreeMap<String, String>,
 ) -> RequestOverrides {
+    RequestOverrides {
+        headers: Some(merge_header_list(original, overlay)),
+        ..RequestOverrides::default()
+    }
+}
+
+/// Rebuild a full header list from `original`, dropping entries the `overlay`
+/// replaces (case-insensitive) and appending the overlay entries. Shared by
+/// `modify_request` (→ [`RequestOverrides`]) and `modify_response`
+/// (→ [`ResponseOverrides`]) because CDP's continue-* header fields are both
+/// full replacements with no merge mode.
+fn merge_header_list(
+    original: &[(String, String)],
+    overlay: &BTreeMap<String, String>,
+) -> Vec<(String, String)> {
     let mut out: Vec<(String, String)> = Vec::with_capacity(original.len() + overlay.len());
     let overlay_keys_lower: std::collections::HashSet<String> =
         overlay.keys().map(|k| k.to_ascii_lowercase()).collect();
     for (k, v) in original {
-        // Drop any original header that the overlay replaces (case-insens).
         if !overlay_keys_lower.contains(&k.to_ascii_lowercase()) {
             out.push((k.clone(), v.clone()));
         }
@@ -221,10 +270,7 @@ fn merge_headers(
     for (k, v) in overlay {
         out.push((k.clone(), v.clone()));
     }
-    RequestOverrides {
-        headers: Some(out),
-        ..RequestOverrides::default()
-    }
+    out
 }
 
 /// Wrap a `zendriver_interception::InterceptionError` (re-exported as

--- a/crates/zendriver-mcp/src/tools/lifecycle.rs
+++ b/crates/zendriver-mcp/src/tools/lifecycle.rs
@@ -223,6 +223,9 @@ pub struct StatusOutput {
     pub tab_count: usize,
     /// `id` / `url` / `title` of the currently-focused tab, or `null`.
     pub current_tab: Option<TabSummary>,
+    /// Chrome DevTools inspector URL for the focused tab, when one is open.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inspector_url: Option<String>,
     /// Configured stealth profile choice for this session.
     pub profile: StealthProfileChoice,
 }
@@ -239,10 +242,12 @@ pub async fn status(
             open: false,
             tab_count: 0,
             current_tab: None,
+            inspector_url: None,
             profile: s.stealth_profile_choice,
         });
     };
     let tabs = b.tabs().await;
+    let mut inspector_url = None;
     let current_tab = match &s.current_tab_id {
         Some(id) => {
             let mut found = None;
@@ -250,6 +255,9 @@ pub async fn status(
                 if t.target_id() == id {
                     let url = t.url().await.map(|u| u.to_string()).unwrap_or_default();
                     let title = t.title().await.unwrap_or_default();
+                    // `inspector_url` is sync + best-effort; a failure just
+                    // leaves the field absent.
+                    inspector_url = t.inspector_url().ok();
                     found = Some(TabSummary {
                         id: t.target_id().to_string(),
                         url,
@@ -266,6 +274,7 @@ pub async fn status(
         open: true,
         tab_count: tabs.len(),
         current_tab,
+        inspector_url,
         profile: s.stealth_profile_choice,
     })
 }

--- a/crates/zendriver-mcp/src/tools/lifecycle.rs
+++ b/crates/zendriver-mcp/src/tools/lifecycle.rs
@@ -16,7 +16,7 @@ use zendriver::Browser;
 use zendriver::stealth::{Platform, StealthProfile};
 
 use crate::errors::{McpServerError, map_error};
-use crate::state::{SessionState, StealthProfileChoice};
+use crate::state::{SessionState, StealthOverrides, StealthPlatformChoice, StealthProfileChoice};
 use crate::tools::common::EmptyInput;
 
 // ---------- browser_open --------------------------------------------------
@@ -65,7 +65,7 @@ pub async fn open(
         return Err(map_error(McpServerError::BrowserAlreadyOpen));
     }
     let profile = input.stealth_profile.unwrap_or(s.stealth_profile_choice);
-    let stealth = stealth_profile_for(profile);
+    let stealth = apply_overrides(stealth_profile_for(profile), &s.stealth_overrides);
     let browser = Browser::builder()
         .headless(input.headless)
         .stealth(stealth)
@@ -98,6 +98,48 @@ fn stealth_profile_for(choice: StealthProfileChoice) -> StealthProfile {
         }
         StealthProfileChoice::SpoofWindows => StealthProfile::spoofed().platform(Platform::Win32),
     }
+}
+
+impl From<StealthPlatformChoice> for Platform {
+    fn from(p: StealthPlatformChoice) -> Self {
+        match p {
+            StealthPlatformChoice::Win32 => Platform::Win32,
+            StealthPlatformChoice::MacIntel => Platform::MacIntel,
+            StealthPlatformChoice::LinuxX86_64 => Platform::LinuxX86_64,
+        }
+    }
+}
+
+/// Layer fine-grained [`StealthOverrides`] onto a base [`StealthProfile`].
+///
+/// Each set field overrides the base profile via the corresponding builder
+/// method; unset fields leave the base value untouched.
+fn apply_overrides(mut profile: StealthProfile, overrides: &StealthOverrides) -> StealthProfile {
+    if let Some(platform) = overrides.platform {
+        profile = profile.platform(platform.into());
+    }
+    if let Some(ref locale) = overrides.locale {
+        profile = profile.locale(locale);
+    }
+    if let Some(ref timezone) = overrides.timezone {
+        profile = profile.timezone(timezone);
+    }
+    if let Some(memory_gb) = overrides.memory_gb {
+        profile = profile.memory_gb(memory_gb);
+    }
+    if let Some(cpu_count) = overrides.cpu_count {
+        profile = profile.cpu_count(cpu_count);
+    }
+    if let Some(chrome_version) = overrides.chrome_version {
+        profile = profile.chrome_version(chrome_version);
+    }
+    if let Some(ref user_agent) = overrides.user_agent {
+        profile = profile.user_agent(user_agent);
+    }
+    if let Some(bypass_csp) = overrides.bypass_csp {
+        profile = profile.bypass_csp(bypass_csp);
+    }
+    profile
 }
 
 // ---------- browser_close -------------------------------------------------

--- a/crates/zendriver-mcp/src/tools/mod.rs
+++ b/crates/zendriver-mcp/src/tools/mod.rs
@@ -25,9 +25,13 @@ pub mod imperva;
 #[cfg(feature = "interception")]
 pub mod intercept;
 pub mod lifecycle;
+pub mod mouse;
 pub mod navigation;
+pub mod pdf;
 pub mod reads;
+pub mod scroll;
 pub mod snapshot;
 pub mod stealth;
 pub mod storage;
 pub mod tabs;
+pub mod window;

--- a/crates/zendriver-mcp/src/tools/mod.rs
+++ b/crates/zendriver-mcp/src/tools/mod.rs
@@ -20,6 +20,8 @@ pub mod expect;
 pub mod fetcher;
 pub mod find;
 pub mod frames;
+#[cfg(feature = "imperva")]
+pub mod imperva;
 #[cfg(feature = "interception")]
 pub mod intercept;
 pub mod lifecycle;

--- a/crates/zendriver-mcp/src/tools/mod.rs
+++ b/crates/zendriver-mcp/src/tools/mod.rs
@@ -13,6 +13,7 @@ pub mod actions;
 pub mod cloudflare;
 pub mod common;
 pub mod cookies;
+pub mod download;
 pub mod eval;
 #[cfg(feature = "expect")]
 pub mod expect;

--- a/crates/zendriver-mcp/src/tools/mouse.rs
+++ b/crates/zendriver-mcp/src/tools/mouse.rs
@@ -1,0 +1,149 @@
+//! Coordinate-mouse tool — `browser_mouse`.
+//!
+//! Wraps [`zendriver::Tab`]'s raw pointer API (`mouse_move`,
+//! `mouse_click_with`, `mouse_drag`) for canvas / drag-and-drop / map / game
+//! interactions that aren't reachable through element-targeted action tools.
+//! Coordinates are CSS pixels relative to the viewport.
+
+use std::sync::Arc;
+
+use rmcp::ErrorData;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use zendriver::ClickOptions;
+
+use crate::errors::{McpServerError, map_error};
+use crate::state::SessionState;
+use crate::tools::actions::{ActionOutput, MouseButtonArg};
+use crate::tools::common::{ModifierArg, current_tab, modifiers_to_bits, page_snapshot};
+
+/// Which pointer operation `browser_mouse` performs.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MouseAction {
+    /// Move the cursor to `(x, y)` along a realistic Bezier path.
+    Move,
+    /// Click at `(x, y)`.
+    Click,
+    /// Press at `(x, y)`, drag to `(to_x, to_y)` over `steps`, release.
+    Drag,
+}
+
+/// Input for `browser_mouse`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct MouseInput {
+    /// Which pointer operation to perform.
+    pub action: MouseAction,
+    /// Target X in CSS pixels (viewport-relative). For `drag`, the start X.
+    pub x: f64,
+    /// Target Y in CSS pixels (viewport-relative). For `drag`, the start Y.
+    pub y: f64,
+    /// Drag destination X (required for `drag`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_x: Option<f64>,
+    /// Drag destination Y (required for `drag`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_y: Option<f64>,
+    /// Which button to dispatch (`click` only). Default `left`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub button: Option<MouseButtonArg>,
+    /// `clickCount` for `click` (set `2` for a double-click). Default `1`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub click_count: Option<u32>,
+    /// Modifier keys held during a `click`. Default none.
+    #[serde(default)]
+    pub modifiers: Vec<ModifierArg>,
+    /// Interpolation steps for `drag`. Default `20`.
+    #[serde(default = "default_steps")]
+    pub steps: usize,
+    /// When `true`, include the trimmed page HTML in the response.
+    #[serde(default)]
+    pub return_snapshot: bool,
+}
+
+fn default_steps() -> usize {
+    20
+}
+
+/// Dispatch a coordinate-anchored pointer action on the current tab.
+pub async fn mouse(
+    state: Arc<Mutex<SessionState>>,
+    input: MouseInput,
+) -> Result<ActionOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    match input.action {
+        MouseAction::Move => tab
+            .mouse_move(input.x, input.y)
+            .await
+            .map_err(|e| map_error(McpServerError::from(e)))?,
+        MouseAction::Click => {
+            let opts = ClickOptions {
+                button: input.button.unwrap_or_default().into(),
+                click_count: input.click_count.unwrap_or(1),
+                modifiers: modifiers_to_bits(&input.modifiers),
+                ..Default::default()
+            };
+            tab.mouse_click_with(input.x, input.y, opts)
+                .await
+                .map_err(|e| map_error(McpServerError::from(e)))?;
+        }
+        MouseAction::Drag => {
+            let to_x = input.to_x.ok_or_else(|| {
+                ErrorData::invalid_params(
+                    "`to_x` and `to_y` are required for action `drag`".to_string(),
+                    None,
+                )
+            })?;
+            let to_y = input.to_y.ok_or_else(|| {
+                ErrorData::invalid_params(
+                    "`to_x` and `to_y` are required for action `drag`".to_string(),
+                    None,
+                )
+            })?;
+            tab.mouse_drag((input.x, input.y), (to_x, to_y), input.steps)
+                .await
+                .map_err(|e| map_error(McpServerError::from(e)))?;
+        }
+    }
+    let snapshot = if input.return_snapshot {
+        Some(page_snapshot(&tab).await?)
+    } else {
+        None
+    };
+    Ok(ActionOutput {
+        ok: true,
+        snapshot,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mouse_with_no_browser_errors() {
+        let state = Arc::new(Mutex::new(SessionState::new()));
+        let err = mouse(
+            state,
+            MouseInput {
+                action: MouseAction::Move,
+                x: 10.0,
+                y: 10.0,
+                to_x: None,
+                to_y: None,
+                button: None,
+                click_count: None,
+                modifiers: Vec::new(),
+                steps: 20,
+                return_snapshot: false,
+            },
+        )
+        .await
+        .expect_err("expected BrowserNotOpen");
+        assert!(err.message.contains("Browser not open"));
+    }
+}

--- a/crates/zendriver-mcp/src/tools/mouse.rs
+++ b/crates/zendriver-mcp/src/tools/mouse.rs
@@ -113,10 +113,7 @@ pub async fn mouse(
     } else {
         None
     };
-    Ok(ActionOutput {
-        ok: true,
-        snapshot,
-    })
+    Ok(ActionOutput { ok: true, snapshot })
 }
 
 #[cfg(test)]

--- a/crates/zendriver-mcp/src/tools/navigation.rs
+++ b/crates/zendriver-mcp/src/tools/navigation.rs
@@ -13,11 +13,12 @@ use rmcp::ErrorData;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
+use zendriver::{ReadyState, ReloadOptions};
 
 use crate::errors::{McpServerError, map_error};
 use crate::snapshot::html_trim;
 use crate::state::SessionState;
-use crate::tools::common::{EmptyInput, current_tab};
+use crate::tools::common::{EmptyInput, current_tab, lookup_frame};
 
 // ---------- shared types --------------------------------------------------
 
@@ -160,17 +161,99 @@ pub async fn forward(
     nav_output(&tab, input.return_snapshot).await
 }
 
-/// Reload the current page.
+/// Arg block for `browser_reload`.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReloadInput {
+    /// Bypass the HTTP cache (hard reload) when `true`. Default `false`
+    /// (normal soft reload).
+    #[serde(default)]
+    pub ignore_cache: bool,
+    /// When `true`, include the trimmed page HTML in the response.
+    #[serde(default)]
+    pub return_snapshot: bool,
+}
+
+/// Reload the current page, optionally bypassing the cache.
 pub async fn reload(
     state: Arc<Mutex<SessionState>>,
-    input: HistoryInput,
+    input: ReloadInput,
 ) -> Result<NavOutput, ErrorData> {
     let s = state.lock().await;
     let tab = current_tab(&s).await?;
-    tab.reload()
+    if input.ignore_cache {
+        tab.reload_with(ReloadOptions {
+            ignore_cache: true,
+            ..ReloadOptions::default()
+        })
         .await
         .map_err(|e| map_error(McpServerError::from(e)))?;
+    } else {
+        tab.reload()
+            .await
+            .map_err(|e| map_error(McpServerError::from(e)))?;
+    }
     nav_output(&tab, input.return_snapshot).await
+}
+
+/// Document-ready milestone `browser_wait_for_load` can target.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReadyStateArg {
+    /// `document.readyState === "interactive"` — DOM parsed, sub-resources
+    /// may still be loading.
+    Interactive,
+    /// `document.readyState === "complete"` — the `load` event has fired.
+    Complete,
+}
+
+impl From<ReadyStateArg> for ReadyState {
+    fn from(r: ReadyStateArg) -> Self {
+        match r {
+            ReadyStateArg::Interactive => ReadyState::Interactive,
+            ReadyStateArg::Complete => ReadyState::Complete,
+        }
+    }
+}
+
+/// Input for `browser_wait_for_load`.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct WaitForLoadInput {
+    /// Wait until the document reaches this `readyState`. When unset (and no
+    /// `frame_id`), waits for the tab's `load` event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ready_state: Option<ReadyStateArg>,
+    /// When set, wait for the given frame's load instead of the tab's main
+    /// frame. `ready_state` is ignored in this case (frames expose only a
+    /// load wait).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frame_id: Option<String>,
+}
+
+/// Wait for a load milestone on the tab (or a specific frame).
+pub async fn wait_for_load(
+    state: Arc<Mutex<SessionState>>,
+    input: WaitForLoadInput,
+) -> Result<NavOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    if let Some(fid) = input.frame_id.as_deref() {
+        let frame = lookup_frame(&tab, fid).await?;
+        frame
+            .wait_for_load()
+            .await
+            .map_err(|e| map_error(McpServerError::from(e)))?;
+    } else if let Some(rs) = input.ready_state {
+        tab.wait_for_ready_state(rs.into())
+            .await
+            .map_err(|e| map_error(McpServerError::from(e)))?;
+    } else {
+        tab.wait_for_load()
+            .await
+            .map_err(|e| map_error(McpServerError::from(e)))?;
+    }
+    nav_output(&tab, false).await
 }
 
 // ---------- browser_wait_for_idle -----------------------------------------
@@ -280,7 +363,7 @@ mod tests {
     #[tokio::test]
     async fn reload_with_no_browser_suggests_browser_open() {
         let state = Arc::new(Mutex::new(SessionState::new()));
-        let err = reload(state, HistoryInput::default())
+        let err = reload(state, ReloadInput::default())
             .await
             .expect_err("must error without an open browser");
         assert!(err.message.contains("browser_open"));

--- a/crates/zendriver-mcp/src/tools/navigation.rs
+++ b/crates/zendriver-mcp/src/tools/navigation.rs
@@ -18,6 +18,7 @@ use zendriver::{ReadyState, ReloadOptions};
 use crate::errors::{McpServerError, map_error};
 use crate::snapshot::html_trim;
 use crate::state::SessionState;
+use crate::tools::actions::AckOutput;
 use crate::tools::common::{EmptyInput, current_tab, lookup_frame};
 
 // ---------- shared types --------------------------------------------------
@@ -254,6 +255,20 @@ pub async fn wait_for_load(
             .map_err(|e| map_error(McpServerError::from(e)))?;
     }
     nav_output(&tab, false).await
+}
+
+/// Click through Chrome's "Your connection is not private" interstitial on
+/// the current tab (the `thisisunsafe` bypass).
+pub async fn bypass_insecure_warning(
+    state: Arc<Mutex<SessionState>>,
+    _: EmptyInput,
+) -> Result<AckOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    tab.bypass_insecure_connection_warning()
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
+    Ok(AckOutput { ok: true })
 }
 
 // ---------- browser_wait_for_idle -----------------------------------------

--- a/crates/zendriver-mcp/src/tools/pdf.rs
+++ b/crates/zendriver-mcp/src/tools/pdf.rs
@@ -1,0 +1,159 @@
+//! Page-export tools — `browser_pdf`, `browser_save_mhtml`.
+//!
+//! `browser_pdf` drives the full [`zendriver::PdfBuilder`] (`Page.printToPDF`);
+//! `browser_save_mhtml` captures an MHTML archive (`Page.captureSnapshot`).
+//! Both return the [`BlobOutput`] shape: bytes go to `save_path` on the MCP
+//! host when given, else base64-inline (subject to the inline size limit).
+
+use std::sync::Arc;
+
+use rmcp::ErrorData;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use crate::errors::{McpServerError, map_error};
+use crate::state::SessionState;
+use crate::tools::common::{BlobOutput, blob_output, current_tab};
+
+/// Input for `browser_pdf`. Every field is optional; an unset field leaves the
+/// corresponding [`zendriver::PdfBuilder`] default in place.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PdfInput {
+    /// Landscape orientation (default portrait).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub landscape: Option<bool>,
+    /// Render background graphics/colors.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub print_background: Option<bool>,
+    /// Render scale (`1.0` = 100%).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<f64>,
+    /// Paper width in inches.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paper_width: Option<f64>,
+    /// Paper height in inches.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paper_height: Option<f64>,
+    /// Top margin in inches.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub margin_top: Option<f64>,
+    /// Bottom margin in inches.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub margin_bottom: Option<f64>,
+    /// Left margin in inches.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub margin_left: Option<f64>,
+    /// Right margin in inches.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub margin_right: Option<f64>,
+    /// Page ranges to print, e.g. `"1-3, 5"`. Empty → all pages.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_ranges: Option<String>,
+    /// Prefer any CSS `@page` size over `paper_width`/`paper_height`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefer_css_page_size: Option<bool>,
+    /// Write the PDF to this path on the MCP host instead of inlining base64.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub save_path: Option<String>,
+}
+
+/// Export the current page to PDF.
+pub async fn pdf(state: Arc<Mutex<SessionState>>, input: PdfInput) -> Result<BlobOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    let mut builder = tab.pdf_builder();
+    if let Some(v) = input.landscape {
+        builder = builder.landscape(v);
+    }
+    if let Some(v) = input.print_background {
+        builder = builder.print_background(v);
+    }
+    if let Some(v) = input.scale {
+        builder = builder.scale(v);
+    }
+    if let Some(v) = input.paper_width {
+        builder = builder.paper_width(v);
+    }
+    if let Some(v) = input.paper_height {
+        builder = builder.paper_height(v);
+    }
+    if let Some(v) = input.margin_top {
+        builder = builder.margin_top(v);
+    }
+    if let Some(v) = input.margin_bottom {
+        builder = builder.margin_bottom(v);
+    }
+    if let Some(v) = input.margin_left {
+        builder = builder.margin_left(v);
+    }
+    if let Some(v) = input.margin_right {
+        builder = builder.margin_right(v);
+    }
+    if let Some(v) = input.page_ranges {
+        builder = builder.page_ranges(v);
+    }
+    if let Some(v) = input.prefer_css_page_size {
+        builder = builder.prefer_css_page_size(v);
+    }
+    let bytes = builder
+        .bytes()
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
+    blob_output(&bytes, input.save_path)
+}
+
+/// Input for `browser_save_mhtml`.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SaveMhtmlInput {
+    /// Write the MHTML to this path on the MCP host instead of inlining base64.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub save_path: Option<String>,
+}
+
+/// Capture an MHTML archive of the current page.
+pub async fn save_mhtml(
+    state: Arc<Mutex<SessionState>>,
+    input: SaveMhtmlInput,
+) -> Result<BlobOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    let mhtml = tab
+        .snapshot_mhtml()
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
+    blob_output(mhtml.as_bytes(), input.save_path)
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn pdf_with_no_browser_errors() {
+        let state = Arc::new(Mutex::new(SessionState::new()));
+        let err = pdf(
+            state,
+            PdfInput {
+                landscape: None,
+                print_background: None,
+                scale: None,
+                paper_width: None,
+                paper_height: None,
+                margin_top: None,
+                margin_bottom: None,
+                margin_left: None,
+                margin_right: None,
+                page_ranges: None,
+                prefer_css_page_size: None,
+                save_path: None,
+            },
+        )
+        .await
+        .expect_err("expected BrowserNotOpen");
+        assert!(err.message.contains("Browser not open"));
+    }
+}

--- a/crates/zendriver-mcp/src/tools/pdf.rs
+++ b/crates/zendriver-mcp/src/tools/pdf.rs
@@ -60,7 +60,10 @@ pub struct PdfInput {
 }
 
 /// Export the current page to PDF.
-pub async fn pdf(state: Arc<Mutex<SessionState>>, input: PdfInput) -> Result<BlobOutput, ErrorData> {
+pub async fn pdf(
+    state: Arc<Mutex<SessionState>>,
+    input: PdfInput,
+) -> Result<BlobOutput, ErrorData> {
     let s = state.lock().await;
     let tab = current_tab(&s).await?;
     let mut builder = tab.pdf_builder();

--- a/crates/zendriver-mcp/src/tools/reads.rs
+++ b/crates/zendriver-mcp/src/tools/reads.rs
@@ -89,6 +89,14 @@ pub struct ElementState {
     /// Serialized `innerHTML`. Populated by `All` and `TextAttrs`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inner_html: Option<String>,
+    /// Serialized `outerHTML` (element + its own tag). Populated by `All`
+    /// and `TextAttrs`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outer_html: Option<String>,
+    /// Page-absolute bounding box (`x`/`y` include scroll offset). Populated
+    /// by `All` and `Geometry`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bounding_box_page: Option<BoundingBox>,
 }
 
 /// Probe an element's state per the requested field preset.
@@ -153,6 +161,16 @@ pub async fn element_state(
         out.bounding_box = bbox;
         // `in_viewport` reserved for v1 — no zendriver primitive yet.
         out.in_viewport = None;
+        // Page-absolute box: origin shifted by the scroll offset.
+        out.bounding_box_page = el.bounding_box_page().await.ok().flatten().map(|pb| {
+            let (x, y) = pb.abs_origin();
+            BoundingBox {
+                x,
+                y,
+                width: pb.viewport.width,
+                height: pb.viewport.height,
+            }
+        });
     }
     if want_text_attrs {
         let text = el
@@ -167,11 +185,124 @@ pub async fn element_state(
             .inner_html()
             .await
             .map_err(|e| map_error(McpServerError::from(e)))?;
+        let outer_html = el
+            .outer_html()
+            .await
+            .map_err(|e| map_error(McpServerError::from(e)))?;
         out.text = Some(text);
         out.attrs = Some(attrs_map.into_iter().collect());
         out.inner_html = Some(inner_html);
+        out.outer_html = Some(outer_html);
     }
     Ok(out)
+}
+
+// ---------- browser_get_links --------------------------------------------
+
+/// Input for `browser_get_links`.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GetLinksInput {
+    /// Resolve relative `href`s to absolute URLs. Default `false`.
+    #[serde(default)]
+    pub absolute: bool,
+    /// Also collect `src`/`href` of linked-resource elements (img, script,
+    /// link, …) into `sources`. Default `false`.
+    #[serde(default)]
+    pub include_sources: bool,
+}
+
+/// Output of `browser_get_links`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct GetLinksOutput {
+    /// Anchor (`<a href>`) URLs on the page.
+    pub urls: Vec<String>,
+    /// Linked-resource source URLs, when `include_sources` was set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sources: Option<Vec<String>>,
+}
+
+/// Harvest anchor URLs (and optionally linked-resource sources) from the page.
+pub async fn get_links(
+    state: Arc<Mutex<SessionState>>,
+    input: GetLinksInput,
+) -> Result<GetLinksOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    let urls = tab
+        .get_all_urls(input.absolute)
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
+    let sources = if input.include_sources {
+        let els = tab
+            .get_all_linked_sources()
+            .await
+            .map_err(|e| map_error(McpServerError::from(e)))?;
+        let mut out = Vec::with_capacity(els.len());
+        for el in &els {
+            // Linked sources are img/script/link/etc — prefer `src`, fall
+            // back to `href`. Best-effort: skip elements with neither.
+            let src = el.attr("src").await.ok().flatten();
+            let href = match src {
+                Some(s) => Some(s),
+                None => el.attr("href").await.ok().flatten(),
+            };
+            if let Some(u) = href {
+                out.push(u);
+            }
+        }
+        Some(out)
+    } else {
+        None
+    };
+    Ok(GetLinksOutput { urls, sources })
+}
+
+// ---------- browser_search_resources -------------------------------------
+
+/// Input for `browser_search_resources`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SearchResourcesInput {
+    /// Substring to search for across every frame's loaded resource URLs.
+    pub query: String,
+}
+
+/// One matched resource from `browser_search_resources`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ResourceMatch {
+    /// Request URL of the matched resource.
+    pub url: String,
+    /// CDP `frameId` of the frame that owns the resource.
+    pub frame_id: String,
+}
+
+/// Output of `browser_search_resources`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct SearchResourcesOutput {
+    /// All resources whose URL contains `query`.
+    pub matches: Vec<ResourceMatch>,
+}
+
+/// Search every frame's loaded resources for a URL substring.
+pub async fn search_resources(
+    state: Arc<Mutex<SessionState>>,
+    input: SearchResourcesInput,
+) -> Result<SearchResourcesOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    let hits = tab
+        .search_frame_resources(&input.query)
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
+    let matches = hits
+        .into_iter()
+        .map(|m| ResourceMatch {
+            url: m.url,
+            frame_id: m.frame_id,
+        })
+        .collect();
+    Ok(SearchResourcesOutput { matches })
 }
 
 /// Mirror of the same predicate in [`crate::tools::find`] — kept private

--- a/crates/zendriver-mcp/src/tools/scroll.rs
+++ b/crates/zendriver-mcp/src/tools/scroll.rs
@@ -1,0 +1,104 @@
+//! Page-scroll tool — `browser_scroll`.
+//!
+//! Wraps [`zendriver::Tab::scroll_with`]. The lib's [`ScrollOptions`] follows
+//! the inverted CDP gesture convention (a *negative* `yDistance` scrolls the
+//! page down); this tool exposes intuitive screen axes (`+dy` = down, `+dx` =
+//! right) and negates both before dispatch, so the wire API reads naturally.
+
+use std::sync::Arc;
+
+use rmcp::ErrorData;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use zendriver::ScrollOptions;
+
+use crate::errors::{McpServerError, map_error};
+use crate::state::SessionState;
+use crate::tools::common::{current_tab, page_snapshot};
+
+/// Input for `browser_scroll`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PageScrollInput {
+    /// Horizontal scroll distance in CSS pixels. Positive scrolls the view
+    /// right; negative scrolls left. Default `0`.
+    #[serde(default)]
+    pub dx: f64,
+    /// Vertical scroll distance in CSS pixels. Positive scrolls the view
+    /// **down** the page; negative scrolls up. Default `0`.
+    #[serde(default)]
+    pub dy: f64,
+    /// Optional gesture speed in pixels/second. Omitted → Chrome's default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub speed: Option<i64>,
+    /// When `true`, include the trimmed page HTML in the response.
+    #[serde(default)]
+    pub return_snapshot: bool,
+}
+
+/// Output of `browser_scroll`: the page scroll offset after the gesture.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PageScrollOutput {
+    /// `window.scrollX` after the gesture.
+    pub scroll_x: f64,
+    /// `window.scrollY` after the gesture.
+    pub scroll_y: f64,
+    /// Trimmed rendered HTML, populated only when `return_snapshot: true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot: Option<String>,
+}
+
+/// Scroll the page by a signed pixel distance (intuitive axes: `+dy` = down,
+/// `+dx` = right), then report the resulting scroll offset.
+pub async fn scroll(
+    state: Arc<Mutex<SessionState>>,
+    input: PageScrollInput,
+) -> Result<PageScrollOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    tab.scroll_with(ScrollOptions {
+        dx: -input.dx,
+        dy: -input.dy,
+        speed: input.speed,
+    })
+    .await
+    .map_err(|e| map_error(McpServerError::from(e)))?;
+    let (scroll_x, scroll_y): (f64, f64) = tab
+        .evaluate_main("[window.scrollX, window.scrollY]")
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
+    let snapshot = if input.return_snapshot {
+        Some(page_snapshot(&tab).await?)
+    } else {
+        None
+    };
+    Ok(PageScrollOutput {
+        scroll_x,
+        scroll_y,
+        snapshot,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn scroll_with_no_browser_errors() {
+        let state = Arc::new(Mutex::new(SessionState::new()));
+        let err = scroll(
+            state,
+            PageScrollInput {
+                dx: 0.0,
+                dy: 500.0,
+                speed: None,
+                return_snapshot: false,
+            },
+        )
+        .await
+        .expect_err("expected BrowserNotOpen");
+        assert!(err.message.contains("Browser not open"));
+    }
+}

--- a/crates/zendriver-mcp/src/tools/snapshot.rs
+++ b/crates/zendriver-mcp/src/tools/snapshot.rs
@@ -50,11 +50,15 @@ use crate::tools::find::resolve;
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct HtmlInput {
-    /// When set, returns `el.innerHTML` for the matched element.
-    /// Mutually exclusive with the tool-level `frame_id` — use the
-    /// selector's own `frame_id` to scope the lookup to a sub-frame.
+    /// When set, returns `el.innerHTML` (or `el.outerHTML` if `outer`) for the
+    /// matched element. Mutually exclusive with the tool-level `frame_id` —
+    /// use the selector's own `frame_id` to scope the lookup to a sub-frame.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub selector: Option<Selector>,
+    /// With `selector`, return `outerHTML` (the element's own tag included)
+    /// instead of `innerHTML`. Ignored without a selector. Default `false`.
+    #[serde(default)]
+    pub outer: bool,
     /// Trim the result: strip `<script>` / `<style>` blocks + collapse
     /// whitespace. Default `true`. Pass `false` for byte-exact output.
     #[serde(default = "default_true")]
@@ -91,9 +95,15 @@ pub async fn html(state: Arc<Mutex<SessionState>>, input: HtmlInput) -> Result<S
 
     let raw = if let Some(sel) = input.selector.as_ref() {
         let el = resolve(&tab, sel).await?;
-        el.inner_html()
-            .await
-            .map_err(|e| map_error(McpServerError::from(e)))?
+        if input.outer {
+            el.outer_html()
+                .await
+                .map_err(|e| map_error(McpServerError::from(e)))?
+        } else {
+            el.inner_html()
+                .await
+                .map_err(|e| map_error(McpServerError::from(e)))?
+        }
     } else if let Some(fid) = input.frame_id.as_deref() {
         let frame = lookup_frame(&tab, fid).await?;
         frame
@@ -311,6 +321,7 @@ mod tests {
             fresh(),
             HtmlInput {
                 selector: None,
+                outer: false,
                 trim: true,
                 frame_id: None,
             },
@@ -331,6 +342,7 @@ mod tests {
             fresh(),
             HtmlInput {
                 selector: Some(css_sel("h1")),
+                outer: false,
                 trim: true,
                 frame_id: Some("frame-X".into()),
             },

--- a/crates/zendriver-mcp/src/tools/stealth.rs
+++ b/crates/zendriver-mcp/src/tools/stealth.rs
@@ -12,8 +12,12 @@ use rmcp::ErrorData;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
+use zendriver::UserAgentOverride;
 
-use crate::state::{SessionState, StealthProfileChoice};
+use crate::errors::{McpServerError, map_error};
+use crate::state::{SessionState, StealthOverrides, StealthProfileChoice};
+use crate::tools::actions::AckOutput;
+use crate::tools::common::current_tab;
 
 /// Input for `browser_set_stealth_profile`.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -21,6 +25,11 @@ use crate::state::{SessionState, StealthProfileChoice};
 pub struct SetStealthProfileInput {
     /// New default stealth profile for this session.
     pub profile: StealthProfileChoice,
+    /// Fine-grained fingerprint overrides layered onto `profile` at the next
+    /// `browser_open`. Replaces any previously-set overrides; omit (or pass
+    /// `{}`) to clear them.
+    #[serde(default)]
+    pub overrides: StealthOverrides,
 }
 
 /// Output of `browser_set_stealth_profile`.
@@ -28,6 +37,8 @@ pub struct SetStealthProfileInput {
 pub struct SetStealthProfileOutput {
     /// The profile that is now configured as the session default.
     pub active_profile: StealthProfileChoice,
+    /// The fine-grained overrides now configured for the next open.
+    pub active_overrides: StealthOverrides,
     /// `true` iff a browser is currently open. When `true`, the new
     /// profile only applies after `browser_close` + `browser_open`. When
     /// `false`, the next `browser_open` call will pick it up directly.
@@ -46,10 +57,48 @@ pub async fn set_stealth_profile(
 ) -> Result<SetStealthProfileOutput, ErrorData> {
     let mut s = state.lock().await;
     s.stealth_profile_choice = input.profile;
+    s.stealth_overrides = input.overrides.clone();
     Ok(SetStealthProfileOutput {
         active_profile: input.profile,
+        active_overrides: input.overrides,
         takes_effect_on_next_open: s.browser.is_some(),
     })
+}
+
+/// Input for `browser_set_user_agent`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SetUserAgentInput {
+    /// Full User-Agent string to send via `Emulation.setUserAgentOverride`.
+    pub user_agent: String,
+    /// Optional `Accept-Language` override applied alongside the UA.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accept_language: Option<String>,
+    /// Optional `navigator.platform` override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platform: Option<String>,
+}
+
+/// Override the current tab's User-Agent at runtime.
+///
+/// This is last-write-wins and sends NO `userAgentMetadata` — under a Spoofed
+/// stealth profile it can clobber UA-Client-Hints coherence and *increase*
+/// detectability. Prefer the stealth profile for stealth-sensitive tabs; use
+/// this for non-stealth tabs or a deliberate per-tab UA change.
+pub async fn set_user_agent(
+    state: Arc<Mutex<SessionState>>,
+    input: SetUserAgentInput,
+) -> Result<AckOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    tab.set_user_agent_with(UserAgentOverride {
+        user_agent: input.user_agent,
+        accept_language: input.accept_language,
+        platform: input.platform,
+    })
+    .await
+    .map_err(|e| map_error(McpServerError::from(e)))?;
+    Ok(AckOutput { ok: true })
 }
 
 #[cfg(test)]
@@ -67,6 +116,7 @@ mod tests {
             state.clone(),
             SetStealthProfileInput {
                 profile: StealthProfileChoice::SpoofLinux,
+                overrides: StealthOverrides::default(),
             },
         )
         .await
@@ -88,6 +138,7 @@ mod tests {
             state.clone(),
             SetStealthProfileInput {
                 profile: StealthProfileChoice::SpoofMacos,
+                overrides: StealthOverrides::default(),
             },
         )
         .await
@@ -96,6 +147,7 @@ mod tests {
             state.clone(),
             SetStealthProfileInput {
                 profile: StealthProfileChoice::SpoofWindows,
+                overrides: StealthOverrides::default(),
             },
         )
         .await
@@ -114,6 +166,7 @@ mod tests {
             state,
             SetStealthProfileInput {
                 profile: StealthProfileChoice::Auto,
+                overrides: StealthOverrides::default(),
             },
         )
         .await

--- a/crates/zendriver-mcp/src/tools/tabs.rs
+++ b/crates/zendriver-mcp/src/tools/tabs.rs
@@ -356,6 +356,11 @@ pub async fn activate(
     tab.activate()
         .await
         .map_err(|e| map_error(McpServerError::from(e)))?;
+    // Also raise the page within its window (`Page.bringToFront`) so the
+    // activated tab is actually frontmost, not just the CDP-active target.
+    tab.bring_to_front()
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
     s.current_tab_id = Some(input.tab_id.clone());
     Ok(TabActivateOutput { id: input.tab_id })
 }

--- a/crates/zendriver-mcp/src/tools/window.rs
+++ b/crates/zendriver-mcp/src/tools/window.rs
@@ -1,0 +1,213 @@
+//! Window / viewport tools — `browser_get_window`, `browser_set_window`.
+//!
+//! Wraps [`zendriver::Tab`]'s window controls (`window_bounds`,
+//! `set_window_bounds`, `set_window_size`, `maximize`, `minimize`,
+//! `fullscreen`). Geometry fields are device-independent pixels; Chrome omits
+//! geometry for a minimized window, so every field on [`WindowBoundsDto`] is
+//! optional.
+
+use std::sync::Arc;
+
+use rmcp::ErrorData;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use zendriver::{WindowBounds, WindowState};
+
+use crate::errors::{McpServerError, map_error};
+use crate::state::SessionState;
+use crate::tools::common::current_tab;
+
+/// Wire mirror of [`zendriver::WindowState`].
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowStateDto {
+    /// Normal (windowed) — the only state that may carry explicit geometry.
+    Normal,
+    /// Minimized to the OS taskbar / dock.
+    Minimized,
+    /// Maximized to fill the screen work area.
+    Maximized,
+    /// Fullscreen (chrome / OS decorations hidden).
+    Fullscreen,
+}
+
+impl From<WindowStateDto> for WindowState {
+    fn from(s: WindowStateDto) -> Self {
+        match s {
+            WindowStateDto::Normal => WindowState::Normal,
+            WindowStateDto::Minimized => WindowState::Minimized,
+            WindowStateDto::Maximized => WindowState::Maximized,
+            WindowStateDto::Fullscreen => WindowState::Fullscreen,
+        }
+    }
+}
+
+impl From<WindowState> for WindowStateDto {
+    fn from(s: WindowState) -> Self {
+        match s {
+            WindowState::Normal => WindowStateDto::Normal,
+            WindowState::Minimized => WindowStateDto::Minimized,
+            WindowState::Maximized => WindowStateDto::Maximized,
+            WindowState::Fullscreen => WindowStateDto::Fullscreen,
+        }
+    }
+}
+
+/// Window geometry + state DTO (output of both window tools).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct WindowBoundsDto {
+    /// Window left edge (screen X), in DIP. `None` when not reported.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub left: Option<i64>,
+    /// Window top edge (screen Y), in DIP. `None` when not reported.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top: Option<i64>,
+    /// Window width, in DIP. `None` when not reported.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub width: Option<i64>,
+    /// Window height, in DIP. `None` when not reported.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub height: Option<i64>,
+    /// Current window state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<WindowStateDto>,
+}
+
+impl From<WindowBounds> for WindowBoundsDto {
+    fn from(b: WindowBounds) -> Self {
+        Self {
+            left: b.left,
+            top: b.top,
+            width: b.width,
+            height: b.height,
+            state: b.state.map(Into::into),
+        }
+    }
+}
+
+/// Read the current window bounds + state.
+pub async fn get_window(state: Arc<Mutex<SessionState>>) -> Result<WindowBoundsDto, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    let bounds = tab
+        .window_bounds()
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
+    Ok(bounds.into())
+}
+
+/// Which window operation `browser_set_window` performs.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SetWindowMode {
+    /// Set explicit bounds (`left`/`top`/`width`/`height`/`state`, any subset).
+    Bounds,
+    /// Resize to `width` × `height` (both required).
+    Size,
+    /// Maximize the window.
+    Maximize,
+    /// Minimize the window.
+    Minimize,
+    /// Enter fullscreen.
+    Fullscreen,
+}
+
+/// Input for `browser_set_window`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SetWindowInput {
+    /// Which operation to perform.
+    pub mode: SetWindowMode,
+    /// Window width in DIP (used by `size` and optionally `bounds`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<i64>,
+    /// Window height in DIP (used by `size` and optionally `bounds`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height: Option<i64>,
+    /// Window left edge in DIP (used by `bounds`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub left: Option<i64>,
+    /// Window top edge in DIP (used by `bounds`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top: Option<i64>,
+    /// Window state to set (used by `bounds`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<WindowStateDto>,
+}
+
+/// Apply a window operation, then report the resulting bounds.
+pub async fn set_window(
+    state: Arc<Mutex<SessionState>>,
+    input: SetWindowInput,
+) -> Result<WindowBoundsDto, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    match input.mode {
+        SetWindowMode::Maximize => tab
+            .maximize()
+            .await
+            .map_err(|e| map_error(McpServerError::from(e)))?,
+        SetWindowMode::Minimize => tab
+            .minimize()
+            .await
+            .map_err(|e| map_error(McpServerError::from(e)))?,
+        SetWindowMode::Fullscreen => tab
+            .fullscreen()
+            .await
+            .map_err(|e| map_error(McpServerError::from(e)))?,
+        SetWindowMode::Size => {
+            let w = input.width.ok_or_else(|| {
+                ErrorData::invalid_params("`width` is required for mode `size`".to_string(), None)
+            })?;
+            let h = input.height.ok_or_else(|| {
+                ErrorData::invalid_params("`height` is required for mode `size`".to_string(), None)
+            })?;
+            tab.set_window_size(w, h)
+                .await
+                .map_err(|e| map_error(McpServerError::from(e)))?;
+        }
+        SetWindowMode::Bounds => {
+            let bounds = WindowBounds {
+                left: input.left,
+                top: input.top,
+                width: input.width,
+                height: input.height,
+                state: input.state.map(Into::into),
+            };
+            tab.set_window_bounds(bounds)
+                .await
+                .map_err(|e| map_error(McpServerError::from(e)))?;
+        }
+    }
+    let bounds = tab
+        .window_bounds()
+        .await
+        .map_err(|e| map_error(McpServerError::from(e)))?;
+    Ok(bounds.into())
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn set_window_with_no_browser_errors() {
+        let state = Arc::new(Mutex::new(SessionState::new()));
+        let err = set_window(
+            state,
+            SetWindowInput {
+                mode: SetWindowMode::Maximize,
+                width: None,
+                height: None,
+                left: None,
+                top: None,
+                state: None,
+            },
+        )
+        .await
+        .expect_err("expected BrowserNotOpen");
+        assert!(err.message.contains("Browser not open"));
+    }
+}

--- a/crates/zendriver-mcp/tests/evals/coverage-expansion.xml
+++ b/crates/zendriver-mcp/tests/evals/coverage-expansion.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Evaluation suite for the coverage-expansion tools (49 → 65).
+
+  Each question is answerable entirely through zendriver-mcp tools against a
+  real, stealth-by-default headless Chrome. Targets are `data:` URLs (or the
+  stable example.com) so answers are deterministic and stable over time. Run
+  the server, then drive these with an MCP-capable model; answers are exact
+  string matches.
+
+  Tools exercised: browser_get_links, browser_element_state (outer_html),
+  browser_evaluate frame_id, browser_key_sequence, browser_set_value (value +
+  text modes), browser_pdf, browser_save_mhtml, browser_wait_for_load,
+  browser_scroll, browser_set_window / browser_get_window.
+-->
+<evaluation>
+  <qa_pair>
+    <question>Open a headless browser and navigate to the URL `data:text/html,&lt;a href="https://example.com/a"&gt;A&lt;/a&gt;&lt;a href="https://example.com/b"&gt;B&lt;/a&gt;&lt;a href="https://example.com/c"&gt;C&lt;/a&gt;`. How many anchor URLs does browser_get_links report for the page?</question>
+    <answer>3</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Navigate to `data:text/html,&lt;p id="t"&gt;Hi&lt;/p&gt;`. Inspect the element matching the CSS selector `#t` with the full field preset and report its outer_html value exactly.</question>
+    <answer>&lt;p id="t"&gt;Hi&lt;/p&gt;</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Navigate to `data:text/html,&lt;iframe name="f" srcdoc="&lt;b&gt;inner-42&lt;/b&gt;"&gt;&lt;/iframe&gt;`. List the frames, then evaluate the JavaScript expression `document.body.textContent` inside the child frame (not the main frame). What string is returned?</question>
+    <answer>inner-42</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Navigate to `data:text/html,&lt;input id="i" value="old"&gt;`. Using a key sequence on `#i`, hold Ctrl and press `a` to select all, then type the text `new`. Then evaluate `document.getElementById('i').value`. What is the value?</question>
+    <answer>new</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Navigate to `data:text/html,&lt;div id="d"&gt;x&lt;/div&gt;`. Use browser_set_value with mode `text` to set `#d` to `filled`, then evaluate `document.getElementById('d').textContent`. What is the result?</question>
+    <answer>filled</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Navigate to `data:text/html,&lt;input id="i"&gt;`. Use browser_set_value (default mode) to set `#i` to `hello`, then evaluate `document.getElementById('i').value`. What is the value?</question>
+    <answer>hello</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Navigate to https://example.com and export the page to PDF with browser_pdf (no save_path, so the bytes come back base64-encoded). Decode the bytes and report the first four characters (the file-format signature).</question>
+    <answer>%PDF</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Navigate to `data:text/html,&lt;title&gt;hi&lt;/title&gt;&lt;p&gt;body&lt;/p&gt;` and capture an MHTML archive with browser_save_mhtml (no save_path). Decode the base64 bytes; what are the first five characters of the MHTML archive?</question>
+    <answer>From:</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Navigate to `data:text/html,&lt;div id="r"&gt;ready&lt;/div&gt;` and call browser_wait_for_load with ready_state `complete`. Afterward, evaluate `document.readyState`. What value does it return?</question>
+    <answer>complete</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Open a headless browser, set the window with browser_set_window using mode `size`, width 1024 and height 768. Then read it back with browser_get_window. What width does it report?</question>
+    <answer>1024</answer>
+  </qa_pair>
+</evaluation>

--- a/crates/zendriver-mcp/tests/integration_expect_drive.rs
+++ b/crates/zendriver-mcp/tests/integration_expect_drive.rs
@@ -1,0 +1,131 @@
+//! Real-Chrome end-to-end test for the expect *drive* extensions — dialog
+//! accept. Gated behind `integration-tests` AND `expect`, marked `#[ignore]`.
+//!
+//! ```bash
+//! cargo test -p zendriver-mcp --features "integration-tests expect" \
+//!     --test integration_expect_drive -- --ignored
+//! ```
+
+#![cfg(all(feature = "integration-tests", feature = "expect"))]
+
+use rmcp::ServiceExt;
+use rmcp::model::CallToolRequestParams;
+use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
+use tokio::process::Command;
+
+const BIN_PATH: &str = env!("CARGO_BIN_EXE_zendriver-mcp");
+
+#[tokio::test]
+#[ignore = "requires real Chrome; run with --features \"integration-tests expect\" -- --ignored"]
+async fn end_to_end_dialog_accept() {
+    let client = ()
+        .serve(
+            TokioChildProcess::new(Command::new(BIN_PATH).configure(|cmd| {
+                cmd.arg("--log").arg("error");
+            }))
+            .expect("spawn child"),
+        )
+        .await
+        .expect("rmcp client init");
+
+    client
+        .call_tool(CallToolRequestParams::new("browser_open").with_arguments({
+            let mut m = serde_json::Map::new();
+            m.insert("headless".into(), serde_json::json!(true));
+            m
+        }))
+        .await
+        .expect("browser_open ok");
+    client
+        .call_tool(CallToolRequestParams::new("browser_goto").with_arguments({
+            let mut m = serde_json::Map::new();
+            m.insert(
+                "url".into(),
+                serde_json::json!("data:text/html,<body>dialog</body>"),
+            );
+            m
+        }))
+        .await
+        .expect("browser_goto ok");
+
+    // Register a dialog expectation that ACCEPTS the dialog. The subscriber is
+    // active by the time register returns, so the later confirm() is caught.
+    let reg = client
+        .call_tool(
+            CallToolRequestParams::new("browser_expect_register").with_arguments({
+                let mut m = serde_json::Map::new();
+                m.insert("kind".into(), serde_json::json!("dialog"));
+                m.insert("dialog_action".into(), serde_json::json!("accept"));
+                m
+            }),
+        )
+        .await
+        .expect("browser_expect_register ok");
+    let reg_body = structured(&reg);
+    let id = reg_body["expectation_id"]
+        .as_str()
+        .expect("expectation_id")
+        .to_string();
+
+    // Trigger a confirm(); the spawned task accepts it, so this resolves true.
+    let eval = client
+        .call_tool(
+            CallToolRequestParams::new("browser_evaluate_main").with_arguments({
+                let mut m = serde_json::Map::new();
+                m.insert("expression".into(), serde_json::json!("confirm('ok?')"));
+                m
+            }),
+        )
+        .await
+        .expect("browser_evaluate_main ok");
+    let eval_body = structured(&eval);
+    assert_eq!(
+        eval_body["value"],
+        serde_json::json!(true),
+        "accepted confirm() returns true; body: {eval_body}"
+    );
+
+    // Await the matched dialog event; it should report it was driven `accept`.
+    let awaited = client
+        .call_tool(
+            CallToolRequestParams::new("browser_expect_await").with_arguments({
+                let mut m = serde_json::Map::new();
+                m.insert("expectation_id".into(), serde_json::json!(id));
+                m.insert("timeout_ms".into(), serde_json::json!(10_000_u64));
+                m
+            }),
+        )
+        .await
+        .expect("browser_expect_await ok");
+    let ev = structured(&awaited);
+    assert_eq!(ev["event"]["kind"], serde_json::json!("dialog"), "ev: {ev}");
+    assert_eq!(
+        ev["event"]["dialog_type"],
+        serde_json::json!("confirm"),
+        "ev: {ev}"
+    );
+    assert_eq!(
+        ev["event"]["driven"],
+        serde_json::json!("accept"),
+        "ev: {ev}"
+    );
+
+    client
+        .call_tool(CallToolRequestParams::new("browser_close").with_arguments(Default::default()))
+        .await
+        .expect("browser_close ok");
+    client.cancel().await.expect("clean shutdown");
+}
+
+fn structured(result: &rmcp::model::CallToolResult) -> serde_json::Value {
+    if let Some(v) = result.structured_content.clone() {
+        return v;
+    }
+    let text = result
+        .content
+        .iter()
+        .find_map(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("text or structured content present");
+    serde_json::from_str(&text).expect("text payload is JSON")
+}

--- a/crates/zendriver-mcp/tests/integration_imperva.rs
+++ b/crates/zendriver-mcp/tests/integration_imperva.rs
@@ -1,0 +1,131 @@
+//! Real-Chrome end-to-end test for `browser_solve_imperva`.
+//!
+//! Gated behind BOTH `integration-tests` AND `imperva` cargo features AND
+//! marked `#[ignore]` so a default `cargo test` run never spawns Chrome. To
+//! exercise it explicitly:
+//!
+//! ```bash
+//! cargo test -p zendriver-mcp \
+//!     --features "integration-tests imperva" \
+//!     --test integration_imperva -- --ignored
+//! ```
+//!
+//! Smoke shape: open → goto an Imperva-protected page →
+//! `browser_solve_imperva` (long timeout) → assert the outcome is one of the
+//! four expected variants → close.
+//!
+//! ## Why this test is "best effort"
+//!
+//! The target is third-party infrastructure that can change shape at any
+//! time — Imperva can rotate surfaces, the site can move behind a different
+//! WAF, or drop Imperva entirely. The test accepts any of the four terminal
+//! outcomes (`token_acquired`, `challenge_gone`, `already_clear`, `timeout`)
+//! as a pass and only fails on a structural error (CAPTCHA-without-solver /
+//! CDP / JS exception, which surface here as a `call_tool` failure). Use it
+//! as a manual smoke when iterating on imperva integration, not as a CI gate.
+
+#![cfg(all(feature = "integration-tests", feature = "imperva"))]
+
+use rmcp::ServiceExt;
+use rmcp::model::CallToolRequestParams;
+use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
+use tokio::process::Command;
+
+const BIN_PATH: &str = env!("CARGO_BIN_EXE_zendriver-mcp");
+
+/// Imperva's own marketing site commonly sits behind their bot-management
+/// surface. Swap if it stops serving an Imperva challenge.
+const IMPERVA_URL: &str = "https://www.imperva.com/";
+
+#[tokio::test]
+#[ignore = "requires real Chrome + reachable Imperva-protected page; run with --features \"integration-tests imperva\" -- --ignored"]
+async fn end_to_end_solve_imperva() {
+    let client = ()
+        .serve(
+            TokioChildProcess::new(Command::new(BIN_PATH).configure(|cmd| {
+                cmd.arg("--log").arg("error");
+            }))
+            .expect("spawn child"),
+        )
+        .await
+        .expect("rmcp client init");
+
+    // 1. Launch headless Chrome (stealth is on by default — required for
+    //    Imperva).
+    client
+        .call_tool(CallToolRequestParams::new("browser_open").with_arguments({
+            let mut m = serde_json::Map::new();
+            m.insert("headless".into(), serde_json::json!(true));
+            m
+        }))
+        .await
+        .expect("browser_open ok");
+
+    // 2. Navigate to the protected page.
+    client
+        .call_tool(CallToolRequestParams::new("browser_goto").with_arguments({
+            let mut m = serde_json::Map::new();
+            m.insert("url".into(), serde_json::json!(IMPERVA_URL));
+            m
+        }))
+        .await
+        .expect("browser_goto ok");
+
+    // 3. Drive the bypass with a long timeout.
+    let solve_resp = client
+        .call_tool(
+            CallToolRequestParams::new("browser_solve_imperva").with_arguments({
+                let mut m = serde_json::Map::new();
+                m.insert("timeout_ms".into(), serde_json::json!(45_000_u64));
+                m
+            }),
+        )
+        .await
+        .expect("browser_solve_imperva ok");
+    let body = structured(&solve_resp);
+    let outcome = body["outcome"]
+        .as_str()
+        .expect("outcome populated")
+        .to_string();
+    assert!(
+        matches!(
+            outcome.as_str(),
+            "token_acquired" | "challenge_gone" | "already_clear" | "timeout"
+        ),
+        "unexpected outcome `{outcome}`; body: {body}"
+    );
+    // `reese84` is populated only on `token_acquired`.
+    if outcome == "token_acquired" {
+        let token = body["reese84"]
+            .as_str()
+            .expect("reese84 populated on token_acquired outcome");
+        assert!(!token.is_empty(), "reese84 empty; body: {body}");
+    } else {
+        assert!(
+            body.get("reese84").is_none_or(serde_json::Value::is_null),
+            "reese84 should not be set for outcome `{outcome}`; body: {body}"
+        );
+    }
+
+    // 4. Close.
+    client
+        .call_tool(CallToolRequestParams::new("browser_close").with_arguments(Default::default()))
+        .await
+        .expect("browser_close ok");
+    client.cancel().await.expect("clean shutdown");
+}
+
+/// Pull the structured payload out of a tool call result, falling back to
+/// parsing the text content slot when rmcp didn't emit a structured one.
+fn structured(result: &rmcp::model::CallToolResult) -> serde_json::Value {
+    if let Some(v) = result.structured_content.clone() {
+        return v;
+    }
+    let text = result
+        .content
+        .iter()
+        .find_map(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("text or structured content present");
+    serde_json::from_str(&text).expect("text payload is JSON")
+}

--- a/crates/zendriver-mcp/tests/integration_pdf.rs
+++ b/crates/zendriver-mcp/tests/integration_pdf.rs
@@ -1,0 +1,104 @@
+//! Real-Chrome end-to-end test for `browser_pdf` / `browser_save_mhtml`.
+//!
+//! Gated behind `integration-tests` AND marked `#[ignore]`. Run with:
+//!
+//! ```bash
+//! cargo test -p zendriver-mcp --features integration-tests \
+//!     --test integration_pdf -- --ignored
+//! ```
+
+#![cfg(feature = "integration-tests")]
+
+use rmcp::ServiceExt;
+use rmcp::model::CallToolRequestParams;
+use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
+use tokio::process::Command;
+
+const BIN_PATH: &str = env!("CARGO_BIN_EXE_zendriver-mcp");
+
+#[tokio::test]
+#[ignore = "requires real Chrome; run with --features integration-tests -- --ignored"]
+async fn end_to_end_pdf_export() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pdf_path = dir.path().join("page.pdf");
+
+    let client = ()
+        .serve(
+            TokioChildProcess::new(Command::new(BIN_PATH).configure(|cmd| {
+                cmd.arg("--log").arg("error");
+            }))
+            .expect("spawn child"),
+        )
+        .await
+        .expect("rmcp client init");
+
+    client
+        .call_tool(CallToolRequestParams::new("browser_open").with_arguments({
+            let mut m = serde_json::Map::new();
+            m.insert("headless".into(), serde_json::json!(true));
+            m
+        }))
+        .await
+        .expect("browser_open ok");
+    client
+        .call_tool(CallToolRequestParams::new("browser_goto").with_arguments({
+            let mut m = serde_json::Map::new();
+            m.insert("url".into(), serde_json::json!("https://example.com"));
+            m
+        }))
+        .await
+        .expect("browser_goto ok");
+
+    // Export to a temp path.
+    let pdf_resp = client
+        .call_tool(CallToolRequestParams::new("browser_pdf").with_arguments({
+            let mut m = serde_json::Map::new();
+            m.insert(
+                "save_path".into(),
+                serde_json::json!(pdf_path.to_string_lossy()),
+            );
+            m
+        }))
+        .await
+        .expect("browser_pdf ok");
+    let body = structured(&pdf_resp);
+    assert!(
+        body["byte_len"].as_u64().unwrap_or(0) > 0,
+        "byte_len should be > 0; body: {body}"
+    );
+    assert!(body["saved_path"].is_string(), "saved_path; body: {body}");
+    let bytes = std::fs::read(&pdf_path).expect("read pdf");
+    assert!(bytes.starts_with(b"%PDF"), "file should be a PDF");
+
+    // MHTML inline (no save_path) returns base64.
+    let mhtml_resp = client
+        .call_tool(
+            CallToolRequestParams::new("browser_save_mhtml").with_arguments(Default::default()),
+        )
+        .await
+        .expect("browser_save_mhtml ok");
+    let mhtml_body = structured(&mhtml_resp);
+    assert!(
+        mhtml_body["base64"].is_string(),
+        "mhtml base64; body: {mhtml_body}"
+    );
+
+    client
+        .call_tool(CallToolRequestParams::new("browser_close").with_arguments(Default::default()))
+        .await
+        .expect("browser_close ok");
+    client.cancel().await.expect("clean shutdown");
+}
+
+fn structured(result: &rmcp::model::CallToolResult) -> serde_json::Value {
+    if let Some(v) = result.structured_content.clone() {
+        return v;
+    }
+    let text = result
+        .content
+        .iter()
+        .find_map(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("text or structured content present");
+    serde_json::from_str(&text).expect("text payload is JSON")
+}

--- a/crates/zendriver-mcp/tests/integration_scroll.rs
+++ b/crates/zendriver-mcp/tests/integration_scroll.rs
@@ -52,11 +52,13 @@ async fn end_to_end_scroll_and_mouse() {
 
     // Scroll down 1000px; positive dy = down.
     let scroll_resp = client
-        .call_tool(CallToolRequestParams::new("browser_scroll").with_arguments({
-            let mut m = serde_json::Map::new();
-            m.insert("dy".into(), serde_json::json!(1000.0));
-            m
-        }))
+        .call_tool(
+            CallToolRequestParams::new("browser_scroll").with_arguments({
+                let mut m = serde_json::Map::new();
+                m.insert("dy".into(), serde_json::json!(1000.0));
+                m
+            }),
+        )
         .await
         .expect("browser_scroll ok");
     let body = structured(&scroll_resp);
@@ -77,7 +79,11 @@ async fn end_to_end_scroll_and_mouse() {
         .await
         .expect("browser_mouse ok");
     let mouse_body = structured(&mouse_resp);
-    assert_eq!(mouse_body["ok"], serde_json::json!(true), "body: {mouse_body}");
+    assert_eq!(
+        mouse_body["ok"],
+        serde_json::json!(true),
+        "body: {mouse_body}"
+    );
 
     client
         .call_tool(CallToolRequestParams::new("browser_close").with_arguments(Default::default()))

--- a/crates/zendriver-mcp/tests/integration_scroll.rs
+++ b/crates/zendriver-mcp/tests/integration_scroll.rs
@@ -1,0 +1,100 @@
+//! Real-Chrome end-to-end test for `browser_scroll` (and a `browser_mouse`
+//! move smoke).
+//!
+//! Gated behind `integration-tests` AND marked `#[ignore]`. Run with:
+//!
+//! ```bash
+//! cargo test -p zendriver-mcp --features integration-tests \
+//!     --test integration_scroll -- --ignored
+//! ```
+
+#![cfg(feature = "integration-tests")]
+
+use rmcp::ServiceExt;
+use rmcp::model::CallToolRequestParams;
+use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
+use tokio::process::Command;
+
+const BIN_PATH: &str = env!("CARGO_BIN_EXE_zendriver-mcp");
+
+/// A document tall enough that scrolling moves `window.scrollY`.
+const TALL_PAGE: &str = "data:text/html,<body style='height:5000px;margin:0'>tall</body>";
+
+#[tokio::test]
+#[ignore = "requires real Chrome; run with --features integration-tests -- --ignored"]
+async fn end_to_end_scroll_and_mouse() {
+    let client = ()
+        .serve(
+            TokioChildProcess::new(Command::new(BIN_PATH).configure(|cmd| {
+                cmd.arg("--log").arg("error");
+            }))
+            .expect("spawn child"),
+        )
+        .await
+        .expect("rmcp client init");
+
+    client
+        .call_tool(CallToolRequestParams::new("browser_open").with_arguments({
+            let mut m = serde_json::Map::new();
+            m.insert("headless".into(), serde_json::json!(true));
+            m
+        }))
+        .await
+        .expect("browser_open ok");
+    client
+        .call_tool(CallToolRequestParams::new("browser_goto").with_arguments({
+            let mut m = serde_json::Map::new();
+            m.insert("url".into(), serde_json::json!(TALL_PAGE));
+            m
+        }))
+        .await
+        .expect("browser_goto ok");
+
+    // Scroll down 1000px; positive dy = down.
+    let scroll_resp = client
+        .call_tool(CallToolRequestParams::new("browser_scroll").with_arguments({
+            let mut m = serde_json::Map::new();
+            m.insert("dy".into(), serde_json::json!(1000.0));
+            m
+        }))
+        .await
+        .expect("browser_scroll ok");
+    let body = structured(&scroll_resp);
+    assert!(
+        body["scroll_y"].as_f64().unwrap_or(0.0) > 0.0,
+        "scroll_y should be > 0 after scrolling down; body: {body}"
+    );
+
+    // Mouse move smoke — should not error.
+    let mouse_resp = client
+        .call_tool(CallToolRequestParams::new("browser_mouse").with_arguments({
+            let mut m = serde_json::Map::new();
+            m.insert("action".into(), serde_json::json!("move"));
+            m.insert("x".into(), serde_json::json!(50.0));
+            m.insert("y".into(), serde_json::json!(50.0));
+            m
+        }))
+        .await
+        .expect("browser_mouse ok");
+    let mouse_body = structured(&mouse_resp);
+    assert_eq!(mouse_body["ok"], serde_json::json!(true), "body: {mouse_body}");
+
+    client
+        .call_tool(CallToolRequestParams::new("browser_close").with_arguments(Default::default()))
+        .await
+        .expect("browser_close ok");
+    client.cancel().await.expect("clean shutdown");
+}
+
+fn structured(result: &rmcp::model::CallToolResult) -> serde_json::Value {
+    if let Some(v) = result.structured_content.clone() {
+        return v;
+    }
+    let text = result
+        .content
+        .iter()
+        .find_map(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("text or structured content present");
+    serde_json::from_str(&text).expect("text payload is JSON")
+}

--- a/crates/zendriver-mcp/tests/integration_window.rs
+++ b/crates/zendriver-mcp/tests/integration_window.rs
@@ -1,0 +1,94 @@
+//! Real-Chrome end-to-end test for `browser_get_window` / `browser_set_window`.
+//!
+//! Gated behind `integration-tests` AND marked `#[ignore]`. Run with:
+//!
+//! ```bash
+//! cargo test -p zendriver-mcp --features integration-tests \
+//!     --test integration_window -- --ignored
+//! ```
+//!
+//! Best-effort: headless Chrome emulates a window and generally honors
+//! `Browser.setWindowBounds`, but exact geometry can be clamped by the
+//! platform. The test asserts the set call round-trips a plausible size.
+
+#![cfg(feature = "integration-tests")]
+
+use rmcp::ServiceExt;
+use rmcp::model::CallToolRequestParams;
+use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
+use tokio::process::Command;
+
+const BIN_PATH: &str = env!("CARGO_BIN_EXE_zendriver-mcp");
+
+#[tokio::test]
+#[ignore = "requires real Chrome; run with --features integration-tests -- --ignored"]
+async fn end_to_end_window_resize() {
+    let client = ()
+        .serve(
+            TokioChildProcess::new(Command::new(BIN_PATH).configure(|cmd| {
+                cmd.arg("--log").arg("error");
+            }))
+            .expect("spawn child"),
+        )
+        .await
+        .expect("rmcp client init");
+
+    client
+        .call_tool(CallToolRequestParams::new("browser_open").with_arguments({
+            let mut m = serde_json::Map::new();
+            m.insert("headless".into(), serde_json::json!(true));
+            m
+        }))
+        .await
+        .expect("browser_open ok");
+
+    // Resize to 800x600.
+    let set_resp = client
+        .call_tool(
+            CallToolRequestParams::new("browser_set_window").with_arguments({
+                let mut m = serde_json::Map::new();
+                m.insert("mode".into(), serde_json::json!("size"));
+                m.insert("width".into(), serde_json::json!(800));
+                m.insert("height".into(), serde_json::json!(600));
+                m
+            }),
+        )
+        .await
+        .expect("browser_set_window ok");
+    let set_body = structured(&set_resp);
+    assert_eq!(set_body["width"], serde_json::json!(800), "body: {set_body}");
+    assert_eq!(
+        set_body["height"],
+        serde_json::json!(600),
+        "body: {set_body}"
+    );
+
+    // Read it back.
+    let get_resp = client
+        .call_tool(
+            CallToolRequestParams::new("browser_get_window").with_arguments(Default::default()),
+        )
+        .await
+        .expect("browser_get_window ok");
+    let get_body = structured(&get_resp);
+    assert_eq!(get_body["width"], serde_json::json!(800), "body: {get_body}");
+
+    client
+        .call_tool(CallToolRequestParams::new("browser_close").with_arguments(Default::default()))
+        .await
+        .expect("browser_close ok");
+    client.cancel().await.expect("clean shutdown");
+}
+
+fn structured(result: &rmcp::model::CallToolResult) -> serde_json::Value {
+    if let Some(v) = result.structured_content.clone() {
+        return v;
+    }
+    let text = result
+        .content
+        .iter()
+        .find_map(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .expect("text or structured content present");
+    serde_json::from_str(&text).expect("text payload is JSON")
+}

--- a/crates/zendriver-mcp/tests/integration_window.rs
+++ b/crates/zendriver-mcp/tests/integration_window.rs
@@ -56,7 +56,11 @@ async fn end_to_end_window_resize() {
         .await
         .expect("browser_set_window ok");
     let set_body = structured(&set_resp);
-    assert_eq!(set_body["width"], serde_json::json!(800), "body: {set_body}");
+    assert_eq!(
+        set_body["width"],
+        serde_json::json!(800),
+        "body: {set_body}"
+    );
     assert_eq!(
         set_body["height"],
         serde_json::json!(600),
@@ -71,7 +75,11 @@ async fn end_to_end_window_resize() {
         .await
         .expect("browser_get_window ok");
     let get_body = structured(&get_resp);
-    assert_eq!(get_body["width"], serde_json::json!(800), "body: {get_body}");
+    assert_eq!(
+        get_body["width"],
+        serde_json::json!(800),
+        "body: {get_body}"
+    );
 
     client
         .call_tool(CallToolRequestParams::new("browser_close").with_arguments(Default::default()))

--- a/crates/zendriver-mcp/tests/schema_snapshots.rs
+++ b/crates/zendriver-mcp/tests/schema_snapshots.rs
@@ -177,6 +177,17 @@ mod cloudflare_snaps {
     schema_snap!(cloudflare_solve_out, tools::cloudflare::SolveOutput);
 }
 
+// ---------- imperva (feature-gated) ---------------------------------------
+
+#[cfg(feature = "imperva")]
+mod imperva_snaps {
+    use super::*;
+
+    schema_snap!(imperva_solve_in, tools::imperva::SolveImpervaInput);
+    schema_snap!(imperva_outcome, tools::imperva::Outcome);
+    schema_snap!(imperva_solve_out, tools::imperva::SolveImpervaOutput);
+}
+
 // ---------- fetcher (feature-gated) ---------------------------------------
 
 #[cfg(feature = "fetcher")]

--- a/crates/zendriver-mcp/tests/schema_snapshots.rs
+++ b/crates/zendriver-mcp/tests/schema_snapshots.rs
@@ -181,6 +181,7 @@ mod expect_snaps {
     use super::*;
 
     schema_snap!(expect_kind, tools::expect::ExpectKind);
+    schema_snap!(expect_dialog_action, tools::expect::DialogAction);
     schema_snap!(expect_matcher, tools::expect::ExpectMatcher);
     schema_snap!(expect_register_in, tools::expect::RegisterInput);
     schema_snap!(expect_register_out, tools::expect::RegisterOutput);

--- a/crates/zendriver-mcp/tests/schema_snapshots.rs
+++ b/crates/zendriver-mcp/tests/schema_snapshots.rs
@@ -26,7 +26,31 @@ macro_rules! schema_snap {
 // ---------- shared ---------------------------------------------------------
 
 schema_snap!(common_empty_input, tools::common::EmptyInput);
+schema_snap!(common_modifier_arg, tools::common::ModifierArg);
+schema_snap!(common_blob_output, tools::common::BlobOutput);
 schema_snap!(selectors_selector, selectors::Selector);
+
+// ---------- scroll ---------------------------------------------------------
+
+schema_snap!(scroll_page_in, tools::scroll::PageScrollInput);
+schema_snap!(scroll_page_out, tools::scroll::PageScrollOutput);
+
+// ---------- window ---------------------------------------------------------
+
+schema_snap!(window_state_dto, tools::window::WindowStateDto);
+schema_snap!(window_bounds_dto, tools::window::WindowBoundsDto);
+schema_snap!(window_set_mode, tools::window::SetWindowMode);
+schema_snap!(window_set_in, tools::window::SetWindowInput);
+
+// ---------- pdf ------------------------------------------------------------
+
+schema_snap!(pdf_in, tools::pdf::PdfInput);
+schema_snap!(pdf_save_mhtml_in, tools::pdf::SaveMhtmlInput);
+
+// ---------- mouse ----------------------------------------------------------
+
+schema_snap!(mouse_action, tools::mouse::MouseAction);
+schema_snap!(mouse_in, tools::mouse::MouseInput);
 
 // ---------- lifecycle ------------------------------------------------------
 

--- a/crates/zendriver-mcp/tests/schema_snapshots.rs
+++ b/crates/zendriver-mcp/tests/schema_snapshots.rs
@@ -68,7 +68,10 @@ schema_snap!(navigation_goto_in, tools::navigation::GotoInput);
 schema_snap!(navigation_history_in, tools::navigation::HistoryInput);
 schema_snap!(navigation_reload_in, tools::navigation::ReloadInput);
 schema_snap!(navigation_ready_state_arg, tools::navigation::ReadyStateArg);
-schema_snap!(navigation_wait_for_load_in, tools::navigation::WaitForLoadInput);
+schema_snap!(
+    navigation_wait_for_load_in,
+    tools::navigation::WaitForLoadInput
+);
 schema_snap!(navigation_idle_in, tools::navigation::IdleInput);
 schema_snap!(navigation_idle_out, tools::navigation::IdleOutput);
 
@@ -111,8 +114,14 @@ schema_snap!(reads_state_in, tools::reads::ElementStateInput);
 schema_snap!(reads_state_out, tools::reads::ElementState);
 schema_snap!(reads_get_links_in, tools::reads::GetLinksInput);
 schema_snap!(reads_get_links_out, tools::reads::GetLinksOutput);
-schema_snap!(reads_search_resources_in, tools::reads::SearchResourcesInput);
-schema_snap!(reads_search_resources_out, tools::reads::SearchResourcesOutput);
+schema_snap!(
+    reads_search_resources_in,
+    tools::reads::SearchResourcesInput
+);
+schema_snap!(
+    reads_search_resources_out,
+    tools::reads::SearchResourcesOutput
+);
 schema_snap!(reads_resource_match, tools::reads::ResourceMatch);
 
 // ---------- actions --------------------------------------------------------

--- a/crates/zendriver-mcp/tests/schema_snapshots.rs
+++ b/crates/zendriver-mcp/tests/schema_snapshots.rs
@@ -109,6 +109,11 @@ schema_snap!(find_all_out, tools::find::FindAllOutput);
 schema_snap!(reads_fields_preset, tools::reads::ReadFieldsPreset);
 schema_snap!(reads_state_in, tools::reads::ElementStateInput);
 schema_snap!(reads_state_out, tools::reads::ElementState);
+schema_snap!(reads_get_links_in, tools::reads::GetLinksInput);
+schema_snap!(reads_get_links_out, tools::reads::GetLinksOutput);
+schema_snap!(reads_search_resources_in, tools::reads::SearchResourcesInput);
+schema_snap!(reads_search_resources_out, tools::reads::SearchResourcesOutput);
+schema_snap!(reads_resource_match, tools::reads::ResourceMatch);
 
 // ---------- actions --------------------------------------------------------
 
@@ -120,7 +125,9 @@ schema_snap!(actions_hover_in, tools::actions::HoverInput);
 schema_snap!(actions_type_in, tools::actions::TypeInput);
 schema_snap!(actions_press_in, tools::actions::PressInput);
 schema_snap!(actions_set_value_in, tools::actions::SetValueInput);
+schema_snap!(actions_set_value_mode, tools::actions::SetValueMode);
 schema_snap!(actions_clear_in, tools::actions::ClearInput);
+schema_snap!(actions_clear_mode, tools::actions::ClearMode);
 schema_snap!(actions_focus_in, tools::actions::FocusInput);
 schema_snap!(actions_scroll_in, tools::actions::ScrollInput);
 schema_snap!(actions_upload_in, tools::actions::UploadInput);

--- a/crates/zendriver-mcp/tests/schema_snapshots.rs
+++ b/crates/zendriver-mcp/tests/schema_snapshots.rs
@@ -66,6 +66,9 @@ schema_snap!(navigation_nav_out, tools::navigation::NavOutput);
 schema_snap!(navigation_wait_for, tools::navigation::WaitFor);
 schema_snap!(navigation_goto_in, tools::navigation::GotoInput);
 schema_snap!(navigation_history_in, tools::navigation::HistoryInput);
+schema_snap!(navigation_reload_in, tools::navigation::ReloadInput);
+schema_snap!(navigation_ready_state_arg, tools::navigation::ReadyStateArg);
+schema_snap!(navigation_wait_for_load_in, tools::navigation::WaitForLoadInput);
 schema_snap!(navigation_idle_in, tools::navigation::IdleInput);
 schema_snap!(navigation_idle_out, tools::navigation::IdleOutput);
 
@@ -84,11 +87,13 @@ schema_snap!(tabs_activate_out, tools::tabs::TabActivateOutput);
 
 schema_snap!(frames_frame_summary, tools::frames::FrameSummary);
 schema_snap!(frames_list_out, tools::frames::FrameListOutput);
+schema_snap!(frames_frame_goto_in, tools::frames::FrameGotoInput);
 
 // ---------- stealth --------------------------------------------------------
 
 schema_snap!(stealth_set_in, tools::stealth::SetStealthProfileInput);
 schema_snap!(stealth_set_out, tools::stealth::SetStealthProfileOutput);
+schema_snap!(stealth_set_user_agent_in, tools::stealth::SetUserAgentInput);
 
 // ---------- find -----------------------------------------------------------
 
@@ -119,6 +124,14 @@ schema_snap!(actions_clear_in, tools::actions::ClearInput);
 schema_snap!(actions_focus_in, tools::actions::FocusInput);
 schema_snap!(actions_scroll_in, tools::actions::ScrollInput);
 schema_snap!(actions_upload_in, tools::actions::UploadInput);
+schema_snap!(actions_key_step, tools::actions::KeyStep);
+schema_snap!(actions_key_sequence_in, tools::actions::KeySequenceInput);
+
+// ---------- download -------------------------------------------------------
+
+schema_snap!(download_in, tools::download::DownloadInput);
+schema_snap!(download_out, tools::download::DownloadOutput);
+schema_snap!(download_set_path_in, tools::download::SetDownloadPathInput);
 
 // ---------- snapshot -------------------------------------------------------
 

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__actions_clear_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__actions_clear_in.snap
@@ -15,6 +15,10 @@ properties:
     type:
       - string
       - "null"
+  mode:
+    description: "Clearing strategy. Default `value`."
+    $ref: "#/$defs/ClearMode"
+    default: value
   nth:
     type:
       - integer
@@ -58,3 +62,13 @@ properties:
       - string
       - "null"
 additionalProperties: false
+$defs:
+  ClearMode:
+    description: "How `browser_clear` empties an element."
+    oneOf:
+      - description: "Reset `.value` to empty + fire `input` (fast). Default."
+        type: string
+        const: value
+      - description: "Focus + select-all + Backspace (emits real key events some inputs\nrequire). Slower but more faithful to user behavior."
+        type: string
+        const: backspace

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__actions_clear_mode.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__actions_clear_mode.snap
@@ -1,0 +1,14 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::actions::ClearMode)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: ClearMode
+description: "How `browser_clear` empties an element."
+oneOf:
+  - description: "Reset `.value` to empty + fire `input` (fast). Default."
+    type: string
+    const: value
+  - description: "Focus + select-all + Backspace (emits real key events some inputs\nrequire). Slower but more faithful to user behavior."
+    type: string
+    const: backspace

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__actions_key_sequence_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__actions_key_sequence_in.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/zendriver-mcp/tests/schema_snapshots.rs
-expression: "schema_for! (tools::actions::PressInput)"
+expression: "schema_for! (tools::actions::KeySequenceInput)"
 ---
 $schema: "https://json-schema.org/draft/2020-12/schema"
-title: PressInput
-description: "Input for `browser_press`."
+title: KeySequenceInput
+description: "Input for `browser_key_sequence`."
 type: object
 properties:
   css:
@@ -15,15 +15,6 @@ properties:
     type:
       - string
       - "null"
-  key:
-    description: "Named special key (e.g. \"Enter\", \"Tab\", \"ArrowUp\") OR a single\ncharacter (e.g. \"a\"). Special-key names are case-insensitive."
-    type: string
-  modifiers:
-    description: "Modifier keys to hold while pressing `key` (a chord, e.g.\n`[\"ctrl\"]` + `key: \"a\"` for select-all). Default none."
-    type: array
-    default: []
-    items:
-      $ref: "#/$defs/ModifierArg"
   nth:
     type:
       - integer
@@ -42,6 +33,11 @@ properties:
     type:
       - string
       - "null"
+  sequence:
+    description: "Ordered steps to dispatch: a mix of typed text and (chorded) key\npresses. Example: `[{ \"key\": \"a\", \"modifiers\": [\"ctrl\"] }, { \"text\":\n\"replacement\" }]` selects-all then types over it."
+    type: array
+    items:
+      $ref: "#/$defs/KeyStep"
   text:
     type:
       - string
@@ -68,8 +64,29 @@ properties:
       - "null"
 additionalProperties: false
 required:
-  - key
+  - sequence
 $defs:
+  KeyStep:
+    description: "One step in a [`KeySequenceInput`]: either literal text or a key press\n(optionally a modifier chord). Exactly one of `text` / `key` must be set."
+    type: object
+    properties:
+      key:
+        description: "Key to press — a special-key name or single character (see\n`browser_press`). Mutually exclusive with `text`."
+        type:
+          - string
+          - "null"
+      modifiers:
+        description: "Modifiers held while pressing `key` (ignored for `text`)."
+        type: array
+        default: []
+        items:
+          $ref: "#/$defs/ModifierArg"
+      text:
+        description: "Literal text to type (grapheme-by-grapheme). Mutually exclusive with\n`key`."
+        type:
+          - string
+          - "null"
+    additionalProperties: false
   ModifierArg:
     description: "MCP-layer keyboard-modifier flag, mapped onto [`zendriver::KeyModifiers`].\n\nShared by coordinate-mouse clicks (`browser_mouse`) and keyboard chords\n(`browser_press` / `browser_key_sequence`)."
     oneOf:

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__actions_key_step.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__actions_key_step.snap
@@ -1,0 +1,42 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::actions::KeyStep)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: KeyStep
+description: "One step in a [`KeySequenceInput`]: either literal text or a key press\n(optionally a modifier chord). Exactly one of `text` / `key` must be set."
+type: object
+properties:
+  key:
+    description: "Key to press — a special-key name or single character (see\n`browser_press`). Mutually exclusive with `text`."
+    type:
+      - string
+      - "null"
+  modifiers:
+    description: "Modifiers held while pressing `key` (ignored for `text`)."
+    type: array
+    default: []
+    items:
+      $ref: "#/$defs/ModifierArg"
+  text:
+    description: "Literal text to type (grapheme-by-grapheme). Mutually exclusive with\n`key`."
+    type:
+      - string
+      - "null"
+additionalProperties: false
+$defs:
+  ModifierArg:
+    description: "MCP-layer keyboard-modifier flag, mapped onto [`zendriver::KeyModifiers`].\n\nShared by coordinate-mouse clicks (`browser_mouse`) and keyboard chords\n(`browser_press` / `browser_key_sequence`)."
+    oneOf:
+      - description: "`Alt` (Option on macOS)."
+        type: string
+        const: alt
+      - description: "`Control`."
+        type: string
+        const: ctrl
+      - description: "`Meta` (Command on macOS, Windows key on Windows)."
+        type: string
+        const: meta
+      - description: "`Shift`."
+        type: string
+        const: shift

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__actions_set_value_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__actions_set_value_in.snap
@@ -15,6 +15,10 @@ properties:
     type:
       - string
       - "null"
+  mode:
+    description: "Whether `value` targets the `.value` property (form fields) or\n`textContent` (other elements). Default `value`."
+    $ref: "#/$defs/SetValueMode"
+    default: value
   nth:
     type:
       - integer
@@ -51,7 +55,7 @@ properties:
     default: 5000
     minimum: 0
   value:
-    description: "New value for the element's `.value` property."
+    description: New value / text for the element.
     type: string
   visible_only:
     type: boolean
@@ -63,3 +67,13 @@ properties:
 additionalProperties: false
 required:
   - value
+$defs:
+  SetValueMode:
+    description: "Which property `browser_set_value` writes."
+    oneOf:
+      - description: "Set the element's `.value` property + fire `input`/`change` (form\nfields). Default."
+        type: string
+        const: value
+      - description: "Set the element's `textContent` (non-form elements like `<div>`)."
+        type: string
+        const: text

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__actions_set_value_mode.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__actions_set_value_mode.snap
@@ -1,0 +1,14 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::actions::SetValueMode)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: SetValueMode
+description: "Which property `browser_set_value` writes."
+oneOf:
+  - description: "Set the element's `.value` property + fire `input`/`change` (form\nfields). Default."
+    type: string
+    const: value
+  - description: "Set the element's `textContent` (non-form elements like `<div>`)."
+    type: string
+    const: text

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__common_blob_output.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__common_blob_output.snap
@@ -1,0 +1,26 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::common::BlobOutput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: BlobOutput
+description: "Structured result for tools that produce a binary blob (PDF, MHTML,\ndownloaded file).\n\nWhen the caller passes a `save_path`, the bytes are written to disk on the\nMCP server host and only `{ saved_path, byte_len }` is returned. Otherwise\nthe bytes are base64-inlined in `base64` (subject to [`MAX_INLINE_BYTES`])."
+type: object
+properties:
+  base64:
+    description: "Base64-encoded bytes. Populated only when no `save_path` was given and\nthe blob is within the inline size limit."
+    type:
+      - string
+      - "null"
+  byte_len:
+    description: Size of the blob in bytes.
+    type: integer
+    format: uint
+    minimum: 0
+  saved_path:
+    description: "Absolute/!relative path the bytes were written to, when `save_path`\nwas supplied. Path is on the MCP server host, not the client machine."
+    type:
+      - string
+      - "null"
+required:
+  - byte_len

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__common_modifier_arg.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__common_modifier_arg.snap
@@ -1,0 +1,20 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::common::ModifierArg)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: ModifierArg
+description: "MCP-layer keyboard-modifier flag, mapped onto [`zendriver::KeyModifiers`].\n\nShared by coordinate-mouse clicks (`browser_mouse`) and keyboard chords\n(`browser_press` / `browser_key_sequence`)."
+oneOf:
+  - description: "`Alt` (Option on macOS)."
+    type: string
+    const: alt
+  - description: "`Control`."
+    type: string
+    const: ctrl
+  - description: "`Meta` (Command on macOS, Windows key on Windows)."
+    type: string
+    const: meta
+  - description: "`Shift`."
+    type: string
+    const: shift

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__download_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__download_in.snap
@@ -1,0 +1,20 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::download::DownloadInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: DownloadInput
+description: "Input for `browser_download`."
+type: object
+properties:
+  filename:
+    description: "Saved file name within the tab's download directory. When omitted, the\nname is derived from the URL's last path segment."
+    type:
+      - string
+      - "null"
+  url:
+    description: "URL to fetch + save. Fetched from the page's own network context."
+    type: string
+additionalProperties: false
+required:
+  - url

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__download_out.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__download_out.snap
@@ -1,0 +1,23 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::download::DownloadOutput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: DownloadOutput
+description: "Output of `browser_download`."
+type: object
+properties:
+  filename:
+    description: "Echoed target filename, when one was supplied."
+    type:
+      - string
+      - "null"
+  ok:
+    description: "Always `true` — the fetch was dispatched. The download itself runs\nasynchronously in Chrome."
+    type: boolean
+  url:
+    description: Echoed source URL.
+    type: string
+required:
+  - ok
+  - url

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__download_set_path_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__download_set_path_in.snap
@@ -1,0 +1,15 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::download::SetDownloadPathInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: SetDownloadPathInput
+description: "Input for `browser_set_download_path`."
+type: object
+properties:
+  path:
+    description: "Directory (on the MCP host) Chrome should save downloads into. Created\nif it does not exist."
+    type: string
+additionalProperties: false
+required:
+  - path

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__expect_snaps__expect_dialog_action.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__expect_snaps__expect_dialog_action.snap
@@ -1,0 +1,14 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::expect::DialogAction)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: DialogAction
+description: "How to drive a matched JavaScript dialog (`kind: dialog` only).\n\nApplied by the spawned task the instant the dialog opens — so the page's\nblocking `alert()` / `confirm()` / `prompt()` call returns promptly and\nthe matched event carries the chosen action. Omitting `dialog_action`\nfalls back to Chrome's default handling (the dialog is accepted when the\nmatched handle is dropped at task end)."
+oneOf:
+  - description: "Accept the dialog. For a `prompt`, submit `dialog_prompt_text` (or the\ndialog's default value when that is unset)."
+    type: string
+    const: accept
+  - description: Dismiss / cancel the dialog.
+    type: string
+    const: dismiss

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__expect_snaps__expect_register_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__expect_snaps__expect_register_in.snap
@@ -7,6 +7,20 @@ title: RegisterInput
 description: "Input for `browser_expect_register`."
 type: object
 properties:
+  dialog_action:
+    description: "Dialog only: drive the matched dialog (`accept` / `dismiss`) instead\nof leaving Chrome's default handling. Decided here, at register time,\nbecause the matched dialog handle is consumed by the spawned task."
+    anyOf:
+      - $ref: "#/$defs/DialogAction"
+      - type: "null"
+  dialog_prompt_text:
+    description: "Dialog only: prompt answer for `dialog_action: accept` on a `prompt`."
+    type:
+      - string
+      - "null"
+  fetch_body:
+    description: "Response only: fetch the response body and include it (base64) in the\nmatched event as `body_base64` + `body_len`. One extra CDP round-trip."
+    type: boolean
+    default: false
   kind:
     description: Which event family to watch.
     $ref: "#/$defs/ExpectKind"
@@ -21,10 +35,24 @@ properties:
     format: uint64
     default: 60000
     minimum: 0
+  save_to:
+    description: "Download only: copy the completed download to this path on the MCP\nhost; the matched event reports it as `saved_path`."
+    type:
+      - string
+      - "null"
 additionalProperties: false
 required:
   - kind
 $defs:
+  DialogAction:
+    description: "How to drive a matched JavaScript dialog (`kind: dialog` only).\n\nApplied by the spawned task the instant the dialog opens — so the page's\nblocking `alert()` / `confirm()` / `prompt()` call returns promptly and\nthe matched event carries the chosen action. Omitting `dialog_action`\nfalls back to Chrome's default handling (the dialog is accepted when the\nmatched handle is dropped at task end)."
+    oneOf:
+      - description: "Accept the dialog. For a `prompt`, submit `dialog_prompt_text` (or the\ndialog's default value when that is unset)."
+        type: string
+        const: accept
+      - description: Dismiss / cancel the dialog.
+        type: string
+        const: dismiss
   ExpectKind:
     description: "Which `Page.*` / `Network.*` family the expectation listens on."
     oneOf:

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__frames_frame_goto_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__frames_frame_goto_in.snap
@@ -1,0 +1,19 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::frames::FrameGotoInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: FrameGotoInput
+description: "Input for `browser_frame_goto`."
+type: object
+properties:
+  frame_id:
+    description: "Target frame id (from `browser_frame_list`)."
+    type: string
+  url:
+    description: URL to navigate the frame to.
+    type: string
+additionalProperties: false
+required:
+  - frame_id
+  - url

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__imperva_snaps__imperva_outcome.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__imperva_snaps__imperva_outcome.snap
@@ -1,0 +1,20 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::imperva::Outcome)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: Outcome
+description: "Terminal outcome of an Imperva bypass attempt.\n\n`TokenAcquired` / `ChallengeGone` / `AlreadyClear` mirror the lib's\n[`ImpervaClearanceOutcome`] variants. `Timeout` is the MCP layer's\ncollapse of [`ImpervaError::Timeout`] into the success channel — agents\nbranch on `outcome` without try/catch around a timeout."
+oneOf:
+  - description: "reese84 token acquired (value in [`SolveImpervaOutput::reese84`])."
+    type: string
+    const: token_acquired
+  - description: "Body markers cleared without a reese84 token (e.g. legacy Incapsula\nflow). `reese84` will be `None`."
+    type: string
+    const: challenge_gone
+  - description: "No Imperva surface was present at call time (fast path, no waiting).\n`reese84` will be `None`."
+    type: string
+    const: already_clear
+  - description: "`timeout_ms` elapsed without reaching clearance. Not a hard error —\nagents can retry or give up. `reese84` will be `None`."
+    type: string
+    const: timeout

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__imperva_snaps__imperva_solve_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__imperva_snaps__imperva_solve_in.snap
@@ -1,0 +1,27 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::imperva::SolveImpervaInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: SolveImpervaInput
+description: "Input for `browser_solve_imperva`."
+type: object
+properties:
+  poll_interval_ms:
+    description: "Override the bypass driver's internal poll cadence, in milliseconds.\nDefaults to the lib's own default. Lowering speeds up detection at the\ncost of more CDP `Runtime.evaluate` round-trips; raising is a safe\nknob for slow / sandboxed environments."
+    type:
+      - integer
+      - "null"
+    format: uint64
+    minimum: 0
+  timeout_ms:
+    description: "Maximum total wait for a terminal outcome, in milliseconds. Default\n30_000 (30s). Maps to [`ImpervaBypass::timeout`].\n\n[`ImpervaBypass::timeout`]: zendriver_imperva::ImpervaBypass::timeout"
+    type: integer
+    format: uint64
+    default: 30000
+    minimum: 0
+  with_interception:
+    description: "Enable the Fetch-domain interception fast-path\n([`ImpervaBypass::with_interception`]) for quicker reese84 capture on\nmodern surfaces. Default `false`.\n\n[`ImpervaBypass::with_interception`]: zendriver_imperva::ImpervaBypass::with_interception"
+    type: boolean
+    default: false
+additionalProperties: false

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__imperva_snaps__imperva_solve_out.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__imperva_snaps__imperva_solve_out.snap
@@ -1,0 +1,35 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::imperva::SolveImpervaOutput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: SolveImpervaOutput
+description: "Output of `browser_solve_imperva`."
+type: object
+properties:
+  outcome:
+    description: Which terminal state the bypass reached.
+    $ref: "#/$defs/Outcome"
+  reese84:
+    description: "reese84 cookie value. Populated only when `outcome == token_acquired`;\n`None` for every other outcome."
+    type:
+      - string
+      - "null"
+required:
+  - outcome
+$defs:
+  Outcome:
+    description: "Terminal outcome of an Imperva bypass attempt.\n\n`TokenAcquired` / `ChallengeGone` / `AlreadyClear` mirror the lib's\n[`ImpervaClearanceOutcome`] variants. `Timeout` is the MCP layer's\ncollapse of [`ImpervaError::Timeout`] into the success channel — agents\nbranch on `outcome` without try/catch around a timeout."
+    oneOf:
+      - description: "reese84 token acquired (value in [`SolveImpervaOutput::reese84`])."
+        type: string
+        const: token_acquired
+      - description: "Body markers cleared without a reese84 token (e.g. legacy Incapsula\nflow). `reese84` will be `None`."
+        type: string
+        const: challenge_gone
+      - description: "No Imperva surface was present at call time (fast path, no waiting).\n`reese84` will be `None`."
+        type: string
+        const: already_clear
+      - description: "`timeout_ms` elapsed without reaching clearance. Not a hard error —\nagents can retry or give up. `reese84` will be `None`."
+        type: string
+        const: timeout

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__intercept_snaps__intercept_action.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__intercept_snaps__intercept_action.snap
@@ -75,3 +75,27 @@ oneOf:
     additionalProperties: false
     required:
       - kind
+  - description: "Continue the *response* with an overridden status and/or headers\n(pauses at the response stage). Other fields are left at Chrome's\noriginals. The body is not rewritten — use `respond` to synthesize a\nwhole response instead."
+    type: object
+    properties:
+      headers:
+        description: "Headers to merge over the response's originals (full-replacement\nsemantics, same as `modify_request`; case-insensitive names)."
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+      kind:
+        type: string
+        const: modify_response
+      status:
+        description: "Override the HTTP status code. Omit to keep Chrome's original."
+        type:
+          - integer
+          - "null"
+        format: uint16
+        default: ~
+        maximum: 65535
+        minimum: 0
+    additionalProperties: false
+    required:
+      - kind

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__intercept_snaps__intercept_add_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__intercept_snaps__intercept_add_in.snap
@@ -90,3 +90,27 @@ $defs:
         additionalProperties: false
         required:
           - kind
+      - description: "Continue the *response* with an overridden status and/or headers\n(pauses at the response stage). Other fields are left at Chrome's\noriginals. The body is not rewritten — use `respond` to synthesize a\nwhole response instead."
+        type: object
+        properties:
+          headers:
+            description: "Headers to merge over the response's originals (full-replacement\nsemantics, same as `modify_request`; case-insensitive names)."
+            type: object
+            additionalProperties:
+              type: string
+            default: {}
+          kind:
+            type: string
+            const: modify_response
+          status:
+            description: "Override the HTTP status code. Omit to keep Chrome's original."
+            type:
+              - integer
+              - "null"
+            format: uint16
+            default: ~
+            maximum: 65535
+            minimum: 0
+        additionalProperties: false
+        required:
+          - kind

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__lifecycle_status_out.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__lifecycle_status_out.snap
@@ -12,6 +12,11 @@ properties:
     anyOf:
       - $ref: "#/$defs/TabSummary"
       - type: "null"
+  inspector_url:
+    description: "Chrome DevTools inspector URL for the focused tab, when one is open."
+    type:
+      - string
+      - "null"
   open:
     description: "`true` iff a Browser is currently launched in this session."
     type: boolean

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__mouse_action.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__mouse_action.snap
@@ -1,0 +1,17 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::mouse::MouseAction)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: MouseAction
+description: "Which pointer operation `browser_mouse` performs."
+oneOf:
+  - description: "Move the cursor to `(x, y)` along a realistic Bezier path."
+    type: string
+    const: move
+  - description: "Click at `(x, y)`."
+    type: string
+    const: click
+  - description: "Press at `(x, y)`, drag to `(to_x, to_y)` over `steps`, release."
+    type: string
+    const: drag

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__mouse_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__mouse_in.snap
@@ -1,0 +1,105 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::mouse::MouseInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: MouseInput
+description: "Input for `browser_mouse`."
+type: object
+properties:
+  action:
+    description: Which pointer operation to perform.
+    $ref: "#/$defs/MouseAction"
+  button:
+    description: "Which button to dispatch (`click` only). Default `left`."
+    anyOf:
+      - $ref: "#/$defs/MouseButtonArg"
+      - type: "null"
+  click_count:
+    description: "`clickCount` for `click` (set `2` for a double-click). Default `1`."
+    type:
+      - integer
+      - "null"
+    format: uint32
+    minimum: 0
+  modifiers:
+    description: "Modifier keys held during a `click`. Default none."
+    type: array
+    default: []
+    items:
+      $ref: "#/$defs/ModifierArg"
+  return_snapshot:
+    description: "When `true`, include the trimmed page HTML in the response."
+    type: boolean
+    default: false
+  steps:
+    description: "Interpolation steps for `drag`. Default `20`."
+    type: integer
+    format: uint
+    default: 20
+    minimum: 0
+  to_x:
+    description: "Drag destination X (required for `drag`)."
+    type:
+      - number
+      - "null"
+    format: double
+  to_y:
+    description: "Drag destination Y (required for `drag`)."
+    type:
+      - number
+      - "null"
+    format: double
+  x:
+    description: "Target X in CSS pixels (viewport-relative). For `drag`, the start X."
+    type: number
+    format: double
+  y:
+    description: "Target Y in CSS pixels (viewport-relative). For `drag`, the start Y."
+    type: number
+    format: double
+additionalProperties: false
+required:
+  - action
+  - x
+  - y
+$defs:
+  ModifierArg:
+    description: "MCP-layer keyboard-modifier flag, mapped onto [`zendriver::KeyModifiers`].\n\nShared by coordinate-mouse clicks (`browser_mouse`) and keyboard chords\n(`browser_press` / `browser_key_sequence`)."
+    oneOf:
+      - description: "`Alt` (Option on macOS)."
+        type: string
+        const: alt
+      - description: "`Control`."
+        type: string
+        const: ctrl
+      - description: "`Meta` (Command on macOS, Windows key on Windows)."
+        type: string
+        const: meta
+      - description: "`Shift`."
+        type: string
+        const: shift
+  MouseAction:
+    description: "Which pointer operation `browser_mouse` performs."
+    oneOf:
+      - description: "Move the cursor to `(x, y)` along a realistic Bezier path."
+        type: string
+        const: move
+      - description: "Click at `(x, y)`."
+        type: string
+        const: click
+      - description: "Press at `(x, y)`, drag to `(to_x, to_y)` over `steps`, release."
+        type: string
+        const: drag
+  MouseButtonArg:
+    description: "MCP-layer mouse button enum, mapped to [`zendriver::MouseButton`].\n\nOnly the three commonly-dispatched buttons; thumb buttons (Back /\nForward) are deliberately omitted to keep the schema small."
+    oneOf:
+      - description: Primary button (default).
+        type: string
+        const: left
+      - description: Middle button (scroll wheel click).
+        type: string
+        const: middle
+      - description: Secondary button.
+        type: string
+        const: right

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__navigation_ready_state_arg.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__navigation_ready_state_arg.snap
@@ -1,0 +1,14 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::navigation::ReadyStateArg)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: ReadyStateArg
+description: "Document-ready milestone `browser_wait_for_load` can target."
+oneOf:
+  - description: "`document.readyState === \"interactive\"` — DOM parsed, sub-resources\nmay still be loading."
+    type: string
+    const: interactive
+  - description: "`document.readyState === \"complete\"` — the `load` event has fired."
+    type: string
+    const: complete

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__navigation_reload_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__navigation_reload_in.snap
@@ -1,0 +1,18 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::navigation::ReloadInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: ReloadInput
+description: "Arg block for `browser_reload`."
+type: object
+properties:
+  ignore_cache:
+    description: "Bypass the HTTP cache (hard reload) when `true`. Default `false`\n(normal soft reload)."
+    type: boolean
+    default: false
+  return_snapshot:
+    description: "When `true`, include the trimmed page HTML in the response."
+    type: boolean
+    default: false
+additionalProperties: false

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__navigation_wait_for_load_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__navigation_wait_for_load_in.snap
@@ -1,0 +1,30 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::navigation::WaitForLoadInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: WaitForLoadInput
+description: "Input for `browser_wait_for_load`."
+type: object
+properties:
+  frame_id:
+    description: "When set, wait for the given frame's load instead of the tab's main\nframe. `ready_state` is ignored in this case (frames expose only a\nload wait)."
+    type:
+      - string
+      - "null"
+  ready_state:
+    description: "Wait until the document reaches this `readyState`. When unset (and no\n`frame_id`), waits for the tab's `load` event."
+    anyOf:
+      - $ref: "#/$defs/ReadyStateArg"
+      - type: "null"
+additionalProperties: false
+$defs:
+  ReadyStateArg:
+    description: "Document-ready milestone `browser_wait_for_load` can target."
+    oneOf:
+      - description: "`document.readyState === \"interactive\"` — DOM parsed, sub-resources\nmay still be loading."
+        type: string
+        const: interactive
+      - description: "`document.readyState === \"complete\"` — the `load` event has fired."
+        type: string
+        const: complete

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__pdf_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__pdf_in.snap
@@ -1,0 +1,77 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::pdf::PdfInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: PdfInput
+description: "Input for `browser_pdf`. Every field is optional; an unset field leaves the\ncorresponding [`zendriver::PdfBuilder`] default in place."
+type: object
+properties:
+  landscape:
+    description: Landscape orientation (default portrait).
+    type:
+      - boolean
+      - "null"
+  margin_bottom:
+    description: Bottom margin in inches.
+    type:
+      - number
+      - "null"
+    format: double
+  margin_left:
+    description: Left margin in inches.
+    type:
+      - number
+      - "null"
+    format: double
+  margin_right:
+    description: Right margin in inches.
+    type:
+      - number
+      - "null"
+    format: double
+  margin_top:
+    description: Top margin in inches.
+    type:
+      - number
+      - "null"
+    format: double
+  page_ranges:
+    description: "Page ranges to print, e.g. `\"1-3, 5\"`. Empty → all pages."
+    type:
+      - string
+      - "null"
+  paper_height:
+    description: Paper height in inches.
+    type:
+      - number
+      - "null"
+    format: double
+  paper_width:
+    description: Paper width in inches.
+    type:
+      - number
+      - "null"
+    format: double
+  prefer_css_page_size:
+    description: "Prefer any CSS `@page` size over `paper_width`/`paper_height`."
+    type:
+      - boolean
+      - "null"
+  print_background:
+    description: Render background graphics/colors.
+    type:
+      - boolean
+      - "null"
+  save_path:
+    description: Write the PDF to this path on the MCP host instead of inlining base64.
+    type:
+      - string
+      - "null"
+  scale:
+    description: "Render scale (`1.0` = 100%)."
+    type:
+      - number
+      - "null"
+    format: double
+additionalProperties: false

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__pdf_save_mhtml_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__pdf_save_mhtml_in.snap
@@ -1,0 +1,15 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::pdf::SaveMhtmlInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: SaveMhtmlInput
+description: "Input for `browser_save_mhtml`."
+type: object
+properties:
+  save_path:
+    description: Write the MHTML to this path on the MCP host instead of inlining base64.
+    type:
+      - string
+      - "null"
+additionalProperties: false

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__reads_get_links_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__reads_get_links_in.snap
@@ -1,0 +1,18 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::reads::GetLinksInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: GetLinksInput
+description: "Input for `browser_get_links`."
+type: object
+properties:
+  absolute:
+    description: "Resolve relative `href`s to absolute URLs. Default `false`."
+    type: boolean
+    default: false
+  include_sources:
+    description: "Also collect `src`/`href` of linked-resource elements (img, script,\nlink, …) into `sources`. Default `false`."
+    type: boolean
+    default: false
+additionalProperties: false

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__reads_get_links_out.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__reads_get_links_out.snap
@@ -1,0 +1,23 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::reads::GetLinksOutput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: GetLinksOutput
+description: "Output of `browser_get_links`."
+type: object
+properties:
+  sources:
+    description: "Linked-resource source URLs, when `include_sources` was set."
+    type:
+      - array
+      - "null"
+    items:
+      type: string
+  urls:
+    description: "Anchor (`<a href>`) URLs on the page."
+    type: array
+    items:
+      type: string
+required:
+  - urls

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__reads_resource_match.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__reads_resource_match.snap
@@ -1,0 +1,18 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::reads::ResourceMatch)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: ResourceMatch
+description: "One matched resource from `browser_search_resources`."
+type: object
+properties:
+  frame_id:
+    description: "CDP `frameId` of the frame that owns the resource."
+    type: string
+  url:
+    description: Request URL of the matched resource.
+    type: string
+required:
+  - url
+  - frame_id

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__reads_search_resources_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__reads_search_resources_in.snap
@@ -1,0 +1,15 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::reads::SearchResourcesInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: SearchResourcesInput
+description: "Input for `browser_search_resources`."
+type: object
+properties:
+  query:
+    description: "Substring to search for across every frame's loaded resource URLs."
+    type: string
+additionalProperties: false
+required:
+  - query

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__reads_search_resources_out.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__reads_search_resources_out.snap
@@ -1,0 +1,30 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::reads::SearchResourcesOutput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: SearchResourcesOutput
+description: "Output of `browser_search_resources`."
+type: object
+properties:
+  matches:
+    description: "All resources whose URL contains `query`."
+    type: array
+    items:
+      $ref: "#/$defs/ResourceMatch"
+required:
+  - matches
+$defs:
+  ResourceMatch:
+    description: "One matched resource from `browser_search_resources`."
+    type: object
+    properties:
+      frame_id:
+        description: "CDP `frameId` of the frame that owns the resource."
+        type: string
+      url:
+        description: Request URL of the matched resource.
+        type: string
+    required:
+      - url
+      - frame_id

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__reads_state_out.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__reads_state_out.snap
@@ -19,6 +19,11 @@ properties:
     anyOf:
       - $ref: "#/$defs/BoundingBox"
       - type: "null"
+  bounding_box_page:
+    description: "Page-absolute bounding box (`x`/`y` include scroll offset). Populated\nby `All` and `Geometry`."
+    anyOf:
+      - $ref: "#/$defs/BoundingBox"
+      - type: "null"
   enabled:
     description: "`true` when the element is not disabled. Populated by `All` and\n`VisibleEnabled`."
     type:
@@ -34,6 +39,11 @@ properties:
       - "null"
   inner_html:
     description: "Serialized `innerHTML`. Populated by `All` and `TextAttrs`."
+    type:
+      - string
+      - "null"
+  outer_html:
+    description: "Serialized `outerHTML` (element + its own tag). Populated by `All`\nand `TextAttrs`."
     type:
       - string
       - "null"

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__scroll_page_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__scroll_page_in.snap
@@ -1,0 +1,30 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::scroll::PageScrollInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: PageScrollInput
+description: "Input for `browser_scroll`."
+type: object
+properties:
+  dx:
+    description: "Horizontal scroll distance in CSS pixels. Positive scrolls the view\nright; negative scrolls left. Default `0`."
+    type: number
+    format: double
+    default: 0
+  dy:
+    description: "Vertical scroll distance in CSS pixels. Positive scrolls the view\n**down** the page; negative scrolls up. Default `0`."
+    type: number
+    format: double
+    default: 0
+  return_snapshot:
+    description: "When `true`, include the trimmed page HTML in the response."
+    type: boolean
+    default: false
+  speed:
+    description: "Optional gesture speed in pixels/second. Omitted → Chrome's default."
+    type:
+      - integer
+      - "null"
+    format: int64
+additionalProperties: false

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__scroll_page_out.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__scroll_page_out.snap
@@ -1,0 +1,25 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::scroll::PageScrollOutput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: PageScrollOutput
+description: "Output of `browser_scroll`: the page scroll offset after the gesture."
+type: object
+properties:
+  scroll_x:
+    description: "`window.scrollX` after the gesture."
+    type: number
+    format: double
+  scroll_y:
+    description: "`window.scrollY` after the gesture."
+    type: number
+    format: double
+  snapshot:
+    description: "Trimmed rendered HTML, populated only when `return_snapshot: true`."
+    type:
+      - string
+      - "null"
+required:
+  - scroll_x
+  - scroll_y

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__snapshot_html_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__snapshot_html_in.snap
@@ -12,8 +12,12 @@ properties:
     type:
       - string
       - "null"
+  outer:
+    description: "With `selector`, return `outerHTML` (the element's own tag included)\ninstead of `innerHTML`. Ignored without a selector. Default `false`."
+    type: boolean
+    default: false
   selector:
-    description: "When set, returns `el.innerHTML` for the matched element.\nMutually exclusive with the tool-level `frame_id` — use the\nselector's own `frame_id` to scope the lookup to a sub-frame."
+    description: "When set, returns `el.innerHTML` (or `el.outerHTML` if `outer`) for the\nmatched element. Mutually exclusive with the tool-level `frame_id` —\nuse the selector's own `frame_id` to scope the lookup to a sub-frame."
     anyOf:
       - $ref: "#/$defs/Selector"
       - type: "null"

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__stealth_set_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__stealth_set_in.snap
@@ -7,6 +7,10 @@ title: SetStealthProfileInput
 description: "Input for `browser_set_stealth_profile`."
 type: object
 properties:
+  overrides:
+    description: "Fine-grained fingerprint overrides layered onto `profile` at the next\n`browser_open`. Replaces any previously-set overrides; omit (or pass\n`{}`) to clear them."
+    $ref: "#/$defs/StealthOverrides"
+    default: {}
   profile:
     description: New default stealth profile for this session.
     $ref: "#/$defs/StealthProfileChoice"
@@ -14,6 +18,69 @@ additionalProperties: false
 required:
   - profile
 $defs:
+  StealthOverrides:
+    description: "Fine-grained stealth fingerprint overrides layered onto the chosen\n[`StealthProfileChoice`] at the next `browser_open`.\n\nEvery field is optional — an unset field leaves the base profile's value\nin place. Most meaningful paired with a `spoof_*` profile; applying these\nto `native` overrides the auto-detected real fingerprint and can *reduce*\nstealth if the values disagree with the host."
+    type: object
+    properties:
+      bypass_csp:
+        description: Toggle Content-Security-Policy bypass.
+        type:
+          - boolean
+          - "null"
+      chrome_version:
+        description: Spoofed Chrome major version.
+        type:
+          - integer
+          - "null"
+        format: uint32
+        minimum: 0
+      cpu_count:
+        description: "Spoofed `navigator.hardwareConcurrency`."
+        type:
+          - integer
+          - "null"
+        format: uint32
+        minimum: 0
+      locale:
+        description: "Spoofed locale (e.g. `\"en-US\"`)."
+        type:
+          - string
+          - "null"
+      memory_gb:
+        description: "Spoofed `navigator.deviceMemory` in GiB."
+        type:
+          - integer
+          - "null"
+        format: uint32
+        minimum: 0
+      platform:
+        description: "Spoofed `navigator.platform` / UA platform token."
+        anyOf:
+          - $ref: "#/$defs/StealthPlatformChoice"
+          - type: "null"
+      timezone:
+        description: "Spoofed timezone (IANA name, e.g. `\"America/New_York\"`)."
+        type:
+          - string
+          - "null"
+      user_agent:
+        description: Full User-Agent string override.
+        type:
+          - string
+          - "null"
+    additionalProperties: false
+  StealthPlatformChoice:
+    description: "Platform to spoof via a fine-grained stealth override.\n\nWire mirror of `zendriver::stealth::Platform`; kept here (platform-agnostic)\nso the override schema stays stable independent of host detection."
+    oneOf:
+      - description: Windows.
+        type: string
+        const: win32
+      - description: macOS (Intel).
+        type: string
+        const: mac_intel
+      - description: Linux x86_64.
+        type: string
+        const: linux_x86_64
   StealthProfileChoice:
     description: "Stealth profile choice carried over the MCP wire.\n\nConcrete `StealthProfile` resolution happens inside the lifecycle\nhandler (it depends on platform detection that only matters at launch\ntime); the wire-level enum stays stable and platform-agnostic."
     oneOf:

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__stealth_set_out.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__stealth_set_out.snap
@@ -7,6 +7,9 @@ title: SetStealthProfileOutput
 description: "Output of `browser_set_stealth_profile`."
 type: object
 properties:
+  active_overrides:
+    description: The fine-grained overrides now configured for the next open.
+    $ref: "#/$defs/StealthOverrides"
   active_profile:
     description: The profile that is now configured as the session default.
     $ref: "#/$defs/StealthProfileChoice"
@@ -15,8 +18,72 @@ properties:
     type: boolean
 required:
   - active_profile
+  - active_overrides
   - takes_effect_on_next_open
 $defs:
+  StealthOverrides:
+    description: "Fine-grained stealth fingerprint overrides layered onto the chosen\n[`StealthProfileChoice`] at the next `browser_open`.\n\nEvery field is optional — an unset field leaves the base profile's value\nin place. Most meaningful paired with a `spoof_*` profile; applying these\nto `native` overrides the auto-detected real fingerprint and can *reduce*\nstealth if the values disagree with the host."
+    type: object
+    properties:
+      bypass_csp:
+        description: Toggle Content-Security-Policy bypass.
+        type:
+          - boolean
+          - "null"
+      chrome_version:
+        description: Spoofed Chrome major version.
+        type:
+          - integer
+          - "null"
+        format: uint32
+        minimum: 0
+      cpu_count:
+        description: "Spoofed `navigator.hardwareConcurrency`."
+        type:
+          - integer
+          - "null"
+        format: uint32
+        minimum: 0
+      locale:
+        description: "Spoofed locale (e.g. `\"en-US\"`)."
+        type:
+          - string
+          - "null"
+      memory_gb:
+        description: "Spoofed `navigator.deviceMemory` in GiB."
+        type:
+          - integer
+          - "null"
+        format: uint32
+        minimum: 0
+      platform:
+        description: "Spoofed `navigator.platform` / UA platform token."
+        anyOf:
+          - $ref: "#/$defs/StealthPlatformChoice"
+          - type: "null"
+      timezone:
+        description: "Spoofed timezone (IANA name, e.g. `\"America/New_York\"`)."
+        type:
+          - string
+          - "null"
+      user_agent:
+        description: Full User-Agent string override.
+        type:
+          - string
+          - "null"
+    additionalProperties: false
+  StealthPlatformChoice:
+    description: "Platform to spoof via a fine-grained stealth override.\n\nWire mirror of `zendriver::stealth::Platform`; kept here (platform-agnostic)\nso the override schema stays stable independent of host detection."
+    oneOf:
+      - description: Windows.
+        type: string
+        const: win32
+      - description: macOS (Intel).
+        type: string
+        const: mac_intel
+      - description: Linux x86_64.
+        type: string
+        const: linux_x86_64
   StealthProfileChoice:
     description: "Stealth profile choice carried over the MCP wire.\n\nConcrete `StealthProfile` resolution happens inside the lifecycle\nhandler (it depends on platform detection that only matters at launch\ntime); the wire-level enum stays stable and platform-agnostic."
     oneOf:

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__stealth_set_user_agent_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__stealth_set_user_agent_in.snap
@@ -1,0 +1,25 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::stealth::SetUserAgentInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: SetUserAgentInput
+description: "Input for `browser_set_user_agent`."
+type: object
+properties:
+  accept_language:
+    description: "Optional `Accept-Language` override applied alongside the UA."
+    type:
+      - string
+      - "null"
+  platform:
+    description: "Optional `navigator.platform` override."
+    type:
+      - string
+      - "null"
+  user_agent:
+    description: "Full User-Agent string to send via `Emulation.setUserAgentOverride`."
+    type: string
+additionalProperties: false
+required:
+  - user_agent

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__window_bounds_dto.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__window_bounds_dto.snap
@@ -1,0 +1,54 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::window::WindowBoundsDto)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: WindowBoundsDto
+description: Window geometry + state DTO (output of both window tools).
+type: object
+properties:
+  height:
+    description: "Window height, in DIP. `None` when not reported."
+    type:
+      - integer
+      - "null"
+    format: int64
+  left:
+    description: "Window left edge (screen X), in DIP. `None` when not reported."
+    type:
+      - integer
+      - "null"
+    format: int64
+  state:
+    description: Current window state.
+    anyOf:
+      - $ref: "#/$defs/WindowStateDto"
+      - type: "null"
+  top:
+    description: "Window top edge (screen Y), in DIP. `None` when not reported."
+    type:
+      - integer
+      - "null"
+    format: int64
+  width:
+    description: "Window width, in DIP. `None` when not reported."
+    type:
+      - integer
+      - "null"
+    format: int64
+$defs:
+  WindowStateDto:
+    description: "Wire mirror of [`zendriver::WindowState`]."
+    oneOf:
+      - description: Normal (windowed) — the only state that may carry explicit geometry.
+        type: string
+        const: normal
+      - description: Minimized to the OS taskbar / dock.
+        type: string
+        const: minimized
+      - description: Maximized to fill the screen work area.
+        type: string
+        const: maximized
+      - description: Fullscreen (chrome / OS decorations hidden).
+        type: string
+        const: fullscreen

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__window_set_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__window_set_in.snap
@@ -1,0 +1,78 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::window::SetWindowInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: SetWindowInput
+description: "Input for `browser_set_window`."
+type: object
+properties:
+  height:
+    description: "Window height in DIP (used by `size` and optionally `bounds`)."
+    type:
+      - integer
+      - "null"
+    format: int64
+  left:
+    description: "Window left edge in DIP (used by `bounds`)."
+    type:
+      - integer
+      - "null"
+    format: int64
+  mode:
+    description: Which operation to perform.
+    $ref: "#/$defs/SetWindowMode"
+  state:
+    description: "Window state to set (used by `bounds`)."
+    anyOf:
+      - $ref: "#/$defs/WindowStateDto"
+      - type: "null"
+  top:
+    description: "Window top edge in DIP (used by `bounds`)."
+    type:
+      - integer
+      - "null"
+    format: int64
+  width:
+    description: "Window width in DIP (used by `size` and optionally `bounds`)."
+    type:
+      - integer
+      - "null"
+    format: int64
+additionalProperties: false
+required:
+  - mode
+$defs:
+  SetWindowMode:
+    description: "Which window operation `browser_set_window` performs."
+    oneOf:
+      - description: "Set explicit bounds (`left`/`top`/`width`/`height`/`state`, any subset)."
+        type: string
+        const: bounds
+      - description: "Resize to `width` × `height` (both required)."
+        type: string
+        const: size
+      - description: Maximize the window.
+        type: string
+        const: maximize
+      - description: Minimize the window.
+        type: string
+        const: minimize
+      - description: Enter fullscreen.
+        type: string
+        const: fullscreen
+  WindowStateDto:
+    description: "Wire mirror of [`zendriver::WindowState`]."
+    oneOf:
+      - description: Normal (windowed) — the only state that may carry explicit geometry.
+        type: string
+        const: normal
+      - description: Minimized to the OS taskbar / dock.
+        type: string
+        const: minimized
+      - description: Maximized to fill the screen work area.
+        type: string
+        const: maximized
+      - description: Fullscreen (chrome / OS decorations hidden).
+        type: string
+        const: fullscreen

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__window_set_mode.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__window_set_mode.snap
@@ -1,0 +1,23 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::window::SetWindowMode)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: SetWindowMode
+description: "Which window operation `browser_set_window` performs."
+oneOf:
+  - description: "Set explicit bounds (`left`/`top`/`width`/`height`/`state`, any subset)."
+    type: string
+    const: bounds
+  - description: "Resize to `width` × `height` (both required)."
+    type: string
+    const: size
+  - description: Maximize the window.
+    type: string
+    const: maximize
+  - description: Minimize the window.
+    type: string
+    const: minimize
+  - description: Enter fullscreen.
+    type: string
+    const: fullscreen

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__window_state_dto.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__window_state_dto.snap
@@ -1,0 +1,20 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::window::WindowStateDto)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: WindowStateDto
+description: "Wire mirror of [`zendriver::WindowState`]."
+oneOf:
+  - description: Normal (windowed) — the only state that may carry explicit geometry.
+    type: string
+    const: normal
+  - description: Minimized to the OS taskbar / dock.
+    type: string
+    const: minimized
+  - description: Maximized to fill the screen work area.
+    type: string
+    const: maximized
+  - description: Fullscreen (chrome / OS decorations hidden).
+    type: string
+    const: fullscreen

--- a/crates/zendriver/src/lib.rs
+++ b/crates/zendriver/src/lib.rs
@@ -118,7 +118,7 @@ pub use zendriver_transport::{CallError, Connection, SessionHandle, TransportErr
 #[cfg(feature = "interception")]
 pub use zendriver_interception::{
     AbortReason, InterceptBuilder, InterceptHandle, InterceptionError, PausedRequest, RequestInfo,
-    RequestOverrides, RequestStage, ResourceType, ResponseInfo,
+    RequestOverrides, RequestStage, ResourceType, ResponseInfo, ResponseOverrides,
 };
 
 /// Cloudflare Turnstile bypass re-exports.

--- a/docs/book/src/mcp.md
+++ b/docs/book/src/mcp.md
@@ -1,7 +1,7 @@
 # MCP server (`zendriver-mcp`)
 
 `zendriver-mcp` is a [Model Context Protocol](https://modelcontextprotocol.io/)
-server that exposes zendriver-rs through 49 MCP tools, so any
+server that exposes zendriver-rs through 65 MCP tools, so any
 MCP-compatible client (Claude Desktop, Claude Code, custom agents) can
 drive a real, stealth-by-default Chrome browser.
 
@@ -12,7 +12,7 @@ cargo install zendriver-mcp
 ```
 
 The default build enables all gated features (`interception`, `expect`,
-`cloudflare`, `fetcher`). For a lean build:
+`cloudflare`, `imperva`, `fetcher`). For a lean build:
 
 ```bash
 cargo install zendriver-mcp --no-default-features
@@ -59,31 +59,39 @@ OPTIONS:
 
 ## Tool surface
 
-49 tools across these categories:
+65 tools across these categories:
 
 | Category               | Tools                                                                                                                       | Count |
 | ---------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----: |
 | Lifecycle              | `browser_open / _close / _status`                                                                                           |     3 |
-| Navigation             | `browser_goto / _back / _forward / _reload / _wait_for_idle`                                                                |     5 |
+| Navigation             | `browser_goto / _back / _forward / _reload / _wait_for_idle / _wait_for_load / _bypass_insecure_warning`                    |     7 |
+| Scroll / Window        | `browser_scroll / _get_window / _set_window`                                                                                |     3 |
 | Tabs                   | `browser_tab_list / _new / _switch / _close / _activate`                                                                    |     5 |
 | Find                   | `browser_find / _find_all`                                                                                                  |     2 |
-| Actions                | `browser_click / _hover / _type / _press / _set_value / _clear / _focus / _scroll_into_view / _upload`                      |     9 |
-| Reads                  | `browser_element_state`                                                                                                     |     1 |
-| Snapshots              | `browser_html / _screenshot`                                                                                                |     2 |
+| Actions                | `browser_click / _hover / _type / _press / _key_sequence / _mouse / _set_value / _clear / _focus / _scroll_into_view / _upload` |    11 |
+| Reads                  | `browser_element_state / _get_links / _search_resources`                                                                    |     3 |
+| Snapshots / Export     | `browser_html / _screenshot / _pdf / _save_mhtml`                                                                           |     4 |
 | Eval                   | `browser_evaluate / _evaluate_main`                                                                                         |     2 |
 | Cookies                | `browser_cookies_get / _set / _delete / _clear / _persist`                                                                  |     5 |
 | Storage                | `browser_storage_get / _set / _delete / _clear`                                                                             |     4 |
-| Frames                 | `browser_frame_list`                                                                                                        |     1 |
-| Stealth                | `browser_set_stealth_profile`                                                                                               |     1 |
+| Downloads              | `browser_download / _set_download_path`                                                                                     |     2 |
+| Frames                 | `browser_frame_list / _frame_goto`                                                                                          |     2 |
+| Stealth                | `browser_set_stealth_profile / _set_user_agent`                                                                             |     2 |
 | Interception (gated)   | `browser_intercept_add_rule / _remove_rule / _list_rules / _clear_rules`                                                    |     4 |
 | Expect (gated)         | `browser_expect_register / _await / _cancel`                                                                                |     3 |
 | Cloudflare (gated)     | `browser_solve_turnstile`                                                                                                   |     1 |
+| Imperva (gated)        | `browser_solve_imperva`                                                                                                     |     1 |
 | Fetcher (gated)        | `browser_install_chrome`                                                                                                    |     1 |
 
 All find / action tools share a `Selector` arg — one-of `css | xpath |
 text | text_exact | text_regex | role`, with modifiers `nth /
 visible_only / timeout_ms / frame_id`. State-changing tools accept
-`return_snapshot: bool` for one-call action + observe.
+`return_snapshot: bool` for one-call action + observe. `browser_pdf` /
+`_save_mhtml` / `_download` return a binary-output shape (`{ byte_len,
+saved_path? , base64? }`): bytes go to `save_path` on the MCP host when
+given, else base64-inline (capped at 5 MiB). The default build adds
+`imperva` to the gated feature set alongside `interception` / `expect` /
+`cloudflare` / `fetcher`.
 
 Full JSON Schema for every tool's input + output is captured in
 `crates/zendriver-mcp/tests/snapshots/` and changes there require an

--- a/docs/superpowers/plans/2026-06-02-zendriver-mcp-coverage-expansion.md
+++ b/docs/superpowers/plans/2026-06-02-zendriver-mcp-coverage-expansion.md
@@ -1,0 +1,214 @@
+# zendriver-mcp Coverage Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Raise `zendriver-mcp` from 49 to 65 tools, closing every Tier 1/2/3 coverage gap in the audit so only documented non-goals remain uncovered.
+
+**Architecture:** Each tool is a free async fn in `crates/zendriver-mcp/src/tools/<group>.rs` taking `Arc<Mutex<SessionState>>` + a typed `*Input`, returning a typed `*Output` (or `ErrorData`). A thin `#[tool]` wrapper in `server.rs` delegates to it. Feature-gated tools live in their own `#[tool_router]` block summed into `combined_tool_router()`. Every input/output type gets an `insta` schema snapshot; every tool gets a no-browser unit test + a gated real-Chrome integration test.
+
+**Tech Stack:** Rust 2024, rmcp 1.7 (`#[tool]`/`#[tool_router]`), schemars 1.0, serde, tokio, insta. Wraps the `zendriver` crate + feature sub-crates (`-imperva`, `-interception`, `-stealth`, `-fetcher`).
+
+---
+
+## Shared recipe (every tool task follows this — do NOT re-paste boilerplate)
+
+For a tool `browser_X` wrapping `zendriver` call(s) `C`:
+
+1. **Module** — in `tools/<group>.rs`: define `#[derive(Debug, Deserialize, JsonSchema)] #[serde(deny_unknown_fields)] pub struct XInput { … }` and `#[derive(Debug, Serialize, JsonSchema)] pub struct XOutput { … }`. Write `pub async fn x(state: Arc<Mutex<SessionState>>, input: XInput) -> Result<XOutput, ErrorData>` that does `let s = state.lock().await; let tab = current_tab(&s).await?;` then calls `C`, mapping lib errors via `.map_err(|e| map_error(McpServerError::from(e)))?`.
+2. **Register** — in `server.rs`, add a `#[tool(name = "browser_X", description = "…")] pub async fn browser_X(&self, Parameters(input): Parameters<group::XInput>) -> Result<Json<group::XOutput>, ErrorData> { group::x(self.state.clone(), input).await.map(Json) }` to the correct router impl block (base, or the feature-gated block).
+3. **Snapshot** — in `tests/schema_snapshots.rs`, add `schema_snap!(group_x_in, tools::group::XInput);` + `schema_snap!(group_x_out, tools::group::XOutput);` (+ any new enums).
+4. **Unit test** — in the module's `#[cfg(test)] mod tests`, add `x_with_no_browser_errors` asserting `err.message.contains("Browser not open")` (mirror `cloudflare.rs:151`). Skip for tools that don't need a tab.
+5. **Integration test** — add/extend `tests/integration_<group>.rs` with a `#[tokio::test] #[ignore]` real-Chrome exercise gated by `feature = "integration-tests"`.
+
+New module files also need: `pub mod <group>;` in `tools/mod.rs`; the trailing `current_tab` import + `use` lines mirroring `cloudflare.rs:28-39`.
+
+**Snapshot regen after each phase:** `cargo test -p zendriver-mcp --test schema_snapshots --all-features --locked` then `cargo insta accept --all`.
+
+**Build gate after each task:** `cargo build -p zendriver-mcp --all-features` must pass. **Unit-test gate after each phase:** `cargo test -p zendriver-mcp --all-features --locked` (non-ignored) green.
+
+---
+
+## Phase A — Tier 1 (zero-tool subsystems)
+
+### Task A1: `imperva` feature + module + `browser_solve_imperva`
+
+**Files:**
+- Modify: `crates/zendriver-mcp/Cargo.toml` (features)
+- Create: `crates/zendriver-mcp/src/tools/imperva.rs`
+- Modify: `crates/zendriver-mcp/src/tools/mod.rs`, `src/server.rs`
+- Modify: `tests/schema_snapshots.rs`
+- Create: `tests/integration_imperva.rs`
+
+- [ ] **Step 1:** `Cargo.toml` — add `imperva = ["zendriver/imperva"]` under `[features]` and add `"imperva"` to the `default = [...]` array.
+- [ ] **Step 2:** Create `tools/imperva.rs` modeled exactly on `tools/cloudflare.rs`. Gate with `#![cfg(feature = "imperva")]`. Wraps `tab.imperva()` → `ImpervaBypass`:
+  - `SolveImpervaInput { #[serde(default = "default_timeout")] timeout_ms: u64 (default 30_000), #[serde(default, skip_serializing_if="Option::is_none")] poll_interval_ms: Option<u64>, #[serde(default)] with_interception: bool }`.
+  - `Outcome` enum (snake_case): `TokenAcquired`, `ChallengeGone`, `AlreadyClear`, `Timeout`.
+  - `SolveImpervaOutput { outcome: Outcome, #[serde(skip_serializing_if="Option::is_none")] reese84: Option<String> }`.
+  - Body: `let mut bypass = tab.imperva(); bypass = bypass.timeout(Duration::from_millis(input.timeout_ms)); if let Some(p)=input.poll_interval_ms { bypass = bypass.poll_interval(Duration::from_millis(p)); } if input.with_interception { bypass = bypass.with_interception(); }` then match `bypass.wait_for_clearance().await`: `Ok(ClearanceOutcome::TokenAcquired{reese84,..}) => Solved+Some(reese84)`, `Ok(ChallengeGone)=>ChallengeGone`, `Ok(AlreadyClear)=>AlreadyClear`, `Err(ImpervaError::…Timeout)=>Timeout` (collapse like cloudflare), `Err(other)=>Err(map_error(McpServerError::from(ZendriverError::from(other))))`. Confirm the exact timeout variant name in `zendriver-imperva/src/error.rs` and the `ImpervaError→ZendriverError` `From` impl before finalizing.
+  - Imports: `use zendriver::{ImpervaBypass?, …}` — imperva re-exports are surfaced via `zendriver` under `#[cfg(feature="imperva")]` (mirror how `ClearanceOutcome`/`CloudflareError` are imported in cloudflare.rs; the imperva `ClearanceOutcome` is a *different* type, so alias if both ever co-import).
+- [ ] **Step 3:** `tools/mod.rs` — add `#[cfg(feature = "imperva")] pub mod imperva;` (alongside the cloudflare line).
+- [ ] **Step 4:** `server.rs` — add a gated block mirroring the cloudflare one:
+  ```
+  #[cfg(feature = "imperva")]
+  #[tool_router(router = imperva_tool_router, vis = "pub")]
+  impl ZendriverServer { #[tool(name="browser_solve_imperva", description="Drive the Imperva/Incapsula clearance flow on the current tab. Polls until token_acquired (reese84 captured), challenge_gone, already_clear, or timeout (deadline elapsed — not an error). Errors only on structural failures (CDP/JS). `with_interception` enables the Fetch fast-path.")] pub async fn browser_solve_imperva(&self, Parameters(input): Parameters<imperva::SolveImpervaInput>) -> Result<Json<imperva::SolveImpervaOutput>, ErrorData> { imperva::solve_imperva(self.state.clone(), input).await.map(Json) } }
+  ```
+  Add `use crate::tools::imperva;` under `#[cfg(feature = "imperva")]`. In `combined_tool_router()` add `#[cfg(feature = "imperva")] let router = router + Self::imperva_tool_router();`.
+- [ ] **Step 5:** Snapshots — `tests/schema_snapshots.rs`: new gated `mod imperva_snaps { schema_snap!(imperva_solve_in, tools::imperva::SolveImpervaInput); schema_snap!(imperva_outcome, tools::imperva::Outcome); schema_snap!(imperva_solve_out, tools::imperva::SolveImpervaOutput); }` under `#[cfg(feature = "imperva")]`.
+- [ ] **Step 6:** Unit test `solve_imperva_with_no_browser_errors` (mirror cloudflare). Integration test `tests/integration_imperva.rs` — `#[ignore]`, gated `integration-tests + imperva`, hits a known Imperva-protected URL and asserts a non-error outcome.
+- [ ] **Step 7:** `cargo build -p zendriver-mcp --all-features` → green. Commit `feat(mcp): browser_solve_imperva + imperva feature`.
+
+### Task A2: `browser_scroll`
+
+**Files:** Create `tools/scroll.rs`; modify `tools/mod.rs`, `server.rs`, `tests/schema_snapshots.rs`; extend `tests/integration_actions.rs`.
+
+- [ ] **Step 1:** `tools/scroll.rs` (not gated). Wraps `Tab::scroll_with(ScrollOptions)` (fallback `scroll_down`/`scroll_up`).
+  - `ScrollInput { #[serde(default)] dx: f64, #[serde(default)] dy: f64, #[serde(default)] return_snapshot: bool }` (positive `dy` = down). Map to `ScrollOptions`; check `tab.rs:112` for `ScrollOptions` field names — use them directly.
+  - `ScrollOutput { scroll_x: f64, scroll_y: f64 }` (read post-scroll via `tab.evaluate_main("[scrollX,scrollY]")` or whatever `scroll_with` returns; if it returns `()`, read scroll offsets with a one-line eval). Reuse `navigation::snapshot_now` pattern if `return_snapshot`.
+- [ ] **Step 2-5:** Register `browser_scroll` in base router; snapshot `scroll_in`/`scroll_out`; no-browser unit test; integration test scrolls a tall page and asserts `scroll_y > 0`. Build. Commit.
+
+> **Naming note:** `tools::actions` already exports a `ScrollInput` (for `browser_scroll_into_view`, snapshot line `actions_scroll_in`). Name the new type `tools::scroll::PageScrollInput`/`PageScrollOutput` to avoid collision, and snapshot as `scroll_page_in`/`scroll_page_out`.
+
+### Task A3: `browser_get_window` + `browser_set_window`
+
+**Files:** Create `tools/window.rs`; modify `tools/mod.rs`, `server.rs`, snapshots; create `tests/integration_window.rs`.
+
+- [ ] **Step 1:** `tools/window.rs`. Wraps `Tab::window_bounds` / `set_window_bounds` / `set_window_size` / `maximize` / `minimize` / `fullscreen` (window.rs:187-325).
+  - `WindowBoundsDto { left: i64, top: i64, width: i64, height: i64, state: WindowStateDto }` where `WindowStateDto` (snake_case enum) mirrors `zendriver::WindowState` variants (read window.rs:42).
+  - `browser_get_window` — `EmptyInput`-style (no args) → `WindowBoundsDto` from `tab.window_bounds()`. `readOnly`.
+  - `SetWindowInput { mode: SetWindowMode, width?: i64, height?: i64, left?: i64, top?: i64, state?: WindowStateDto }`; `SetWindowMode` enum: `bounds|size|maximize|minimize|fullscreen`. Dispatch to the matching `Tab` method; for `bounds` build a `WindowBounds` (window.rs:83). Output: resulting `WindowBoundsDto`.
+- [ ] **Step 2-7:** Register both in base router; snapshots for the DTOs + inputs/outputs; unit tests; integration test sets 800×600 then asserts `get_window` reports it. Build. Commit.
+
+### Task A4: `browser_pdf` + `browser_save_mhtml`
+
+**Files:** Create `tools/pdf.rs`; modify `tools/mod.rs`, `server.rs`, snapshots; add `binary_output` helper to `tools/common.rs`; create `tests/integration_pdf.rs`.
+
+- [ ] **Step 1:** Add to `tools/common.rs`: a `BlobOutput { #[serde(skip_serializing_if="Option::is_none")] saved_path: Option<String>, byte_len: usize, #[serde(skip_serializing_if="Option::is_none")] base64: Option<String> }` struct + `pub fn blob_output(bytes: Vec<u8>, save_path: Option<String>) -> Result<BlobOutput, ErrorData>` that, when `save_path` set, writes bytes to disk (`std::fs::write`) and returns `saved_path`+`byte_len` (no base64); else base64-encodes when `bytes.len() <= MAX_INLINE` (e.g. 5 MiB) and otherwise errors with a "set save_path for large blobs" message. Pull in a base64 dep if not present (check screenshot's current handling first — reuse whatever it uses; `snapshot.rs` already builds an image content block, inspect it for the encoder).
+- [ ] **Step 2:** `tools/pdf.rs`:
+  - `PdfInput { landscape?: bool, print_background?: bool, scale?: f64, paper_width?: f64, paper_height?: f64, margin_top?: f64, margin_bottom?: f64, margin_left?: f64, margin_right?: f64, page_ranges?: String, prefer_css_page_size?: bool, save_path?: String }` — all optional, each maps to the matching `PdfBuilder` method (pdf/mod.rs:115-313) only when `Some`. Terminal `.bytes()`.
+  - `browser_pdf` → `blob_output(bytes, input.save_path)`. `readOnly:true`.
+  - `browser_save_mhtml` — `SaveMhtmlInput { save_path?: String }` → `tab.snapshot_mhtml()` (returns `String`) → `blob_output(s.into_bytes(), save_path)`. `readOnly:true`.
+- [ ] **Step 3-7:** Register both (base router); snapshots; unit tests; integration test exports example.com → asserts `byte_len > 0` and PDF magic bytes when saved. Build. Commit.
+
+### Task A5: `browser_mouse`
+
+**Files:** Create `tools/mouse.rs`; modify `tools/mod.rs`, `server.rs`, snapshots; extend `tests/integration_actions.rs`.
+
+- [ ] **Step 1:** `tools/mouse.rs`. Wraps `Tab::mouse_move`/`mouse_click_with`/`mouse_drag`.
+  - `MouseInput { action: MouseAction, x: f64, y: f64, to_x?: f64, to_y?: f64, button?: MouseButtonArg, click_count?: u32, modifiers?: Vec<ModifierArg>, #[serde(default = "default_steps")] steps: usize, #[serde(default)] return_snapshot: bool }`. `MouseAction` enum: `move|click|drag`. Reuse `tools::actions::MouseButtonArg` (already snapshotted) for `button`; define `ModifierArg` (`alt|ctrl|meta|shift`) → `KeyModifiers` bitflags (keyboard.rs:164).
+  - Dispatch: `move`→`mouse_move(x,y)`; `click`→`mouse_click_with(x,y,ClickOptions{button,click_count,modifiers,..})`; `drag`→`mouse_drag((x,y),(to_x,to_y),steps)` (require `to_x/to_y`, else `invalid_params`).
+  - `MouseOutput` = nav-style snapshot option or `AckOutput`.
+- [ ] **Step 2-7:** Register `browser_mouse` (base); snapshots (`MouseInput`, `MouseAction`, `ModifierArg`, output); unit test; integration test clicks a coordinate on a canvas/test page. Build. Commit.
+
+### Task A6: Dialog-drive — extend `browser_expect_await`
+
+**Files:** Modify `tools/expect.rs`, `server.rs` (description), snapshots; extend `tests/integration_expect.rs`.
+
+- [ ] **Step 1:** Read `tools/expect.rs` await path (the `ExpectKind::Dialog` arm, ~line 198). Add to `AwaitInput`: `#[serde(default, skip_serializing_if="Option::is_none")] dialog_action: Option<DialogAction>` (enum `accept|dismiss`) + `dialog_prompt_text: Option<String>`; `fetch_body: bool` (Response); `save_to: Option<String>` (Download).
+- [ ] **Step 2:** Currently the dialog/download/response handles are awaited inside a spawned task that serializes the matched event to JSON and drops the handle (state.rs:71 `ExpectationHandle`). Driving `accept`/`dismiss`/`body`/`save_to` requires acting on the live `Matched*` BEFORE drop. Change the **register** path so the spawned task, for `Dialog`, parks the `MatchedDialog` awaiting a oneshot command (`accept{text}`/`dismiss`) forwarded by `await`; for `Response` with `fetch_body`, call `.body()` and include base64 in the serialized JSON; for `Download` with `save_to`, call `.save_to(path)` and include the final path. Simplest correct shape: fold the action INTO the await call — register stays detect-only, and `await` re-resolves and drives. **Pick the inline-await approach:** move dialog/response-body/download-save handling so the `await` tool performs the drive using fields above, keeping register unchanged. Document the chosen mechanism in the module header.
+- [ ] **Step 3-5:** Update `browser_expect_await` description in `server.rs`. Snapshot `AwaitInput` (re-accept), add `DialogAction` snapshot. Unit test for the new input fields' schema. Integration test: register dialog → trigger `alert()` via `browser_evaluate` → `await` with `dialog_action: accept` → assert resolved. Build. Commit.
+
+### Task A7: Frame-scoped eval — extend `browser_evaluate` / `_evaluate_main`
+
+**Files:** Modify `tools/eval.rs`, `server.rs` (descriptions), snapshots; extend `tests/integration_*` (frames).
+
+- [ ] **Step 1:** Read `tools/eval.rs`. Add `#[serde(default, skip_serializing_if="Option::is_none")] frame_id: Option<String>` to `EvalInput`. When set, resolve the frame via `tab.frames().await` → `find(|f| f.id()==fid)` (mirror `find.rs:116 lookup_frame`; consider extracting that helper to `common.rs` and reusing in both) and call `frame.evaluate::<Value>` / `frame.evaluate_main::<Value>` instead of `tab.*`. Error `FrameNotFound` when no match.
+- [ ] **Step 2-5:** Update both tool descriptions. Re-accept `EvalInput` snapshot. Unit test schema. Integration test: page with named iframe → `browser_evaluate` with that `frame_id` returns the frame's `location.href`. Build. Commit.
+
+---
+
+## Phase B — Tier 2
+
+### Task B1: Keyboard chords — `browser_press` modifiers + `browser_key_sequence`
+
+**Files:** Modify `tools/actions.rs`, `server.rs`, snapshots; extend `tests/integration_actions.rs`.
+
+- [ ] **Step 1:** `actions.rs` — add `#[serde(default)] modifiers: Vec<ModifierArg>` to `PressInput`; when non-empty call `el.press_with(key, mods)` else `el.press(key)`. Define/reuse `ModifierArg`→`KeyModifiers` (share with `tools::mouse` — put `ModifierArg` in `actions.rs` and re-export, or in `common.rs`).
+- [ ] **Step 2:** Add `browser_key_sequence` — `KeySequenceInput { selector: Selector, sequence: Vec<KeyStep> }`; `KeyStep` is an untagged/tagged enum: `{text: String}` | `{key: String, #[serde(default)] modifiers: Vec<ModifierArg>}`. Build `zendriver::KeySequence` (keyboard.rs:652) via `.text()`/`.key()`/`.chord()` then `el.type_keys(seq)`. Reuse `actions::parse_key` for key strings.
+- [ ] **Step 3-7:** Register `browser_key_sequence` (base); snapshots (`PressInput` re-accept, `KeySequenceInput`, `KeyStep`, `ModifierArg`); unit tests; integration test: focus an input, send `Ctrl+A` then type — assert selection/replace. Build. Commit.
+
+### Task B2: `browser_download` (direct fetch) + download-dir
+
+**Files:** Create `tools/download.rs`; modify mod/server/snapshots; create `tests/integration_download.rs`.
+
+- [ ] **Step 1:** `tools/download.rs`. `DownloadInput { url: String, save_path?: String }` → `tab.download_file(&url, save_path.map(PathBuf::from)).await` (tab.rs:2362). Output `BlobOutput`-style `{ saved_path, byte_len }` (read the saved file len; `download_file` returns the path or `()` — inspect signature and adapt).
+- [ ] **Step 2:** `browser_set_download_path` — `SetDownloadPathInput { path: String }` → `tab.set_download_path(PathBuf)` → `AckOutput`. (Tier 3 but cheap; co-locate here.)
+- [ ] **Step 3-7:** Register both (base); snapshots; unit tests; integration test downloads a small static asset → asserts byte_len. Build. Commit.
+
+### Task B3: Runtime UA + fine-grained stealth
+
+**Files:** Modify `tools/stealth.rs`, `server.rs`, snapshots; extend `tests/integration_*`.
+
+- [ ] **Step 1:** `browser_set_user_agent` (new, in `stealth.rs` or `navigation.rs`) — `SetUserAgentInput { user_agent: String, accept_language?: String, platform?: String }` → `tab.set_user_agent_with(UserAgentOverride{..})` (tab.rs:157,1745). Output `AckOutput`.
+- [ ] **Step 2:** Extend `SetStealthProfileInput` with optional overrides `{ platform?, locale?, timezone?, memory_gb?: u32, cpu_count?: u32, chrome_version?: u32, user_agent?, bypass_csp?: bool }`. These are applied at the next `browser_open`; store them on `SessionState` (extend `stealth_profile_choice` into a struct OR add a `stealth_overrides: StealthOverrides` field). Lifecycle handler layers them onto the resolved `StealthProfile` builder (profile.rs:187-248). Keep wire enum `StealthProfileChoice` stable; add a sibling `StealthOverrides` struct in `state.rs`.
+- [ ] **Step 3-7:** Register `browser_set_user_agent`; re-accept `SetStealthProfileInput` snapshot + add `StealthOverrides`; unit tests; integration test sets UA then `browser_evaluate("navigator.userAgent")` asserts match. Build. Commit.
+
+### Task B4: Interception `modify_response`
+
+**Files:** Modify `tools/intercept.rs`, snapshots; extend `tests/integration_interception.rs`.
+
+- [ ] **Step 1:** Read `tools/intercept.rs` `InterceptAction` enum (~line 60). Add variant `ModifyResponse { #[serde(default, skip_serializing_if="Option::is_none")] status: Option<u16>, #[serde(default)] headers: BTreeMap<String,String> }`. In the add-rule dispatch, call the builder's `modify_response(pattern, closure)` (interception `InterceptBuilder`) returning a `ResponseOverrides`. Confirm the lib exposes `modify_response` on `InterceptBuilder`; if only `PausedRequest::continue_response` exists, document and wire via the response-stage rule path.
+- [ ] **Step 2-5:** Re-accept `InterceptAction` + `AddRuleInput` snapshots; unit test schema; integration test rewrites a response status. Build. Commit.
+
+### Task B5: Frame navigation + load waits + hard reload
+
+**Files:** Modify `tools/frames.rs`, `tools/navigation.rs`, `server.rs`, snapshots.
+
+- [ ] **Step 1:** `browser_frame_goto` (frames.rs) — `FrameGotoInput { frame_id: String, url: String, timeout_ms?: u64 }` → lookup frame → `frame.goto(url)` then `frame.wait_for_load()` (frame/mod.rs:373,416). Output `AckOutput`.
+- [ ] **Step 2:** `browser_wait_for_load` (navigation.rs) — `WaitForLoadInput { ready_state?: ReadyStateArg (interactive|complete), frame_id?: String, timeout_ms?: u64 }` → `tab.wait_for_ready_state(ReadyState)` or `tab.wait_for_load()` (tab.rs:833,904); frame variant uses `frame.wait_for_load()`. `readOnly`.
+- [ ] **Step 3:** Extend `HistoryInput` (reload path only) — add `#[serde(default)] ignore_cache: bool`; reload fn: when true call `tab.reload_with(ReloadOptions{ ignore_cache: true, ..})` (tab.rs:74,1437) else `tab.reload()`. (Confirm `ReloadOptions` field name.)
+- [ ] **Step 4-7:** Register `browser_frame_goto`, `browser_wait_for_load`; snapshots; unit tests; integration tests. Build. Commit.
+
+---
+
+## Phase C — Tier 3
+
+### Task C1: Link harvest + element extras + set-text + resource search
+
+**Files:** Modify `tools/reads.rs`, `tools/snapshot.rs`, `tools/actions.rs`, `server.rs`, snapshots.
+
+- [ ] **Step 1:** `browser_get_links` (reads.rs) — `GetLinksInput { #[serde(default)] absolute: bool, #[serde(default)] include_sources: bool }` → `tab.get_all_urls(absolute)` + (when `include_sources`) `tab.get_all_linked_sources()` (tab.rs:2224,2270). Output `{ urls: Vec<String>, #[serde(skip_serializing_if="Option::is_none")] sources: Option<Vec<String>> }`. `readOnly`.
+- [ ] **Step 2:** `browser_element_state` — extend `ReadFieldsPreset`/`ElementState` with `outer_html: Option<String>` (`el.outer_html()`) + `bounding_box_page: Option<…>` (`el.bounding_box_page()`, reads.rs:267). Re-accept snapshots.
+- [ ] **Step 3:** `browser_html` (snapshot.rs) — add `#[serde(default)] outer: bool`; selector mode → `el.outer_html()` when `outer` else `el.inner_html()`.
+- [ ] **Step 4:** `browser_set_value` — add `#[serde(default)] mode: SetValueMode` (`value|text`); `text` → `el.set_text(v)` (actions.rs:500) else `el.set_value(v)`. `browser_clear` — add `#[serde(default)] mode: ClearMode` (`value|backspace`); `backspace` → `el.clear_by_deleting()` (actions.rs:545).
+- [ ] **Step 5:** `browser_search_resources` (reads.rs) — `SearchResourcesInput { query: String }` → `tab.search_frame_resources(&query)` (tab.rs:2003). Output list of `{ frame_id, url, .. }` per `FrameResourceMatch` (tab.rs:246). `readOnly`.
+- [ ] **Step 6-8:** Register new tools; re-accept all touched snapshots + add new ones; unit tests; integration tests. Build. Commit.
+
+### Task C2: `browser_bypass_insecure_warning` + folds
+
+**Files:** Modify `tools/navigation.rs` (or `lifecycle.rs`), `tools/lifecycle.rs` (status), `tools/tabs.rs`, `server.rs`, snapshots.
+
+- [ ] **Step 1:** `browser_bypass_insecure_warning` — no-arg → `tab.bypass_insecure_connection_warning()` (tab.rs:2099) → `AckOutput`. Register (base).
+- [ ] **Step 2:** Fold `inspector_url` — add `inspector_url: Option<String>` to `lifecycle::StatusOutput`, populated from `tab.inspector_url()` (tab.rs:2131). Re-accept `lifecycle_status_out` snapshot.
+- [ ] **Step 3:** Fold `bring_to_front` — `browser_tab_activate` handler additionally calls `tab.bring_to_front()` after `activate()`; update description. (No new tool.)
+- [ ] **Step 4-6:** Snapshots; unit tests; integration smoke. Build. Commit.
+
+---
+
+## Phase D — Docs + final verification
+
+### Task D1: mdBook + counts
+
+**Files:** Modify `docs/book/src/mcp.md`, `crates/zendriver-mcp/README.md`.
+
+- [ ] **Step 1:** Update `mcp.md` tool table: add Scroll/Window/PDF/Mouse/Imperva/Download rows; bump counts 49 → 65; mark Imperva gated (note: in `default`). Update the prose "49 MCP tools" line.
+- [ ] **Step 2:** Update the `Selector`-modifier and `return_snapshot` notes if any new modifiers were added.
+- [ ] **Step 3:** Commit `docs: mcp tool surface 49 → 65`.
+
+### Task D2: Full verification + evals
+
+- [ ] **Step 1:** `cargo build -p zendriver-mcp --all-features --locked` → green.
+- [ ] **Step 2:** `cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings` → clean (repo uses `clippy.toml`).
+- [ ] **Step 3:** `cargo test -p zendriver-mcp --all-features --locked` (non-ignored) → green; `cargo insta accept --all` for new schema snapshots; re-run to confirm no `.snap.new` remain.
+- [ ] **Step 4:** `cargo test -p zendriver-mcp --no-default-features --locked` → green (lean build still compiles; gated tools cleanly absent).
+- [ ] **Step 5:** Write `crates/zendriver-mcp/tests/evals/coverage-expansion.xml` — 10 stable read-only real-Chrome eval questions per mcp-builder Phase 4, exercising scroll/window/pdf/mouse/frame-eval/get_links/etc.
+- [ ] **Step 6:** Final commit.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Every Tier 1 (A1-A7), Tier 2 (B1-B5), Tier 3 (C1-C2) item from the design maps to a task. Imperva feature-wiring (A1) covers the design's biggest gap. Docs/feature/test cross-cutting concerns → D1/D2. ✅
+- **Non-goals respected:** No task touches the ref/handle model, interception stream, JS sandbox, workflow tools, fast variants, or debug viz. ✅
+- **Naming consistency:** `ModifierArg` shared across mouse (A5) + keyboard (B1) — defined once in `actions.rs`, reused. `BlobOutput`/`blob_output` defined once in `common.rs` (A4), reused by download (B2). `ScrollInput` collision flagged → new type is `PageScrollInput` (A2). `lookup_frame` helper reused by eval (A7) + frames (B5) — extract to `common.rs`. ✅
+- **Open confirmations flagged inline (resolve while implementing, not placeholders):** exact `ImpervaError` timeout variant + `From` impl (A1); `ScrollOptions` field names (A2); `WindowState` variants (A3); base64 encoder already in tree (A4); `download_file` return type (B2); `InterceptBuilder::modify_response` existence (B4); `ReloadOptions` field name (B5). Each names the source file/line to check.

--- a/docs/superpowers/specs/2026-06-02-zendriver-mcp-coverage-expansion-design.md
+++ b/docs/superpowers/specs/2026-06-02-zendriver-mcp-coverage-expansion-design.md
@@ -1,0 +1,280 @@
+# zendriver-mcp Coverage Expansion — Design
+
+**Date:** 2026-06-02
+**Status:** Proposed
+**Predecessor:** [`2026-05-24-zendriver-rs-mcp-server-design.md`](./2026-05-24-zendriver-rs-mcp-server-design.md) (v0, the 49-tool server)
+
+## Problem
+
+MCP coverage of the `zendriver` public API is treated like test coverage: every
+user-facing library operation should be reachable through a tool unless there is
+a deliberate reason not to. Today `zendriver-mcp` ships **49 tools** covering
+~60–65% of the MCP-worthy surface. Seven whole subsystems have **zero** tools,
+and several shipped subsystems are detect-only or shallow.
+
+This design closes the gap to the practical maximum: **all Tier 1/2/3 gaps**
+identified in the coverage audit, leaving only the explicitly documented
+non-goals uncovered.
+
+## Coverage audit (method + result)
+
+- **Denominator** — every `pub fn` / method on user-facing types across 8 crates
+  (`Browser`, `Tab`, `Element`, `Frame`, query builders, `CookieJar`, `Storage`,
+  `ScreenshotBuilder`, `PdfBuilder`, and feature crates `zendriver-stealth`,
+  `-cloudflare`, `-imperva`, `-interception`, `-fetcher`). ~230 public items.
+  Excluded: transport/CDP internals, `pub(crate)`, std-trait impls, opaque wire
+  structs, pure config helpers.
+- **Numerator** — the 49 `#[tool]` registrations in `crates/zendriver-mcp/src/server.rs`,
+  each mapped to the `zendriver` call it wraps.
+
+### Already covered (49 tools — unchanged)
+
+Lifecycle/nav/tabs (open/close/status, goto/back/forward/reload/wait_for_idle,
+5 tab tools); find/find_all (css/xpath/text_exact/text_regex/role(+name),
+nth/visible_only/timeout/frame_id); element actions
+(click/hover/type/press/set_value/clear/focus/scroll_into_view/upload);
+element_state reads (visible/enabled/bbox/text/attrs/inner_html); html +
+screenshot (png/jpeg/webp/full_page/quality/clip/save); evaluate/evaluate_main
+(tab main-world); cookies (get/set/delete/clear/persist); storage local+session
+(get/set/delete/clear); frame_list; set_stealth_profile (kind);
+intercept add/remove/list/clear (block/redirect/respond/modify_request);
+expect register/await/cancel (request/response/dialog/download — **detect-only**);
+solve_turnstile; install_chrome (version/channel).
+
+### Gaps to close (this design)
+
+#### Tier 1 — whole subsystems, zero tools
+
+| # | Gap | Unexposed `zendriver` API |
+|---|-----|---------------------------|
+| 1 | Imperva bypass | `Tab::imperva()` + entire `zendriver-imperva` crate — **not even a MCP feature flag** |
+| 2 | Page scroll | `Tab::scroll_down` / `scroll_up` / `scroll_with(ScrollOptions)` |
+| 3 | Window / viewport | `Tab::set_window_size` / `maximize` / `minimize` / `fullscreen` / `window_bounds` / `set_window_bounds` |
+| 4 | PDF / MHTML export | `Tab::pdf_builder` / `print_to_pdf` / `snapshot_mhtml` / `save_snapshot` (full `PdfBuilder`) |
+| 5 | Coordinate mouse | `Tab::mouse_move` / `mouse_click` / `mouse_click_with` / `mouse_drag`, `Element::mouse_drag` |
+| 6 | Dialog drive | `MatchedDialog::accept(prompt)` / `dismiss` — currently detect, cannot answer |
+| 7 | Frame-scoped eval | `Frame::evaluate` / `evaluate_main` — OOPIF JS unreachable |
+
+#### Tier 2 — medium value
+
+| # | Gap | Unexposed API |
+|---|-----|---------------|
+| 8  | Keyboard chords | `Element::press_with(KeyModifiers)`, `type_keys(KeySequence)` — no Ctrl+A / Cmd+C |
+| 9  | Response body | `MatchedResponse::body()` |
+| 10 | Download retrieval | `MatchedDownload::save_to` / `path` |
+| 11 | Direct download | `Tab::download_file(url, dest)` |
+| 12 | Runtime UA | `Tab::set_user_agent` / `set_user_agent_with(UserAgentOverride)` |
+| 13 | Fine-grained stealth | `StealthProfile::platform` / `locale` / `timezone` / `memory_gb` / `cpu_count` / `chrome_version` / `user_agent` / `bypass_csp` |
+| 14 | modify_response | `InterceptBuilder` response override (only `modify_request` exposed) |
+| 15 | Frame navigation | `Frame::goto` / `wait_for_load` |
+| 16 | Load waits | `Tab::wait_for_load` / `wait_for_ready_state(ReadyState)` |
+| 17 | Hard reload | `Tab::reload_with(ReloadOptions)` (ignore-cache) |
+
+#### Tier 3 — convenience
+
+| # | Gap | Unexposed API |
+|---|-----|---------------|
+| 18 | Link harvest | `Tab::get_all_urls(absolute)` / `get_all_linked_sources` |
+| 19 | Element extras | `Element::outer_html` / `bounding_box_page` |
+| 20 | Set text content | `Element::set_text` (≠ `set_value`) / `clear_by_deleting` |
+| 21 | Download dir | `Tab::set_download_path` |
+| 22 | Resource search | `Tab::search_frame_resources` |
+| 23 | Page focus | `Tab::bring_to_front` |
+| 24 | SSL interstitial | `Tab::bypass_insecure_connection_warning` |
+| 25 | Inspector URL | `Tab::inspector_url` |
+
+### Deliberate non-goals (NOT covered — documented, unchanged from v0)
+
+- **Element ref/handle model.** Selectors remain the only handle. This is *why*
+  relative DOM traversal (`Element::parent` / `children` / subtree `find`) is not
+  a tool — it would need handle-passing. Covering it later means a
+  selector-relative-query design, not a ref model. Out of scope here.
+- **Stream-based interception escape hatch** (`InterceptBuilder::subscribe`) —
+  needs server-side event buffering + backpressure.
+- **Code-exec / JS sandbox tool** — `evaluate` already covers ad-hoc JS.
+- **Workflow / recipe tools** — primitive coverage only; agents compose.
+- **Fast non-stealth action variants** (`click_fast` / `hover_fast` /
+  `type_text_fast`) — stealth-by-default philosophy; realistic variants ship.
+- **Debug visualization** (`Element::flash` / `highlight_overlay`, `Tab::flash_point`)
+  — operator-debug only, no agent value. (Mouse-flash debug folded out of
+  `browser_mouse`.)
+- **Raw transport** (`Connection` / `SessionHandle` / observers) — internal.
+
+## Goals
+
+1. Every Tier 1/2/3 API above reachable through a tool or a documented
+   parameter extension to an existing tool.
+2. Zero new wire-shape conventions — reuse the existing `Selector` arg,
+   `return_snapshot` flag, `frame_id` modifier, and binary-output shape.
+3. Each new tool ships with: integration test (real Chrome, gated), an `insta`
+   JSON-schema snapshot, and an entry in the mdBook tool table.
+4. The `imperva` subsystem becomes a first-class gated feature, mirroring
+   `cloudflare`.
+
+## Design
+
+### Conventions reused (no new patterns)
+
+- **`Selector` arg** — one-of `css|xpath|text|text_exact|text_regex|role(+name)`
+  with `nth|visible_only|timeout_ms|frame_id`. All new element-targeted tools
+  take it verbatim.
+- **`return_snapshot: bool`** — state-changing tools optionally return a trimmed
+  HTML snapshot for one-call act-and-observe.
+- **`frame_id: Option<String>`** — the existing frame-retarget convention,
+  extended to `evaluate` and the new load-wait tool.
+- **Binary-output shape** — `{ byte_len, saved_path?, base64? }` (PNG screenshot
+  is the precedent). `pdf` / `save_mhtml` / `download` reuse it: when `save_path`
+  is set the bytes go to disk and `base64` is omitted; otherwise base64 is
+  returned. Large blobs default to save-to-path with a size guard.
+
+### New tools (one module per group, matching existing `tools/*.rs` layout)
+
+**`tools/scroll.rs`**
+- `browser_scroll` — `Tab::scroll_with(ScrollOptions)`. In:
+  `{ dx?: f64, dy?: f64, direction?: up|down, amount_px?: f64, return_snapshot?: bool }`.
+  Out: `{ scroll_x, scroll_y }`. `readOnly:false, idempotent:false, openWorld:true`.
+
+**`tools/window.rs`**
+- `browser_get_window` — `Tab::window_bounds`. Out: `WindowBounds { left, top, width, height, state }`. `readOnly:true`.
+- `browser_set_window` — `set_window_size` / `set_window_bounds` / `maximize` / `minimize` / `fullscreen`.
+  In: `{ mode: bounds|size|maximize|minimize|fullscreen, width?, height?, left?, top?, state? }`. `readOnly:false`.
+
+**`tools/pdf.rs`**
+- `browser_pdf` — full `PdfBuilder`. In:
+  `{ landscape?, print_background?, scale?, paper_width?, paper_height?, margin_top?, margin_bottom?, margin_left?, margin_right?, page_ranges?, prefer_css_page_size?, save_path? }`.
+  Out: binary-output shape. `readOnly:true` (no page mutation).
+- `browser_save_mhtml` — `Tab::snapshot_mhtml` / `save_snapshot`. In: `{ save_path? }`. Out: binary-output shape. `readOnly:true`.
+
+**`tools/mouse.rs`**
+- `browser_mouse` — `Tab::mouse_move` / `mouse_click_with` / `mouse_drag`. In:
+  `{ action: move|click|drag, x: f64, y: f64, to_x?, to_y?, button?, click_count?, modifiers?, steps?, return_snapshot? }`.
+  Out: `{}` or snapshot. `readOnly:false`.
+
+**`tools/imperva.rs`** (gated `feature = "imperva"`)
+- `browser_solve_imperva` — `Tab::imperva()` → `ImpervaBypass::wait_for_clearance`.
+  In: `{ timeout_ms?, poll_interval_ms?, with_interception? }`. Out:
+  `{ outcome: token_acquired|challenge_gone|already_clear, reese84?, surface? }`.
+  Mirrors `cloudflare.rs`. `readOnly:false, openWorld:true`. (CAPTCHA-solver
+  callback `on_captcha` is **not** wired over MCP — same rationale as the
+  interception stream non-goal; documented.)
+
+**`tools/download.rs`**
+- `browser_download` — `Tab::download_file(url, dest)`. In: `{ url, save_path? }`. Out: binary-output shape. `readOnly:false`.
+
+**Extend `tools/navigation.rs`**
+- `browser_wait_for_load` (new) — `Tab::wait_for_load` / `wait_for_ready_state`.
+  In: `{ ready_state?: interactive|complete, frame_id?, timeout_ms? }`. `readOnly:true`.
+- `browser_reload` (extend) — add `{ ignore_cache?: bool }` → `reload_with(ReloadOptions)`.
+
+**Extend `tools/frames.rs`**
+- `browser_frame_goto` (new) — `Frame::goto` + `wait_for_load`. In: `{ frame_id, url, timeout_ms? }`. `readOnly:false`.
+
+**Extend `tools/eval.rs`**
+- `browser_evaluate` / `browser_evaluate_main` — add `frame_id?: Option<String>`
+  → `Frame::evaluate` / `evaluate_main` when set, else `Tab::*`.
+
+**Extend `tools/actions.rs`**
+- `browser_press` — add `modifiers?: [alt,ctrl,meta,shift]` → `press_with`.
+- `browser_key_sequence` (new) — `Element::type_keys(KeySequence)`. In:
+  `{ selector, sequence: [ {text} | {key} | {key, modifiers} ] }`. `readOnly:false`.
+- `browser_set_value` — add `mode?: value|text` → `set_text` when `text`.
+- `browser_clear` — add `mode?: value|backspace` → `clear_by_deleting` when `backspace`.
+
+**Extend `tools/expect.rs`** (completes detect-only → drive)
+- await for `Dialog` — add `{ dialog_action?: accept|dismiss, prompt_text? }`,
+  driven inline before return (fits no-handle model: register → trigger → await-and-respond in one call).
+- await for `Response` — add `{ fetch_body?: bool }` → `MatchedResponse::body()` (base64 in output).
+- await for `Download` — add `{ save_to?: string }` → `MatchedDownload::save_to`, return final path.
+
+**Extend `tools/stealth.rs`**
+- `browser_set_stealth_profile` — add optional overrides
+  `{ platform?, locale?, timezone?, memory_gb?, cpu_count?, chrome_version?, user_agent?, bypass_csp? }`
+  layered on the chosen `kind` (`StealthProfile` builder chain).
+- `browser_set_user_agent` (new) — `Tab::set_user_agent_with(UserAgentOverride)`.
+  In: `{ user_agent, accept_language?, platform? }`. `readOnly:false`.
+
+**Extend `tools/intercept.rs`** (gated `interception`)
+- `browser_intercept_add_rule` — add `InterceptAction::ModifyResponse { status?, headers? }` → `modify_response`.
+
+**Extend `tools/reads.rs` + `tools/snapshot.rs` (Tier 3)**
+- `browser_element_state` — `include` preset gains `outer_html` + `bounding_box_page` fields (`Element::outer_html` / `bounding_box_page`).
+- `browser_html` — add `outer?: bool` (selector mode → `Element::outer_html` vs `inner_html`).
+- `browser_get_links` (new) — `Tab::get_all_urls(absolute)` / `get_all_linked_sources`. In: `{ absolute?, include_sources? }`. Out: `{ urls: [], sources?: [] }`. `readOnly:true`.
+- `browser_search_resources` (new) — `Tab::search_frame_resources`. In: `{ query }`. Out: `{ matches: [{ frame_id, url, ... }] }`. `readOnly:true`.
+
+**Small Tier-3 standalone tools** (kept minimal; trivial reads folded to cut surface noise)
+- `browser_set_download_path` (new) — `Tab::set_download_path`. In: `{ path }`. `readOnly:false`.
+- `browser_bypass_insecure_warning` (new) — `Tab::bypass_insecure_connection_warning`. `readOnly:false`.
+- `inspector_url` — **folded** into `browser_status` output (read state; no new tool).
+- `bring_to_front` — **folded** into `browser_tab_activate` (`activate` already foregrounds; add note, no new tool).
+
+### Tool-count delta
+
+49 → **65** registered tools (16 new tools + ~10 in-place parameter extensions).
+Two folds (`inspector_url`, `bring_to_front`) avoid trivial single-call tools.
+
+New tools: `browser_scroll`, `_get_window`, `_set_window`, `_pdf`, `_save_mhtml`,
+`_mouse`, `_solve_imperva`, `_download`, `_wait_for_load`, `_frame_goto`,
+`_key_sequence`, `_set_user_agent`, `_get_links`, `_search_resources`,
+`_set_download_path`, `_bypass_insecure_warning`.
+
+### Architecture impact
+
+- **New modules:** `tools/scroll.rs`, `tools/window.rs`, `tools/pdf.rs`,
+  `tools/mouse.rs`, `tools/imperva.rs`, `tools/download.rs`. Registered as
+  one-liner wrappers in `server.rs`.
+- **New feature flag.** `crates/zendriver-mcp/Cargo.toml`: add
+  `imperva = ["zendriver/imperva"]` and include it in `default`. New
+  `#[cfg(feature = "imperva")] #[tool_router(router = imperva_tool_router)]`
+  block in `server.rs`, summed in `combined_tool_router()` exactly like
+  `cloudflare_tool_router`.
+- **Binary-output guard.** A shared `binary_output(bytes, save_path)` helper in
+  `tools/common.rs` (size threshold → force save-to-path, omit base64). Reused by
+  pdf / mhtml / download / response-body.
+- **Docs.** `docs/book/src/mcp.md` tool table + counts updated (49 → 66; add
+  Scroll/Window/PDF/Mouse/Imperva/Download rows; mark Imperva gated). 49 → 65.
+
+### Testing strategy
+
+- **Integration tests** (`tests/integration_*.rs`, `feature = "integration-tests"`,
+  `#[ignore]`, real Chrome) — one new file per new module: `integration_scroll`,
+  `_window`, `_pdf`, `_mouse`, `_imperva`, `_download`; extend existing
+  `integration_actions` / `_expect` / `_lifecycle` for the parameter extensions.
+- **Schema snapshots** (`tests/schema_snapshots.rs` + `tests/snapshots/`, `insta`)
+  — every new tool and every extended input/output schema gets a snapshot; CI
+  diff requires `cargo insta accept`. This is the wire-shape review gate.
+- **Evaluations** (mcp-builder Phase 4) — 10 stable, read-only, real-Chrome
+  questions exercising the new surface (e.g. "scroll to the page footer and
+  return the copyright year", "export this page to PDF and report the byte
+  length", "evaluate `navigator.userAgent` inside the OOPIF named `checkout`").
+
+### Phasing (for writing-plans)
+
+- **Phase A — Tier 1** (highest value): imperva (+feature wiring), scroll, window,
+  pdf + mhtml, mouse, dialog-drive, frame-eval.
+- **Phase B — Tier 2**: key chords/modifiers, response-body, download-save,
+  download_file, runtime-UA, fine-grained stealth, modify_response, frame-goto,
+  load-waits, hard-reload.
+- **Phase C — Tier 3**: links, element outer_html/bbox_page, set_text/clear-by-backspace,
+  set_download_path, search_resources, bypass_insecure_warning, + the two folds.
+
+Each phase ends with: `cargo build`, gated integration run, `insta` accept,
+mdBook table update.
+
+## Assumptions
+
+1. **"API" = user-facing library operations**, not transport/CDP internals or
+   pure config structs.
+2. **Scope = everything (all Tier 1/2/3)** per user selection; only the listed
+   non-goals stay uncovered.
+3. **Imperva is promoted to a default MCP feature** (mirrors cloudflare). If a
+   leaner default is wanted, it can be gated-but-off-by-default instead.
+4. **Binary blobs default to save-to-path** above a size threshold rather than
+   always base64-inlining (token-cost guard).
+5. **Dialog drive folds into the await call** (no separate handle tool),
+   consistent with the no-ref-model non-goal.
+6. **`inspector_url` and `bring_to_front` are folded** into existing tools to
+   avoid trivial-tool surface bloat; everything else gets a dedicated tool or a
+   named parameter.
+7. **Imperva CAPTCHA-solver callback (`on_captcha`) is not wired over MCP** —
+   same class as the interception-stream non-goal.


### PR DESCRIPTION
## Summary

Treats MCP coverage like test coverage: audits the full `zendriver` public API (~230 user-facing items across 8 crates) against the 49-tool server, then closes **every** Tier 1/2/3 gap. Result: **49 → 65 tools**, leaving only 8 deliberately-documented non-goals uncovered.

Design + plan committed under `docs/superpowers/{specs,plans}/2026-06-02-*`.

## New tools (16)

- **Tier 1:** `browser_solve_imperva` (+ new default `imperva` feature), `browser_scroll`, `browser_get_window`, `browser_set_window`, `browser_pdf`, `browser_save_mhtml`, `browser_mouse`
- **Tier 2:** `browser_key_sequence`, `browser_download`, `browser_set_download_path`, `browser_wait_for_load`, `browser_frame_goto`, `browser_set_user_agent`
- **Tier 3:** `browser_get_links`, `browser_search_resources`, `browser_bypass_insecure_warning`

## Tool extensions

- `browser_expect_*` — **drive** matched events: dialog `accept`/`dismiss` (+ prompt text), response `fetch_body` (base64), download `save_to` (was detect-only)
- `browser_press` — modifier chords (Ctrl+A, etc.)
- `browser_reload` — `ignore_cache` (hard reload)
- `browser_intercept_add_rule` — `modify_response` rule kind
- `browser_set_stealth_profile` — fine-grained fingerprint overrides (platform/locale/timezone/memory/cpu/chrome_version/UA/bypass_csp)
- `browser_element_state` — `outer_html` + `bounding_box_page`
- `browser_html` — `outer` flag; `browser_set_value`/`browser_clear` — `mode`
- `browser_status` — `inspector_url`; `browser_tab_activate` — also raises page front

## Not covered (documented non-goals)

Element ref/handle model (→ relative DOM traversal), interception event-stream, JS sandbox, workflow/recipe tools, fast non-stealth action variants, debug visualization, raw transport, imperva CAPTCHA-solver callback.

## Verification

- `cargo clippy --all-features --all-targets -- -D warnings` clean
- All unit + schema-snapshot tests pass (`--all-features` and `--no-default-features`)
- Each new tool ships a no-browser unit test, a gated `#[ignore]` real-Chrome integration test, and an `insta` JSON-schema snapshot
- mdBook tool reference + 10-question evaluation suite updated

## Notes

- `imperva` was the single largest gap — a shipped, parity-complete bypass crate with zero MCP reach. Promoted to a default feature (mirrors `cloudflare`).
- Re-exports `zendriver::ResponseOverrides` (its `RequestOverrides` twin was already exported) — needed by `modify_response`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)