### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3315,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dirs",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ zendriver-interception  = { path = "crates/zendriver-interception", version = "0
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.2" }
 zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.2.2" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.1.3" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.1.0" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.1.1" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.1] - 2026-06-02
+
+
 ## [0.1.0] - 2026-06-02
 
 ### Added

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.1.4 -> 0.2.0
* `zendriver`: 0.2.2 -> 0.2.3
* `zendriver-mcp`: 0.2.1 -> 0.2.2
* `zendriver-fingerprints`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-stealth`

<blockquote>

## [0.2.0] - 2026-06-02

### Added

- Seed type (random/from_system/from_u64)
- Per-surface persona spec types
- Persona struct + serde
- Persona::overlay field-wise merge
- Persona JSON ingestion (try_from_json + FromStr)
- PersonaBuilder
- Persona::system() host probe (cached)
- Persona patch-templating accessors
- Surface/Strategy + per-kind resolution
- Canvas farble patch
- Audio farble patch
- Webgl vendor/renderer substitution
- Font metrics + enumeration patch
- ClientRects sub-pixel patch
- Webrtc ip-leak guard
- Hardware surface patch
- Lib.rs top-level re-exports + clippy fix
- Bootstrap_script(persona, identity) + surface patch wiring
- Persona::from_browser live-probe via JsProbe trait
- Browser builder .persona/.persona_overlay/.surface

### Fixed

- Canvas restore + audio guard + getClientRects consistency
</blockquote>

## `zendriver`

<blockquote>

## [0.2.3] - 2026-06-02

### Added

- Persona::from_browser live-probe via JsProbe trait
- Browser builder .persona/.persona_overlay/.surface
- Persist persona seed alongside user_data_dir
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).