### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.2", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.3", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.3" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.1.4" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.2.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.1.4" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.2.0" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.2" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.2.1" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.2.2" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.1.3" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.1.0" }
 

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this crate documented here. Format: [Keep a
+Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
+
+## [0.1.0] - 2026-06-02
+
+### Added
+
+- New crate skeleton (pool/generative features)
+- Pool source (download-on-first-use + seeded sample)
+- Generative BN persona source (browserforge port)
+

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.2] - 2026-06-02
+
+
 ## [0.2.1] - 2026-06-02
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.0] - 2026-06-02
+
+### Added
+
+- Seed type (random/from_system/from_u64)
+- Per-surface persona spec types
+- Persona struct + serde
+- Persona::overlay field-wise merge
+- Persona JSON ingestion (try_from_json + FromStr)
+- PersonaBuilder
+- Persona::system() host probe (cached)
+- Persona patch-templating accessors
+- Surface/Strategy + per-kind resolution
+- Canvas farble patch
+- Audio farble patch
+- Webgl vendor/renderer substitution
+- Font metrics + enumeration patch
+- ClientRects sub-pixel patch
+- Webrtc ip-leak guard
+- Hardware surface patch
+- Lib.rs top-level re-exports + clippy fix
+- Bootstrap_script(persona, identity) + surface patch wiring
+- Persona::from_browser live-probe via JsProbe trait
+- Browser builder .persona/.persona_overlay/.surface
+
+### Fixed
+
+- Canvas restore + audio guard + getClientRects consistency
+
+
 ## [0.1.4] - 2026-06-02
 
 

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.1.4"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,15 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-06-02
+
+### Added
+
+- Persona::from_browser live-probe via JsProbe trait
+- Browser builder .persona/.persona_overlay/.surface
+- Persist persona seed alongside user_data_dir
+
+
 ## [0.2.2] - 2026-06-02
 
 

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.1.4 -> 0.2.0 (⚠ API breaking changes)
* `zendriver`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `zendriver-fingerprints`: 0.1.0
* `zendriver-mcp`: 0.2.1 -> 0.2.2

### ⚠ `zendriver-stealth` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_parameter_count_changed.ron

Failed in:
  zendriver_stealth::patches::bootstrap_script now takes 2 parameters instead of 1, in /tmp/.tmpsxutS5/zendriver-rs/crates/zendriver-stealth/src/patches.rs:57
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-stealth`

<blockquote>

## [0.2.0] - 2026-06-02

### Added

- Seed type (random/from_system/from_u64)
- Per-surface persona spec types
- Persona struct + serde
- Persona::overlay field-wise merge
- Persona JSON ingestion (try_from_json + FromStr)
- PersonaBuilder
- Persona::system() host probe (cached)
- Persona patch-templating accessors
- Surface/Strategy + per-kind resolution
- Canvas farble patch
- Audio farble patch
- Webgl vendor/renderer substitution
- Font metrics + enumeration patch
- ClientRects sub-pixel patch
- Webrtc ip-leak guard
- Hardware surface patch
- Lib.rs top-level re-exports + clippy fix
- Bootstrap_script(persona, identity) + surface patch wiring
- Persona::from_browser live-probe via JsProbe trait
- Browser builder .persona/.persona_overlay/.surface

### Fixed

- Canvas restore + audio guard + getClientRects consistency
</blockquote>

## `zendriver`

<blockquote>

## [0.2.3] - 2026-06-02

### Added

- Persona::from_browser live-probe via JsProbe trait
- Browser builder .persona/.persona_overlay/.surface
- Persist persona seed alongside user_data_dir
</blockquote>

## `zendriver-fingerprints`

<blockquote>

## [0.1.0] - 2026-06-02

### Added

- New crate skeleton (pool/generative features)
- Pool source (download-on-first-use + seeded sample)
- Generative BN persona source (browserforge port)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).