### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.0", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.1", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.3" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.1.4" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.1.4" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.2.0" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.2" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.1.5" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.2.0" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.1.3" }
 
 # MCP server

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.0] - 2026-06-02
+
+### Added
+
+- Browser_solve_imperva + imperva feature (Task A1)
+- Scroll, window, pdf/mhtml, coordinate-mouse tools (Tasks A2-A5)
+- Drive matched expectations — dialog accept/dismiss, response body, download save (Task A6)
+- Tier 2 tools — chords, download, runtime-UA, fine stealth, modify_response, frame nav/load waits (Phase B)
+- Tier 3 tools + docs — links, resource search, element extras, set-text/clear modes, TLS bypass (Phase C + D1)
+
+
 ## [0.1.5] - 2026-06-02
 
 ### Added

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.1.5"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-02
+
+### Added
+
+- Tier 2 tools — chords, download, runtime-UA, fine stealth, modify_response, frame nav/load waits (Phase B)
+
+
 ## [0.2.0] - 2026-06-02
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `zendriver-mcp`: 0.1.5 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `zendriver-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SetStealthProfileOutput.active_overrides in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/tools/stealth.rs:41
  field PressInput.modifiers in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/tools/actions.rs:320
  field SetValueInput.mode in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/tools/actions.rs:451
  field ClearInput.mode in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/tools/actions.rs:500
  field SessionState.stealth_overrides in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/state.rs:102
  field ElementState.outer_html in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/tools/reads.rs:95
  field ElementState.bounding_box_page in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/tools/reads.rs:99
  field HtmlInput.outer in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/tools/snapshot.rs:61
  field SetStealthProfileInput.overrides in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/tools/stealth.rs:32
  field RegisterInput.dialog_action in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/tools/expect.rs:170
  field RegisterInput.dialog_prompt_text in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/tools/expect.rs:173
  field RegisterInput.fetch_body in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/tools/expect.rs:177
  field RegisterInput.save_to in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/tools/expect.rs:181
  field StatusOutput.inspector_url in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/tools/lifecycle.rs:228

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant InterceptAction:ModifyResponse in /tmp/.tmpxfhIYd/zendriver-rs/crates/zendriver-mcp/src/tools/intercept.rs:100
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver`

<blockquote>

## [0.2.1] - 2026-06-02

### Added

- Tier 2 tools — chords, download, runtime-UA, fine stealth, modify_response, frame nav/load waits (Phase B)
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.2.0] - 2026-06-02

### Added

- Browser_solve_imperva + imperva feature (Task A1)
- Scroll, window, pdf/mhtml, coordinate-mouse tools (Tasks A2-A5)
- Drive matched expectations — dialog accept/dismiss, response body, download save (Task A6)
- Tier 2 tools — chords, download, runtime-UA, fine stealth, modify_response, frame nav/load waits (Phase B)
- Tier 3 tools + docs — links, resource search, element extras, set-text/clear modes, TLS bypass (Phase C + D1)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).