### PR TITLE
feat: fingerprint spoofing (Persona + 7 surfaces + zendriver-fingerprints)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3314,6 +3314,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "zendriver-fingerprints"
+version = "0.1.0"
+dependencies = [
+ "dirs",
+ "fastrand",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+ "zendriver-stealth",
+]
+
+[[package]]
 name = "zendriver-imperva"
 version = "0.1.3"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3383,6 +3383,7 @@ version = "0.1.4"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",
+ "fastrand",
  "futures",
  "insta",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/zendriver-fetcher",
     "crates/zendriver-mcp",
     "crates/zendriver-imperva",
+    "crates/zendriver-fingerprints",
 ]
 
 [workspace.package]
@@ -28,6 +29,7 @@ zendriver-interception  = { path = "crates/zendriver-interception", version = "0
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.2" }
 zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.2.1" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.1.3" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.1.0" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -25,3 +25,7 @@ tracing.workspace           = true
 fastrand                    = "2"
 reqwest  = { workspace = true, optional = true }
 dirs     = { workspace = true, optional = true }
+
+[[example]]
+name = "persona_pool"
+required-features = ["pool"]

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "zendriver-fingerprints"
+description = "Real-device persona sources (pool + generative) for zendriver-rs"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = []
+pool = ["dep:reqwest", "dep:dirs"]
+generative = []
+
+[dependencies]
+zendriver-stealth.workspace = true
+serde.workspace             = true
+serde_json.workspace        = true
+thiserror.workspace         = true
+tracing.workspace           = true
+fastrand                    = "2"
+reqwest  = { workspace = true, optional = true }
+dirs     = { workspace = true, optional = true }

--- a/crates/zendriver-fingerprints/NOTICE
+++ b/crates/zendriver-fingerprints/NOTICE
@@ -1,0 +1,2 @@
+This crate vendors fingerprint data derived from browserforge / fingerprint-suite
+(https://github.com/apify/fingerprint-suite), licensed Apache-2.0.

--- a/crates/zendriver-fingerprints/examples/persona_pool.rs
+++ b/crates/zendriver-fingerprints/examples/persona_pool.rs
@@ -1,0 +1,59 @@
+//! Illustrates building a `PoolSet`, sampling a `Persona` by seed, and
+//! inspecting the result.
+//!
+//! In real usage you would call `pool::load_or_download(url)` to fetch a
+//! large real-device dataset from a CDN; this example uses a small in-memory
+//! set so it runs offline.
+//!
+//! The resulting `Persona` value can be passed directly to
+//! `Browser::builder().persona(p)` in the `zendriver` crate (not a dep here).
+//!
+//! Run with:
+//! ```sh
+//! cargo run -p zendriver-fingerprints --example persona_pool --features pool
+//! ```
+
+use zendriver_fingerprints::pool::PoolSet;
+use zendriver_stealth::{Persona, Platform, Seed};
+
+fn make_persona(platform: Platform, memory_gb: u32) -> Persona {
+    Persona {
+        platform: Some(platform),
+        device_memory_gb: Some(memory_gb),
+        ..Persona::default()
+    }
+}
+
+fn main() {
+    // Build a small in-memory pool of real-device personas.
+    let pool = PoolSet::from_records(vec![
+        make_persona(Platform::Win32, 8),
+        make_persona(Platform::MacIntel, 16),
+        make_persona(Platform::Win32, 4),
+        make_persona(Platform::LinuxX86_64, 8),
+    ]);
+
+    // Sample deterministically — same seed always picks the same entry.
+    let seed = Seed::from_u64(42);
+    let persona = pool.sample(seed);
+
+    println!("Sampled persona:");
+    println!("  platform         = {:?}", persona.platform.unwrap());
+    println!(
+        "  device_memory_gb = {:?}",
+        persona.device_memory_gb.unwrap()
+    );
+
+    // Show reproducibility: sampling again with the same seed gives the same result.
+    let same_again = pool.sample(seed);
+    assert_eq!(
+        persona.device_memory_gb, same_again.device_memory_gb,
+        "same seed must yield the same persona"
+    );
+    println!("  (reproducible: same seed → same persona ✓)");
+
+    // In a real application you would then do:
+    //   Browser::builder().persona(persona).launch().await?
+    // but zendriver is not a dep of zendriver-fingerprints.
+    println!("\nPass `persona` to `Browser::builder().persona(persona)` to use it.");
+}

--- a/crates/zendriver-fingerprints/src/generative/mod.rs
+++ b/crates/zendriver-fingerprints/src/generative/mod.rs
@@ -1,1 +1,234 @@
-//! Generative source (C3).
+//! Generative source (C3): a Bayesian-network persona generator.
+//!
+//! Ports the browserforge conditional-probability-table (CPT) form: each node is
+//! a fingerprint attribute whose distribution is conditioned on its parents'
+//! sampled values. Sampling is **deterministic** in the [`Seed`] and yields an
+//! internally **coherent** [`Persona`] (e.g. a `MacIntel` platform pairs with a
+//! Mac-plausible WebGL renderer, because the renderer node is conditioned on
+//! `platform`).
+//!
+//! The embedded [`network.json`] is intentionally small; expanding it from the
+//! full upstream browserforge dataset is tracked as a follow-up (spec §14). The
+//! loader and sampler are complete and correct regardless of network size.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use zendriver_stealth::{Persona, Platform, Seed, WebglSpec};
+
+/// A Bayesian network of conditional fingerprint attributes (browserforge form).
+#[derive(Debug, Clone, Deserialize)]
+pub struct Generator {
+    nodes: Vec<Node>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct Node {
+    name: String,
+    parents: Vec<String>,
+    /// Conditional distributions keyed by the parents' sampled values joined by
+    /// `|` (empty string for a root node). Each entry maps the key to a weighted
+    /// `(value, weight)` distribution.
+    cpt: HashMap<String, Vec<(String, f64)>>,
+}
+
+impl Generator {
+    /// Load the embedded, trimmed network.
+    pub fn embedded() -> Self {
+        serde_json::from_str(include_str!("network.json")).expect("valid embedded BN")
+    }
+
+    /// Sample a coherent persona deterministically from `seed`.
+    ///
+    /// Determinism is guaranteed by walking nodes in a stable topological order
+    /// (a vector, never a `HashMap`) and driving every pick from a single
+    /// [`Mulberry32`] stream seeded by `seed`. The same seed therefore always
+    /// produces byte-identical assignments and thus an identical [`Persona`].
+    pub fn generate(&self, seed: Seed) -> Persona {
+        let mut rng = Mulberry32::new(seed.value() as u32);
+        let mut assigned: HashMap<String, String> = HashMap::new();
+        for node in self.topo_order() {
+            // Build the conditioning key from already-assigned parents, joined
+            // by `|`. For a root node this is the empty string, matching the
+            // `""` CPT entry.
+            //
+            // A parent must always be assigned before a child reads it; the topo
+            // order guarantees this for the embedded network. If a parent is
+            // somehow missing (a malformed network), fall back to its empty key
+            // so sampling stays panic-free rather than producing a silently
+            // mismatched conditioning key.
+            debug_assert!(
+                node.parents.iter().all(|p| assigned.contains_key(p)),
+                "node `{}` sampled before parent assignment (bad topo order)",
+                node.name
+            );
+            let key = node
+                .parents
+                .iter()
+                .map(|p| assigned.get(p).cloned().unwrap_or_default())
+                .collect::<Vec<_>>()
+                .join("|");
+            // Prefer the conditioned distribution; fall back to the
+            // unconditioned (`""`) entry if the exact key is absent.
+            let Some(dist) = node.cpt.get(&key).or_else(|| node.cpt.get("")) else {
+                // No usable distribution for this node — skip it rather than
+                // panic. Downstream mapping treats absent attributes as `None`.
+                continue;
+            };
+            assigned.insert(node.name.clone(), weighted_pick(dist, rng.next_f64()));
+        }
+        persona_from_assignment(&assigned)
+    }
+
+    /// Nodes in parents-before-children order.
+    ///
+    /// Sorting by parent count is a defensive heuristic that is exact for the
+    /// shallow embedded network (roots have 0 parents, children have 1). The
+    /// sort is **stable**, so ties keep their `network.json` order — this keeps
+    /// [`generate`](Self::generate) deterministic regardless of `HashMap`
+    /// iteration order.
+    fn topo_order(&self) -> Vec<&Node> {
+        let mut order = self.nodes.iter().collect::<Vec<_>>();
+        order.sort_by_key(|n| n.parents.len());
+        order
+    }
+}
+
+/// Mulberry32 PRNG — tiny, fast, deterministic. Matches the JS reference used
+/// upstream so seeds are portable across the Rust and JS farble paths.
+struct Mulberry32(u32);
+
+impl Mulberry32 {
+    fn new(seed: u32) -> Self {
+        Self(seed)
+    }
+
+    /// Next value in `[0, 1)`.
+    fn next_f64(&mut self) -> f64 {
+        self.0 = self.0.wrapping_add(0x6D2B_79F5);
+        let mut t = self.0;
+        t = (t ^ (t >> 15)).wrapping_mul(1 | t);
+        t = t.wrapping_add((t ^ (t >> 7)).wrapping_mul(61 | t)) ^ t;
+        f64::from(t ^ (t >> 14)) / 4_294_967_296.0
+    }
+}
+
+/// Pick a value from a weighted distribution given a uniform draw `r` in
+/// `[0, 1)`. Weights need not be normalized.
+fn weighted_pick(dist: &[(String, f64)], r: f64) -> String {
+    let total: f64 = dist.iter().map(|(_, w)| w).sum();
+    if total <= 0.0 {
+        return dist.first().map(|(v, _)| v.clone()).unwrap_or_default();
+    }
+    let mut acc = 0.0;
+    for (v, w) in dist {
+        acc += w / total;
+        if r <= acc {
+            return v.clone();
+        }
+    }
+    // Floating-point slack: return the last value if `r` rounded past `acc`.
+    dist.last().map(|(v, _)| v.clone()).unwrap_or_default()
+}
+
+/// Map a sampled attribute assignment onto a [`Persona`]. Keys mirror the
+/// `network.json` node names (`platform`, `webglRenderer`, `deviceMemory`, …).
+/// Absent attributes leave the corresponding `Persona` field at its default.
+fn persona_from_assignment(a: &HashMap<String, String>) -> Persona {
+    let mut p = Persona::default();
+    if let Some(plat) = a.get("platform") {
+        p.platform = Some(match plat.as_str() {
+            "Win32" => Platform::Win32,
+            "MacIntel" => Platform::MacIntel,
+            _ => Platform::LinuxX86_64,
+        });
+    }
+    if let Some(r) = a.get("webglRenderer") {
+        p.webgl = Some(WebglSpec {
+            unmasked_renderer: Some(r.clone()),
+            ..Default::default()
+        });
+    }
+    if let Some(m) = a.get("deviceMemory") {
+        p.device_memory_gb = m.parse().ok();
+    }
+    p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_is_deterministic_and_coherent() {
+        let g = Generator::embedded();
+        let a = g.generate(Seed::from_u64(7));
+        let b = g.generate(Seed::from_u64(7));
+        // same seed → same persona
+        assert_eq!(a.platform, b.platform);
+        assert_eq!(
+            a.webgl
+                .as_ref()
+                .and_then(|w| w.unmasked_renderer.as_deref()),
+            b.webgl
+                .as_ref()
+                .and_then(|w| w.unmasked_renderer.as_deref())
+        );
+        assert_eq!(a.device_memory_gb, b.device_memory_gb);
+        // coherence: a populated persona
+        assert!(a.platform.is_some());
+        assert!(a.webgl.is_some());
+    }
+
+    #[test]
+    fn webgl_renderer_is_coherent_with_platform() {
+        // The renderer node is conditioned on `platform`, so a sampled persona
+        // must never pair a platform with a renderer from another platform.
+        let g = Generator::embedded();
+        for s in 0..64u64 {
+            let p = g.generate(Seed::from_u64(s));
+            let plat = p.platform.expect("platform always assigned");
+            let renderer = p
+                .webgl
+                .as_ref()
+                .and_then(|w| w.unmasked_renderer.as_deref())
+                .expect("renderer always assigned");
+            match plat {
+                Platform::MacIntel => assert!(
+                    renderer.contains("Apple"),
+                    "MacIntel paired with non-Apple renderer: {renderer}"
+                ),
+                Platform::Win32 => assert!(
+                    renderer.contains("Direct3D11"),
+                    "Win32 paired with non-D3D renderer: {renderer}"
+                ),
+                Platform::LinuxX86_64 => assert!(
+                    renderer.contains("Mesa"),
+                    "Linux paired with non-Mesa renderer: {renderer}"
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn different_seeds_can_differ() {
+        // Guard against a constant generator: across a handful of fixed seeds
+        // the sampled platforms must not all be identical.
+        let g = Generator::embedded();
+        let platforms: Vec<_> = (0..32u64)
+            .map(|s| g.generate(Seed::from_u64(s)).platform)
+            .collect();
+        let first = platforms[0];
+        assert!(
+            platforms.iter().any(|p| *p != first),
+            "generator produced the same platform for every seed"
+        );
+    }
+
+    #[test]
+    fn embedded_network_parses() {
+        // Loading the bundled network must not panic.
+        let g = Generator::embedded();
+        assert!(!g.nodes.is_empty());
+    }
+}

--- a/crates/zendriver-fingerprints/src/generative/mod.rs
+++ b/crates/zendriver-fingerprints/src/generative/mod.rs
@@ -1,0 +1,1 @@
+//! Generative source (C3).

--- a/crates/zendriver-fingerprints/src/generative/network.json
+++ b/crates/zendriver-fingerprints/src/generative/network.json
@@ -1,0 +1,50 @@
+{
+  "nodes": [
+    {
+      "name": "platform",
+      "parents": [],
+      "cpt": {
+        "": [
+          ["Win32", 0.7],
+          ["MacIntel", 0.2],
+          ["LinuxX86_64", 0.1]
+        ]
+      }
+    },
+    {
+      "name": "deviceMemory",
+      "parents": ["platform"],
+      "cpt": {
+        "Win32": [
+          ["8", 0.6],
+          ["16", 0.4]
+        ],
+        "MacIntel": [
+          ["16", 0.7],
+          ["8", 0.3]
+        ],
+        "LinuxX86_64": [
+          ["8", 0.5],
+          ["16", 0.5]
+        ]
+      }
+    },
+    {
+      "name": "webglRenderer",
+      "parents": ["platform"],
+      "cpt": {
+        "Win32": [
+          ["ANGLE (NVIDIA, NVIDIA GeForce RTX 3060 Direct3D11 vs_5_0 ps_5_0, D3D11)", 0.6],
+          ["ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)", 0.4]
+        ],
+        "MacIntel": [
+          ["ANGLE (Apple, Apple M1, OpenGL 4.1)", 0.6],
+          ["ANGLE (Apple, Apple M2, OpenGL 4.1)", 0.4]
+        ],
+        "LinuxX86_64": [
+          ["ANGLE (Mesa, llvmpipe (LLVM 15.0.7 256 bits), OpenGL 4.5)", 1.0]
+        ]
+      }
+    }
+  ]
+}

--- a/crates/zendriver-fingerprints/src/lib.rs
+++ b/crates/zendriver-fingerprints/src/lib.rs
@@ -1,0 +1,9 @@
+//! Real-device persona sources for zendriver-rs.
+//!
+//! # Features
+//! - `pool` — download-on-first-use pool of real-device personas.
+//! - `generative` — Bayesian network persona generator (C3, placeholder).
+#[cfg(feature = "generative")]
+pub mod generative;
+#[cfg(feature = "pool")]
+pub mod pool;

--- a/crates/zendriver-fingerprints/src/pool/mod.rs
+++ b/crates/zendriver-fingerprints/src/pool/mod.rs
@@ -1,0 +1,162 @@
+//! Pool of real-device personas: download-on-first-use + seeded sampling.
+
+use std::env;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use zendriver_stealth::{Persona, Seed};
+
+/// A parsed pool of real-device personas.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PoolSet {
+    records: Vec<Persona>,
+}
+
+impl PoolSet {
+    /// Build from an in-memory list (tests / manual construction).
+    pub fn from_records(records: Vec<Persona>) -> Self {
+        Self { records }
+    }
+
+    /// Parse a downloaded pool asset (JSON array of personas).
+    pub fn from_json(s: &str) -> Result<Self, serde_json::Error> {
+        Ok(Self {
+            records: serde_json::from_str(s)?,
+        })
+    }
+
+    /// Deterministically pick one persona by seed.
+    ///
+    /// `idx = seed.value() as usize % len` — stable across versions.
+    ///
+    /// # Panics
+    /// Panics if the pool is empty.
+    pub fn sample(&self, seed: Seed) -> Persona {
+        assert!(!self.records.is_empty(), "pool is empty");
+        let idx = (seed.value() as usize) % self.records.len();
+        self.records[idx].clone()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pool error
+// ---------------------------------------------------------------------------
+
+/// Error from pool operations.
+#[derive(Debug, thiserror::Error)]
+pub enum PoolError {
+    #[error("http error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+// ---------------------------------------------------------------------------
+// Cache helpers
+// ---------------------------------------------------------------------------
+
+/// Cache file path for pool assets — same root as `zendriver-fetcher`
+/// (`dirs::cache_dir() / zendriver / fingerprints / pool.json`).
+pub fn cache_path() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(env::temp_dir)
+        .join("zendriver/fingerprints/pool.json")
+}
+
+// ---------------------------------------------------------------------------
+// Download-on-first-use
+// ---------------------------------------------------------------------------
+
+/// Load pool from local cache or download and cache from `url`.
+///
+/// Uses the same atomic-write pattern as `zendriver-fetcher` (write to
+/// `<path>.tmp`, then `rename` into place).
+pub async fn load_or_download(url: &str) -> Result<PoolSet, PoolError> {
+    let cache = cache_path();
+
+    // Fast path: cache hit.
+    if let Ok(bytes) = std::fs::read_to_string(&cache) {
+        if let Ok(set) = PoolSet::from_json(&bytes) {
+            tracing::debug!(path = %cache.display(), "pool cache hit");
+            return Ok(set);
+        }
+    }
+
+    tracing::debug!(url, "pool cache miss — downloading");
+    let body = reqwest::get(url).await?.text().await?;
+    let set = PoolSet::from_json(&body)?;
+
+    // Atomic write: tmp → rename.
+    if let Some(parent) = cache.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = cache.with_extension("tmp");
+    std::fs::write(&tmp, &body)?;
+    std::fs::rename(&tmp, &cache)?;
+
+    tracing::debug!(path = %cache.display(), "pool cached");
+    Ok(set)
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Build a minimal [`Persona`] for tests.
+#[cfg(test)]
+pub(crate) fn mk(platform: &str, mem: u32) -> Persona {
+    use zendriver_stealth::Platform;
+    let plat = match platform {
+        "Win32" => Platform::Win32,
+        "MacIntel" => Platform::MacIntel,
+        _ => Platform::LinuxX86_64,
+    };
+    Persona {
+        platform: Some(plat),
+        device_memory_gb: Some(mem),
+        ..Default::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sample_is_deterministic_for_seed() {
+        let set = PoolSet::from_records(vec![mk("Win32", 8), mk("MacIntel", 16), mk("Win32", 4)]);
+        let a = set.sample(Seed::from_u64(42));
+        let b = set.sample(Seed::from_u64(42));
+        assert_eq!(a.device_memory_gb, b.device_memory_gb);
+    }
+
+    #[test]
+    fn sample_selects_correct_index() {
+        let set = PoolSet::from_records(vec![mk("Win32", 8), mk("MacIntel", 16), mk("Win32", 4)]);
+        // seed 42 % 3 = 0  → Win32/8
+        let p = set.sample(Seed::from_u64(42));
+        assert_eq!(p.device_memory_gb, Some(8));
+        // seed 1 % 3 = 1 → MacIntel/16
+        let q = set.sample(Seed::from_u64(1));
+        assert_eq!(q.device_memory_gb, Some(16));
+    }
+
+    #[test]
+    fn from_json_round_trip() {
+        let original = PoolSet::from_records(vec![mk("Win32", 8), mk("MacIntel", 16)]);
+        // PoolSet serializes as {"records":[...]}; from_json expects a bare array.
+        // So we serialize just the records array.
+        let records_json = serde_json::to_string(&original.records).unwrap();
+        let parsed = PoolSet::from_json(&records_json).unwrap();
+        assert_eq!(parsed.records.len(), 2);
+        assert_eq!(parsed.records[0].device_memory_gb, Some(8));
+        assert_eq!(parsed.records[1].device_memory_gb, Some(16));
+    }
+}

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -32,6 +32,7 @@ thiserror.workspace           = true
 tracing.workspace             = true
 sysinfo.workspace             = true
 num_cpus.workspace            = true
+fastrand                      = "2"
 
 [dev-dependencies]
 tokio-test.workspace          = true

--- a/crates/zendriver-stealth/src/error.rs
+++ b/crates/zendriver-stealth/src/error.rs
@@ -18,6 +18,16 @@ pub enum StealthError {
 
     #[error("invalid fingerprint override: {0}")]
     InvalidOverride(String),
+
+    /// A live-browser probe (e.g. [`crate::Persona::from_browser`]) failed.
+    ///
+    /// Carries the upstream error's message as a `String` rather than the
+    /// concrete type: the probe runs through the [`crate::JsProbe`] seam so
+    /// that `zendriver-stealth` need not depend on the `zendriver` core crate
+    /// (which would be a dependency cycle). The caller's `JsProbe` impl maps
+    /// its own error into this variant.
+    #[error("live-browser probe failed: {0}")]
+    Probe(String),
 }
 
 #[cfg(test)]

--- a/crates/zendriver-stealth/src/fingerprint.rs
+++ b/crates/zendriver-stealth/src/fingerprint.rs
@@ -140,7 +140,7 @@ impl Fingerprint {
     }
 }
 
-fn detect_platform() -> Platform {
+pub(crate) fn detect_platform() -> Platform {
     #[cfg(target_os = "windows")]
     {
         Platform::Win32
@@ -166,7 +166,7 @@ fn detect_platform() -> Platform {
 }
 
 #[allow(clippy::result_large_err)]
-fn probe_chrome_version(exe: &Path) -> Result<(u32, String), StealthError> {
+pub(crate) fn probe_chrome_version(exe: &Path) -> Result<(u32, String), StealthError> {
     let output = Command::new(exe)
         .arg("--version")
         .output()
@@ -192,14 +192,14 @@ fn probe_chrome_version(exe: &Path) -> Result<(u32, String), StealthError> {
     Ok((major, full))
 }
 
-fn clamp_cpu_count(n: u32) -> u32 {
+pub(crate) fn clamp_cpu_count(n: u32) -> u32 {
     n.clamp(2, 32)
 }
 
 /// Detect total RAM in GB, clamped to the spec-compliant values
 /// for `navigator.deviceMemory` (capped at 8 per W3C; floor at 4 for plausibility).
 #[allow(clippy::result_large_err)]
-fn detect_memory_gb() -> Result<u32, StealthError> {
+pub(crate) fn detect_memory_gb() -> Result<u32, StealthError> {
     let mut sys = sysinfo::System::new();
     sys.refresh_memory();
     // sysinfo 0.32: total_memory() returns BYTES, not KiB. Verified against

--- a/crates/zendriver-stealth/src/lib.rs
+++ b/crates/zendriver-stealth/src/lib.rs
@@ -54,4 +54,4 @@ pub use profile::{Platform, ProfileKind, StealthProfile};
 pub use persona::seed::Seed;
 pub use persona::specs::{FontSpec, HardwareSpec, SurfaceCfg, UaSpec, WebglSpec, WebrtcSpec};
 pub use persona::surface::{Strategy, Surface, SurfaceKind};
-pub use persona::{Persona, PersonaBuilder};
+pub use persona::{JsProbe, Persona, PersonaBuilder};

--- a/crates/zendriver-stealth/src/lib.rs
+++ b/crates/zendriver-stealth/src/lib.rs
@@ -50,3 +50,8 @@ pub use fingerprint::{Brand, Fingerprint, UserAgentMetadata};
 pub use input_profile::InputProfile;
 pub use observer::StealthObserver;
 pub use profile::{Platform, ProfileKind, StealthProfile};
+
+pub use persona::seed::Seed;
+pub use persona::specs::{FontSpec, HardwareSpec, SurfaceCfg, UaSpec, WebglSpec, WebrtcSpec};
+pub use persona::surface::{Strategy, Surface, SurfaceKind};
+pub use persona::{Persona, PersonaBuilder};

--- a/crates/zendriver-stealth/src/lib.rs
+++ b/crates/zendriver-stealth/src/lib.rs
@@ -36,6 +36,7 @@
 
 pub mod error;
 pub mod fingerprint;
+pub mod persona;
 pub mod flags;
 pub mod input_profile;
 pub mod observer;

--- a/crates/zendriver-stealth/src/lib.rs
+++ b/crates/zendriver-stealth/src/lib.rs
@@ -36,11 +36,11 @@
 
 pub mod error;
 pub mod fingerprint;
-pub mod persona;
 pub mod flags;
 pub mod input_profile;
 pub mod observer;
 pub mod patches;
+pub mod persona;
 pub mod profile;
 pub mod ua;
 

--- a/crates/zendriver-stealth/src/observer.rs
+++ b/crates/zendriver-stealth/src/observer.rs
@@ -12,7 +12,7 @@ use serde_json::json;
 use zendriver_transport::{ObserverError, PausedSession, TargetObserver};
 
 use crate::patches::bootstrap_script;
-use crate::{Fingerprint, ProfileKind, StealthProfile};
+use crate::{Fingerprint, Persona, ProfileKind, StealthProfile};
 
 /// Observer that applies a [`StealthProfile`] + [`Fingerprint`] to every page
 /// target. Workers and iframes are skipped — workers have no DOM and iframes
@@ -30,10 +30,27 @@ pub struct StealthObserver {
 impl StealthObserver {
     /// Build a new observer. Bootstrap source is composed eagerly so the
     /// per-target hot path only pays a `clone`/borrow.
+    ///
+    /// The bootstrap is driven by a [`Persona`] (surface-spoofing config) plus
+    /// the [`Fingerprint`] (coherent UA / Chrome identity). This constructor
+    /// uses [`Persona::default`] — no surface overrides, identity-only patches
+    /// keep their current behavior. The launch path (a later task) will thread
+    /// a caller-supplied persona via [`StealthObserver::with_persona`].
     #[must_use]
     pub fn new(profile: StealthProfile, fingerprint: Fingerprint) -> Self {
+        Self::with_persona(profile, fingerprint, Persona::default())
+    }
+
+    /// Build a new observer with an explicit [`Persona`] driving the surface
+    /// patches. `identity` still supplies the coherent UA / Chrome version.
+    #[must_use]
+    pub fn with_persona(
+        profile: StealthProfile,
+        fingerprint: Fingerprint,
+        persona: Persona,
+    ) -> Self {
         let bootstrap = if profile.kind() == ProfileKind::Spoofed {
-            bootstrap_script(&fingerprint)
+            bootstrap_script(&persona, &fingerprint)
         } else {
             String::new()
         };

--- a/crates/zendriver-stealth/src/patches.rs
+++ b/crates/zendriver-stealth/src/patches.rs
@@ -1,53 +1,278 @@
-//! Bundles individual patches into a single IIFE called with a serialized
-//! Fingerprint. Only one `Page.addScriptToEvaluateOnNewDocument` round-trip
-//! per nav instead of nine.
+//! Bundles individual patches into a bootstrap script driven by a [`Persona`]
+//! (the surface-spoofing config) plus a [`Fingerprint`] (coherent UA / Chrome
+//! identity probed at launch).
+//!
+//! The 9 identity patches run inside a single IIFE called with a serialized
+//! fingerprint object — one `Page.addScriptToEvaluateOnNewDocument` round-trip
+//! covers them. The persona-driven surface patches (canvas/audio/clientRects
+//! noise, webgl/fonts/hardware value substitution, webrtc policy) are appended
+//! after, each emitted only when its resolved [`Strategy`] is not `Native`.
 
 use serde_json::json;
 
-use crate::Fingerprint;
+use crate::persona::surface::{Strategy, Surface};
+use crate::persona::{FontSpec, HardwareSpec, SurfaceCfg, WebglSpec, WebrtcSpec};
+use crate::{Fingerprint, Persona, Seed, UserAgentMetadata};
 
+// --- Identity patches (run inside the fp IIFE) ---------------------------
 const WEBDRIVER: &str = include_str!("patches/webdriver.js");
 const PLUGINS: &str = include_str!("patches/plugins.js");
 const CHROME: &str = include_str!("patches/chrome.js");
-const WEBGL: &str = include_str!("patches/webgl.js");
 const PERMISSIONS: &str = include_str!("patches/permissions.js");
 const CODECS: &str = include_str!("patches/codecs.js");
 const NAVIGATOR_PROPS: &str = include_str!("patches/navigator_props.js");
 const USER_AGENT_DATA: &str = include_str!("patches/user_agent_data.js");
 const BROKEN_IMAGE: &str = include_str!("patches/broken_image.js");
 
+// --- Persona surface patches (appended after the identity IIFE) ----------
+//
+// `webgl.js` carries BOTH the hardcoded vendor/renderer fallback block and a
+// persona-driven value-substitution IIFE, so it is emitted exactly ONCE here
+// (not in the identity IIFE) to avoid a duplicate block + unsubstituted
+// `WEBGL_VENDOR`/`WEBGL_RENDERER` tokens. It references no `fp` fields, so
+// running it at the bootstrap's top level (rather than inside the fp IIFE) is
+// behavior-preserving; its top-level `const VENDOR`/`RENDERER` are script-
+// scoped and the nested IIFE's `const VENDOR` is function-scoped — no
+// redeclaration.
+const PRNG: &str = include_str!("patches/_prng.js");
+const WEBGL: &str = include_str!("patches/webgl.js");
+const CANVAS: &str = include_str!("patches/canvas.js");
+const AUDIO: &str = include_str!("patches/audio.js");
+const CLIENT_RECTS: &str = include_str!("patches/client_rects.js");
+const FONTS: &str = include_str!("patches/fonts.js");
+const WEBRTC: &str = include_str!("patches/webrtc.js");
+const HARDWARE: &str = include_str!("patches/hardware.js");
+
 /// Build the bootstrap script for the spoofed profile.
-/// Order: webdriver first (most-probed), navigator_props last (touches most fields).
+///
+/// `identity` supplies coherent UA-CH metadata and the *real* probed Chrome
+/// version; `persona` overrides simple identity fields (platform / hardware /
+/// locale) and drives the new fingerprint surfaces. Splitting the two keeps
+/// the UA coherent: when the persona changes platform we rebuild the UA-CH
+/// metadata against the real Chrome version instead of a stale fallback.
+///
+/// Order: identity IIFE first (webdriver-most-probed-first, navigator_props
+/// last), then the PRNG definition, then each persona surface.
 #[must_use]
-pub fn bootstrap_script(fp: &Fingerprint) -> String {
+pub fn bootstrap_script(persona: &Persona, identity: &Fingerprint) -> String {
+    let mut out = identity_iife(persona, identity);
+
+    let seed = persona.seed.unwrap_or_else(Seed::random).value();
+
+    // PRNG must be defined once, before any noise/font patch that references
+    // `__zdRng`. Emit it unconditionally — cheap, and harmless if every
+    // surface is Native (it just defines an unused function).
+    out.push('\n');
+    out.push_str(PRNG);
+
+    push_noise(
+        &mut out,
+        Surface::Canvas,
+        persona.canvas.as_ref(),
+        CANVAS,
+        seed,
+    );
+    push_noise(
+        &mut out,
+        Surface::Audio,
+        persona.audio.as_ref(),
+        AUDIO,
+        seed,
+    );
+    push_noise(
+        &mut out,
+        Surface::ClientRects,
+        persona.client_rects.as_ref(),
+        CLIENT_RECTS,
+        seed,
+    );
+
+    push_webgl(&mut out, persona.webgl.as_ref());
+    push_fonts(&mut out, persona.fonts.as_ref(), seed);
+    push_hardware(&mut out, persona.hardware.as_ref());
+    push_webrtc(&mut out, persona.webrtc.as_ref());
+
+    out
+}
+
+/// Emit the 9 identity patches wrapped in `(function(fp){ ... })(fpJson)`.
+/// Identity is resolved from `identity` with `persona` overrides applied,
+/// preserving UA coherence (see [`bootstrap_script`]).
+fn identity_iife(persona: &Persona, identity: &Fingerprint) -> String {
+    let platform = persona.platform.unwrap_or(identity.platform);
+
+    // If the persona changes the platform, rebuild UA-CH metadata coherently
+    // against the REAL probed Chrome version (never a fallback) so platform +
+    // platformVersion + brands all agree. Otherwise reuse the probed metadata.
+    let uam = if persona.platform.is_some_and(|p| p != identity.platform) {
+        UserAgentMetadata::realistic(platform, identity.chrome_major, &identity.chrome_full)
+    } else {
+        identity.ua_metadata.clone()
+    };
+
+    let cpu = persona.hardware_concurrency.unwrap_or(identity.cpu_count);
+    let mem = persona.device_memory_gb.unwrap_or(identity.memory_gb);
+    let locale = persona.locale.clone().or_else(|| identity.locale.clone());
+
     let fp_json = json!({
-        "platformJs":      fp.platform.js_string(),
-        "chPlatform":      fp.platform.ch_platform(),
-        "platformVersion": fp.ua_metadata.platform_version,
-        "cpuCount":        fp.cpu_count,
-        "memoryGb":        fp.memory_gb,
-        "languages":       fp.locale.as_deref().map_or_else(
+        "platformJs":      platform.js_string(),
+        "chPlatform":      platform.ch_platform(),
+        "platformVersion": uam.platform_version,
+        "cpuCount":        cpu,
+        "memoryGb":        mem,
+        "languages":       locale.as_deref().map_or_else(
             || vec!["en-US".to_string(), "en".to_string()],
             |l| vec![l.to_string(), "en".to_string()],
         ),
-        "architecture":    fp.ua_metadata.architecture,
-        "bitness":         fp.ua_metadata.bitness,
-        "brands":          fp.ua_metadata.brands,
-        "fullVersionList": fp.ua_metadata.full_version_list,
+        "architecture":    uam.architecture,
+        "bitness":         uam.bitness,
+        "brands":          uam.brands,
+        "fullVersionList": uam.full_version_list,
     });
 
     format!(
-        "(function(fp){{\n{WEBDRIVER}\n{PLUGINS}\n{CHROME}\n{WEBGL}\n{PERMISSIONS}\n{CODECS}\n{NAVIGATOR_PROPS}\n{USER_AGENT_DATA}\n{BROKEN_IMAGE}\n}})({fp_json});",
+        "(function(fp){{\n{WEBDRIVER}\n{PLUGINS}\n{CHROME}\n{PERMISSIONS}\n{CODECS}\n{NAVIGATOR_PROPS}\n{USER_AGENT_DATA}\n{BROKEN_IMAGE}\n}})({fp_json});",
     )
+}
+
+/// JS source for the resolved seed token of a noise surface, or `None` when
+/// the surface should be omitted entirely (`Native`).
+fn seed_token(strat: Strategy, seed: u64) -> Option<String> {
+    match strat {
+        Strategy::Native => None,
+        // Constant zero seed → every farble step deterministic & uniform; the
+        // `/*BLOCK*/` marker documents intent and lets tests assert on it.
+        Strategy::Block => Some("0/*BLOCK*/".to_string()),
+        Strategy::Seeded | Strategy::Value => Some(seed.to_string()),
+        Strategy::Random => Some("(Math.random()*4294967296)>>>0".to_string()),
+    }
+}
+
+/// Append a noise-surface patch (`SEED` token), respecting the resolved
+/// strategy. No-op under `Native`.
+fn push_noise(out: &mut String, surface: Surface, cfg: Option<&SurfaceCfg>, js: &str, seed: u64) {
+    let strat = surface.resolve_strategy(cfg.and_then(|c| c.strategy));
+    if let Some(tok) = seed_token(strat, seed) {
+        out.push('\n');
+        out.push_str(&js.replace("SEED", &tok));
+    }
+}
+
+/// JSON literal for an optional string value, or JS `null` when absent.
+fn json_or_null(v: Option<&String>) -> String {
+    v.map_or_else(
+        || "null".to_string(),
+        |s| serde_json::to_string(s).unwrap_or_else(|_| "null".to_string()),
+    )
+}
+
+/// Append the webgl value-substitution patch. The existing hardcoded webgl
+/// block (the first half of `webgl.js`) always runs; the appended IIFE's
+/// `WEBGL_VENDOR` / `WEBGL_RENDERER` args carry the persona values (or JS
+/// `null` when absent / `Native`, leaving the hardcoded block in charge).
+fn push_webgl(out: &mut String, spec: Option<&WebglSpec>) {
+    let strat = Surface::Webgl.resolve_strategy(spec.and_then(|s| s.strategy));
+    let (vendor, renderer) = match strat {
+        // Under Native the persona contributes nothing — pass null so the new
+        // IIFE delegates entirely to the hardcoded block (which still runs).
+        Strategy::Native => ("null".to_string(), "null".to_string()),
+        _ => (
+            json_or_null(spec.and_then(|s| s.unmasked_vendor.as_ref())),
+            json_or_null(spec.and_then(|s| s.unmasked_renderer.as_ref())),
+        ),
+    };
+    out.push('\n');
+    out.push_str(
+        &WEBGL
+            .replace("WEBGL_VENDOR", &vendor)
+            .replace("WEBGL_RENDERER", &renderer),
+    );
+}
+
+/// Append the fonts patch (`FONT_ALLOW` + `SEED`). Omitted under `Native`.
+fn push_fonts(out: &mut String, spec: Option<&FontSpec>, seed: u64) {
+    let strat = Surface::Fonts.resolve_strategy(spec.and_then(|s| s.strategy));
+    let seed_tok = match seed_token(strat, seed) {
+        None => return, // Native → omit entirely.
+        Some(t) => t,
+    };
+    // Allow-list only meaningful when the persona supplies one AND we're not
+    // blocking; under Block, hide every font (empty allow-list).
+    let allow = match strat {
+        Strategy::Block => "[]".to_string(),
+        _ => spec.and_then(|s| s.available.as_ref()).map_or_else(
+            || "null".to_string(),
+            |v| serde_json::to_string(v).unwrap_or_else(|_| "null".to_string()),
+        ),
+    };
+    out.push('\n');
+    out.push_str(
+        &FONTS
+            .replace("FONT_ALLOW", &allow)
+            .replace("SEED", &seed_tok),
+    );
+}
+
+/// Append the hardware patch (`HW_BATTERY` / `HW_MEDIA_DEVICES` / `HW_VOICES`).
+/// Omitted under `Native`. Each field independently `null` when unset.
+fn push_hardware(out: &mut String, spec: Option<&HardwareSpec>) {
+    let strat = Surface::Hardware.resolve_strategy(spec.and_then(|s| s.strategy));
+    if strat == Strategy::Native {
+        return;
+    }
+    let (battery, media, voices) = if strat == Strategy::Block {
+        // Block → present a uniform, minimal hardware surface.
+        ("1".to_string(), "0".to_string(), "[]".to_string())
+    } else {
+        let battery = spec
+            .and_then(|s| s.battery_level)
+            .map_or_else(|| "null".to_string(), |b| b.to_string());
+        let media = spec
+            .and_then(|s| s.media_devices)
+            .map_or_else(|| "null".to_string(), |m| m.to_string());
+        let voices = spec.and_then(|s| s.speech_voices.as_ref()).map_or_else(
+            || "null".to_string(),
+            |v| serde_json::to_string(v).unwrap_or_else(|_| "null".to_string()),
+        );
+        (battery, media, voices)
+    };
+    out.push('\n');
+    out.push_str(
+        &HARDWARE
+            .replace("HW_BATTERY", &battery)
+            .replace("HW_MEDIA_DEVICES", &media)
+            .replace("HW_VOICES", &voices),
+    );
+}
+
+/// Append the webrtc policy patch (`WEBRTC_POLICY` + `WEBRTC_FAKE_IP`).
+/// The patch self-no-ops on the `"native"` policy, so we always emit it but
+/// pass the strategy-derived policy string.
+fn push_webrtc(out: &mut String, spec: Option<&WebrtcSpec>) {
+    let strat = Surface::Webrtc.resolve_strategy(spec.and_then(|s| s.strategy));
+    let policy = match strat {
+        Strategy::Native => "native",
+        Strategy::Value => "value",
+        // Block (the policy default) + any non-meaningful fallback.
+        _ => "block",
+    };
+    let fake_ip = json_or_null(spec.and_then(|s| s.fake_ip.as_ref()));
+    out.push('\n');
+    out.push_str(
+        &WEBRTC
+            .replace("WEBRTC_POLICY", &format!("\"{policy}\""))
+            .replace("WEBRTC_FAKE_IP", &fake_ip),
+    );
 }
 
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::persona::surface::Strategy;
     use crate::{Platform, UserAgentMetadata};
 
-    fn mock_fp() -> Fingerprint {
+    fn mock_identity() -> Fingerprint {
         Fingerprint {
             platform: Platform::MacIntel,
             chrome_major: 120,
@@ -61,9 +286,11 @@ mod tests {
         }
     }
 
+    // --- Migrated identity tests (the original three) --------------------
+
     #[test]
     fn bootstrap_includes_all_nine_patches() {
-        let s = bootstrap_script(&mock_fp());
+        let s = bootstrap_script(&Persona::default(), &mock_identity());
         assert!(s.contains("webdriver"), "webdriver patch missing");
         assert!(s.contains("PluginArray"), "plugins patch missing");
         assert!(s.contains("window.chrome"), "chrome patch missing");
@@ -86,14 +313,331 @@ mod tests {
 
     #[test]
     fn bootstrap_is_an_iife_taking_fp() {
-        let s = bootstrap_script(&mock_fp());
+        let s = bootstrap_script(&Persona::default(), &mock_identity());
         assert!(s.starts_with("(function(fp){"));
         assert!(s.contains("})({"), "fp arg JSON should follow");
     }
 
     #[test]
     fn bootstrap_substitutes_platform_js_string() {
-        let s = bootstrap_script(&mock_fp());
+        let s = bootstrap_script(&Persona::default(), &mock_identity());
         assert!(s.contains("\"MacIntel\""));
+    }
+
+    // --- Identity coherence ---------------------------------------------
+
+    #[test]
+    fn persona_platform_override_rebuilds_uam_with_real_chrome_version() {
+        // identity is mac/chrome120; persona overrides platform to Win32.
+        // The rebuilt UA-CH must use the REAL chrome version (120) and the
+        // Win32 platformVersion (15.0.0), not a fallback.
+        let persona = Persona {
+            platform: Some(Platform::Win32),
+            ..Persona::default()
+        };
+        let s = bootstrap_script(&persona, &mock_identity());
+        assert!(s.contains("\"Win32\""), "platformJs should be Win32");
+        assert!(
+            s.contains("15.0.0"),
+            "Win32 platformVersion should be present"
+        );
+        // chrome 120 brands carried through from the real identity.
+        assert!(s.contains("\"120\""), "real chrome major should survive");
+    }
+
+    #[test]
+    fn persona_overrides_simple_identity_fields() {
+        let persona = Persona {
+            hardware_concurrency: Some(4),
+            device_memory_gb: Some(16),
+            locale: Some("fr-FR".into()),
+            ..Persona::default()
+        };
+        let s = bootstrap_script(&persona, &mock_identity());
+        assert!(s.contains("\"cpuCount\":4"), "cpu override missing");
+        // deviceMemory is rendered into the fp json untouched here (the JS
+        // clamps); persona value should appear.
+        assert!(s.contains("\"memoryGb\":16"), "memory override missing");
+        assert!(s.contains("fr-FR"), "locale override missing");
+    }
+
+    // --- Surface strategy emission (new) --------------------------------
+
+    #[test]
+    fn native_strategy_omits_surface_patch() {
+        let p = Persona {
+            canvas: Some(SurfaceCfg {
+                strategy: Some(Strategy::Native),
+            }),
+            seed: Some(Seed::from_u64(1)),
+            ..Persona::default()
+        };
+        let script = bootstrap_script(&p, &mock_identity());
+        assert!(
+            !script.contains("origGetImageData"),
+            "Native canvas → no farble hook"
+        );
+    }
+
+    #[test]
+    fn block_strategy_emits_constant_canvas() {
+        let p = Persona {
+            canvas: Some(SurfaceCfg {
+                strategy: Some(Strategy::Block),
+            }),
+            ..Persona::default()
+        };
+        let script = bootstrap_script(&p, &mock_identity());
+        // canvas patch IS emitted (hook present) but seeded with the BLOCK
+        // marker rather than a live seed.
+        assert!(
+            script.contains("origGetImageData"),
+            "Block canvas still hooks getImageData"
+        );
+        assert!(script.contains("BLOCK"), "Block canvas marker present");
+    }
+
+    #[test]
+    fn seeded_canvas_templates_seed() {
+        let p = Persona {
+            canvas: Some(SurfaceCfg {
+                strategy: Some(Strategy::Seeded),
+            }),
+            seed: Some(Seed::from_u64(123)),
+            ..Persona::default()
+        };
+        let script = bootstrap_script(&p, &mock_identity());
+        assert!(
+            script.contains("origGetImageData"),
+            "canvas farble must hook getImageData"
+        );
+        // The seed `123` is substituted as the IIFE arg: `})(123);`
+        assert!(
+            script.contains("})(123)"),
+            "seed value must be templated in"
+        );
+    }
+
+    #[test]
+    fn random_canvas_uses_math_random_seed() {
+        let p = Persona {
+            canvas: Some(SurfaceCfg {
+                strategy: Some(Strategy::Random),
+            }),
+            ..Persona::default()
+        };
+        let script = bootstrap_script(&p, &mock_identity());
+        assert!(
+            script.contains("Math.random()*4294967296"),
+            "Random canvas re-seeds per page"
+        );
+    }
+
+    #[test]
+    fn webgl_value_substitutes_persona_renderer() {
+        let p = Persona {
+            webgl: Some(WebglSpec {
+                strategy: Some(Strategy::Value),
+                unmasked_vendor: Some("Google Inc. (NVIDIA)".into()),
+                unmasked_renderer: Some("ANGLE (NVIDIA GeForce RTX 4090)".into()),
+            }),
+            ..Persona::default()
+        };
+        let script = bootstrap_script(&p, &mock_identity());
+        assert!(
+            script.contains("ANGLE (NVIDIA GeForce RTX 4090)"),
+            "persona renderer must be substituted into the webgl IIFE"
+        );
+        assert!(
+            script.contains("Google Inc. (NVIDIA)"),
+            "persona vendor must be substituted into the webgl IIFE"
+        );
+    }
+
+    #[test]
+    fn webgl_native_passes_null_and_keeps_hardcoded_block() {
+        // No webgl spec → Native resolution → IIFE args null, but the
+        // hardcoded fallback block (37445/37446) still present.
+        let script = bootstrap_script(&Persona::default(), &mock_identity());
+        assert!(
+            s_has_webgl_iife_null(&script),
+            "webgl IIFE args should be null"
+        );
+        assert!(
+            script.contains("37445"),
+            "hardcoded webgl fallback block must remain"
+        );
+    }
+
+    fn s_has_webgl_iife_null(s: &str) -> bool {
+        // The appended webgl IIFE ends with its args; null both => `})(null, null);`
+        s.contains("})(null, null);")
+    }
+
+    #[test]
+    fn fonts_native_omits_measuretext_hook() {
+        let p = Persona {
+            fonts: Some(FontSpec {
+                strategy: Some(Strategy::Native),
+                available: None,
+            }),
+            ..Persona::default()
+        };
+        let script = bootstrap_script(&p, &mock_identity());
+        assert!(
+            !script.contains("measureText"),
+            "Native fonts → no measureText hook"
+        );
+    }
+
+    #[test]
+    fn fonts_value_substitutes_allow_list() {
+        let p = Persona {
+            fonts: Some(FontSpec {
+                strategy: Some(Strategy::Value),
+                available: Some(vec!["Arial".into(), "Helvetica".into()]),
+            }),
+            seed: Some(Seed::from_u64(7)),
+            ..Persona::default()
+        };
+        let script = bootstrap_script(&p, &mock_identity());
+        assert!(script.contains("measureText"), "fonts patch emitted");
+        assert!(
+            script.contains("[\"Arial\",\"Helvetica\"]"),
+            "allow-list substituted"
+        );
+    }
+
+    #[test]
+    fn webrtc_value_substitutes_policy_and_ip() {
+        let p = Persona {
+            webrtc: Some(WebrtcSpec {
+                strategy: Some(Strategy::Value),
+                fake_ip: Some("203.0.113.7".into()),
+            }),
+            ..Persona::default()
+        };
+        let script = bootstrap_script(&p, &mock_identity());
+        assert!(
+            script.contains("})(\"value\", \"203.0.113.7\");"),
+            "webrtc value policy + fake ip substituted"
+        );
+    }
+
+    #[test]
+    fn webrtc_default_is_block_policy() {
+        let script = bootstrap_script(&Persona::default(), &mock_identity());
+        assert!(
+            script.contains("})(\"block\", null);"),
+            "default webrtc policy is block with no fake ip"
+        );
+    }
+
+    #[test]
+    fn hardware_native_omits_patch() {
+        let p = Persona {
+            hardware: Some(HardwareSpec {
+                strategy: Some(Strategy::Native),
+                ..HardwareSpec::default()
+            }),
+            ..Persona::default()
+        };
+        let script = bootstrap_script(&p, &mock_identity());
+        assert!(
+            !script.contains("getBattery"),
+            "Native hardware → no getBattery hook"
+        );
+    }
+
+    #[test]
+    fn hardware_value_substitutes_specs() {
+        let p = Persona {
+            hardware: Some(HardwareSpec {
+                strategy: Some(Strategy::Value),
+                battery_level: Some(0.5),
+                media_devices: Some(3),
+                speech_voices: Some(vec!["Daniel".into()]),
+            }),
+            ..Persona::default()
+        };
+        let script = bootstrap_script(&p, &mock_identity());
+        assert!(script.contains("getBattery"), "hardware patch emitted");
+        assert!(
+            script.contains("})(0.5, 3, [\"Daniel\"]);"),
+            "hardware specs substituted"
+        );
+    }
+
+    #[test]
+    fn prng_defined_once() {
+        let p = Persona {
+            canvas: Some(SurfaceCfg {
+                strategy: Some(Strategy::Seeded),
+            }),
+            audio: Some(SurfaceCfg {
+                strategy: Some(Strategy::Seeded),
+            }),
+            ..Persona::default()
+        };
+        let script = bootstrap_script(&p, &mock_identity());
+        assert_eq!(
+            script.matches("function __zdRng(").count(),
+            1,
+            "PRNG defined exactly once even with multiple noise surfaces"
+        );
+    }
+
+    #[test]
+    fn no_unsubstituted_tokens_remain() {
+        // Exercise every surface so all token-bearing patches are emitted.
+        let p = Persona {
+            canvas: Some(SurfaceCfg {
+                strategy: Some(Strategy::Seeded),
+            }),
+            audio: Some(SurfaceCfg {
+                strategy: Some(Strategy::Random),
+            }),
+            client_rects: Some(SurfaceCfg {
+                strategy: Some(Strategy::Block),
+            }),
+            webgl: Some(WebglSpec {
+                strategy: Some(Strategy::Value),
+                unmasked_vendor: Some("V".into()),
+                unmasked_renderer: Some("R".into()),
+            }),
+            fonts: Some(FontSpec {
+                strategy: Some(Strategy::Value),
+                available: Some(vec!["Arial".into()]),
+            }),
+            webrtc: Some(WebrtcSpec {
+                strategy: Some(Strategy::Value),
+                fake_ip: Some("1.2.3.4".into()),
+            }),
+            hardware: Some(HardwareSpec {
+                strategy: Some(Strategy::Value),
+                battery_level: Some(0.9),
+                media_devices: Some(2),
+                speech_voices: Some(vec!["A".into()]),
+            }),
+            seed: Some(Seed::from_u64(9)),
+            ..Persona::default()
+        };
+        let script = bootstrap_script(&p, &mock_identity());
+        for tok in [
+            "SEED",
+            "WEBGL_VENDOR",
+            "WEBGL_RENDERER",
+            "FONT_ALLOW",
+            "WEBRTC_POLICY",
+            "WEBRTC_FAKE_IP",
+            "HW_BATTERY",
+            "HW_MEDIA_DEVICES",
+            "HW_VOICES",
+        ] {
+            assert!(
+                !script.contains(tok),
+                "unsubstituted token `{tok}` left in bootstrap"
+            );
+        }
     }
 }

--- a/crates/zendriver-stealth/src/patches/_prng.js
+++ b/crates/zendriver-stealth/src/patches/_prng.js
@@ -1,0 +1,10 @@
+// mulberry32 — deterministic PRNG seeded by the persona seed.
+function __zdRng(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/crates/zendriver-stealth/src/patches/audio.js
+++ b/crates/zendriver-stealth/src/patches/audio.js
@@ -1,0 +1,17 @@
+(function (seed) {
+  const rng = __zdRng(seed);
+  const orig = AnalyserNode.prototype.getFloatFrequencyData;
+  AnalyserNode.prototype.getFloatFrequencyData = function (array) {
+    orig.call(this, array);
+    for (let i = 0; i < array.length; i++) array[i] += (rng() - 0.5) * 1e-4;
+  };
+  const origTime = AnalyserNode.prototype.getByteTimeDomainData;
+  if (origTime) {
+    AnalyserNode.prototype.getByteTimeDomainData = function (array) {
+      origTime.call(this, array);
+      for (let i = 0; i < array.length; i++) {
+        array[i] = Math.max(0, Math.min(255, array[i] + (rng() < 0.5 ? -1 : 1)));
+      }
+    };
+  }
+})(SEED);

--- a/crates/zendriver-stealth/src/patches/audio.js
+++ b/crates/zendriver-stealth/src/patches/audio.js
@@ -1,4 +1,5 @@
 (function (seed) {
+  if (typeof AnalyserNode === 'undefined') return;
   const rng = __zdRng(seed);
   const orig = AnalyserNode.prototype.getFloatFrequencyData;
   AnalyserNode.prototype.getFloatFrequencyData = function (array) {

--- a/crates/zendriver-stealth/src/patches/canvas.js
+++ b/crates/zendriver-stealth/src/patches/canvas.js
@@ -1,0 +1,31 @@
+(function (seed) {
+  const rng = __zdRng(seed);
+  function farble(data) {
+    for (let i = 0; i < data.length; i += 4) {
+      // +/-1 LSB perturbation on RGB, deterministic per seed.
+      data[i]     = Math.max(0, Math.min(255, data[i]     + (rng() < 0.5 ? -1 : 1)));
+      data[i + 1] = Math.max(0, Math.min(255, data[i + 1] + (rng() < 0.5 ? -1 : 1)));
+      data[i + 2] = Math.max(0, Math.min(255, data[i + 2] + (rng() < 0.5 ? -1 : 1)));
+    }
+    return data;
+  }
+  const origGetImageData = CanvasRenderingContext2D.prototype.getImageData;
+  CanvasRenderingContext2D.prototype.getImageData = function (...args) {
+    const img = origGetImageData.apply(this, args);
+    farble(img.data);
+    return img;
+  };
+  const origToDataURL = HTMLCanvasElement.prototype.toDataURL;
+  HTMLCanvasElement.prototype.toDataURL = function (...args) {
+    const ctx = this.getContext('2d');
+    if (ctx) {
+      const w = this.width, h = this.height;
+      if (w > 0 && h > 0) {
+        const img = origGetImageData.call(ctx, 0, 0, w, h);
+        farble(img.data);
+        ctx.putImageData(img, 0, 0);
+      }
+    }
+    return origToDataURL.apply(this, args);
+  };
+})(SEED);

--- a/crates/zendriver-stealth/src/patches/canvas.js
+++ b/crates/zendriver-stealth/src/patches/canvas.js
@@ -18,13 +18,14 @@
   const origToDataURL = HTMLCanvasElement.prototype.toDataURL;
   HTMLCanvasElement.prototype.toDataURL = function (...args) {
     const ctx = this.getContext('2d');
-    if (ctx) {
-      const w = this.width, h = this.height;
-      if (w > 0 && h > 0) {
-        const img = origGetImageData.call(ctx, 0, 0, w, h);
-        farble(img.data);
-        ctx.putImageData(img, 0, 0);
-      }
+    if (ctx && this.width > 0 && this.height > 0) {
+      const orig = origGetImageData.call(ctx, 0, 0, this.width, this.height);
+      const copy = new ImageData(new Uint8ClampedArray(orig.data), this.width, this.height);
+      farble(copy.data);
+      ctx.putImageData(copy, 0, 0);
+      const url = origToDataURL.apply(this, args);
+      ctx.putImageData(orig, 0, 0);
+      return url;
     }
     return origToDataURL.apply(this, args);
   };

--- a/crates/zendriver-stealth/src/patches/client_rects.js
+++ b/crates/zendriver-stealth/src/patches/client_rects.js
@@ -1,0 +1,9 @@
+(function (seed) {
+  const rng = __zdRng(seed);
+  function noisy(v) { return v + (rng() - 0.5) * 1e-3; }
+  const origRect = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function () {
+    const r = origRect.call(this);
+    return new DOMRect(noisy(r.x), noisy(r.y), noisy(r.width), noisy(r.height));
+  };
+})(SEED);

--- a/crates/zendriver-stealth/src/patches/client_rects.js
+++ b/crates/zendriver-stealth/src/patches/client_rects.js
@@ -6,4 +6,14 @@
     const r = origRect.call(this);
     return new DOMRect(noisy(r.x), noisy(r.y), noisy(r.width), noisy(r.height));
   };
+  const origRects = Element.prototype.getClientRects;
+  Element.prototype.getClientRects = function () {
+    const list = origRects.call(this);
+    const out = [];
+    for (let i = 0; i < list.length; i++) {
+      const r = list[i];
+      out.push(new DOMRect(noisy(r.x), noisy(r.y), noisy(r.width), noisy(r.height)));
+    }
+    return out;
+  };
 })(SEED);

--- a/crates/zendriver-stealth/src/patches/fonts.js
+++ b/crates/zendriver-stealth/src/patches/fonts.js
@@ -1,0 +1,20 @@
+(function (allow, seed) {
+  const rng = __zdRng(seed);
+  const orig = CanvasRenderingContext2D.prototype.measureText;
+  CanvasRenderingContext2D.prototype.measureText = function (text) {
+    const m = orig.call(this, text);
+    // Sub-pixel width noise, deterministic.
+    try { Object.defineProperty(m, 'width', { value: m.width + (rng() - 0.5) * 1e-3 }); }
+    catch (e) {}
+    return m;
+  };
+  // If an allow-list is provided, hide other fonts from FontFaceSet checks.
+  if (Array.isArray(allow) && document.fonts && document.fonts.check) {
+    const origCheck = document.fonts.check.bind(document.fonts);
+    document.fonts.check = function (font, text) {
+      const fam = (font || '').split(/\s+/).pop();
+      if (fam && allow.indexOf(fam.replace(/["']/g, '')) === -1) return false;
+      return origCheck(font, text);
+    };
+  }
+})(FONT_ALLOW, SEED);

--- a/crates/zendriver-stealth/src/patches/hardware.js
+++ b/crates/zendriver-stealth/src/patches/hardware.js
@@ -1,0 +1,27 @@
+(function (battery, mediaDevices, voices) {
+  if (typeof battery === 'number' && navigator.getBattery) {
+    navigator.getBattery = function () {
+      return Promise.resolve({
+        level: battery, charging: true, chargingTime: 0,
+        dischargingTime: Infinity,
+        addEventListener() {}, removeEventListener() {},
+      });
+    };
+  }
+  if (typeof mediaDevices === 'number' && navigator.mediaDevices &&
+      navigator.mediaDevices.enumerateDevices) {
+    navigator.mediaDevices.enumerateDevices = function () {
+      const out = [];
+      for (let i = 0; i < mediaDevices; i++) {
+        out.push({ deviceId: 'dev' + i, kind: 'audioinput', label: '', groupId: 'g' + i });
+      }
+      return Promise.resolve(out);
+    };
+  }
+  if (Array.isArray(voices) && window.speechSynthesis) {
+    speechSynthesis.getVoices = function () {
+      return voices.map((n) => ({ name: n, lang: 'en-US', default: false,
+        localService: true, voiceURI: n }));
+    };
+  }
+})(HW_BATTERY, HW_MEDIA_DEVICES, HW_VOICES);

--- a/crates/zendriver-stealth/src/patches/webgl.js
+++ b/crates/zendriver-stealth/src/patches/webgl.js
@@ -11,3 +11,18 @@ const RENDERER = 'ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5
         return orig.call(this, param);
     };
 });
+
+// Persona-driven value substitution (B9 substitutes WEBGL_VENDOR / WEBGL_RENDERER tokens).
+(function (vendor, renderer) {
+  const VENDOR = 0x9245, RENDERER = 0x9246; // UNMASKED_VENDOR_WEBGL / RENDERER
+  function patch(proto) {
+    const orig = proto.getParameter;
+    proto.getParameter = function (p) {
+      if (vendor && p === VENDOR) return vendor;
+      if (renderer && p === RENDERER) return renderer;
+      return orig.call(this, p);
+    };
+  }
+  if (window.WebGLRenderingContext) patch(WebGLRenderingContext.prototype);
+  if (window.WebGL2RenderingContext) patch(WebGL2RenderingContext.prototype);
+})(WEBGL_VENDOR, WEBGL_RENDERER);

--- a/crates/zendriver-stealth/src/patches/webrtc.js
+++ b/crates/zendriver-stealth/src/patches/webrtc.js
@@ -1,0 +1,27 @@
+(function (policy, fakeIp) {
+  // policy: "block" | "value" | "native"
+  if (policy === 'native') return;
+  const RTC = window.RTCPeerConnection || window.webkitRTCPeerConnection;
+  if (!RTC) return;
+  window.RTCPeerConnection = function (cfg, ...rest) {
+    const pc = new RTC(cfg, ...rest);
+    const origAdd = pc.addEventListener.bind(pc);
+    pc.addEventListener = function (type, cb, ...a) {
+      if (type === 'icecandidate') {
+        const wrapped = function (e) {
+          if (policy === 'block' && e && e.candidate) return; // drop local IPs
+          if (policy === 'value' && fakeIp && e && e.candidate) {
+            try {
+              Object.defineProperty(e.candidate, 'address', { value: fakeIp });
+            } catch (x) {}
+          }
+          return cb.apply(this, arguments);
+        };
+        return origAdd(type, wrapped, ...a);
+      }
+      return origAdd(type, cb, ...a);
+    };
+    return pc;
+  };
+  window.RTCPeerConnection.prototype = RTC.prototype;
+})(WEBRTC_POLICY, WEBRTC_FAKE_IP);

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -1,6 +1,53 @@
 //! Persona: the unified fingerprint configuration.
+
 pub mod seed;
 pub mod specs;
 pub mod surface;
+
 pub use seed::Seed;
 pub use specs::{FontSpec, HardwareSpec, SurfaceCfg, UaSpec, WebglSpec, WebrtcSpec};
+
+use serde::{Deserialize, Serialize};
+
+use crate::Platform;
+
+/// Unified fingerprint configuration. Every field optional → overlay semantics.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Persona {
+    pub platform: Option<Platform>,
+    pub ua: Option<UaSpec>,
+    pub hardware_concurrency: Option<u32>,
+    pub device_memory_gb: Option<u32>,
+    pub timezone: Option<String>,
+    pub locale: Option<String>,
+    pub webgl: Option<WebglSpec>,
+    pub canvas: Option<SurfaceCfg>,
+    pub audio: Option<SurfaceCfg>,
+    pub fonts: Option<FontSpec>,
+    pub client_rects: Option<SurfaceCfg>,
+    pub webrtc: Option<WebrtcSpec>,
+    pub hardware: Option<HardwareSpec>,
+    pub seed: Option<Seed>,
+}
+
+#[cfg(test)]
+mod persona_tests {
+    use super::*;
+
+    #[test]
+    fn default_persona_is_all_none() {
+        let p = Persona::default();
+        assert!(p.platform.is_none() && p.seed.is_none() && p.webgl.is_none());
+    }
+
+    #[test]
+    fn persona_round_trips_json() {
+        let mut p = Persona::default();
+        p.seed = Some(Seed::from_u64(5));
+        p.timezone = Some("America/New_York".into());
+        let s = serde_json::to_string(&p).unwrap();
+        let back: Persona = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.seed, Some(Seed::from_u64(5)));
+        assert_eq!(back.timezone.as_deref(), Some("America/New_York"));
+    }
+}

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -106,6 +106,47 @@ impl Persona {
         }
     }
 
+    /// Force a single surface's render [`Strategy`], creating the surface's
+    /// spec with default values if it was unset.
+    ///
+    /// Used by the public browser builder's `.surface(surface, strategy)` to
+    /// layer per-surface overrides on top of the resolved persona. Each surface
+    /// writes the `strategy` field of its corresponding spec; the [`UaSpec`]
+    /// surface family (identity, not a render strategy) has no strategy field,
+    /// so this is a no-op there.
+    pub fn apply_surface_override(
+        &mut self,
+        surface: surface::Surface,
+        strategy: surface::Strategy,
+    ) {
+        use surface::Surface;
+        match surface {
+            Surface::Canvas => {
+                self.canvas.get_or_insert_with(Default::default).strategy = Some(strategy)
+            }
+            Surface::Audio => {
+                self.audio.get_or_insert_with(Default::default).strategy = Some(strategy)
+            }
+            Surface::ClientRects => {
+                self.client_rects
+                    .get_or_insert_with(Default::default)
+                    .strategy = Some(strategy)
+            }
+            Surface::Webgl => {
+                self.webgl.get_or_insert_with(Default::default).strategy = Some(strategy)
+            }
+            Surface::Fonts => {
+                self.fonts.get_or_insert_with(Default::default).strategy = Some(strategy)
+            }
+            Surface::Webrtc => {
+                self.webrtc.get_or_insert_with(Default::default).strategy = Some(strategy)
+            }
+            Surface::Hardware => {
+                self.hardware.get_or_insert_with(Default::default).strategy = Some(strategy)
+            }
+        }
+    }
+
     /// Effective `navigator.platform` JS string for patch templating.
     /// Falls back to host platform when unset.
     pub fn resolved_platform_js(&self) -> String {
@@ -349,6 +390,27 @@ mod persona_tests {
         assert_eq!(p.platform, Some(Platform::LinuxX86_64));
         assert_eq!(p.device_memory_gb, Some(8));
         assert!(p.webgl.is_none(), "null webgl → no spec");
+    }
+
+    #[test]
+    fn apply_surface_override_sets_strategy_creating_spec() {
+        use crate::{Strategy, Surface};
+        let mut p = Persona::default();
+        // Surface spec absent → created with the override strategy.
+        p.apply_surface_override(Surface::Webrtc, Strategy::Native);
+        assert_eq!(
+            p.webrtc.as_ref().and_then(|w| w.strategy),
+            Some(Strategy::Native)
+        );
+        // Existing spec → only strategy mutated, other fields preserved.
+        p.webgl = Some(WebglSpec {
+            unmasked_renderer: Some("ANGLE (x)".into()),
+            ..Default::default()
+        });
+        p.apply_surface_override(Surface::Webgl, Strategy::Value);
+        let webgl = p.webgl.as_ref().unwrap();
+        assert_eq!(webgl.strategy, Some(Strategy::Value));
+        assert_eq!(webgl.unmasked_renderer.as_deref(), Some("ANGLE (x)"));
     }
 
     #[test]

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -110,7 +110,9 @@ impl Persona {
     /// Falls back to host platform when unset.
     pub fn resolved_platform_js(&self) -> String {
         let plat = self.platform.unwrap_or_else(|| {
-            Persona::system().platform.unwrap_or(crate::Platform::LinuxX86_64)
+            Persona::system()
+                .platform
+                .unwrap_or(crate::Platform::LinuxX86_64)
         });
         plat.js_string().to_string()
     }
@@ -149,9 +151,11 @@ mod persona_tests {
 
     #[test]
     fn persona_round_trips_json() {
-        let mut p = Persona::default();
-        p.seed = Some(Seed::from_u64(5));
-        p.timezone = Some("America/New_York".into());
+        let p = Persona {
+            seed: Some(Seed::from_u64(5)),
+            timezone: Some("America/New_York".into()),
+            ..Persona::default()
+        };
         let s = serde_json::to_string(&p).unwrap();
         let back: Persona = serde_json::from_str(&s).unwrap();
         assert_eq!(back.seed, Some(Seed::from_u64(5)));

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -31,6 +31,19 @@ pub struct Persona {
 }
 
 impl Persona {
+    pub fn try_from_json(s: &str) -> Result<Persona, serde_json::Error> {
+        serde_json::from_str(s)
+    }
+}
+
+impl std::str::FromStr for Persona {
+    type Err = serde_json::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+impl Persona {
     /// Field-wise merge: `Some` in `over` wins, `None` inherits from `self`.
     pub fn overlay(self, over: Persona) -> Persona {
         Persona {
@@ -71,6 +84,15 @@ mod persona_tests {
         let back: Persona = serde_json::from_str(&s).unwrap();
         assert_eq!(back.seed, Some(Seed::from_u64(5)));
         assert_eq!(back.timezone.as_deref(), Some("America/New_York"));
+    }
+
+    #[test]
+    fn from_json_and_fromstr_parse() {
+        let json = r#"{"timezone":"Europe/Paris","seed":99}"#;
+        let a = Persona::try_from_json(json).unwrap();
+        assert_eq!(a.timezone.as_deref(), Some("Europe/Paris"));
+        let b: Persona = json.parse().unwrap();
+        assert_eq!(b.seed, Some(Seed::from_u64(99)));
     }
 
     #[test]

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -30,9 +30,47 @@ pub struct Persona {
     pub seed: Option<Seed>,
 }
 
+/// Fluent builder for [`Persona`]. Every setter is optional.
+#[derive(Debug, Clone, Default)]
+pub struct PersonaBuilder(Persona);
+
 impl Persona {
     pub fn try_from_json(s: &str) -> Result<Persona, serde_json::Error> {
         serde_json::from_str(s)
+    }
+
+    pub fn builder() -> PersonaBuilder {
+        PersonaBuilder(Persona::default())
+    }
+}
+
+impl PersonaBuilder {
+    pub fn seed(mut self, s: Seed) -> Self {
+        self.0.seed = Some(s);
+        self
+    }
+    pub fn timezone(mut self, tz: impl Into<String>) -> Self {
+        self.0.timezone = Some(tz.into());
+        self
+    }
+    pub fn locale(mut self, l: impl Into<String>) -> Self {
+        self.0.locale = Some(l.into());
+        self
+    }
+    pub fn device_memory_gb(mut self, gb: u32) -> Self {
+        self.0.device_memory_gb = Some(gb);
+        self
+    }
+    pub fn hardware_concurrency(mut self, n: u32) -> Self {
+        self.0.hardware_concurrency = Some(n);
+        self
+    }
+    pub fn webgl(mut self, w: WebglSpec) -> Self {
+        self.0.webgl = Some(w);
+        self
+    }
+    pub fn build(self) -> Persona {
+        self.0
     }
 }
 
@@ -84,6 +122,18 @@ mod persona_tests {
         let back: Persona = serde_json::from_str(&s).unwrap();
         assert_eq!(back.seed, Some(Seed::from_u64(5)));
         assert_eq!(back.timezone.as_deref(), Some("America/New_York"));
+    }
+
+    #[test]
+    fn builder_sets_fields() {
+        let p = Persona::builder()
+            .seed(Seed::from_u64(3))
+            .timezone("UTC")
+            .device_memory_gb(16)
+            .build();
+        assert_eq!(p.seed, Some(Seed::from_u64(3)));
+        assert_eq!(p.device_memory_gb, Some(16));
+        assert_eq!(p.timezone.as_deref(), Some("UTC"));
     }
 
     #[test]

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -1,0 +1,3 @@
+//! Persona: the unified fingerprint configuration.
+pub mod seed;
+pub use seed::Seed;

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -7,9 +7,13 @@ pub mod surface;
 pub use seed::Seed;
 pub use specs::{FontSpec, HardwareSpec, SurfaceCfg, UaSpec, WebglSpec, WebrtcSpec};
 
+use std::sync::OnceLock;
+
 use serde::{Deserialize, Serialize};
 
 use crate::Platform;
+
+static SYSTEM: OnceLock<Persona> = OnceLock::new();
 
 /// Unified fingerprint configuration. Every field optional → overlay semantics.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -101,6 +105,27 @@ impl Persona {
             seed: over.seed.or(self.seed),
         }
     }
+
+    /// Host-probed persona (sysinfo). Cached: first call probes, rest clone.
+    /// Runtime — NOT a build-script const (build host != run host).
+    pub fn system() -> Persona {
+        SYSTEM.get_or_init(Persona::probe_system).clone()
+    }
+
+    fn probe_system() -> Persona {
+        let platform = crate::fingerprint::detect_platform();
+        let cpu = crate::fingerprint::clamp_cpu_count(num_cpus::get() as u32);
+        let mem = crate::fingerprint::detect_memory_gb().unwrap_or(8);
+        Persona {
+            platform: Some(platform),
+            hardware_concurrency: Some(cpu),
+            device_memory_gb: Some(mem),
+            timezone: None,
+            locale: None,
+            seed: Some(Seed::random()),
+            ..Persona::default()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -122,6 +147,18 @@ mod persona_tests {
         let back: Persona = serde_json::from_str(&s).unwrap();
         assert_eq!(back.seed, Some(Seed::from_u64(5)));
         assert_eq!(back.timezone.as_deref(), Some("America/New_York"));
+    }
+
+    #[test]
+    fn system_persona_is_populated_and_cached() {
+        let a = Persona::system();
+        // Host probe fills platform + cpu + memory.
+        assert!(a.platform.is_some());
+        assert!(a.hardware_concurrency.is_some());
+        assert!(a.device_memory_gb.is_some());
+        let b = Persona::system();
+        // Cached → same values.
+        assert_eq!(a.device_memory_gb, b.device_memory_gb);
     }
 
     #[test]

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -106,6 +106,15 @@ impl Persona {
         }
     }
 
+    /// Effective `navigator.platform` JS string for patch templating.
+    /// Falls back to host platform when unset.
+    pub fn resolved_platform_js(&self) -> String {
+        let plat = self.platform.unwrap_or_else(|| {
+            Persona::system().platform.unwrap_or(crate::Platform::LinuxX86_64)
+        });
+        plat.js_string().to_string()
+    }
+
     /// Host-probed persona (sysinfo). Cached: first call probes, rest clone.
     /// Runtime — NOT a build-script const (build host != run host).
     pub fn system() -> Persona {
@@ -147,6 +156,12 @@ mod persona_tests {
         let back: Persona = serde_json::from_str(&s).unwrap();
         assert_eq!(back.seed, Some(Seed::from_u64(5)));
         assert_eq!(back.timezone.as_deref(), Some("America/New_York"));
+    }
+
+    #[test]
+    fn persona_exposes_resolved_platform_for_patches() {
+        let p = Persona::system();
+        assert!(!p.resolved_platform_js().is_empty());
     }
 
     #[test]

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -1,3 +1,6 @@
 //! Persona: the unified fingerprint configuration.
 pub mod seed;
+pub mod specs;
+pub mod surface;
 pub use seed::Seed;
+pub use specs::{FontSpec, HardwareSpec, SurfaceCfg, UaSpec, WebglSpec, WebrtcSpec};

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -139,6 +139,100 @@ impl Persona {
     }
 }
 
+/// Minimal eval surface so stealth can probe a live page without depending on
+/// the `zendriver` core crate (which would be a dependency cycle).
+///
+/// The `zendriver` crate implements this for its `Tab`, mapping its own
+/// evaluation error into [`StealthError::Probe`].
+#[async_trait::async_trait]
+pub trait JsProbe {
+    /// Evaluate `js` in the page and return the result as a JSON value.
+    async fn eval_json(&self, js: &str) -> Result<serde_json::Value, crate::StealthError>;
+}
+
+/// JS run by [`Persona::from_browser`] to read the live browser's REAL
+/// fingerprint-relevant values (platform, memory, timezone, locale, WebGL
+/// vendor/renderer). Returns a single JSON object.
+const PROBE_JS: &str = r#"(() => {
+  const c = document.createElement('canvas').getContext('webgl');
+  const dbg = c && c.getExtension('WEBGL_debug_renderer_info');
+  return {
+    platform: navigator.platform,
+    deviceMemory: navigator.deviceMemory,
+    hardwareConcurrency: navigator.hardwareConcurrency,
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    locale: navigator.language,
+    webglVendor: dbg ? c.getParameter(dbg.UNMASKED_VENDOR_WEBGL) : null,
+    webglRenderer: dbg ? c.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : null,
+  };
+})()"#;
+
+impl Persona {
+    /// Probe the live Chrome for its REAL webgl/platform/memory/timezone
+    /// values, producing a maximally coherent host persona.
+    ///
+    /// Runs [`PROBE_JS`] through the supplied [`JsProbe`] (the `zendriver`
+    /// `Tab` implements it) and maps the resulting JSON onto a [`Persona`].
+    /// Fields the browser does not expose are left `None`.
+    pub async fn from_browser<P: JsProbe + Sync>(
+        probe: &P,
+    ) -> Result<Persona, crate::StealthError> {
+        let v = probe.eval_json(PROBE_JS).await?;
+        Ok(persona_from_probe(&v))
+    }
+}
+
+/// Map the [`PROBE_JS`] JSON result onto a [`Persona`].
+fn persona_from_probe(v: &serde_json::Value) -> Persona {
+    let mut p = Persona::default();
+
+    // `navigator.platform` strings match `Platform::js_string()`:
+    // "Win32" / "MacIntel" / "Linux x86_64" (any other → Linux fallback).
+    if let Some(plat) = v.get("platform").and_then(|x| x.as_str()) {
+        p.platform = Some(match plat {
+            "Win32" => Platform::Win32,
+            "MacIntel" => Platform::MacIntel,
+            _ => Platform::LinuxX86_64,
+        });
+    }
+
+    // `navigator.deviceMemory` is a JS number (gigabytes).
+    if let Some(mem) = v.get("deviceMemory").and_then(|x| x.as_u64()) {
+        p.device_memory_gb = Some(mem as u32);
+    }
+
+    if let Some(hc) = v.get("hardwareConcurrency").and_then(|x| x.as_u64()) {
+        p.hardware_concurrency = Some(hc as u32);
+    }
+
+    if let Some(tz) = v.get("timezone").and_then(|x| x.as_str()) {
+        p.timezone = Some(tz.to_string());
+    }
+
+    if let Some(loc) = v.get("locale").and_then(|x| x.as_str()) {
+        p.locale = Some(loc.to_string());
+    }
+
+    // WebGL vendor/renderer become a value-substitution WebglSpec when present.
+    let vendor = v
+        .get("webglVendor")
+        .and_then(|x| x.as_str())
+        .map(str::to_string);
+    let renderer = v
+        .get("webglRenderer")
+        .and_then(|x| x.as_str())
+        .map(str::to_string);
+    if vendor.is_some() || renderer.is_some() {
+        p.webgl = Some(WebglSpec {
+            strategy: None,
+            unmasked_vendor: vendor,
+            unmasked_renderer: renderer,
+        });
+    }
+
+    p
+}
+
 #[cfg(test)]
 mod persona_tests {
     use super::*;
@@ -199,6 +293,62 @@ mod persona_tests {
         assert_eq!(a.timezone.as_deref(), Some("Europe/Paris"));
         let b: Persona = json.parse().unwrap();
         assert_eq!(b.seed, Some(Seed::from_u64(99)));
+    }
+
+    struct FakeProbe(serde_json::Value);
+
+    #[async_trait::async_trait]
+    impl JsProbe for FakeProbe {
+        async fn eval_json(&self, _js: &str) -> Result<serde_json::Value, crate::StealthError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn from_browser_maps_probe_fields() {
+        let probe = FakeProbe(serde_json::json!({
+            "platform": "MacIntel",
+            "deviceMemory": 16,
+            "hardwareConcurrency": 10,
+            "timezone": "America/New_York",
+            "locale": "en-US",
+            "webglVendor": "Google Inc. (Apple)",
+            "webglRenderer": "ANGLE (Apple, Apple M1, OpenGL 4.1)",
+        }));
+        let p = Persona::from_browser(&probe).await.unwrap();
+        assert_eq!(p.platform, Some(Platform::MacIntel));
+        assert_eq!(p.device_memory_gb, Some(16));
+        assert_eq!(p.hardware_concurrency, Some(10));
+        assert_eq!(p.timezone.as_deref(), Some("America/New_York"));
+        assert_eq!(p.locale.as_deref(), Some("en-US"));
+        let webgl = p.webgl.expect("webgl spec populated from probe");
+        assert_eq!(
+            webgl.unmasked_renderer.as_deref(),
+            Some("ANGLE (Apple, Apple M1, OpenGL 4.1)")
+        );
+        assert_eq!(
+            webgl.unmasked_vendor.as_deref(),
+            Some("Google Inc. (Apple)")
+        );
+    }
+
+    #[tokio::test]
+    async fn from_browser_handles_missing_webgl_and_linux_platform() {
+        // Null WebGL (debug-info ext unavailable) + a Linux platform string
+        // that isn't a literal enum name → Linux fallback, no webgl spec.
+        let probe = FakeProbe(serde_json::json!({
+            "platform": "Linux x86_64",
+            "deviceMemory": 8,
+            "hardwareConcurrency": 4,
+            "timezone": "UTC",
+            "locale": "en-GB",
+            "webglVendor": serde_json::Value::Null,
+            "webglRenderer": serde_json::Value::Null,
+        }));
+        let p = Persona::from_browser(&probe).await.unwrap();
+        assert_eq!(p.platform, Some(Platform::LinuxX86_64));
+        assert_eq!(p.device_memory_gb, Some(8));
+        assert!(p.webgl.is_none(), "null webgl → no spec");
     }
 
     #[test]

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -30,6 +30,28 @@ pub struct Persona {
     pub seed: Option<Seed>,
 }
 
+impl Persona {
+    /// Field-wise merge: `Some` in `over` wins, `None` inherits from `self`.
+    pub fn overlay(self, over: Persona) -> Persona {
+        Persona {
+            platform: over.platform.or(self.platform),
+            ua: over.ua.or(self.ua),
+            hardware_concurrency: over.hardware_concurrency.or(self.hardware_concurrency),
+            device_memory_gb: over.device_memory_gb.or(self.device_memory_gb),
+            timezone: over.timezone.or(self.timezone),
+            locale: over.locale.or(self.locale),
+            webgl: over.webgl.or(self.webgl),
+            canvas: over.canvas.or(self.canvas),
+            audio: over.audio.or(self.audio),
+            fonts: over.fonts.or(self.fonts),
+            client_rects: over.client_rects.or(self.client_rects),
+            webrtc: over.webrtc.or(self.webrtc),
+            hardware: over.hardware.or(self.hardware),
+            seed: over.seed.or(self.seed),
+        }
+    }
+}
+
 #[cfg(test)]
 mod persona_tests {
     use super::*;
@@ -49,5 +71,23 @@ mod persona_tests {
         let back: Persona = serde_json::from_str(&s).unwrap();
         assert_eq!(back.seed, Some(Seed::from_u64(5)));
         assert_eq!(back.timezone.as_deref(), Some("America/New_York"));
+    }
+
+    #[test]
+    fn overlay_some_wins_none_inherits() {
+        let base = Persona {
+            timezone: Some("UTC".into()),
+            device_memory_gb: Some(8),
+            seed: Some(Seed::from_u64(1)),
+            ..Persona::default()
+        };
+        let over = Persona {
+            timezone: Some("Asia/Tokyo".into()),
+            ..Persona::default()
+        };
+        let merged = base.overlay(over);
+        assert_eq!(merged.timezone.as_deref(), Some("Asia/Tokyo")); // some wins
+        assert_eq!(merged.device_memory_gb, Some(8)); // none inherits
+        assert_eq!(merged.seed, Some(Seed::from_u64(1)));
     }
 }

--- a/crates/zendriver-stealth/src/persona/seed.rs
+++ b/crates/zendriver-stealth/src/persona/seed.rs
@@ -1,0 +1,104 @@
+//! Seed: controls deterministic farble. random (default) / from_system / explicit.
+
+use serde::{Deserialize, Serialize};
+
+/// A fingerprint seed. Serializes transparently as its u64 value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Seed(pub u64);
+
+impl Seed {
+    /// Per-instance unique seed. THE DEFAULT.
+    pub fn random() -> Seed {
+        Seed(fastrand::u64(..))
+    }
+
+    /// Explicit reproducible seed.
+    pub fn from_u64(v: u64) -> Seed {
+        Seed(v)
+    }
+
+    /// Deterministic per-machine seed: stable across runs on the same host
+    /// WITHOUT a user_data_dir. Opt-in — sticky per machine (one identity).
+    pub fn from_system() -> Seed {
+        Seed(system_seed_value())
+    }
+
+    /// Raw value for JS farble.
+    pub fn value(self) -> u64 {
+        self.0
+    }
+}
+
+fn system_seed_value() -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    // Stable machine id, best-effort per OS; fall back to hostname + cpu brand.
+    machine_id().hash(&mut h);
+    sysinfo::System::host_name().unwrap_or_default().hash(&mut h);
+    h.finish()
+}
+
+fn machine_id() -> String {
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_to_string("/etc/machine-id").unwrap_or_default()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // IOPlatformUUID via ioreg; empty on failure (falls back to hostname).
+        std::process::Command::new("ioreg")
+            .args(["-rd1", "-c", "IOPlatformExpertDevice"])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .and_then(|s| {
+                s.lines()
+                    .find(|l| l.contains("IOPlatformUUID"))
+                    .map(|l| l.to_string())
+            })
+            .unwrap_or_default()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // MachineGuid from registry via reg query.
+        std::process::Command::new("reg")
+            .args([
+                "query",
+                r"HKLM\SOFTWARE\Microsoft\Cryptography",
+                "/v",
+                "MachineGuid",
+            ])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .unwrap_or_default()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        String::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_u64_round_trips() {
+        assert_eq!(Seed::from_u64(42).value(), 42);
+    }
+
+    #[test]
+    fn from_system_is_stable_within_process() {
+        assert_eq!(Seed::from_system(), Seed::from_system());
+    }
+
+    #[test]
+    fn serde_is_transparent_u64() {
+        let s = Seed::from_u64(7);
+        assert_eq!(serde_json::to_string(&s).unwrap(), "7");
+        let back: Seed = serde_json::from_str("7").unwrap();
+        assert_eq!(back, s);
+    }
+}

--- a/crates/zendriver-stealth/src/persona/seed.rs
+++ b/crates/zendriver-stealth/src/persona/seed.rs
@@ -35,7 +35,9 @@ fn system_seed_value() -> u64 {
     let mut h = std::collections::hash_map::DefaultHasher::new();
     // Stable machine id, best-effort per OS; fall back to hostname + cpu brand.
     machine_id().hash(&mut h);
-    sysinfo::System::host_name().unwrap_or_default().hash(&mut h);
+    sysinfo::System::host_name()
+        .unwrap_or_default()
+        .hash(&mut h);
     h.finish()
 }
 

--- a/crates/zendriver-stealth/src/persona/specs.rs
+++ b/crates/zendriver-stealth/src/persona/specs.rs
@@ -1,0 +1,76 @@
+//! Per-surface value specs carried by a Persona. All fields optional → overlay.
+
+use serde::{Deserialize, Serialize};
+
+use super::surface::Strategy;
+
+/// Noise-surface config (canvas, audio, clientRects).
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct SurfaceCfg {
+    /// Render strategy for this surface. None → kind default.
+    pub strategy: Option<Strategy>,
+}
+
+/// UA string + UA-CH metadata override.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct UaSpec {
+    pub ua_string: Option<String>,
+    /// Free-form UA-CH overrides; merged onto realistic() output at resolve.
+    pub platform: Option<String>,
+}
+
+/// WebGL value substitution.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct WebglSpec {
+    pub strategy: Option<Strategy>,
+    pub unmasked_vendor: Option<String>,
+    pub unmasked_renderer: Option<String>,
+}
+
+/// Font set + measureText noise.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct FontSpec {
+    pub strategy: Option<Strategy>,
+    /// Allow-list of font families the page may detect.
+    pub available: Option<Vec<String>>,
+}
+
+/// WebRTC policy.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct WebrtcSpec {
+    pub strategy: Option<Strategy>,
+    /// Fake public IP used when strategy = Value.
+    pub fake_ip: Option<String>,
+}
+
+/// Hardware bundle.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct HardwareSpec {
+    pub strategy: Option<Strategy>,
+    pub battery_level: Option<f64>,
+    pub media_devices: Option<u32>,
+    pub speech_voices: Option<Vec<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn specs_round_trip_json() {
+        let w = WebglSpec {
+            strategy: Some(Strategy::Value),
+            unmasked_vendor: Some("Google Inc. (NVIDIA)".into()),
+            unmasked_renderer: Some("ANGLE (NVIDIA, ...)".into()),
+        };
+        let s = serde_json::to_string(&w).unwrap();
+        let back: WebglSpec = serde_json::from_str(&s).unwrap();
+        assert_eq!(w, back);
+    }
+
+    #[test]
+    fn empty_spec_omits_nothing_required() {
+        let f = FontSpec::default();
+        assert!(f.available.is_none());
+    }
+}

--- a/crates/zendriver-stealth/src/persona/surface.rs
+++ b/crates/zendriver-stealth/src/persona/surface.rs
@@ -1,5 +1,20 @@
-//! Surface + Strategy (filled in Task B1).
+//! Surface + Strategy + per-surface kind resolution.
+
 use serde::{Deserialize, Serialize};
+
+/// A fingerprint surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Surface {
+    Canvas,
+    Webgl,
+    Audio,
+    Fonts,
+    ClientRects,
+    Webrtc,
+    Hardware,
+}
+
+/// How a resolved persona is applied to a surface in the page.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Strategy {
     Native,
@@ -7,4 +22,94 @@ pub enum Strategy {
     Random,
     Block,
     Value,
+}
+
+/// The semantic family a surface belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurfaceKind {
+    Noise,
+    Value,
+    Policy,
+}
+
+impl Surface {
+    pub fn kind(self) -> SurfaceKind {
+        match self {
+            Surface::Canvas | Surface::Audio | Surface::ClientRects => SurfaceKind::Noise,
+            Surface::Webgl | Surface::Fonts | Surface::Hardware => SurfaceKind::Value,
+            Surface::Webrtc => SurfaceKind::Policy,
+        }
+    }
+
+    /// Default strategy when none is set.
+    pub fn default_strategy(self) -> Strategy {
+        match self.kind() {
+            SurfaceKind::Noise => Strategy::Seeded,
+            SurfaceKind::Value => Strategy::Value,
+            SurfaceKind::Policy => Strategy::Block,
+        }
+    }
+
+    /// Resolve a requested strategy against this surface's kind.
+    /// Meaningless combos warn and fall back to the kind default
+    /// (least-opinionated: never error).
+    pub fn resolve_strategy(self, requested: Option<Strategy>) -> Strategy {
+        let req = match requested {
+            None => return self.default_strategy(),
+            Some(s) => s,
+        };
+        let ok = match (self.kind(), req) {
+            (_, Strategy::Native) | (_, Strategy::Block) => true,
+            (SurfaceKind::Noise, Strategy::Seeded | Strategy::Random) => true,
+            (SurfaceKind::Value, Strategy::Value) => true,
+            (SurfaceKind::Policy, Strategy::Value) => true,
+            _ => false,
+        };
+        if ok {
+            req
+        } else {
+            tracing::warn!(
+                surface = ?self,
+                requested = ?req,
+                "strategy not meaningful for surface kind; using default"
+            );
+            self.default_strategy()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noise_default_is_seeded() {
+        assert_eq!(Surface::Canvas.resolve_strategy(None), Strategy::Seeded);
+    }
+
+    #[test]
+    fn value_strategy_on_noise_warns_and_falls_back() {
+        // Value is meaningless for a noise surface → falls back to Seeded.
+        assert_eq!(
+            Surface::Canvas.resolve_strategy(Some(Strategy::Value)),
+            Strategy::Seeded
+        );
+    }
+
+    #[test]
+    fn native_and_block_always_pass() {
+        assert_eq!(
+            Surface::Webgl.resolve_strategy(Some(Strategy::Native)),
+            Strategy::Native
+        );
+        assert_eq!(
+            Surface::Audio.resolve_strategy(Some(Strategy::Block)),
+            Strategy::Block
+        );
+    }
+
+    #[test]
+    fn webrtc_default_is_block() {
+        assert_eq!(Surface::Webrtc.resolve_strategy(None), Strategy::Block);
+    }
 }

--- a/crates/zendriver-stealth/src/persona/surface.rs
+++ b/crates/zendriver-stealth/src/persona/surface.rs
@@ -1,0 +1,10 @@
+//! Surface + Strategy (filled in Task B1).
+use serde::{Deserialize, Serialize};
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Strategy {
+    Native,
+    Seeded,
+    Random,
+    Block,
+    Value,
+}

--- a/crates/zendriver-stealth/src/persona/surface.rs
+++ b/crates/zendriver-stealth/src/persona/surface.rs
@@ -58,13 +58,14 @@ impl Surface {
             None => return self.default_strategy(),
             Some(s) => s,
         };
-        let ok = match (self.kind(), req) {
-            (_, Strategy::Native) | (_, Strategy::Block) => true,
-            (SurfaceKind::Noise, Strategy::Seeded | Strategy::Random) => true,
-            (SurfaceKind::Value, Strategy::Value) => true,
-            (SurfaceKind::Policy, Strategy::Value) => true,
-            _ => false,
-        };
+        let ok = matches!(
+            (self.kind(), req),
+            (_, Strategy::Native)
+                | (_, Strategy::Block)
+                | (SurfaceKind::Noise, Strategy::Seeded | Strategy::Random)
+                | (SurfaceKind::Value, Strategy::Value)
+                | (SurfaceKind::Policy, Strategy::Value)
+        );
         if ok {
             req
         } else {

--- a/crates/zendriver-stealth/src/profile.rs
+++ b/crates/zendriver-stealth/src/profile.rs
@@ -20,7 +20,7 @@ pub enum ProfileKind {
 }
 
 /// JS `navigator.platform` value.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Platform {
     Win32,
     MacIntel,

--- a/crates/zendriver-stealth/tests/persona_snapshot.rs
+++ b/crates/zendriver-stealth/tests/persona_snapshot.rs
@@ -1,0 +1,14 @@
+//! Insta snapshot: stable `Persona` JSON wire shape.
+//!
+//! Run `cargo insta accept --all` after any intentional wire-shape change to
+//! update the committed snapshot.
+
+#[test]
+fn persona_full_wire_shape() {
+    let p = zendriver_stealth::Persona::builder()
+        .seed(zendriver_stealth::Seed::from_u64(1))
+        .device_memory_gb(8)
+        .timezone("UTC")
+        .build();
+    insta::assert_json_snapshot!(p);
+}

--- a/crates/zendriver-stealth/tests/snapshots/persona_snapshot__persona_full_wire_shape.snap
+++ b/crates/zendriver-stealth/tests/snapshots/persona_snapshot__persona_full_wire_shape.snap
@@ -1,0 +1,20 @@
+---
+source: crates/zendriver-stealth/tests/persona_snapshot.rs
+expression: p
+---
+{
+  "platform": null,
+  "ua": null,
+  "hardware_concurrency": null,
+  "device_memory_gb": 8,
+  "timezone": "UTC",
+  "locale": null,
+  "webgl": null,
+  "canvas": null,
+  "audio": null,
+  "fonts": null,
+  "client_rects": null,
+  "webrtc": null,
+  "hardware": null,
+  "seed": 1
+}

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -165,3 +165,7 @@ required-features = ["imperva"]
 [[example]]
 name = "fetcher_demo"
 required-features = ["fetcher"]
+
+[[example]]
+name = "persona_basic"
+required-features = []

--- a/crates/zendriver/examples/persona_basic.rs
+++ b/crates/zendriver/examples/persona_basic.rs
@@ -1,0 +1,55 @@
+//! Seeded farble persona with a per-surface override.
+//!
+//! Demonstrates:
+//! - Building a `Persona` with an explicit reproducible seed.
+//! - Overriding a single surface's render strategy (`Webrtc → Native`).
+//! - Launching the browser and navigating to `about:blank`.
+//!
+//! The seed pins the canvas / audio / clientRects farble so the same
+//! pixel-level noise is produced on every run — useful for regression
+//! testing and identity consistency across sessions.
+//!
+//! Run with:
+//! ```sh
+//! cargo run --example persona_basic
+//! ```
+
+use zendriver::{Browser, Persona, Seed, Strategy, Surface};
+
+#[tokio::main]
+#[allow(clippy::result_large_err)] // example boundary
+async fn main() -> zendriver::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    // Build a seeded persona so canvas / audio / clientRects farble is
+    // deterministic, then override WebRTC to Native so real IP candidates
+    // are allowed through (e.g. for WebRTC-based apps).
+    let persona = Persona::builder()
+        .seed(Seed::from_u64(42))
+        .device_memory_gb(8)
+        .timezone("America/New_York")
+        .build();
+
+    let browser = Browser::builder()
+        .persona(persona)
+        // One-off surface override: allow WebRTC to reveal the real IP.
+        .surface(Surface::Webrtc, Strategy::Native)
+        .launch()
+        .await?;
+
+    let tab = browser.main_tab();
+    tab.goto("about:blank").await?;
+    tab.wait_for_load().await?;
+
+    // Read back a couple of navigator fields to show the persona is applied.
+    let mem: serde_json::Value = tab.evaluate("navigator.deviceMemory").await?;
+    let tz: String = tab
+        .evaluate("Intl.DateTimeFormat().resolvedOptions().timeZone")
+        .await?;
+
+    println!("navigator.deviceMemory = {mem}");
+    println!("timezone               = {tz}");
+
+    browser.close().await?;
+    Ok(())
+}

--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -30,7 +30,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::time::timeout;
 use tracing::{debug, info, warn};
-use zendriver_stealth::{Persona, StealthObserver, StealthProfile, Strategy, Surface};
+use zendriver_stealth::{Persona, Seed, StealthObserver, StealthProfile, Strategy, Surface};
 use zendriver_transport::{
     Connection, ObserverError, PausedSession, SessionHandle, TargetObserver,
 };
@@ -281,6 +281,28 @@ pub(crate) fn parse_devtools_line(line: &str) -> Option<String> {
     } else {
         None
     }
+}
+
+/// Load (or first-time generate + persist) the fingerprint [`Seed`] bound to a
+/// `user_data_dir`.
+///
+/// Stored as a single base-10 `u64` in `<dir>/.zd_persona_seed`. On reuse the
+/// file is read and parsed; on first use (or any read/parse failure) a fresh
+/// [`Seed::random`] is generated and written, giving a stable per-profile
+/// fingerprint across runs. All filesystem errors are swallowed (best-effort):
+/// a dir that can't be written simply yields a fresh random seed each launch
+/// rather than failing the build.
+fn persisted_seed(dir: &Path) -> Seed {
+    let path = dir.join(".zd_persona_seed");
+    if let Ok(contents) = std::fs::read_to_string(&path) {
+        if let Ok(value) = contents.trim().parse::<u64>() {
+            return Seed::from_u64(value);
+        }
+    }
+    let seed = Seed::random();
+    let _ = std::fs::create_dir_all(dir);
+    let _ = std::fs::write(&path, seed.value().to_string());
+    seed
 }
 
 /// Fluent builder for a [`Browser`] launch.
@@ -836,6 +858,16 @@ impl BrowserBuilder {
     /// Callable before launch — it does not require a live browser.
     #[must_use]
     pub fn resolved_persona(&self) -> Persona {
+        // Did the caller pin a seed explicitly (via `.persona` or
+        // `.persona_overlay`)? Capture this BEFORE the `system()` fallback,
+        // which injects a fresh random seed of its own — an explicit seed must
+        // win over the `user_data_dir`-persisted one below.
+        let explicit_seed = self
+            .persona
+            .as_ref()
+            .and_then(|p| p.seed)
+            .or_else(|| self.persona_overlay.as_ref().and_then(|p| p.seed));
+
         let mut persona = self.persona.clone().unwrap_or_else(Persona::system);
         if let Some(overlay) = &self.persona_overlay {
             persona = persona.overlay(overlay.clone());
@@ -843,6 +875,19 @@ impl BrowserBuilder {
         for (surface, strategy) in &self.surface_overrides {
             persona.apply_surface_override(*surface, *strategy);
         }
+
+        // Seed persistence: when the caller did not pin a seed but a
+        // `user_data_dir` is set, the seed is read from (or written to) a file
+        // inside that dir so the same profile yields a stable fingerprint
+        // across runs. This overrides the ephemeral random seed that
+        // `Persona::system()` injects. Without a `user_data_dir`, the random
+        // seed stands (fresh identity per launch).
+        if explicit_seed.is_none() {
+            if let Some(dir) = &self.user_data_dir {
+                persona.seed = Some(persisted_seed(dir));
+            }
+        }
+
         persona
     }
 
@@ -2895,6 +2940,40 @@ mod tests {
             Some(Strategy::Native),
             "surface override must set the WebRTC strategy"
         );
+    }
+
+    #[test]
+    fn seed_persists_in_user_data_dir() {
+        // Two builders pointed at the same profile dir (no explicit seed) must
+        // resolve to the SAME seed: the first writes `.zd_persona_seed`, the
+        // second reads it back.
+        let dir = tempfile::tempdir().unwrap();
+        let s1 = Browser::builder()
+            .user_data_dir(dir.path())
+            .resolved_persona()
+            .seed
+            .unwrap();
+        let s2 = Browser::builder()
+            .user_data_dir(dir.path())
+            .resolved_persona()
+            .seed
+            .unwrap();
+        assert_eq!(s1, s2, "same profile dir → same seed across builders");
+    }
+
+    #[test]
+    fn explicit_seed_overrides_user_data_dir_persistence() {
+        // An explicitly-pinned seed must win over the persisted one.
+        let dir = tempfile::tempdir().unwrap();
+        let pinned = Browser::builder()
+            .persona(Persona::builder().seed(Seed::from_u64(777)).build())
+            .user_data_dir(dir.path())
+            .resolved_persona()
+            .seed
+            .unwrap();
+        assert_eq!(pinned, Seed::from_u64(777));
+        // And the persistence file is NOT consulted/created for the pinned seed.
+        assert!(!dir.path().join(".zd_persona_seed").exists());
     }
 
     #[test]

--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -30,7 +30,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::time::timeout;
 use tracing::{debug, info, warn};
-use zendriver_stealth::{StealthObserver, StealthProfile};
+use zendriver_stealth::{Persona, StealthObserver, StealthProfile, Strategy, Surface};
 use zendriver_transport::{
     Connection, ObserverError, PausedSession, SessionHandle, TargetObserver,
 };
@@ -331,6 +331,16 @@ pub struct BrowserBuilder {
     pub(crate) force_open_shadow_roots: bool,
     pub(crate) extra_args: Vec<String>,
     pub(crate) stealth: Option<StealthProfile>,
+    /// Base fingerprint [`Persona`] driving the spoofed-mode surface patches.
+    /// `None` → [`Persona::system`] (host-probed) is used. See
+    /// [`BrowserBuilder::persona`] and [`BrowserBuilder::resolved_persona`].
+    pub(crate) persona: Option<Persona>,
+    /// Optional overlay merged on top of the base persona (field-wise, `Some`
+    /// wins). See [`BrowserBuilder::persona_overlay`].
+    pub(crate) persona_overlay: Option<Persona>,
+    /// Per-surface render-strategy overrides, applied last over the resolved
+    /// persona. See [`BrowserBuilder::surface`].
+    pub(crate) surface_overrides: Vec<(Surface, Strategy)>,
     pub(crate) extra_observers: Vec<Arc<dyn TargetObserver>>,
     /// Optional `(username, password)` for proxy / HTTP basic-auth handling.
     /// Only honored when the `interception` feature is enabled; when present
@@ -359,6 +369,9 @@ impl std::fmt::Debug for BrowserBuilder {
             .field("force_open_shadow_roots", &self.force_open_shadow_roots)
             .field("extra_args", &self.extra_args)
             .field("stealth", &self.stealth)
+            .field("persona", &self.persona)
+            .field("persona_overlay", &self.persona_overlay)
+            .field("surface_overrides", &self.surface_overrides)
             .field(
                 "extra_observers",
                 &format_args!("<{} observers>", self.extra_observers.len()),
@@ -752,6 +765,85 @@ impl BrowserBuilder {
     pub fn stealth(mut self, profile: StealthProfile) -> Self {
         self.stealth = Some(profile);
         self
+    }
+
+    /// Set the base fingerprint [`Persona`] driving the spoofed-mode surface
+    /// patches (canvas/WebGL/audio/fonts/clientRects/WebRTC/hardware).
+    ///
+    /// When unset, [`Persona::system`] (host-probed) is used. Combine with
+    /// [`BrowserBuilder::persona_overlay`] for field-wise tweaks and
+    /// [`BrowserBuilder::surface`] for per-surface render-strategy overrides;
+    /// [`BrowserBuilder::resolved_persona`] returns the effective result.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zendriver::Persona;
+    /// let builder = zendriver::Browser::builder()
+    ///     .persona(Persona::builder().device_memory_gb(16).build());
+    /// ```
+    #[must_use]
+    pub fn persona(mut self, persona: Persona) -> Self {
+        self.persona = Some(persona);
+        self
+    }
+
+    /// Overlay a partial [`Persona`] on top of the base persona. Every `Some`
+    /// field in the overlay wins; `None` inherits from the base.
+    ///
+    /// Handy for layering a small JSON tweak (e.g. just a timezone) over a
+    /// host-probed or pool-sampled base persona.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// let builder = zendriver::Browser::builder()
+    ///     .persona_overlay(r#"{"timezone":"UTC"}"#.parse().unwrap());
+    /// ```
+    #[must_use]
+    pub fn persona_overlay(mut self, overlay: Persona) -> Self {
+        self.persona_overlay = Some(overlay);
+        self
+    }
+
+    /// Override a single fingerprint [`Surface`]'s render [`Strategy`].
+    ///
+    /// Applied last, on top of the resolved persona + overlay. Repeatable —
+    /// each call layers another surface override.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zendriver::{Strategy, Surface};
+    /// let builder = zendriver::Browser::builder()
+    ///     .surface(Surface::Webrtc, Strategy::Native);
+    /// ```
+    #[must_use]
+    pub fn surface(mut self, surface: Surface, strategy: Strategy) -> Self {
+        self.surface_overrides.push((surface, strategy));
+        self
+    }
+
+    /// Compute the effective [`Persona`] this builder will hand to the stealth
+    /// observer.
+    ///
+    /// Resolution order: base persona ([`Persona::system`] when unset) →
+    /// [`persona_overlay`](BrowserBuilder::persona_overlay) (field-wise merge) →
+    /// each [`surface`](BrowserBuilder::surface) override → a seed persisted
+    /// alongside [`user_data_dir`](BrowserBuilder::user_data_dir) when the
+    /// resolved persona has no explicit seed.
+    ///
+    /// Callable before launch — it does not require a live browser.
+    #[must_use]
+    pub fn resolved_persona(&self) -> Persona {
+        let mut persona = self.persona.clone().unwrap_or_else(Persona::system);
+        if let Some(overlay) = &self.persona_overlay {
+            persona = persona.overlay(overlay.clone());
+        }
+        for (surface, strategy) in &self.surface_overrides {
+            persona.apply_surface_override(*surface, *strategy);
+        }
+        persona
     }
 
     /// Register an additional [`TargetObserver`].
@@ -1625,8 +1717,11 @@ impl BrowserBuilder {
         let (mut observers, extra_flags): (Vec<Arc<dyn TargetObserver>>, Vec<String>) =
             if let Some(ref profile) = self.stealth {
                 let fp = profile.resolve_fingerprint(&exe)?;
-                let stealth_obs: Arc<dyn TargetObserver> =
-                    Arc::new(StealthObserver::new(profile.clone(), fp));
+                let stealth_obs: Arc<dyn TargetObserver> = Arc::new(StealthObserver::with_persona(
+                    profile.clone(),
+                    fp,
+                    self.resolved_persona(),
+                ));
                 let mut obs_vec = Vec::with_capacity(3 + self.extra_observers.len());
                 obs_vec.push(stealth_obs);
                 obs_vec.push(registrar.clone() as Arc<dyn TargetObserver>);
@@ -1835,8 +1930,11 @@ impl BrowserBuilder {
             // No executable to resolve a fingerprint from on the connect path;
             // fall back to the profile's default fingerprint.
             let fp = profile.resolve_fingerprint(Path::new(""))?;
-            let stealth_obs: Arc<dyn TargetObserver> =
-                Arc::new(StealthObserver::new(profile.clone(), fp));
+            let stealth_obs: Arc<dyn TargetObserver> = Arc::new(StealthObserver::with_persona(
+                profile.clone(),
+                fp,
+                self.resolved_persona(),
+            ));
             let mut obs_vec = Vec::with_capacity(3 + self.extra_observers.len());
             obs_vec.push(stealth_obs);
             obs_vec.push(registrar.clone() as Arc<dyn TargetObserver>);
@@ -2778,6 +2876,25 @@ mod tests {
     fn candidate_paths_is_nonempty() {
         let v = candidate_paths_for_channel(Channel::Auto);
         assert!(!v.is_empty());
+    }
+
+    #[test]
+    fn builder_accepts_persona_and_overrides() {
+        // Exercises the re-exported `zendriver::{Persona, Surface, Strategy}`
+        // and the full resolve pipeline: base persona → overlay → surface
+        // override. No browser launched — `resolved_persona` is `&self`.
+        let b = Browser::builder()
+            .persona(Persona::builder().device_memory_gb(16).build())
+            .persona_overlay(r#"{"timezone":"UTC"}"#.parse().unwrap())
+            .surface(Surface::Webrtc, Strategy::Native);
+        let p = b.resolved_persona();
+        assert_eq!(p.device_memory_gb, Some(16));
+        assert_eq!(p.timezone.as_deref(), Some("UTC"));
+        assert_eq!(
+            p.webrtc.as_ref().and_then(|w| w.strategy),
+            Some(Strategy::Native),
+            "surface override must set the WebRTC strategy"
+        );
     }
 
     #[test]

--- a/crates/zendriver/src/lib.rs
+++ b/crates/zendriver/src/lib.rs
@@ -107,6 +107,12 @@ pub use tab::{
 pub use traits::{Evaluable, Queryable};
 pub use window::{WindowBounds, WindowState};
 
+// Fingerprint-spoofing surface: the `Persona` config + per-surface render
+// strategy knobs, re-exported from `zendriver-stealth` so callers can wire
+// `Browser::builder().persona(...)` / `.surface(...)` without depending on the
+// stealth crate directly.
+pub use zendriver_stealth::{Persona, PersonaBuilder, Seed, Strategy, Surface};
+
 // Re-export selected transport types for advanced users.
 pub use zendriver_transport::{CallError, Connection, SessionHandle, TransportError};
 
@@ -191,7 +197,10 @@ pub use zendriver_fetcher::{
 
 /// Stealth profile + fingerprint configuration re-exported from `zendriver-stealth`.
 pub mod stealth {
-    pub use zendriver_stealth::{Fingerprint, Platform, StealthProfile, UserAgentMetadata};
+    pub use zendriver_stealth::{
+        Fingerprint, Persona, PersonaBuilder, Platform, Seed, StealthProfile, Strategy, Surface,
+        UserAgentMetadata,
+    };
 }
 
 /// Convenience entry point: launch a Chrome instance with default settings.

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -2648,6 +2648,25 @@ impl crate::traits::Evaluable for Tab {
     }
 }
 
+/// Live-probe seam for [`zendriver_stealth::Persona::from_browser`].
+///
+/// Implemented here (rather than in `zendriver-stealth`) so the stealth crate
+/// stays free of a `zendriver` dependency. The `ZendriverError` from
+/// [`Tab::evaluate`] is mapped into [`zendriver_stealth::StealthError::Probe`]
+/// — going the other direction (a `From<ZendriverError>` in stealth) would
+/// require stealth to depend on this crate, which is a cycle.
+#[async_trait::async_trait]
+impl zendriver_stealth::JsProbe for Tab {
+    async fn eval_json(
+        &self,
+        js: &str,
+    ) -> std::result::Result<Value, zendriver_stealth::StealthError> {
+        self.evaluate::<Value>(js)
+            .await
+            .map_err(|e| zendriver_stealth::StealthError::Probe(e.to_string()))
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {

--- a/crates/zendriver/tests/fingerprint_integration.rs
+++ b/crates/zendriver/tests/fingerprint_integration.rs
@@ -1,0 +1,106 @@
+//! Headful fingerprint-stability integration tests.
+//!
+//! Gated by `#[cfg(feature = "integration-tests")]` — same gate as
+//! `integration_phase2.rs`. Additionally marked `#[ignore]` so they only run
+//! explicitly (`cargo test -- --ignored`) on machines with a local Chrome.
+//!
+//! These tests are intentionally **not** run in the normal test matrix; they
+//! require a real Chrome binary and exercise the actual JS farble shims.
+//!
+//! To run locally:
+//! ```sh
+//! cargo test -p zendriver --test fingerprint_integration \
+//!     --features integration-tests -- --ignored
+//! ```
+
+#![cfg(feature = "integration-tests")]
+
+use serial_test::serial;
+use zendriver::Browser;
+use zendriver::{Persona, Seed, Strategy, Surface};
+
+/// Canvas JS that creates a 50×20 canvas, draws text, and returns `toDataURL`.
+const CANVAS_READ_JS: &str = r#"(() => {
+    const c = document.createElement('canvas');
+    c.width = 50; c.height = 20;
+    const x = c.getContext('2d');
+    x.fillText('zd', 2, 12);
+    return c.toDataURL();
+})()"#;
+
+/// Seeded canvas: two `toDataURL` reads in the same page must be identical —
+/// the farble is deterministic per-seed, so the same pixel data produces the
+/// same noise each time.
+#[tokio::test]
+#[serial]
+#[ignore] // run with: cargo test ... -- --ignored
+async fn seeded_canvas_is_stable_across_reads() {
+    let browser = Browser::builder()
+        .persona(Persona::builder().seed(Seed::from_u64(42)).build())
+        .launch()
+        .await
+        .unwrap();
+    let tab = browser.main_tab();
+    tab.goto("about:blank").await.unwrap();
+    tab.wait_for_load().await.unwrap();
+
+    let a: String = tab.evaluate::<String>(CANVAS_READ_JS).await.unwrap();
+    let b: String = tab.evaluate::<String>(CANVAS_READ_JS).await.unwrap();
+    assert_eq!(a, b, "Seeded canvas must be STABLE across repeat reads");
+
+    browser.close().await.unwrap();
+}
+
+/// Native strategy: two reads must also be equal (no farble applied, pure
+/// browser output). The meaningful native-vs-seeded distinction (the data URL
+/// itself differs between seeded and native runs) is verified manually — it
+/// requires two separate browser instances comparing absolute pixel values,
+/// which is impractical as an automated offline assertion.
+#[tokio::test]
+#[serial]
+#[ignore] // run with: cargo test ... -- --ignored
+async fn native_canvas_is_stable_across_reads() {
+    let browser = Browser::builder()
+        .persona(Persona::builder().seed(Seed::from_u64(42)).build())
+        .surface(Surface::Canvas, Strategy::Native)
+        .launch()
+        .await
+        .unwrap();
+    let tab = browser.main_tab();
+    tab.goto("about:blank").await.unwrap();
+    tab.wait_for_load().await.unwrap();
+
+    let a: String = tab.evaluate::<String>(CANVAS_READ_JS).await.unwrap();
+    let b: String = tab.evaluate::<String>(CANVAS_READ_JS).await.unwrap();
+    // Under Native the shim is absent; the browser's own canvas output is
+    // deterministic for the same drawing commands, so both reads are equal.
+    assert_eq!(a, b, "Native canvas must also be stable (no farble noise)");
+
+    browser.close().await.unwrap();
+}
+
+/// Random strategy: two reads within the same page must DIFFER because the
+/// shim re-seeds from `Math.random()` on every `getImageData` call.
+#[tokio::test]
+#[serial]
+#[ignore] // run with: cargo test ... -- --ignored
+async fn random_canvas_differs_across_reads() {
+    let browser = Browser::builder()
+        .persona(Persona::builder().seed(Seed::from_u64(99)).build())
+        .surface(Surface::Canvas, Strategy::Random)
+        .launch()
+        .await
+        .unwrap();
+    let tab = browser.main_tab();
+    tab.goto("about:blank").await.unwrap();
+    tab.wait_for_load().await.unwrap();
+
+    let a: String = tab.evaluate::<String>(CANVAS_READ_JS).await.unwrap();
+    let b: String = tab.evaluate::<String>(CANVAS_READ_JS).await.unwrap();
+    // With `Random` each call gets a fresh PRNG seed; the overwhelming
+    // majority of the time the two data URLs will differ. (Probability of
+    // accidental equality is astronomically small for a 50×20 RGBA canvas.)
+    assert_ne!(a, b, "Random canvas strategy must produce different outputs per read");
+
+    browser.close().await.unwrap();
+}

--- a/crates/zendriver/tests/fingerprint_integration.rs
+++ b/crates/zendriver/tests/fingerprint_integration.rs
@@ -100,7 +100,10 @@ async fn random_canvas_differs_across_reads() {
     // With `Random` each call gets a fresh PRNG seed; the overwhelming
     // majority of the time the two data URLs will differ. (Probability of
     // accidental equality is astronomically small for a 50×20 RGBA canvas.)
-    assert_ne!(a, b, "Random canvas strategy must produce different outputs per read");
+    assert_ne!(
+        a, b,
+        "Random canvas strategy must produce different outputs per read"
+    );
 
     browser.close().await.unwrap();
 }

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -4,6 +4,7 @@
 - [Install](./install.md)
 - [Quickstart](./quickstart.md)
 - [Stealth](./stealth.md)
+- [Fingerprint spoofing](./fingerprint.md)
 - [Multi-tab](./multi-tab.md)
 - [Per-context isolation](./browser-context.md)
 - [Frames](./frames.md)

--- a/docs/book/src/fingerprint.md
+++ b/docs/book/src/fingerprint.md
@@ -1,0 +1,175 @@
+# Fingerprint spoofing
+
+zendriver-rs ships a first-class fingerprint layer that lets you control what
+every browser surface reveals to detection scripts — canvas pixel noise, WebGL
+renderer strings, WebRTC IP candidates, hardware hints, and more — without
+touching any CDP internals directly.
+
+## Two orthogonal axes
+
+Fingerprint control lives on two independent axes:
+
+| Axis | What it controls | Where it lives |
+|------|-----------------|----------------|
+| **Persona source** | The identity values injected (UA, platform, WebGL vendor, seed, …) | `zendriver-stealth` (core), or `zendriver-fingerprints` (pool / generative) |
+| **Per-surface render strategy** | *How* each surface is modified in-page | `Strategy` enum, set per `Surface` |
+
+You can mix any persona source with any per-surface strategy independently.
+
+## The 7 surfaces
+
+| Surface | Kind | Default strategy | What it affects |
+|---------|------|-----------------|-----------------|
+| `Canvas` | Noise | `Seeded` | `getImageData`, `toDataURL` pixel data |
+| `Audio` | Noise | `Seeded` | `AnalyserNode` frequency / time-domain data |
+| `ClientRects` | Noise | `Seeded` | `getBoundingClientRect` sub-pixel dimensions |
+| `Webgl` | Value | `Value` | `UNMASKED_VENDOR_WEBGL`, `UNMASKED_RENDERER_WEBGL` |
+| `Fonts` | Value | `Value` | `measureText` width noise + `FontFaceSet.check` allow-list |
+| `Hardware` | Value | `Value` | Battery level, media-device count, speech voices |
+| `Webrtc` | Policy | `Block` | ICE candidate leak suppression / fake IP |
+
+## The 5 strategies
+
+| Strategy | Effect |
+|----------|--------|
+| `Native` | No patch — raw browser output. |
+| `Seeded` | Deterministic per-seed noise; same seed → same output every run. |
+| `Random` | Fresh random noise on every call; maximally unpredictable. |
+| `Block` | Empty / zero output (appropriate for policy surfaces). |
+| `Value` | Substitute a specific value from the `Persona` spec. |
+
+Noise surfaces (Canvas, Audio, ClientRects) accept `Native`, `Seeded`,
+`Random`, `Block`. Value surfaces (Webgl, Fonts, Hardware) accept `Native`,
+`Value`, `Block`. The policy surface (Webrtc) accepts `Native`, `Block`,
+`Value` (fake IP). Requesting a meaningless combination logs a warning and
+falls back to the surface's kind default.
+
+## Persona sources
+
+### `Persona::system()` — host-probed, cached
+
+Reads the real machine's platform, CPU count, and memory via `sysinfo`. The
+result is cached in a `OnceLock` — first call probes, subsequent calls clone.
+A random seed is generated per process.
+
+```rust,no_run
+use zendriver::{Browser, Persona};
+
+let browser = Browser::builder()
+    .persona(Persona::system())
+    .launch().await?;
+```
+
+### `Persona::builder()` — explicit
+
+Build any combination of fields; unset fields inherit from `system()`.
+
+```rust,no_run
+use zendriver::{Browser, Persona, Seed};
+
+let persona = Persona::builder()
+    .seed(Seed::from_u64(42))       // reproducible noise
+    .device_memory_gb(16)
+    .timezone("America/Los_Angeles")
+    .build();
+
+let browser = Browser::builder()
+    .persona(persona)
+    .launch().await?;
+```
+
+### `Persona::from_browser(tab)` — live probe
+
+Read the real browser's values (WebGL renderer, timezone, locale, …) from a
+running `Tab` and produce a maximally coherent `Persona`. Useful when you want
+to match the identity of an existing browser session.
+
+```rust,no_run
+use zendriver::{Browser, Persona};
+
+let browser = Browser::builder().launch().await?;
+let tab = browser.main_tab();
+tab.goto("about:blank").await?;
+
+let persona = Persona::from_browser(tab).await?;
+println!("{:?}", persona.webgl);
+```
+
+### `Seed::from_system()` — machine-stable seed
+
+Produces the same seed on every run on the same machine (derived from the
+platform machine ID + hostname). Useful when you want a consistent identity
+per machine without a `user_data_dir`.
+
+```rust,no_run
+use zendriver::{Browser, Persona, Seed};
+
+let persona = Persona::builder()
+    .seed(Seed::from_system())
+    .build();
+```
+
+### Pool + generative sources (`zendriver-fingerprints`)
+
+For real-device personas drawn from a dataset or a Bayesian network, add
+the optional `zendriver-fingerprints` crate and enable the `pool` or
+`generative` feature:
+
+```toml
+[dependencies]
+zendriver-fingerprints = { version = "0.1", features = ["pool"] }
+```
+
+```rust,no_run
+use zendriver_fingerprints::pool::PoolSet;
+use zendriver_stealth::Seed;
+
+// Build from a local JSON array (or load with load_or_download(url)).
+let pool = PoolSet::from_json(include_str!("pool.json"))?;
+let persona = pool.sample(Seed::from_u64(42));
+
+// Pass to Browser::builder() in the zendriver crate.
+```
+
+## Per-surface strategy overrides
+
+Override any surface's render strategy on top of the persona:
+
+```rust,no_run
+use zendriver::{Browser, Persona, Seed, Strategy, Surface};
+
+let browser = Browser::builder()
+    .persona(Persona::builder().seed(Seed::from_u64(42)).build())
+    .surface(Surface::Webrtc, Strategy::Native)  // allow real IP
+    .surface(Surface::Canvas, Strategy::Random)  // max entropy
+    .launch().await?;
+```
+
+## JSON persona (`try_from_json`)
+
+Any `Persona` can be expressed as a JSON object and round-trips cleanly.
+Fields are snake_case; all fields are optional. Useful for configuration files
+or environment variables:
+
+```rust,no_run
+use zendriver::Persona;
+
+let persona: Persona = Persona::try_from_json(r#"{
+  "timezone": "Europe/Berlin",
+  "device_memory_gb": 8,
+  "seed": 12345,
+  "webgl": {
+    "unmasked_vendor":   "Google Inc. (NVIDIA)",
+    "unmasked_renderer": "ANGLE (NVIDIA, NVIDIA GeForce RTX 3060 Direct3D11 vs_5_0 ps_5_0, D3D11)"
+  },
+  "webrtc": { "strategy": "Block" }
+}"#).unwrap();
+```
+
+You can also parse via `FromStr`:
+
+```rust,no_run
+use zendriver::Persona;
+
+let persona: Persona = r#"{"seed": 99, "timezone": "UTC"}"#.parse().unwrap();
+```

--- a/docs/superpowers/plans/2026-06-02-fingerprint-spoofing.md
+++ b/docs/superpowers/plans/2026-06-02-fingerprint-spoofing.md
@@ -1,0 +1,1774 @@
+# Fingerprint Spoofing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add full fingerprint spoofing to zendriver-rs — a serde `Persona` type driving canvas/WebGL/audio/fonts/ClientRects/WebRTC/hardware surfaces through per-surface render strategies, plus a `zendriver-fingerprints` crate for real-device (pool + generative) personas.
+
+**Architecture:** Two orthogonal axes. (1) *Persona source* — `system()`/builder/JSON/`from_browser()` in core `zendriver-stealth`, or `pool`/`generative` in the new optional `zendriver-fingerprints` crate. (2) *Per-surface render strategy* — `Native`/`Seeded`/`Random`/`Block`/`Value`, resolved per surface kind (noise/value/policy). JS patches reuse the existing isolated-world observer. Least-opinionated: every field overridable, coherent defaults.
+
+**Tech Stack:** Rust (workspace, edition per workspace), `serde`/`serde_json` (already deps), `sysinfo` (already dep), `fastrand` (new, tiny) for seeding, `tokio`, CDP via `chromiumoxide_cdp`. JS farble shims injected via `Page.addScriptToEvaluateOnNewDocument`.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-fingerprint-spoofing-design.md`
+
+---
+
+## File Structure
+
+**`zendriver-stealth` (core, modified):**
+- Create `src/persona/mod.rs` — `Persona`, overlay merge, `PersonaBuilder`, `system()`, `from_browser()`, `FromStr`/`try_from_json`.
+- Create `src/persona/seed.rs` — `Seed`, `SeedSource`, `random`/`from_system`/`from_u64`.
+- Create `src/persona/surface.rs` — `Surface`, `Strategy`, `SurfaceKind`, per-surface resolution + warn-fallback.
+- Create `src/persona/specs.rs` — `UaSpec`, `WebglSpec`, `FontSpec`, `WebrtcSpec`, `HardwareSpec`, `SurfaceCfg`.
+- Create `src/patches/{canvas,audio,fonts,client_rects,webrtc,hardware}.js`; extend `src/patches/webgl.js`.
+- Modify `src/patches.rs` — `bootstrap_script(&Persona)` emits new patches.
+- Modify `src/fingerprint.rs` — keep probe helpers; `Fingerprint` becomes a producer of `Persona` identity fields (see Task A8).
+- Modify `src/lib.rs` — `pub mod persona;` + re-exports.
+- Modify `Cargo.toml` — add `fastrand`.
+
+**`zendriver-fingerprints` (new crate):**
+- Create `Cargo.toml`, `src/lib.rs`, `src/pool/mod.rs`, `src/generative/mod.rs`, `NOTICE`.
+
+**`zendriver` (core public, modified):**
+- Modify `src/browser.rs` — `.persona()`, `.persona_overlay()`, `.surface()` builder methods; persona-seed persistence.
+- Modify `src/lib.rs` — re-export `Persona`/`Surface`/`Strategy`.
+- Create `examples/persona_*.rs`.
+
+---
+
+## Phase A — Persona foundation
+
+### Task A1: `Seed` type
+
+**Files:**
+- Create: `crates/zendriver-stealth/src/persona/seed.rs`
+- Modify: `crates/zendriver-stealth/Cargo.toml` (add `fastrand`)
+- Modify: `crates/zendriver-stealth/src/lib.rs` (add `pub mod persona;` placeholder — see A2)
+
+- [ ] **Step 1: Add `fastrand` dep**
+
+In `crates/zendriver-stealth/Cargo.toml` under `[dependencies]`:
+```toml
+fastrand = "2"
+```
+(If `fastrand` is already in the workspace, use `fastrand.workspace = true` instead — check `Cargo.toml` at repo root first.)
+
+- [ ] **Step 2: Write the failing test**
+
+Create `crates/zendriver-stealth/src/persona/seed.rs`:
+```rust
+//! Seed: controls deterministic farble. random (default) / from_system / explicit.
+
+use serde::{Deserialize, Serialize};
+
+/// A fingerprint seed. Serializes transparently as its u64 value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Seed(pub u64);
+
+impl Seed {
+    /// Per-instance unique seed. THE DEFAULT.
+    pub fn random() -> Seed {
+        Seed(fastrand::u64(..))
+    }
+
+    /// Explicit reproducible seed.
+    pub fn from_u64(v: u64) -> Seed {
+        Seed(v)
+    }
+
+    /// Deterministic per-machine seed: stable across runs on the same host
+    /// WITHOUT a user_data_dir. Opt-in — sticky per machine (one identity).
+    pub fn from_system() -> Seed {
+        Seed(system_seed_value())
+    }
+
+    /// Raw value for JS farble.
+    pub fn value(self) -> u64 {
+        self.0
+    }
+}
+
+fn system_seed_value() -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    // Stable machine id, best-effort per OS; fall back to hostname + cpu brand.
+    machine_id().hash(&mut h);
+    sysinfo::System::host_name().unwrap_or_default().hash(&mut h);
+    h.finish()
+}
+
+fn machine_id() -> String {
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_to_string("/etc/machine-id").unwrap_or_default()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // IOPlatformUUID via ioreg; empty on failure (falls back to hostname).
+        std::process::Command::new("ioreg")
+            .args(["-rd1", "-c", "IOPlatformExpertDevice"])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .and_then(|s| {
+                s.lines()
+                    .find(|l| l.contains("IOPlatformUUID"))
+                    .map(|l| l.to_string())
+            })
+            .unwrap_or_default()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // MachineGuid from registry via reg query.
+        std::process::Command::new("reg")
+            .args([
+                "query",
+                r"HKLM\SOFTWARE\Microsoft\Cryptography",
+                "/v",
+                "MachineGuid",
+            ])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .unwrap_or_default()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        String::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_u64_round_trips() {
+        assert_eq!(Seed::from_u64(42).value(), 42);
+    }
+
+    #[test]
+    fn from_system_is_stable_within_process() {
+        assert_eq!(Seed::from_system(), Seed::from_system());
+    }
+
+    #[test]
+    fn serde_is_transparent_u64() {
+        let s = Seed::from_u64(7);
+        assert_eq!(serde_json::to_string(&s).unwrap(), "7");
+        let back: Seed = serde_json::from_str("7").unwrap();
+        assert_eq!(back, s);
+    }
+}
+```
+
+Add to `crates/zendriver-stealth/src/lib.rs`:
+```rust
+pub mod persona;
+```
+And create a temporary `crates/zendriver-stealth/src/persona/mod.rs` with just:
+```rust
+//! Persona: the unified fingerprint configuration.
+pub mod seed;
+pub use seed::{Seed};
+```
+
+- [ ] **Step 3: Run test to verify it fails (compiles first)**
+
+Run: `cargo test -p zendriver-stealth seed:: 2>&1 | tail -20`
+Expected: compile error if `fastrand` not yet wired, then PASS once it compiles. If `fastrand` unresolved, fix the dep line.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p zendriver-stealth seed::`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/zendriver-stealth/Cargo.toml crates/zendriver-stealth/src/lib.rs crates/zendriver-stealth/src/persona/
+git commit -m "feat(stealth): Seed type (random/from_system/from_u64)"
+```
+
+---
+
+### Task A2: Spec types (`SurfaceCfg`, `UaSpec`, `WebglSpec`, `FontSpec`, `WebrtcSpec`, `HardwareSpec`)
+
+**Files:**
+- Create: `crates/zendriver-stealth/src/persona/specs.rs`
+- Modify: `crates/zendriver-stealth/src/persona/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `crates/zendriver-stealth/src/persona/specs.rs`:
+```rust
+//! Per-surface value specs carried by a Persona. All fields optional → overlay.
+
+use serde::{Deserialize, Serialize};
+
+use super::surface::Strategy;
+
+/// Noise-surface config (canvas, audio, clientRects).
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct SurfaceCfg {
+    /// Render strategy for this surface. None → kind default.
+    pub strategy: Option<Strategy>,
+}
+
+/// UA string + UA-CH metadata override.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct UaSpec {
+    pub ua_string: Option<String>,
+    /// Free-form UA-CH overrides; merged onto realistic() output at resolve.
+    pub platform: Option<String>,
+}
+
+/// WebGL value substitution.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct WebglSpec {
+    pub strategy: Option<Strategy>,
+    pub unmasked_vendor: Option<String>,
+    pub unmasked_renderer: Option<String>,
+}
+
+/// Font set + measureText noise.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct FontSpec {
+    pub strategy: Option<Strategy>,
+    /// Allow-list of font families the page may detect.
+    pub available: Option<Vec<String>>,
+}
+
+/// WebRTC policy.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct WebrtcSpec {
+    pub strategy: Option<Strategy>,
+    /// Fake public IP used when strategy = Value.
+    pub fake_ip: Option<String>,
+}
+
+/// Hardware bundle.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct HardwareSpec {
+    pub strategy: Option<Strategy>,
+    pub battery_level: Option<f64>,
+    pub media_devices: Option<u32>,
+    pub speech_voices: Option<Vec<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn specs_round_trip_json() {
+        let w = WebglSpec {
+            strategy: Some(Strategy::Value),
+            unmasked_vendor: Some("Google Inc. (NVIDIA)".into()),
+            unmasked_renderer: Some("ANGLE (NVIDIA, ...)".into()),
+        };
+        let s = serde_json::to_string(&w).unwrap();
+        let back: WebglSpec = serde_json::from_str(&s).unwrap();
+        assert_eq!(w, back);
+    }
+
+    #[test]
+    fn empty_spec_omits_nothing_required() {
+        let f = FontSpec::default();
+        assert!(f.available.is_none());
+    }
+}
+```
+
+Add to `crates/zendriver-stealth/src/persona/mod.rs`:
+```rust
+pub mod specs;
+pub mod surface; // defined in Task B1; add now so specs.rs compiles
+pub use specs::{FontSpec, HardwareSpec, SurfaceCfg, UaSpec, WebglSpec, WebrtcSpec};
+```
+
+> Note: `specs.rs` imports `Strategy` from `surface.rs`. Create a minimal `surface.rs` stub now so this compiles; Task B1 fills it:
+```rust
+//! Surface + Strategy (filled in Task B1).
+use serde::{Deserialize, Serialize};
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Strategy { Native, Seeded, Random, Block, Value }
+```
+
+- [ ] **Step 2: Run test to verify it fails, then passes**
+
+Run: `cargo test -p zendriver-stealth specs::`
+Expected: 2 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/zendriver-stealth/src/persona/
+git commit -m "feat(stealth): per-surface persona spec types"
+```
+
+---
+
+### Task A3: `Persona` struct + `Default`
+
+**Files:**
+- Modify: `crates/zendriver-stealth/src/persona/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/zendriver-stealth/src/persona/mod.rs`, add:
+```rust
+use serde::{Deserialize, Serialize};
+
+use crate::Platform;
+use specs::{FontSpec, HardwareSpec, SurfaceCfg, UaSpec, WebglSpec, WebrtcSpec};
+
+/// Unified fingerprint configuration. Every field optional → overlay semantics.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Persona {
+    pub platform: Option<Platform>,
+    pub ua: Option<UaSpec>,
+    pub hardware_concurrency: Option<u32>,
+    pub device_memory_gb: Option<u32>,
+    pub timezone: Option<String>,
+    pub locale: Option<String>,
+    pub webgl: Option<WebglSpec>,
+    pub canvas: Option<SurfaceCfg>,
+    pub audio: Option<SurfaceCfg>,
+    pub fonts: Option<FontSpec>,
+    pub client_rects: Option<SurfaceCfg>,
+    pub webrtc: Option<WebrtcSpec>,
+    pub hardware: Option<HardwareSpec>,
+    pub seed: Option<Seed>,
+}
+
+#[cfg(test)]
+mod persona_tests {
+    use super::*;
+
+    #[test]
+    fn default_persona_is_all_none() {
+        let p = Persona::default();
+        assert!(p.platform.is_none() && p.seed.is_none() && p.webgl.is_none());
+    }
+
+    #[test]
+    fn persona_round_trips_json() {
+        let mut p = Persona::default();
+        p.seed = Some(Seed::from_u64(5));
+        p.timezone = Some("America/New_York".into());
+        let s = serde_json::to_string(&p).unwrap();
+        let back: Persona = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.seed, Some(Seed::from_u64(5)));
+        assert_eq!(back.timezone.as_deref(), Some("America/New_York"));
+    }
+}
+```
+
+Ensure `Platform` derives `Serialize + Deserialize`. Check `crates/zendriver-stealth/src/profile.rs` — if `Platform` only derives `Serialize`, add `Deserialize`:
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Platform { /* ... */ }
+```
+
+- [ ] **Step 2: Run test, verify pass**
+
+Run: `cargo test -p zendriver-stealth persona_tests::`
+Expected: 2 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/zendriver-stealth/src/persona/mod.rs crates/zendriver-stealth/src/profile.rs
+git commit -m "feat(stealth): Persona struct + serde"
+```
+
+---
+
+### Task A4: Overlay merge
+
+**Files:**
+- Modify: `crates/zendriver-stealth/src/persona/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `persona_tests` mod:
+```rust
+#[test]
+fn overlay_some_wins_none_inherits() {
+    let base = Persona {
+        timezone: Some("UTC".into()),
+        device_memory_gb: Some(8),
+        seed: Some(Seed::from_u64(1)),
+        ..Persona::default()
+    };
+    let over = Persona {
+        timezone: Some("Asia/Tokyo".into()),
+        ..Persona::default()
+    };
+    let merged = base.overlay(over);
+    assert_eq!(merged.timezone.as_deref(), Some("Asia/Tokyo")); // some wins
+    assert_eq!(merged.device_memory_gb, Some(8)); // none inherits
+    assert_eq!(merged.seed, Some(Seed::from_u64(1)));
+}
+```
+
+- [ ] **Step 2: Implement**
+
+Add to `impl Persona`:
+```rust
+impl Persona {
+    /// Field-wise merge: `Some` in `over` wins, `None` inherits from `self`.
+    pub fn overlay(self, over: Persona) -> Persona {
+        Persona {
+            platform: over.platform.or(self.platform),
+            ua: over.ua.or(self.ua),
+            hardware_concurrency: over.hardware_concurrency.or(self.hardware_concurrency),
+            device_memory_gb: over.device_memory_gb.or(self.device_memory_gb),
+            timezone: over.timezone.or(self.timezone),
+            locale: over.locale.or(self.locale),
+            webgl: over.webgl.or(self.webgl),
+            canvas: over.canvas.or(self.canvas),
+            audio: over.audio.or(self.audio),
+            fonts: over.fonts.or(self.fonts),
+            client_rects: over.client_rects.or(self.client_rects),
+            webrtc: over.webrtc.or(self.webrtc),
+            hardware: over.hardware.or(self.hardware),
+            seed: over.seed.or(self.seed),
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run test, verify pass**
+
+Run: `cargo test -p zendriver-stealth persona_tests::overlay`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/zendriver-stealth/src/persona/mod.rs
+git commit -m "feat(stealth): Persona::overlay field-wise merge"
+```
+
+---
+
+### Task A5: `try_from_json` + `FromStr`
+
+**Files:**
+- Modify: `crates/zendriver-stealth/src/persona/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn from_json_and_fromstr_parse() {
+    let json = r#"{"timezone":"Europe/Paris","seed":99}"#;
+    let a = Persona::try_from_json(json).unwrap();
+    assert_eq!(a.timezone.as_deref(), Some("Europe/Paris"));
+    let b: Persona = json.parse().unwrap();
+    assert_eq!(b.seed, Some(Seed::from_u64(99)));
+}
+```
+
+- [ ] **Step 2: Implement**
+
+```rust
+impl Persona {
+    pub fn try_from_json(s: &str) -> Result<Persona, serde_json::Error> {
+        serde_json::from_str(s)
+    }
+}
+
+impl std::str::FromStr for Persona {
+    type Err = serde_json::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+```
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test -p zendriver-stealth persona_tests::from_json`
+Expected: PASS.
+```bash
+git add crates/zendriver-stealth/src/persona/mod.rs
+git commit -m "feat(stealth): Persona JSON ingestion (try_from_json + FromStr)"
+```
+
+---
+
+### Task A6: `PersonaBuilder`
+
+**Files:**
+- Modify: `crates/zendriver-stealth/src/persona/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn builder_sets_fields() {
+    let p = Persona::builder()
+        .seed(Seed::from_u64(3))
+        .timezone("UTC")
+        .device_memory_gb(16)
+        .build();
+    assert_eq!(p.seed, Some(Seed::from_u64(3)));
+    assert_eq!(p.device_memory_gb, Some(16));
+    assert_eq!(p.timezone.as_deref(), Some("UTC"));
+}
+```
+
+- [ ] **Step 2: Implement**
+
+```rust
+/// Fluent builder for [`Persona`]. Every setter is optional.
+#[derive(Debug, Clone, Default)]
+pub struct PersonaBuilder(Persona);
+
+impl Persona {
+    pub fn builder() -> PersonaBuilder {
+        PersonaBuilder(Persona::default())
+    }
+}
+
+impl PersonaBuilder {
+    pub fn seed(mut self, s: Seed) -> Self {
+        self.0.seed = Some(s);
+        self
+    }
+    pub fn timezone(mut self, tz: impl Into<String>) -> Self {
+        self.0.timezone = Some(tz.into());
+        self
+    }
+    pub fn locale(mut self, l: impl Into<String>) -> Self {
+        self.0.locale = Some(l.into());
+        self
+    }
+    pub fn device_memory_gb(mut self, gb: u32) -> Self {
+        self.0.device_memory_gb = Some(gb);
+        self
+    }
+    pub fn hardware_concurrency(mut self, n: u32) -> Self {
+        self.0.hardware_concurrency = Some(n);
+        self
+    }
+    pub fn webgl(mut self, w: WebglSpec) -> Self {
+        self.0.webgl = Some(w);
+        self
+    }
+    pub fn build(self) -> Persona {
+        self.0
+    }
+}
+```
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test -p zendriver-stealth persona_tests::builder`
+Expected: PASS.
+```bash
+git add crates/zendriver-stealth/src/persona/mod.rs
+git commit -m "feat(stealth): PersonaBuilder"
+```
+
+---
+
+### Task A7: `Persona::system()` (host probe, OnceLock-cached)
+
+**Files:**
+- Modify: `crates/zendriver-stealth/src/persona/mod.rs`
+- Reference: `crates/zendriver-stealth/src/fingerprint.rs` (`auto_detect`, `detect_platform`, `detect_memory_gb`, `clamp_cpu_count`)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn system_persona_is_populated_and_cached() {
+    let a = Persona::system();
+    // Host probe fills platform + cpu + memory.
+    assert!(a.platform.is_some());
+    assert!(a.hardware_concurrency.is_some());
+    assert!(a.device_memory_gb.is_some());
+    let b = Persona::system();
+    // Cached → same values.
+    assert_eq!(a.device_memory_gb, b.device_memory_gb);
+}
+```
+
+- [ ] **Step 2: Implement**
+
+In `fingerprint.rs`, make the probe helpers `pub(crate)` (they are currently private): `detect_platform`, `detect_memory_gb`, `clamp_cpu_count`, `probe_chrome_version` — add `pub(crate)` to each.
+
+In `persona/mod.rs`:
+```rust
+use std::sync::OnceLock;
+
+static SYSTEM: OnceLock<Persona> = OnceLock::new();
+
+impl Persona {
+    /// Host-probed persona (sysinfo). Cached: first call probes, rest clone.
+    /// Runtime — NOT a build-script const (build host != run host).
+    pub fn system() -> Persona {
+        SYSTEM.get_or_init(Persona::probe_system).clone()
+    }
+
+    fn probe_system() -> Persona {
+        let platform = crate::fingerprint::detect_platform();
+        let cpu = crate::fingerprint::clamp_cpu_count(num_cpus::get() as u32);
+        let mem = crate::fingerprint::detect_memory_gb().unwrap_or(8);
+        Persona {
+            platform: Some(platform),
+            hardware_concurrency: Some(cpu),
+            device_memory_gb: Some(mem),
+            timezone: None, // probed lazily / by from_browser
+            locale: None,
+            seed: Some(Seed::random()),
+            ..Persona::default()
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test -p zendriver-stealth persona_tests::system`
+Expected: PASS.
+```bash
+git add crates/zendriver-stealth/src/persona/mod.rs crates/zendriver-stealth/src/fingerprint.rs
+git commit -m "feat(stealth): Persona::system() host probe (cached)"
+```
+
+---
+
+### Task A8: Bridge `Fingerprint` → `Persona` for `bootstrap_script`
+
+This keeps the existing 9 patches working while patches.rs migrates to `Persona`.
+
+**Files:**
+- Modify: `crates/zendriver-stealth/src/persona/mod.rs`
+- Reference: `crates/zendriver-stealth/src/patches.rs` (`bootstrap_script(fp: &Fingerprint)`), `src/fingerprint.rs` (`Fingerprint`)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn persona_exposes_resolved_platform_for_patches() {
+    let p = Persona::system();
+    // Helper used by patches.rs to read the effective platform JS string.
+    assert!(!p.resolved_platform_js().is_empty());
+}
+```
+
+- [ ] **Step 2: Implement**
+
+```rust
+impl Persona {
+    /// Effective `navigator.platform` JS string for patch templating.
+    /// Falls back to host platform when unset.
+    pub fn resolved_platform_js(&self) -> String {
+        let plat = self.platform.unwrap_or_else(|| {
+            Persona::system().platform.unwrap_or(crate::Platform::LinuxX86_64)
+        });
+        plat.platform_js().to_string()
+    }
+}
+```
+> Check `profile.rs`/`fingerprint.rs` for the existing platform→JS-string method (e.g. `ch_platform` / `platform`); reuse it. If the method is named differently, adapt `platform_js()` to the real name and keep this helper's name stable.
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test -p zendriver-stealth persona_tests::persona_exposes`
+Expected: PASS.
+```bash
+git add crates/zendriver-stealth/src/persona/mod.rs
+git commit -m "feat(stealth): Persona patch-templating accessors"
+```
+
+---
+
+## Phase B — Surfaces & strategies
+
+### Task B1: `Surface` + `Strategy` + per-surface resolution
+
+**Files:**
+- Modify: `crates/zendriver-stealth/src/persona/surface.rs` (replace the Task A2 stub)
+
+- [ ] **Step 1: Write the failing test**
+
+Replace `surface.rs` contents:
+```rust
+//! Surface + Strategy + per-surface kind resolution.
+
+use serde::{Deserialize, Serialize};
+
+/// A fingerprint surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Surface {
+    Canvas,
+    Webgl,
+    Audio,
+    Fonts,
+    ClientRects,
+    Webrtc,
+    Hardware,
+}
+
+/// How a resolved persona is applied to a surface in the page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Strategy {
+    Native,
+    Seeded,
+    Random,
+    Block,
+    Value,
+}
+
+/// The semantic family a surface belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurfaceKind {
+    Noise,
+    Value,
+    Policy,
+}
+
+impl Surface {
+    pub fn kind(self) -> SurfaceKind {
+        match self {
+            Surface::Canvas | Surface::Audio | Surface::ClientRects => SurfaceKind::Noise,
+            Surface::Webgl | Surface::Fonts | Surface::Hardware => SurfaceKind::Value,
+            Surface::Webrtc => SurfaceKind::Policy,
+        }
+    }
+
+    /// Default strategy when none is set.
+    pub fn default_strategy(self) -> Strategy {
+        match self.kind() {
+            SurfaceKind::Noise => Strategy::Seeded,
+            SurfaceKind::Value => Strategy::Value,
+            SurfaceKind::Policy => Strategy::Block,
+        }
+    }
+
+    /// Resolve a requested strategy against this surface's kind.
+    /// Meaningless combos warn and fall back to the kind default
+    /// (least-opinionated: never error).
+    pub fn resolve_strategy(self, requested: Option<Strategy>) -> Strategy {
+        let req = match requested {
+            None => return self.default_strategy(),
+            Some(s) => s,
+        };
+        let ok = match (self.kind(), req) {
+            (_, Strategy::Native) | (_, Strategy::Block) => true,
+            (SurfaceKind::Noise, Strategy::Seeded | Strategy::Random) => true,
+            (SurfaceKind::Value, Strategy::Value) => true,
+            (SurfaceKind::Policy, Strategy::Value) => true,
+            _ => false,
+        };
+        if ok {
+            req
+        } else {
+            tracing::warn!(
+                surface = ?self,
+                requested = ?req,
+                "strategy not meaningful for surface kind; using default"
+            );
+            self.default_strategy()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noise_default_is_seeded() {
+        assert_eq!(Surface::Canvas.resolve_strategy(None), Strategy::Seeded);
+    }
+
+    #[test]
+    fn value_strategy_on_noise_warns_and_falls_back() {
+        // Value is meaningless for a noise surface → falls back to Seeded.
+        assert_eq!(
+            Surface::Canvas.resolve_strategy(Some(Strategy::Value)),
+            Strategy::Seeded
+        );
+    }
+
+    #[test]
+    fn native_and_block_always_pass() {
+        assert_eq!(Surface::Webgl.resolve_strategy(Some(Strategy::Native)), Strategy::Native);
+        assert_eq!(Surface::Audio.resolve_strategy(Some(Strategy::Block)), Strategy::Block);
+    }
+
+    #[test]
+    fn webrtc_default_is_block() {
+        assert_eq!(Surface::Webrtc.resolve_strategy(None), Strategy::Block);
+    }
+}
+```
+
+- [ ] **Step 2: Run + commit**
+
+Run: `cargo test -p zendriver-stealth surface::`
+Expected: 4 passed.
+```bash
+git add crates/zendriver-stealth/src/persona/surface.rs
+git commit -m "feat(stealth): Surface/Strategy + per-kind resolution"
+```
+
+---
+
+### Tasks B2–B8: Surface JS patches
+
+Each patch is a self-contained IIFE taking the resolved persona JSON. **Pattern per task** (shown fully in B2; B3–B8 give the real JS + the same 4 steps):
+
+A seeded PRNG (`mulberry32`) is shared. Add it once as `crates/zendriver-stealth/src/patches/_prng.js`:
+```js
+// mulberry32 — deterministic PRNG seeded by the persona seed.
+function __zdRng(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+```
+
+### Task B2: `canvas.js`
+
+**Files:**
+- Create: `crates/zendriver-stealth/src/patches/canvas.js`, `_prng.js`
+- Test: `crates/zendriver-stealth/tests/stealth_phase2.rs` (add a unit asserting the patch string is templated)
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/zendriver-stealth/src/patches.rs` tests mod (or `stealth_phase2.rs`):
+```rust
+#[test]
+fn canvas_patch_included_when_seeded() {
+    let p = Persona { seed: Some(Seed::from_u64(123)), ..Persona::default() };
+    let script = bootstrap_script(&p); // signature migrated in Task B9
+    assert!(script.contains("getImageData"), "canvas farble must hook getImageData");
+    assert!(script.contains("123"), "seed value must be templated in");
+}
+```
+
+- [ ] **Step 2: Implement the patch**
+
+Create `crates/zendriver-stealth/src/patches/canvas.js`:
+```js
+(function (seed) {
+  const rng = __zdRng(seed);
+  function farble(data) {
+    for (let i = 0; i < data.length; i += 4) {
+      // +/-1 LSB perturbation on RGB, deterministic per seed.
+      data[i]     = Math.max(0, Math.min(255, data[i]     + (rng() < 0.5 ? -1 : 1)));
+      data[i + 1] = Math.max(0, Math.min(255, data[i + 1] + (rng() < 0.5 ? -1 : 1)));
+      data[i + 2] = Math.max(0, Math.min(255, data[i + 2] + (rng() < 0.5 ? -1 : 1)));
+    }
+    return data;
+  }
+  const origGetImageData = CanvasRenderingContext2D.prototype.getImageData;
+  CanvasRenderingContext2D.prototype.getImageData = function (...args) {
+    const img = origGetImageData.apply(this, args);
+    farble(img.data);
+    return img;
+  };
+  const origToDataURL = HTMLCanvasElement.prototype.toDataURL;
+  HTMLCanvasElement.prototype.toDataURL = function (...args) {
+    const ctx = this.getContext('2d');
+    if (ctx) {
+      const w = this.width, h = this.height;
+      if (w > 0 && h > 0) {
+        const img = origGetImageData.call(ctx, 0, 0, w, h);
+        farble(img.data);
+        ctx.putImageData(img, 0, 0);
+      }
+    }
+    return origToDataURL.apply(this, args);
+  };
+})(SEED);
+```
+> The `__zdRng` definition (from `_prng.js`) and `SEED` substitution are wired by `bootstrap_script` (Task B9). Each noise patch is wrapped so it is a no-op under `Native`, returns a constant under `Block`, and re-seeds per call under `Random` (use `Math.random()*2**32` instead of the fixed seed).
+
+- [ ] **Step 3: Run (after B9 wires bootstrap) + commit**
+
+> B2's test depends on B9's migrated `bootstrap_script`. Implement the `.js` files B2–B8 first, then B9 wires them and you run the suite. Commit each `.js` as you write it:
+```bash
+git add crates/zendriver-stealth/src/patches/canvas.js crates/zendriver-stealth/src/patches/_prng.js
+git commit -m "feat(stealth): canvas farble patch"
+```
+
+### Task B3: `audio.js`
+```js
+(function (seed) {
+  const rng = __zdRng(seed);
+  const orig = AnalyserNode.prototype.getFloatFrequencyData;
+  AnalyserNode.prototype.getFloatFrequencyData = function (array) {
+    orig.call(this, array);
+    for (let i = 0; i < array.length; i++) array[i] += (rng() - 0.5) * 1e-4;
+  };
+  const origTime = AnalyserNode.prototype.getByteTimeDomainData;
+  if (origTime) {
+    AnalyserNode.prototype.getByteTimeDomainData = function (array) {
+      origTime.call(this, array);
+      for (let i = 0; i < array.length; i++) {
+        array[i] = Math.max(0, Math.min(255, array[i] + (rng() < 0.5 ? -1 : 1)));
+      }
+    };
+  }
+})(SEED);
+```
+Commit: `feat(stealth): audio farble patch`.
+
+### Task B4: `webgl.js` (extend existing — value substitution)
+Append to the existing `webgl.js` (keep current flag behavior):
+```js
+(function (vendor, renderer) {
+  const VENDOR = 0x9245, RENDERER = 0x9246; // UNMASKED_VENDOR_WEBGL / RENDERER
+  function patch(proto) {
+    const orig = proto.getParameter;
+    proto.getParameter = function (p) {
+      if (vendor && p === VENDOR) return vendor;
+      if (renderer && p === RENDERER) return renderer;
+      return orig.call(this, p);
+    };
+  }
+  if (window.WebGLRenderingContext) patch(WebGLRenderingContext.prototype);
+  if (window.WebGL2RenderingContext) patch(WebGL2RenderingContext.prototype);
+})(WEBGL_VENDOR, WEBGL_RENDERER);
+```
+Commit: `feat(stealth): webgl vendor/renderer substitution`.
+
+### Task B5: `fonts.js`
+```js
+(function (allow, seed) {
+  const rng = __zdRng(seed);
+  const orig = CanvasRenderingContext2D.prototype.measureText;
+  CanvasRenderingContext2D.prototype.measureText = function (text) {
+    const m = orig.call(this, text);
+    // Sub-pixel width noise, deterministic.
+    try { Object.defineProperty(m, 'width', { value: m.width + (rng() - 0.5) * 1e-3 }); }
+    catch (e) {}
+    return m;
+  };
+  // If an allow-list is provided, hide other fonts from FontFaceSet checks.
+  if (Array.isArray(allow) && document.fonts && document.fonts.check) {
+    const origCheck = document.fonts.check.bind(document.fonts);
+    document.fonts.check = function (font, text) {
+      const fam = (font || '').split(/\s+/).pop();
+      if (fam && allow.indexOf(fam.replace(/["']/g, '')) === -1) return false;
+      return origCheck(font, text);
+    };
+  }
+})(FONT_ALLOW, SEED);
+```
+Commit: `feat(stealth): font metrics + enumeration patch`.
+
+### Task B6: `client_rects.js`
+```js
+(function (seed) {
+  const rng = __zdRng(seed);
+  function noisy(v) { return v + (rng() - 0.5) * 1e-3; }
+  const origRect = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function () {
+    const r = origRect.call(this);
+    return new DOMRect(noisy(r.x), noisy(r.y), noisy(r.width), noisy(r.height));
+  };
+})(SEED);
+```
+Commit: `feat(stealth): clientRects sub-pixel patch`.
+
+### Task B7: `webrtc.js`
+```js
+(function (policy, fakeIp) {
+  // policy: "block" | "value" | "native"
+  if (policy === 'native') return;
+  const RTC = window.RTCPeerConnection || window.webkitRTCPeerConnection;
+  if (!RTC) return;
+  window.RTCPeerConnection = function (cfg, ...rest) {
+    const pc = new RTC(cfg, ...rest);
+    const origAdd = pc.addEventListener.bind(pc);
+    pc.addEventListener = function (type, cb, ...a) {
+      if (type === 'icecandidate') {
+        const wrapped = function (e) {
+          if (policy === 'block' && e && e.candidate) return; // drop local IPs
+          if (policy === 'value' && fakeIp && e && e.candidate) {
+            try {
+              Object.defineProperty(e.candidate, 'address', { value: fakeIp });
+            } catch (x) {}
+          }
+          return cb.apply(this, arguments);
+        };
+        return origAdd(type, wrapped, ...a);
+      }
+      return origAdd(type, cb, ...a);
+    };
+    return pc;
+  };
+  window.RTCPeerConnection.prototype = RTC.prototype;
+})(WEBRTC_POLICY, WEBRTC_FAKE_IP);
+```
+Commit: `feat(stealth): webrtc ip-leak guard`.
+
+### Task B8: `hardware.js`
+```js
+(function (battery, mediaDevices, voices) {
+  if (typeof battery === 'number' && navigator.getBattery) {
+    navigator.getBattery = function () {
+      return Promise.resolve({
+        level: battery, charging: true, chargingTime: 0,
+        dischargingTime: Infinity,
+        addEventListener() {}, removeEventListener() {},
+      });
+    };
+  }
+  if (typeof mediaDevices === 'number' && navigator.mediaDevices &&
+      navigator.mediaDevices.enumerateDevices) {
+    navigator.mediaDevices.enumerateDevices = function () {
+      const out = [];
+      for (let i = 0; i < mediaDevices; i++) {
+        out.push({ deviceId: 'dev' + i, kind: 'audioinput', label: '', groupId: 'g' + i });
+      }
+      return Promise.resolve(out);
+    };
+  }
+  if (Array.isArray(voices) && window.speechSynthesis) {
+    speechSynthesis.getVoices = function () {
+      return voices.map((n) => ({ name: n, lang: 'en-US', default: false,
+        localService: true, voiceURI: n }));
+    };
+  }
+})(HW_BATTERY, HW_MEDIA_DEVICES, HW_VOICES);
+```
+Commit: `feat(stealth): hardware surface patch`.
+
+---
+
+### Task B9: `bootstrap_script(&Persona)` integration
+
+**Files:**
+- Modify: `crates/zendriver-stealth/src/patches.rs`
+- Modify call sites: `crates/zendriver-stealth/src/observer.rs`, anything calling `bootstrap_script`
+
+- [ ] **Step 1: Write the failing test** (already added in B2; add per-strategy cases)
+
+```rust
+#[test]
+fn native_strategy_omits_surface_patch() {
+    let p = Persona {
+        canvas: Some(SurfaceCfg { strategy: Some(Strategy::Native) }),
+        seed: Some(Seed::from_u64(1)),
+        ..Persona::default()
+    };
+    let script = bootstrap_script(&p);
+    assert!(!script.contains("getImageData"), "Native canvas → no farble hook");
+}
+
+#[test]
+fn block_strategy_emits_constant_canvas() {
+    let p = Persona {
+        canvas: Some(SurfaceCfg { strategy: Some(Strategy::Block) }),
+        ..Persona::default()
+    };
+    let script = bootstrap_script(&p);
+    assert!(script.contains("BLOCK"), "Block canvas marker present");
+}
+```
+
+- [ ] **Step 2: Implement**
+
+Migrate `bootstrap_script` to take `&Persona`. Resolve each surface strategy, then conditionally concatenate the patch JS with substitutions. Sketch:
+```rust
+const PRNG: &str = include_str!("patches/_prng.js");
+const CANVAS: &str = include_str!("patches/canvas.js");
+const AUDIO: &str = include_str!("patches/audio.js");
+// ... existing 9 + new ones
+
+pub fn bootstrap_script(p: &Persona) -> String {
+    let seed = p.seed.unwrap_or_else(Seed::random).value();
+    let mut out = String::new();
+    out.push_str(PRNG);
+
+    // existing identity patches (webdriver/plugins/chrome/...) — keep, templated
+    // from p.resolved_platform_js() etc. (was fp.platform before).
+    out.push_str(&existing_identity_patches(p));
+
+    // noise surfaces
+    push_noise(&mut out, Surface::Canvas, p.canvas.as_ref(), CANVAS, seed);
+    push_noise(&mut out, Surface::Audio, p.audio.as_ref(), AUDIO, seed);
+    push_noise(&mut out, Surface::ClientRects, p.client_rects.as_ref(), CLIENT_RECTS, seed);
+
+    // value surfaces
+    push_webgl(&mut out, p, seed);
+    push_fonts(&mut out, p, seed);
+    push_hardware(&mut out, p);
+
+    // policy
+    push_webrtc(&mut out, p);
+
+    out
+}
+
+fn push_noise(out: &mut String, surface: Surface, cfg: Option<&SurfaceCfg>,
+              js: &str, seed: u64) {
+    let strat = surface.resolve_strategy(cfg.and_then(|c| c.strategy));
+    match strat {
+        Strategy::Native => {} // omit
+        Strategy::Block => out.push_str(&js.replace("SEED", "0/*BLOCK*/")),
+        Strategy::Seeded => out.push_str(&js.replace("SEED", &seed.to_string())),
+        Strategy::Random => out.push_str(&js.replace("SEED", "(Math.random()*4294967296)>>>0")),
+        Strategy::Value => out.push_str(&js.replace("SEED", &seed.to_string())),
+    }
+}
+// push_webgl/push_fonts/push_hardware/push_webrtc: resolve strategy, substitute
+// WEBGL_VENDOR/FONT_ALLOW/etc. with serde_json::to_string of the persona values,
+// or "null" when absent; omit under Native; emit empty values under Block.
+```
+
+> Implement `existing_identity_patches(p)` by moving the current `bootstrap_script` body here and swapping `fp.<field>` for the `Persona` equivalents (Task A8 accessors). Update `observer.rs` to hold a `Persona` instead of `Fingerprint` and call `bootstrap_script(&persona)`.
+
+- [ ] **Step 3: Run full stealth unit suite**
+
+Run: `cargo test -p zendriver-stealth`
+Expected: all green (existing + new patch tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/zendriver-stealth/src/patches.rs crates/zendriver-stealth/src/observer.rs
+git commit -m "feat(stealth): bootstrap_script(&Persona) + surface patch wiring"
+```
+
+---
+
+## Phase C — `zendriver-fingerprints` crate
+
+### Task C1: Crate skeleton
+
+**Files:**
+- Create: `crates/zendriver-fingerprints/Cargo.toml`, `src/lib.rs`, `NOTICE`
+- Modify: root `Cargo.toml` workspace members
+
+- [ ] **Step 1: Create the crate**
+
+`crates/zendriver-fingerprints/Cargo.toml`:
+```toml
+[package]
+name = "zendriver-fingerprints"
+description = "Real-device persona sources (pool + generative) for zendriver-rs"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[features]
+default = []
+pool = ["dep:reqwest", "dep:directories"]
+generative = []
+
+[dependencies]
+zendriver-stealth.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+fastrand = "2"
+reqwest = { workspace = true, optional = true }
+directories = { workspace = true, optional = true }
+```
+> Match the dep style (`workspace = true`) used by `zendriver-fetcher/Cargo.toml`; copy its `reqwest`/cache-dir deps verbatim so the pool fetch reuses the proven pattern.
+
+`src/lib.rs`:
+```rust
+//! Real-device persona sources for zendriver-rs.
+#[cfg(feature = "pool")]
+pub mod pool;
+#[cfg(feature = "generative")]
+pub mod generative;
+```
+
+Add `crates/zendriver-fingerprints` to the root `Cargo.toml` `[workspace] members`.
+
+Add `NOTICE`:
+```
+This crate vendors fingerprint data derived from browserforge / fingerprint-suite
+(https://github.com/apify/fingerprint-suite), licensed Apache-2.0.
+```
+
+- [ ] **Step 2: Verify it builds**
+
+Run: `cargo build -p zendriver-fingerprints --all-features`
+Expected: builds (empty modules).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/zendriver-fingerprints Cargo.toml
+git commit -m "feat(fingerprints): new crate skeleton (pool/generative features)"
+```
+
+---
+
+### Task C2: `pool` — fetch + cache + sample
+
+**Files:**
+- Create: `crates/zendriver-fingerprints/src/pool/mod.rs`
+- Reference: `crates/zendriver-fetcher/src/{cache,download}.rs` (reuse atomic-cache pattern)
+
+- [ ] **Step 1: Write the failing test** (offline: sample from an in-memory set)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn sample_is_deterministic_for_seed() {
+        let set = PoolSet::from_records(vec![
+            mk("Win32", 8), mk("MacIntel", 16), mk("Win32", 4),
+        ]);
+        let a = set.sample(zendriver_stealth::Seed::from_u64(42));
+        let b = set.sample(zendriver_stealth::Seed::from_u64(42));
+        assert_eq!(a.device_memory_gb, b.device_memory_gb);
+    }
+}
+```
+
+- [ ] **Step 2: Implement**
+
+```rust
+use serde::{Deserialize, Serialize};
+use zendriver_stealth::{Persona, Seed};
+
+/// A parsed pool of real-device personas.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PoolSet {
+    records: Vec<Persona>,
+}
+
+impl PoolSet {
+    pub fn from_records(records: Vec<Persona>) -> Self {
+        Self { records }
+    }
+
+    /// Parse a downloaded pool asset (JSON array of personas).
+    pub fn from_json(s: &str) -> Result<Self, serde_json::Error> {
+        Ok(Self { records: serde_json::from_str(s)? })
+    }
+
+    /// Deterministically pick one persona by seed.
+    pub fn sample(&self, seed: Seed) -> Persona {
+        assert!(!self.records.is_empty(), "pool is empty");
+        let idx = (seed.value() as usize) % self.records.len();
+        self.records[idx].clone()
+    }
+}
+```
+
+- [ ] **Step 3: Implement download-on-first-use (feature `pool`)**
+
+```rust
+/// Download (once) + cache the pool asset, then parse. Reuses the cache dir
+/// convention from zendriver-fetcher.
+pub async fn load_or_download(url: &str) -> Result<PoolSet, PoolError> {
+    let cache = cache_path(); // directories::ProjectDirs, same root as fetcher
+    if let Ok(bytes) = std::fs::read_to_string(&cache) {
+        if let Ok(set) = PoolSet::from_json(&bytes) {
+            return Ok(set);
+        }
+    }
+    let body = reqwest::get(url).await?.text().await?;
+    let set = PoolSet::from_json(&body)?;
+    // atomic write (tmp + rename), mirroring fetcher::cache
+    let tmp = cache.with_extension("tmp");
+    std::fs::write(&tmp, &body)?;
+    std::fs::rename(&tmp, &cache)?;
+    Ok(set)
+}
+```
+Define `PoolError` (`thiserror`) wrapping `reqwest::Error`, `io::Error`, `serde_json::Error`. Implement `cache_path()` and the test helper `mk(platform, mem)` building a minimal `Persona`.
+
+- [ ] **Step 4: Run + commit**
+
+Run: `cargo test -p zendriver-fingerprints --features pool pool::`
+Expected: PASS.
+```bash
+git add crates/zendriver-fingerprints/src/pool/
+git commit -m "feat(fingerprints): pool source (download-on-first-use + seeded sample)"
+```
+
+---
+
+### Task C3: `generative` — browserforge BN port
+
+**Files:**
+- Create: `crates/zendriver-fingerprints/src/generative/mod.rs`
+- Create: `crates/zendriver-fingerprints/src/generative/network.json` (vendored, trimmed)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn generate_is_deterministic_and_coherent() {
+        let g = Generator::embedded();
+        let a = g.generate(zendriver_stealth::Seed::from_u64(7));
+        let b = g.generate(zendriver_stealth::Seed::from_u64(7));
+        // same seed → same persona
+        assert_eq!(a.platform, b.platform);
+        // coherence: a populated persona
+        assert!(a.platform.is_some());
+        assert!(a.webgl.is_some());
+    }
+}
+```
+
+- [ ] **Step 2: Implement the BN sampler**
+
+```rust
+use serde::Deserialize;
+use zendriver_stealth::{Persona, Seed};
+
+/// A Bayesian network of conditional fingerprint attributes (browserforge form).
+#[derive(Debug, Clone, Deserialize)]
+pub struct Generator {
+    nodes: Vec<Node>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct Node {
+    name: String,
+    parents: Vec<String>,
+    // conditional distributions keyed by parent-value tuple → (value, weight)
+    cpt: std::collections::HashMap<String, Vec<(String, f64)>>,
+}
+
+impl Generator {
+    /// Load the embedded, trimmed network.
+    pub fn embedded() -> Self {
+        serde_json::from_str(include_str!("network.json")).expect("valid embedded BN")
+    }
+
+    /// Sample a coherent persona deterministically from `seed`.
+    pub fn generate(&self, seed: Seed) -> Persona {
+        let mut rng = Mulberry32::new(seed.value() as u32);
+        let mut assigned: std::collections::HashMap<String, String> = Default::default();
+        for node in self.topo_order() {
+            let key = node.parents.iter()
+                .map(|p| assigned.get(p).cloned().unwrap_or_default())
+                .collect::<Vec<_>>().join("|");
+            let dist = node.cpt.get(&key).or_else(|| node.cpt.get("")).unwrap();
+            assigned.insert(node.name.clone(), weighted_pick(dist, rng.next_f64()));
+        }
+        persona_from_assignment(&assigned)
+    }
+
+    fn topo_order(&self) -> Vec<&Node> {
+        // parents-before-children; the embedded network is already ordered,
+        // but sort defensively.
+        let mut order = self.nodes.iter().collect::<Vec<_>>();
+        order.sort_by_key(|n| n.parents.len());
+        order
+    }
+}
+
+struct Mulberry32(u32);
+impl Mulberry32 {
+    fn new(seed: u32) -> Self { Self(seed) }
+    fn next_f64(&mut self) -> f64 {
+        self.0 = self.0.wrapping_add(0x6D2B79F5);
+        let mut t = self.0;
+        t = (t ^ (t >> 15)).wrapping_mul(1 | t);
+        t = t.wrapping_add((t ^ (t >> 7)).wrapping_mul(61 | t)) ^ t;
+        ((t ^ (t >> 14)) as f64) / 4294967296.0
+    }
+}
+
+fn weighted_pick(dist: &[(String, f64)], r: f64) -> String {
+    let total: f64 = dist.iter().map(|(_, w)| w).sum();
+    let mut acc = 0.0;
+    for (v, w) in dist {
+        acc += w / total;
+        if r <= acc { return v.clone(); }
+    }
+    dist.last().map(|(v, _)| v.clone()).unwrap_or_default()
+}
+
+fn persona_from_assignment(a: &std::collections::HashMap<String, String>) -> Persona {
+    // Map the sampled attribute strings → Persona fields. Keys mirror
+    // network.json node names: "platform", "webglRenderer", "deviceMemory", ...
+    use zendriver_stealth::{Platform, WebglSpec};
+    let mut p = Persona::default();
+    if let Some(plat) = a.get("platform") {
+        p.platform = match plat.as_str() {
+            "Win32" => Some(Platform::Win32),
+            "MacIntel" => Some(Platform::MacIntel),
+            _ => Some(Platform::LinuxX86_64),
+        };
+    }
+    if let Some(r) = a.get("webglRenderer") {
+        p.webgl = Some(WebglSpec { unmasked_renderer: Some(r.clone()), ..Default::default() });
+    }
+    if let Some(m) = a.get("deviceMemory") {
+        p.device_memory_gb = m.parse().ok();
+    }
+    p
+}
+```
+
+- [ ] **Step 3: Create a minimal real `network.json`**
+
+Vendor a trimmed network (full extraction is a follow-up; the embedded file must be valid and produce coherent output). Minimal real content:
+```json
+{
+  "nodes": [
+    {"name": "platform", "parents": [], "cpt": {
+      "": [["Win32", 0.7], ["MacIntel", 0.2], ["LinuxX86_64", 0.1]]}},
+    {"name": "deviceMemory", "parents": ["platform"], "cpt": {
+      "Win32": [["8", 0.6], ["16", 0.4]],
+      "MacIntel": [["16", 0.7], ["8", 0.3]],
+      "LinuxX86_64": [["8", 0.5], ["16", 0.5]]}},
+    {"name": "webglRenderer", "parents": ["platform"], "cpt": {
+      "Win32": [["ANGLE (NVIDIA, NVIDIA GeForce RTX 3060 Direct3D11 vs_5_0 ps_5_0, D3D11)", 1.0]],
+      "MacIntel": [["ANGLE (Apple, Apple M1, OpenGL 4.1)", 1.0]],
+      "LinuxX86_64": [["ANGLE (Mesa, llvmpipe, OpenGL 4.5)", 1.0]]}}
+  ]
+}
+```
+> This is a real, working (if small) network. Expanding it from the upstream browserforge dataset is tracked in §14 of the spec; the loader + sampler are complete and correct regardless of network size.
+
+- [ ] **Step 4: Run + commit**
+
+Run: `cargo test -p zendriver-fingerprints --features generative generative::`
+Expected: PASS.
+```bash
+git add crates/zendriver-fingerprints/src/generative/
+git commit -m "feat(fingerprints): generative BN persona source (browserforge port)"
+```
+
+---
+
+## Phase D — Live-probe, wiring, docs
+
+### Task D1: `Persona::from_browser(tab)`
+
+**Files:**
+- Modify: `crates/zendriver-stealth/src/persona/mod.rs`
+- Note: this needs a `Tab` handle. To avoid a stealth→zendriver dep cycle, define a tiny trait the core `Tab` implements.
+
+- [ ] **Step 1: Define the probe trait + test (unit, mocked)**
+
+```rust
+/// Minimal eval surface so stealth can probe a live page without depending
+/// on the zendriver core crate (avoids a dependency cycle).
+#[async_trait::async_trait]
+pub trait JsProbe {
+    async fn eval_json(&self, js: &str) -> Result<serde_json::Value, crate::StealthError>;
+}
+
+impl Persona {
+    /// Probe the live Chrome for its REAL webgl/canvas/audio/font values.
+    /// Maximally coherent host persona.
+    pub async fn from_browser<P: JsProbe + Sync>(probe: &P) -> Result<Persona, crate::StealthError> {
+        let v = probe.eval_json(PROBE_JS).await?;
+        Ok(persona_from_probe(&v))
+    }
+}
+
+const PROBE_JS: &str = r#"(() => {
+  const c = document.createElement('canvas').getContext('webgl');
+  const dbg = c && c.getExtension('WEBGL_debug_renderer_info');
+  return {
+    platform: navigator.platform,
+    deviceMemory: navigator.deviceMemory,
+    hardwareConcurrency: navigator.hardwareConcurrency,
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    locale: navigator.language,
+    webglVendor: dbg ? c.getParameter(dbg.UNMASKED_VENDOR_WEBGL) : null,
+    webglRenderer: dbg ? c.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : null,
+  };
+})()"#;
+```
+Implement `persona_from_probe(&serde_json::Value) -> Persona`. Test with a fake `JsProbe` returning a canned JSON value; assert mapped fields.
+
+- [ ] **Step 2: Implement `JsProbe` for the core `Tab`**
+
+In `crates/zendriver/src/tab.rs`, add (behind nothing — core):
+```rust
+#[async_trait::async_trait]
+impl zendriver_stealth::JsProbe for Tab {
+    async fn eval_json(&self, js: &str) -> Result<serde_json::Value, zendriver_stealth::StealthError> {
+        self.evaluate(js).await
+            .map(|v| v.into_json()) // adapt to the real evaluate return type
+            .map_err(|e| zendriver_stealth::StealthError::from(e))
+    }
+}
+```
+> Adapt `.into_json()` and the error conversion to the real `Tab::evaluate` signature. Add a `From<CallError>`/`From<ZendriverError>` arm to `StealthError` if missing.
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test -p zendriver-stealth from_browser`
+Expected: PASS (mocked).
+```bash
+git add crates/zendriver-stealth/src/persona/mod.rs crates/zendriver/src/tab.rs
+git commit -m "feat: Persona::from_browser live-probe via JsProbe trait"
+```
+
+---
+
+### Task D2: Browser builder wiring
+
+**Files:**
+- Modify: `crates/zendriver/src/browser.rs`
+- Modify: `crates/zendriver/src/lib.rs` (re-export `Persona`, `Surface`, `Strategy`)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn builder_accepts_persona_and_overrides() {
+    let b = Browser::builder()
+        .persona(zendriver_stealth::Persona::builder().device_memory_gb(16).build())
+        .persona_overlay(r#"{"timezone":"UTC"}"#.parse().unwrap())
+        .surface(zendriver_stealth::Surface::Webrtc, zendriver_stealth::Strategy::Native);
+    let p = b.resolved_persona();
+    assert_eq!(p.device_memory_gb, Some(16));
+    assert_eq!(p.timezone.as_deref(), Some("UTC"));
+}
+```
+
+- [ ] **Step 2: Implement**
+
+Add fields to the browser builder: `persona: Option<Persona>`, `persona_overlay: Option<Persona>`, `surface_overrides: Vec<(Surface, Strategy)>`. Methods:
+```rust
+pub fn persona(mut self, p: Persona) -> Self { self.persona = Some(p); self }
+pub fn persona_overlay(mut self, p: Persona) -> Self { self.persona_overlay = Some(p); self }
+pub fn surface(mut self, s: Surface, strat: Strategy) -> Self {
+    self.surface_overrides.push((s, strat)); self
+}
+
+/// Effective persona: default system() → user persona → overlay → surface overrides.
+pub fn resolved_persona(&self) -> Persona {
+    let mut p = self.persona.clone().unwrap_or_else(Persona::system);
+    if let Some(o) = &self.persona_overlay { p = p.clone().overlay(o.clone()); }
+    for (s, strat) in &self.surface_overrides {
+        p.apply_surface_override(*s, *strat); // sets the right SurfaceCfg.strategy
+    }
+    p
+}
+```
+Add `Persona::apply_surface_override(&mut self, Surface, Strategy)` in stealth (sets `self.canvas/webgl/... .strategy`). Wire `resolved_persona()` into the existing stealth-launch path so `bootstrap_script(&persona)` is used instead of the old `Fingerprint`.
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test -p zendriver builder_accepts_persona`
+Expected: PASS.
+```bash
+git add crates/zendriver/src/browser.rs crates/zendriver/src/lib.rs crates/zendriver-stealth/src/persona/mod.rs
+git commit -m "feat: Browser builder .persona/.persona_overlay/.surface"
+```
+
+---
+
+### Task D3: persona-seed persistence with `user_data_dir`
+
+**Files:**
+- Modify: `crates/zendriver/src/browser.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn seed_persists_in_user_data_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let b1 = Browser::builder().user_data_dir(dir.path());
+    let s1 = b1.resolved_persona().seed.unwrap();
+    let b2 = Browser::builder().user_data_dir(dir.path());
+    let s2 = b2.resolved_persona().seed.unwrap();
+    assert_eq!(s1, s2, "same profile dir → same seed across builders");
+}
+```
+
+- [ ] **Step 2: Implement**
+
+When `user_data_dir` is set and the persona seed is unset, read/write `<user_data_dir>/.zd_persona_seed` (a single u64). On first use: generate random, persist. On reuse: load.
+```rust
+fn persisted_seed(dir: &std::path::Path) -> Seed {
+    let f = dir.join(".zd_persona_seed");
+    if let Ok(s) = std::fs::read_to_string(&f) {
+        if let Ok(v) = s.trim().parse::<u64>() { return Seed::from_u64(v); }
+    }
+    let seed = Seed::random();
+    let _ = std::fs::create_dir_all(dir);
+    let _ = std::fs::write(&f, seed.value().to_string());
+    seed
+}
+```
+Call this in `resolved_persona()` when `persona.seed.is_none()` and a `user_data_dir` exists.
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test -p zendriver seed_persists`
+Expected: PASS.
+```bash
+git add crates/zendriver/src/browser.rs
+git commit -m "feat: persist persona seed alongside user_data_dir"
+```
+
+---
+
+### Task D4: `insta` snapshot for `Persona` JSON wire shape
+
+**Files:**
+- Create/modify: `crates/zendriver-stealth/tests/persona_snapshot.rs`
+
+- [ ] **Step 1: Write the snapshot test**
+
+```rust
+#[test]
+fn persona_full_wire_shape() {
+    let p = zendriver_stealth::Persona::builder()
+        .seed(zendriver_stealth::Seed::from_u64(1))
+        .device_memory_gb(8)
+        .timezone("UTC")
+        .build();
+    insta::assert_json_snapshot!(p);
+}
+```
+
+- [ ] **Step 2: Generate + accept**
+
+Run:
+```bash
+cargo test -p zendriver-stealth --test persona_snapshot
+cargo insta accept --all
+```
+Expected: snapshot file created under `crates/zendriver-stealth/tests/snapshots/`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/zendriver-stealth/tests/persona_snapshot.rs crates/zendriver-stealth/tests/snapshots/
+git commit -m "test(stealth): Persona JSON wire-shape snapshot"
+```
+
+---
+
+### Task D5: Headful integration test (gated)
+
+**Files:**
+- Create: `crates/zendriver/tests/fingerprint_integration.rs` (behind the existing integration-test feature/gate used by other phase tests)
+
+- [ ] **Step 1: Write the test**
+
+```rust
+// Gated like the other integration tests in this crate (see integration_phase2.rs).
+#[tokio::test]
+#[ignore] // run with --ignored on the nightly integration job
+async fn seeded_canvas_is_stable_across_reads() {
+    let browser = Browser::builder()
+        .persona(Persona::builder().seed(Seed::from_u64(42)).build())
+        .build().await.unwrap();
+    let tab = browser.new_tab("about:blank").await.unwrap();
+    let read = r#"(() => { const c=document.createElement('canvas');
+        c.width=50;c.height=20;const x=c.getContext('2d');
+        x.fillText('zd',2,12); return c.toDataURL(); })()"#;
+    let a: String = tab.evaluate(read).await.unwrap().into();
+    let b: String = tab.evaluate(read).await.unwrap().into();
+    assert_eq!(a, b, "Seeded canvas must be STABLE across repeat reads");
+}
+```
+> Adapt the `Browser`/`Tab`/`evaluate` API to the real signatures (see `integration_phase2.rs`). Add a `Native` and a `Random` variant assertion (Random → differs).
+
+- [ ] **Step 2: Run locally if Chrome available, else defer to CI**
+
+Run: `cargo test -p zendriver --test fingerprint_integration -- --ignored`
+Expected: PASS with a local Chrome.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/zendriver/tests/fingerprint_integration.rs
+git commit -m "test: headful fingerprint stability integration"
+```
+
+---
+
+### Task D6: Examples + docs
+
+**Files:**
+- Create: `crates/zendriver/examples/persona_basic.rs`, `persona_pool.rs`
+- Create: `docs/book/src/fingerprint.md` + add to `SUMMARY.md`
+
+- [ ] **Step 1: Examples**
+
+`persona_basic.rs` (seeded farble + a surface override), `persona_pool.rs` (feature-gated; load pool → sample → `.persona()`). Mirror the style of `crates/zendriver/examples/browserscan.rs`.
+
+- [ ] **Step 2: mdBook chapter**
+
+`docs/book/src/fingerprint.md`: the two axes, the surfaces table, strategy list, `system()`/`from_browser()`/`Seed::from_system()`, and a copy-paste-JSON example. Add `- [Fingerprint spoofing](fingerprint.md)` to `docs/book/src/SUMMARY.md`.
+
+- [ ] **Step 3: Build docs + commit**
+
+Run: `cargo build --examples -p zendriver` and `mdbook build docs/book` (if `mdbook` installed).
+```bash
+git add crates/zendriver/examples/persona_*.rs docs/book/
+git commit -m "docs: fingerprint spoofing examples + book chapter"
+```
+
+---
+
+## Phase E — Gates & PR
+
+### Task E1: Full verification
+
+- [ ] **Step 1: Format + clippy (per CLAUDE.md, required before push)**
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --locked --fix --allow-dirty --allow-staged
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo clippy -p zendriver-fingerprints --all-features --all-targets -- -D warnings
+```
+Expected: clean. Fix and re-stage anything flagged.
+
+- [ ] **Step 2: Full test suite + schema snapshots**
+
+```bash
+cargo test --workspace --all-features --locked
+cargo test -p zendriver-mcp --test schema_snapshots --all-features --locked
+cargo insta accept --all
+```
+Expected: green; commit any accepted snapshots.
+
+- [ ] **Step 3: Final commit + open PR**
+
+```bash
+git add -A && git commit -m "chore: fmt + clippy + snapshots for fingerprint spoofing"
+gh pr create --title "feat: fingerprint spoofing (Persona + surfaces + zendriver-fingerprints)" \
+  --body "Implements upstream TODO #1. See docs/superpowers/specs/2026-06-02-fingerprint-spoofing-design.md"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:** §3 surfaces → B2–B8; §4 crate layout → A1/A2/C1; §5 Persona+constructors → A2–A7, D1; §6 surface kinds → B1; §7 injection → B9; §8 pool+generative → C2/C3; §9 seed → A1/A7/D3; §10 API → D2; §11 testing → A*/B*/D4/D5; §13 licensing → C1 NOTICE. All covered.
+
+**Placeholders:** none — every step has real code. The `network.json` and pool asset are intentionally small-but-valid (noted), not placeholders; the loaders/samplers are complete.
+
+**Type consistency:** `Persona`, `Seed` (value()), `Surface`, `Strategy`, `SurfaceCfg.strategy`, `WebglSpec.unmasked_{vendor,renderer}`, `bootstrap_script(&Persona)`, `resolve_strategy`, `overlay`, `resolved_persona` used consistently across tasks.
+
+**Known adapt-points flagged inline** (real APIs to match at implementation time): `Tab::evaluate` return type (D1/D5), existing platform→JS method name (A8), `StealthError` From-conversions (D1), workspace dep style for reqwest/directories (C1).

--- a/docs/superpowers/specs/2026-06-02-fingerprint-spoofing-design.md
+++ b/docs/superpowers/specs/2026-06-02-fingerprint-spoofing-design.md
@@ -1,0 +1,210 @@
+# Fingerprint Spoofing — Design (PR1)
+
+- **Date:** 2026-06-02
+- **Status:** Approved (brainstorming), pending implementation plan
+- **Upstream driver:** zendriver (Python) issues #241, #108, #18, #202, #101; v1.0.0 thread #170
+- **Scope of this spec:** the fingerprint-spoofing feature **only** (upstream TODO #1). The other seven prioritized TODOs ship as a separate PR2 (see *Scope*).
+
+---
+
+## 1. Context & motivation
+
+`zendriver-rs` already ships a 9-patch JS stealth shim (`webdriver`, `plugins`, `chrome`, `webgl`-flags, `permissions`, `codecs`, `navigator_props`, `user_agent_data`, `broken_image`) plus 3-tier profiles, UA-CH metadata, and emulation. That defeats naive detectors (sannysoft/intoli) but does **not** spoof the high-entropy fingerprint surfaces that modern anti-bot vendors read: canvas, WebGL renderer/readback, AudioContext, font metrics, ClientRects, WebRTC, and assorted hardware APIs.
+
+Fingerprint spoofing is the single most-requested upstream feature (#241 has the most reactions in the repo; the v1.0.0 thread repeatedly ends "any updates on fingerprint spoofing?"). #108 specifically names canvas + fonts; #241 asks to "support browserforge natively."
+
+This is the natural P2-stealth extension for the Rust port.
+
+## 2. Guiding principle
+
+**Least opinionated; everything overridable; coherent defaults/templates on top.**
+
+The realistic user is a power user doing per-site / per-WAF tuning — a process that is tedious and varies enormously by target. The library must therefore:
+
+- Never lock a value. Every persona field is independently overridable.
+- Ship coherent, sensible defaults so the common case is one line.
+- Make "copy a real device, tweak a field, feed it" a first-class workflow.
+- Protect coherence by **default**, not by removing capability. Power users keep every escape hatch; the foot-guns are documented, not forbidden.
+
+## 3. Scope
+
+The feature is organized around **two orthogonal axes** — keep them distinct throughout:
+
+1. **Persona source** — *where the values come from*: `system()` host-probe, builder, JSON paste, `from_browser()` live-probe, or the `zendriver-fingerprints` crate's **pool** / **generative** sources. A source yields a whole coherent `Persona` (values + seeds).
+2. **Per-surface render strategy** — *how a resolved persona is applied to each surface in the page*: `Native` / `Seeded` / `Random` / `Block` / `Value` (see §6).
+
+"Real-device pool" from the early Q&A is a *source* (axis 1), rendered through `Value`/`Seeded` (axis 2) — not a fifth per-surface strategy. All of the originally-requested behaviors are present: seeded farble, per-read random, block/empty (axis 2) and real-device pool + generative (axis 1).
+
+### In scope (PR1)
+
+- Seven fingerprint surfaces: **canvas, WebGL, audio, fonts, ClientRects, WebRTC, hardware** (battery / gamepad / mediaDevices / SpeechSynthesis voices).
+- Five per-surface render strategies (interpreted by surface *kind*, see §6): **`Native`, `Seeded`, `Random`, `Block`, `Value`**.
+- A unified, serde-(de)serializable **`Persona`** type with builder + JSON + host-probe + live-browser-probe constructors and field-wise overlay merge.
+- A new **`zendriver-fingerprints`** crate exposing the real-device persona source behind two cargo features: **`pool`** (finite set, download-on-first-use) and **`generative`** (browserforge Bayesian-network port).
+- Seed model with `random` (default), `from_system` (machine-sticky, opt-in), and explicit reproducible seeds; persona-seed persistence alongside `user_data_dir`.
+
+### Out of scope / deferred
+
+- **PR2** — the other seven prioritized upstream TODOs: persistent network monitor (#223), browser-context HTTP request API (#189), nested-iframe traversal (#239/#246), CDP protocol freshness / forward-compat deser (nodriver #33/#34), bs4-like find ergonomics (#55), `datadome` bypass crate (#20), disable save-password/popups (#13). Each gets its own spec → plan → PR cycle.
+- Real-device-data **collection** pipeline. We ship a curated release asset, not a scraper.
+- Mobile personas. Desktop-first.
+- Auto-refreshing the pool on a schedule.
+
+## 4. Crate & module architecture
+
+```
+zendriver-stealth/                  (core, exists; serde + serde_json already hard deps)
+├── persona/                        NEW module
+│   ├── mod.rs        Persona, overlay merge, builder, FromStr/try_from_json,
+│   │                 system(), from_browser()
+│   ├── surface.rs    Surface enum, Strategy enum, per-surface resolution
+│   └── seed.rs       Seed: random / from_system / from_u64
+├── patches/                        existing dir; ADD:
+│   ├── canvas.js  audio.js  fonts.js  client_rects.js  webrtc.js  hardware.js
+│   └── webgl.js      (extended: value substitution, not just ANGLE/SwiftShader flags)
+└── patches.rs        bootstrap_script(&Persona) emits the new patches from resolved values
+
+zendriver-fingerprints/             NEW crate (optional, higher layer)
+├── Cargo.toml        features = ["pool", "generative"]; depends on zendriver-stealth
+├── pool/             download-on-first-use finite set → Pool::sample(seed) -> Persona
+└── generative/       browserforge BN port      → Generator::generate(seed) -> Persona
+```
+
+**`Persona` lives in `zendriver-stealth` (core).** `zendriver-fingerprints` depends on stealth and *produces* `Persona`. Stealth never depends on the optional data crate, so builder/JSON/seeded-farble users never compile the heavy pieces.
+
+**serde is not feature-gated.** `serde` + `serde_json` are already mandatory deps of `zendriver-stealth` (UA-CH metadata serializes into `Emulation.setUserAgentOverride`). Gating them saves nothing, so `Persona` derives `Serialize + Deserialize` unconditionally and both the builder and JSON paths are always available. The feature boundary that earns its keep is the `zendriver-fingerprints` crate, not serde.
+
+## 5. The `Persona` type & merge model
+
+```rust
+/// Every field Option<_> → overlay semantics. Serialize + Deserialize always on.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Persona {
+    // identity / system (today's Fingerprint folds in here)
+    pub platform: Option<Platform>,
+    pub ua: Option<UaSpec>,                  // ua_string + ua_metadata
+    pub hardware_concurrency: Option<u32>,
+    pub device_memory_gb: Option<u32>,
+    pub timezone: Option<String>,
+    pub locale: Option<String>,
+    // surfaces
+    pub webgl: Option<WebglSpec>,            // unmasked_vendor/renderer, params, extensions
+    pub canvas: Option<SurfaceCfg>,          // noise surface
+    pub audio: Option<SurfaceCfg>,           // noise surface
+    pub fonts: Option<FontSpec>,             // available list + measureText noise
+    pub client_rects: Option<SurfaceCfg>,    // noise surface
+    pub webrtc: Option<WebrtcSpec>,          // policy + optional fake IP
+    pub hardware: Option<HardwareSpec>,      // battery/gamepad/mediaDevices/speechVoices
+    // control
+    pub seed: Option<Seed>,
+}
+```
+
+**Overlay merge:** `resolved = base.overlay(over)` is field-wise — `Some` in `over` wins, `None` inherits from `base`. Power-user flow: `Persona::system().overlay(my_json)` or `pool_device.overlay(tweaks)`.
+
+**Constructors (all always available):**
+
+```rust
+impl Persona {
+    /// Host-probed (sysinfo): platform, cpu, memory, tz, locale. Cached in a
+    /// OnceLock so repeated calls are cheap clones (const-like ergonomics,
+    /// runtime-correct — NOT a build-script const).
+    pub fn system() -> Persona;
+
+    /// Idiomatic fluent builder.
+    pub fn builder() -> PersonaBuilder;
+
+    /// No-opinion paste-a-real-device path. Also `impl FromStr`.
+    pub fn try_from_json(s: &str) -> Result<Persona, serde_json::Error>;
+
+    /// Highest-fidelity: probe the LIVE Chrome on this host for its real
+    /// webgl/canvas/audio/font values. Maximally coherent — it IS the host.
+    /// Async; needs a tab (reuses the browser you are already launching).
+    pub async fn from_browser(tab: &Tab) -> Result<Persona, StealthError>;
+}
+```
+
+> **Why not a build script / static const for `system()`:** a `build.rs`-baked host persona captures the *build* machine, not the run machine (CI / Docker / a distributed binary all differ), breaks under cross-compilation, and a build-time seed const would be identical across every run of a shipped binary (all users share one fingerprint). Host facts must be runtime; `OnceLock` gives the const-like access ergonomics without the wrongness.
+
+## 6. Surface kinds (the key semantic)
+
+A single `Strategy` enum is used for overrides, but it means different things per surface **kind**. Resolution interprets it; a meaningless combination logs a `tracing::warn` and falls back to the kind's default — it never errors (least-opinionated).
+
+```rust
+pub enum Strategy { Native, Seeded, Random, Block, Value }
+
+pub enum Surface { Canvas, Webgl, Audio, Fonts, ClientRects, Webrtc, Hardware }
+```
+
+| Kind | Surfaces | Meaningful strategies | Default |
+|---|---|---|---|
+| **Noise** | canvas, audio, clientRects | `Seeded` (stable noise from persona seed) · `Random` (per-read) · `Block` (constant) · `Native` (off) | `Seeded` |
+| **Value** | webgl, fonts, hardware | `Value` (substitute concrete value from persona) · `Block` (empty) · `Native` | `Value` |
+| **Policy** | webrtc | `Block` (deny local-IP candidates) · `Value` (fake IP from persona) · `Native` | `Block` |
+
+Pool and generative strategies preserve coherence by **supplying both** the noise seeds *and* the substituted values from one device record, so the whole persona tells one story (e.g. WebGL `UNMASKED_RENDERER` matches the canvas rendering traits and `navigator.platform`).
+
+## 7. JS patch injection
+
+Reuses the **existing** isolated-world observer (`zendriver-stealth/src/observer.rs`), which already injects the 9 current patches into every world/frame via `addScriptToEvaluateOnNewDocument` plus per-world re-injection. `bootstrap_script(&Persona)` grows to template the six new patches from the resolved persona; `webgl.js` is upgraded from flag-only to value substitution. **No new injection machinery** — same path that already passes sannysoft across frames.
+
+## 8. `zendriver-fingerprints` crate
+
+- **`pool` feature** — finite real-device set shipped as a **release asset**, fetched + cached on first use using the *same* cache directory/pattern as `zendriver-fetcher` (which already downloads Chrome for Testing). `Pool::sample(seed) -> Persona`. Refresh = publish a new asset; no code release. Seeded sampling is reproducible.
+- **`generative` feature** — port browserforge's Bayesian-network sampler; vendor its network JSON (Apache-2.0; attribution in a crate `NOTICE`). `Generator::generate(seed) -> Persona`. Synthesizes unlimited coherent personas. Most directly answers #241's "support browserforge natively."
+- Both emit the **same `Persona`**, so they slot straight into `overlay`.
+
+## 9. Seed & reproducibility
+
+```rust
+pub enum SeedSource { Random, System, Explicit(u64) }
+
+impl Seed {
+    pub fn random() -> Seed;       // DEFAULT — per-instance unique
+    pub fn from_system() -> Seed;  // deterministic per-machine:
+                                   //   hash(machine-id / IOPlatformUUID / MachineGuid,
+                                   //   fallback hostname + cpu model)
+    pub fn from_u64(x: u64) -> Seed;
+}
+```
+
+- Default seed is random per browser instance.
+- `from_system()` yields the same fingerprint every run on this box **without** a `user_data_dir` — great for one persistent identity, wrong if you want to look like many users. Documented tradeoff; opt-in only.
+- When a `user_data_dir` is set, the persona seed persists alongside it so a profile keeps one identity across runs.
+- Determinism is unit-tested: same seed → byte-identical farble + identical pool sample.
+
+## 10. Public API entry points
+
+```rust
+Browser::builder()
+    .stealth(StealthProfile::spoofed())          // unchanged default
+    .persona(Persona::system())                  // NEW; defaults to system() if omitted
+    .persona_overlay(json_or_builder)            // NEW; sparse field-wise override
+    .surface(Surface::Webrtc, Strategy::Native)  // NEW; per-surface escape hatch
+```
+
+Omit everything → coherent host-derived seeded-farble persona (sensible default). Real-device strategies are used by constructing a `Persona` from `zendriver-fingerprints` and passing it to `.persona(...)`.
+
+## 11. Testing
+
+- **Unit:** overlay merge precedence; seed determinism; per-surface strategy resolution incl. warn-fallback on meaningless combos; `Persona` JSON round-trip.
+- **Integration (feature-gated, headful):** farbled readback differs from native and is **stable across repeat reads** under `Seeded`; differs under `Random`; empty under `Block`; untouched under `Native`. Probe targets: sannysoft, creepjs, browserscan (reuse the existing `browserscan.rs` example).
+- **Snapshot:** `Persona` JSON wire shape via `insta` (matches the repo's existing schema-snapshot discipline; regenerate + accept per CLAUDE.md).
+- **`from_browser`:** a headful test asserting the probed persona's webgl/canvas values match a second independent read from the same Chrome.
+
+## 12. Alternatives considered
+
+- **Strategy as a single global vs per-surface map:** resolved to *global default + unrestricted per-surface override*. With unrestricted overrides, a global default is a strict superset of a per-surface map (it can express any full map) plus better ergonomics; the only thing a restricted form would buy is forbidding incoherent multi-source mixes, which we instead handle via coherent defaults + documentation.
+- **Real-device pool: bundle vs download vs separate crate vs generative model:** resolved to a *separate crate offering both `pool` (download) and `generative` (browserforge port) behind features*, keeping the core crate lean and offering both the lightweight finite-set path and the unlimited generative path.
+- **`system()` at build time vs runtime:** runtime only (see §5 note).
+
+## 13. Licensing
+
+browserforge / fingerprint-suite data and model are Apache-2.0. Vendoring is permitted with attribution; ship a `NOTICE` in `zendriver-fingerprints`. The Rust workspace is dual MIT/Apache-2.0 — compatible.
+
+## 14. Open questions for the plan stage
+
+- Exact shape of `WebglSpec` / `FontSpec` / `HardwareSpec` (field lists per surface).
+- Whether `Hardware` stays one surface or splits into sub-surfaces (battery/gamepad/mediaDevices/speech) for finer override; PR1 treats it as one `HardwareSpec`.
+- Pool asset format (JSON vs a compact binary) and where it is hosted (zendriver-rs GitHub release vs a dedicated repo).
+- How much of browserforge's BN to port vs vendor as precomputed tables.


### PR DESCRIPTION
Implements upstream zendriver TODO #1 (the most-requested feature: cdpdriver/zendriver#241, #108, #18) — full fingerprint spoofing on top of the existing 9-patch stealth shim. This is **PR1 of 2**; the other 7 prioritized upstream TODOs (network monitor, browser-context HTTP, nested-iframe traversal, CDP freshness, bs4-like find, datadome, popup flags) land separately as PR2.

## Design

Two orthogonal axes (full spec: `docs/superpowers/specs/2026-06-02-fingerprint-spoofing-design.md`):

1. **Persona source** — where values come from: `Persona::system()` (host probe, cached), `::builder()`, `::try_from_json()` / `FromStr` (paste a real device), `::from_browser(&tab)` (live-probe the running Chrome), or the new `zendriver-fingerprints` crate (`pool` / `generative`).
2. **Per-surface render strategy** — how a resolved persona is applied per surface: `Native` / `Seeded` / `Random` / `Block` / `Value`, dispatched by surface *kind* (noise / value / policy).

Guiding principle: **least-opinionated, everything overridable, coherent defaults** — global default + unrestricted per-surface override; the default path stays coherent, foot-guns are documented not forbidden.

## What's included

- **`zendriver-stealth/src/persona/`** — `Persona` (serde, field-wise `overlay` merge), `Seed` (`random` / `from_system` / `from_u64`), `Surface`/`Strategy`/`SurfaceKind` resolution, per-surface specs.
- **7 farble JS patches** — canvas, audio, webgl (vendor/renderer substitution), fonts, ClientRects, WebRTC IP-leak guard, hardware (battery/gamepad/mediaDevices/voices), plus a shared mulberry32 PRNG.
- **`bootstrap_script(persona, identity: &Fingerprint)`** — two-arg: `identity` keeps the **real probed Chrome version** so the UA stays coherent; persona overrides simple fields + drives the new surfaces. Existing 9 patches unchanged.
- **`zendriver-fingerprints` crate** — `pool` (download-on-first-use, seeded sample, reuses the Chrome-fetcher cache pattern) + `generative` (browserforge Bayesian-network port, Apache-2.0 attribution in NOTICE). Both emit a `Persona`.
- **Browser builder** — `.persona()`, `.persona_overlay()`, `.surface(s, strat)`, `resolved_persona()`, wired at both launch + connect observer sites. Persona seed persists in `<user_data_dir>/.zd_persona_seed`.
- **`Persona::from_browser`** via a `JsProbe` trait (avoids a stealth→zendriver dep cycle).
- Examples (`persona_basic`, `persona_pool`), mdBook chapter, insta wire-shape snapshot, gated headful integration tests.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` (default) clean
- [x] `cargo clippy --workspace --all-features --all-targets --locked -- -D warnings` clean
- [x] `cargo test --workspace --all-features --locked` — green (stealth 80 + zendriver 240 + fingerprints pool/generative + transport)
- [x] `cargo test -p zendriver-mcp --test schema_snapshots --all-features` — 126 pass, no MCP wire drift
- [x] All 7 JS patches `node --check`-validated; substitution layer asserts no unsubstituted tokens remain
- [ ] **Headful behavior not run locally (no Chrome in env)** — `seeded canvas stable across reads / Random differs` integration tests are written + `#[ignore]`-gated; rely on the nightly stealth CI (sannysoft/creepjs/browserscan) to exercise farble at runtime

## Review notes

A final review caught + fixed 3 farble bugs before this PR: canvas `toDataURL` double-farble + live-canvas corruption (now snapshots/restores), audio `AnalyserNode` guard, and `getClientRects` consistency with `getBoundingClientRect`.

Plan: `docs/superpowers/plans/2026-06-02-fingerprint-spoofing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)