### PR TITLE
feat: bs4-like predicate finders + select/select_all + nested-iframe (#55, #239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SEMVER.md].
 
 ### Added
 
+- bs4-like combinable predicate finders on `find()`/`find_all()`: `tag`,
+  `attr`, `attr_contains`, `attr_starts_with`, `attr_ends_with`, `has_attr`,
+  `attr_regex`, `containing_text`, `text_equals`, `text_matches` (#55).
+- `select`/`select_all` CSS convenience aliases on `Tab`/`Frame`/`Element`.
+- Verified `include_frames()` finds elements in nested iframes (#239).
 - **Parity with nodriver / zendriver-py (phases P-A…P-D).** A large additive
   surface closing the feature gap with upstream while preserving every rs-only
   strength (3-tier stealth, single-socket flat transport, actionability,

--- a/crates/zendriver/src/element/traversal.rs
+++ b/crates/zendriver/src/element/traversal.rs
@@ -110,6 +110,52 @@ impl Element {
         crate::query::FindAllBuilder::new_for_element(self)
     }
 
+    /// Find one descendant element by CSS selector. Python-parity convenience
+    /// for `find().css(sel).one()`. Scoped to this element's subtree.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::ZendriverError::ElementNotFound`] if no element
+    /// matches.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn ex() -> zendriver::Result<()> {
+    /// # let browser = zendriver::Browser::builder().launch().await?;
+    /// # let tab = browser.main_tab();
+    /// let card = tab.find().css(".card").one().await?;
+    /// let title = card.select("h2").await?;
+    /// # let _ = title;
+    /// # Ok(()) }
+    /// ```
+    pub async fn select(&self, css: &str) -> crate::error::Result<crate::Element> {
+        self.find().css(css).one().await
+    }
+
+    /// Find all descendant elements by CSS selector. Python-parity convenience
+    /// for `find_all().css(sel).many()`. Scoped to this element's subtree.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::ZendriverError::ElementNotFound`] if no elements
+    /// match.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn ex() -> zendriver::Result<()> {
+    /// # let browser = zendriver::Browser::builder().launch().await?;
+    /// # let tab = browser.main_tab();
+    /// let list = tab.find().css("ul").one().await?;
+    /// let items = list.select_all("li").await?;
+    /// println!("{} items", items.len());
+    /// # Ok(()) }
+    /// ```
+    pub async fn select_all(&self, css: &str) -> crate::error::Result<Vec<crate::Element>> {
+        self.find_all().css(css).many().await
+    }
+
     /// Return this element's child elements as a `Vec<Element>`.
     ///
     /// HTMLCollection is materialized via `Array.from`. The returned

--- a/crates/zendriver/src/error.rs
+++ b/crates/zendriver/src/error.rs
@@ -72,6 +72,14 @@ pub enum ZendriverError {
         selector: String,
     },
 
+    /// A predicate method (`.tag`/`.attr`/`.containing_text`/…) was combined
+    /// with a single-selector method (`.css`/`.xpath`/`.text`/`.role`) on one
+    /// query. Use one selector style per query.
+    #[error(
+        "predicate methods (.tag/.attr/…) cannot be combined with .css()/.xpath()/.text()/.role(); use one selector style per query"
+    )]
+    ConflictingSelectors,
+
     /// Generic operation timeout.
     #[error("timed out after {0:?}")]
     Timeout(Duration),
@@ -450,6 +458,13 @@ mod tests {
     fn display_history_navigation() {
         let e = ZendriverError::HistoryNavigation("no back history".into());
         assert_eq!(e.to_string(), "history navigation failed: no back history");
+    }
+
+    #[test]
+    fn conflicting_selectors_message() {
+        let e = ZendriverError::ConflictingSelectors;
+        assert!(e.to_string().contains("predicate"));
+        assert!(e.to_string().contains("css"));
     }
 
     #[test]

--- a/crates/zendriver/src/frame/mod.rs
+++ b/crates/zendriver/src/frame/mod.rs
@@ -480,6 +480,52 @@ impl Frame {
         crate::query::FindAllBuilder::new_for_frame(self)
     }
 
+    /// Find one element by CSS selector. Python-parity convenience for
+    /// `find().css(sel).one()`. For modifiers use the builder directly.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::ZendriverError::ElementNotFound`] if no element
+    /// matches.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn ex() -> zendriver::Result<()> {
+    /// # let browser = zendriver::Browser::builder().launch().await?;
+    /// # let tab = browser.main_tab();
+    /// let frame = tab.main_frame().await?;
+    /// let h1 = frame.select("h1").await?;
+    /// # let _ = h1;
+    /// # Ok(()) }
+    /// ```
+    pub async fn select(&self, css: &str) -> crate::error::Result<crate::Element> {
+        self.find().css(css).one().await
+    }
+
+    /// Find all elements by CSS selector. Python-parity convenience for
+    /// `find_all().css(sel).many()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::ZendriverError::ElementNotFound`] if no elements
+    /// match.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn ex() -> zendriver::Result<()> {
+    /// # let browser = zendriver::Browser::builder().launch().await?;
+    /// # let tab = browser.main_tab();
+    /// let frame = tab.main_frame().await?;
+    /// let links = frame.select_all("a").await?;
+    /// # let _ = links;
+    /// # Ok(()) }
+    /// ```
+    pub async fn select_all(&self, css: &str) -> crate::error::Result<Vec<crate::Element>> {
+        self.find_all().css(css).many().await
+    }
+
     /// Ensure an isolated-world execution context exists for *this frame*,
     /// returning its `executionContextId`. Cached after first call.
     ///

--- a/crates/zendriver/src/query/mod.rs
+++ b/crates/zendriver/src/query/mod.rs
@@ -107,8 +107,88 @@ use tokio::time::Instant;
 use crate::element::Element;
 use crate::error::{Result, ZendriverError};
 use crate::frame::Frame;
+use crate::query::predicate::{AttrPred, PredicateSet, TextPred};
 use crate::query::selectors::{QueryScope, RemoteRef, SelectorKind, text_len_of};
 use crate::tab::Tab;
+
+/// Generates the 10 predicate setters shared by `FindBuilder` + `FindAllBuilder`.
+/// Both structs must have a `predicates: PredicateSet` field.
+macro_rules! predicate_methods {
+    () => {
+        /// Match by tag name (compiles into the CSS selector). Predicate mode.
+        #[must_use]
+        pub fn tag(mut self, name: impl Into<String>) -> Self {
+            self.predicates.tag = Some(name.into());
+            self
+        }
+        /// Match an exact attribute value `[name="value"]`.
+        #[must_use]
+        pub fn attr(mut self, name: &str, value: &str) -> Self {
+            self.predicates
+                .attrs
+                .push(AttrPred::Exact(name.into(), value.into()));
+            self
+        }
+        /// Match a substring of an attribute value `[name*="sub"]`.
+        #[must_use]
+        pub fn attr_contains(mut self, name: &str, sub: &str) -> Self {
+            self.predicates
+                .attrs
+                .push(AttrPred::Contains(name.into(), sub.into()));
+            self
+        }
+        /// Match an attribute value prefix `[name^="pre"]`.
+        #[must_use]
+        pub fn attr_starts_with(mut self, name: &str, pre: &str) -> Self {
+            self.predicates
+                .attrs
+                .push(AttrPred::StartsWith(name.into(), pre.into()));
+            self
+        }
+        /// Match an attribute value suffix `[name$="suf"]`.
+        #[must_use]
+        pub fn attr_ends_with(mut self, name: &str, suf: &str) -> Self {
+            self.predicates
+                .attrs
+                .push(AttrPred::EndsWith(name.into(), suf.into()));
+            self
+        }
+        /// Require the attribute be present `[name]`.
+        #[must_use]
+        pub fn has_attr(mut self, name: &str) -> Self {
+            self.predicates.attrs.push(AttrPred::Has(name.into()));
+            self
+        }
+        /// Match an attribute value against a JS regex (post-filter).
+        #[must_use]
+        pub fn attr_regex(mut self, name: &str, pattern: &str) -> Self {
+            self.predicates
+                .attrs
+                .push(AttrPred::Regex(name.into(), pattern.into()));
+            self
+        }
+        /// Match elements whose text contains `sub` (post-filter).
+        #[must_use]
+        pub fn containing_text(mut self, sub: &str) -> Self {
+            self.predicates.texts.push(TextPred::Contains(sub.into()));
+            self
+        }
+        /// Match elements whose trimmed text equals `exact` (post-filter).
+        #[must_use]
+        pub fn text_equals(mut self, exact: &str) -> Self {
+            self.predicates.texts.push(TextPred::Equals(exact.into()));
+            self
+        }
+        /// Match elements whose text matches a JS regex `pattern` (post-filter).
+        #[must_use]
+        pub fn text_matches(mut self, pattern: &str) -> Self {
+            self.predicates
+                .texts
+                .push(TextPred::Matches(pattern.into()));
+            self
+        }
+    };
+}
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
@@ -153,6 +233,9 @@ pub struct FindBuilder<'scope> {
     /// `tab = None`).
     pub(crate) frame: Option<&'scope Frame>,
     pub(crate) selector: Option<SelectorKind>,
+    /// Accumulated bs4-like predicates. Mutually exclusive with `selector`
+    /// (enforced at the terminal — see `one`/`one_or_none`).
+    pub(crate) predicates: PredicateSet,
     pub(crate) timeout: Duration,
     pub(crate) nth: Option<usize>,
     pub(crate) visible_only: bool,
@@ -177,12 +260,15 @@ pub struct FindBuilder<'scope> {
 }
 
 impl<'scope> FindBuilder<'scope> {
+    predicate_methods! {}
+
     pub(crate) fn new_for_tab(tab: &'scope Tab) -> Self {
         Self {
             tab: Some(tab),
             element: None,
             frame: None,
             selector: None,
+            predicates: Default::default(),
             timeout: DEFAULT_TIMEOUT,
             nth: None,
             visible_only: false,
@@ -203,6 +289,7 @@ impl<'scope> FindBuilder<'scope> {
             element: Some(element),
             frame: None,
             selector: None,
+            predicates: Default::default(),
             timeout: DEFAULT_TIMEOUT,
             nth: None,
             visible_only: false,
@@ -223,6 +310,7 @@ impl<'scope> FindBuilder<'scope> {
             element: None,
             frame: Some(frame),
             selector: None,
+            predicates: Default::default(),
             timeout: DEFAULT_TIMEOUT,
             nth: None,
             visible_only: false,
@@ -488,6 +576,7 @@ impl<'scope> FindBuilder<'scope> {
             element: self.element,
             frame: self.frame,
             selector: self.selector,
+            predicates: self.predicates,
             timeout: self.timeout,
             nth: self.nth,
             visible_only: self.visible_only,
@@ -1944,6 +2033,48 @@ mod tests {
     /// main scope returns an empty array, then the single registered frame's
     /// session resolves one node — `.one()` must return it, dispatching the
     /// frame query on the frame's own session.
+    // --- T4/T5: predicate builder accumulation -----------------------
+
+    #[cfg(test)]
+    mod predicate_builder_tests {
+        use super::super::*;
+        use crate::query::predicate::{AttrPred, TextPred};
+
+        fn bare() -> FindBuilder<'static> {
+            FindBuilder {
+                tab: None,
+                element: None,
+                frame: None,
+                selector: None,
+                predicates: Default::default(),
+                timeout: DEFAULT_TIMEOUT,
+                nth: None,
+                visible_only: false,
+                in_frame: None,
+                include_frames: false,
+                best_match: false,
+            }
+        }
+
+        #[test]
+        fn predicate_methods_accumulate() {
+            let b = bare()
+                .tag("div")
+                .attr("data-x", "y")
+                .attr_contains("class", "z")
+                .has_attr("ready")
+                .attr_regex("id", r"\d+")
+                .containing_text("Buy")
+                .text_equals("OK")
+                .text_matches(r"^\$");
+            assert_eq!(b.predicates.tag.as_deref(), Some("div"));
+            assert_eq!(b.predicates.attrs.len(), 4);
+            assert_eq!(b.predicates.texts.len(), 3);
+            assert!(matches!(b.predicates.attrs[0], AttrPred::Exact(_, _)));
+            assert!(matches!(b.predicates.texts[2], TextPred::Matches(_)));
+        }
+    }
+
     #[tokio::test]
     async fn include_frames_one_falls_through_to_frame() {
         let (mut mock, conn) = MockConnection::pair();

--- a/crates/zendriver/src/query/mod.rs
+++ b/crates/zendriver/src/query/mod.rs
@@ -848,15 +848,17 @@ impl<'scope> FindBuilder<'scope> {
         let best_match = selector
             .as_ref()
             .is_some_and(|s| effective_best_match(self.best_match, s));
-        let resolver = match (&selector, predicate_mode) {
-            (Some(sel), _) => Resolver::Selector {
+        // `selector` is `Some` iff we are *not* in predicate mode (the
+        // `else` arm above either bound it or returned early), so the
+        // resolver follows directly from whether a selector is present.
+        let resolver = match &selector {
+            Some(sel) => Resolver::Selector {
                 selector: sel,
                 best_match,
             },
-            (None, true) => Resolver::Predicate {
+            None => Resolver::Predicate {
                 predicates: &self.predicates,
             },
-            (None, false) => unreachable!("selector is Some whenever predicate_mode is false"),
         };
 
         let deadline = Instant::now() + self.timeout;
@@ -1233,15 +1235,16 @@ impl<'scope> FindAllBuilder<'scope> {
         let best_match = selector
             .as_ref()
             .is_some_and(|s| effective_best_match(self.best_match, s));
-        let resolver = match (&selector, predicate_mode) {
-            (Some(sel), _) => Resolver::Selector {
+        // See `FindBuilder::one`: `selector` is `Some` iff not in predicate
+        // mode, so the resolver follows directly from its presence.
+        let resolver = match &selector {
+            Some(sel) => Resolver::Selector {
                 selector: sel,
                 best_match,
             },
-            (None, true) => Resolver::Predicate {
+            None => Resolver::Predicate {
                 predicates: &self.predicates,
             },
-            (None, false) => unreachable!("selector is Some whenever predicate_mode is false"),
         };
 
         let deadline = Instant::now() + self.timeout;

--- a/crates/zendriver/src/query/mod.rs
+++ b/crates/zendriver/src/query/mod.rs
@@ -28,6 +28,7 @@
 
 pub mod actionability;
 pub mod modifiers;
+pub(crate) mod predicate;
 pub mod role;
 pub mod selectors;
 

--- a/crates/zendriver/src/query/mod.rs
+++ b/crates/zendriver/src/query/mod.rs
@@ -799,6 +799,9 @@ pub struct FindAllBuilder<'scope> {
     /// [`FindAllBuilder::new_for_frame`].
     pub(crate) frame: Option<&'scope Frame>,
     pub(crate) selector: Option<SelectorKind>,
+    /// Accumulated bs4-like predicates. Mutually exclusive with `selector`
+    /// (enforced at the terminal — see `many`/`many_or_empty`).
+    pub(crate) predicates: PredicateSet,
     pub(crate) timeout: Duration,
     pub(crate) visible_only: bool,
     /// Frame override populated by [`FindAllBuilder::in_frame`]. See
@@ -816,12 +819,15 @@ pub struct FindAllBuilder<'scope> {
 }
 
 impl<'scope> FindAllBuilder<'scope> {
+    predicate_methods! {}
+
     pub(crate) fn new_for_tab(tab: &'scope Tab) -> Self {
         Self {
             tab: Some(tab),
             element: None,
             frame: None,
             selector: None,
+            predicates: Default::default(),
             timeout: DEFAULT_TIMEOUT,
             visible_only: false,
             in_frame: None,
@@ -840,6 +846,7 @@ impl<'scope> FindAllBuilder<'scope> {
             element: Some(element),
             frame: None,
             selector: None,
+            predicates: Default::default(),
             timeout: DEFAULT_TIMEOUT,
             visible_only: false,
             in_frame: None,
@@ -857,6 +864,7 @@ impl<'scope> FindAllBuilder<'scope> {
             element: None,
             frame: Some(frame),
             selector: None,
+            predicates: Default::default(),
             timeout: DEFAULT_TIMEOUT,
             visible_only: false,
             in_frame: None,
@@ -961,6 +969,7 @@ impl<'scope> FindAllBuilder<'scope> {
             element: self.element,
             frame: self.frame,
             selector: self.selector,
+            predicates: self.predicates,
             timeout: self.timeout,
             visible_only: self.visible_only,
             in_frame: Some(frame),
@@ -2033,8 +2042,7 @@ mod tests {
     /// main scope returns an empty array, then the single registered frame's
     /// session resolves one node — `.one()` must return it, dispatching the
     /// frame query on the frame's own session.
-    // --- T4/T5: predicate builder accumulation -----------------------
-
+    // --- T4/T5: predicate builder accumulation (separate nested mod) ---
     #[cfg(test)]
     mod predicate_builder_tests {
         use super::super::*;
@@ -2072,6 +2080,29 @@ mod tests {
             assert_eq!(b.predicates.texts.len(), 3);
             assert!(matches!(b.predicates.attrs[0], AttrPred::Exact(_, _)));
             assert!(matches!(b.predicates.texts[2], TextPred::Matches(_)));
+        }
+
+        fn bare_all() -> FindAllBuilder<'static> {
+            FindAllBuilder {
+                tab: None,
+                element: None,
+                frame: None,
+                selector: None,
+                predicates: Default::default(),
+                timeout: DEFAULT_TIMEOUT,
+                visible_only: false,
+                in_frame: None,
+                include_frames: false,
+                best_match: false,
+            }
+        }
+
+        #[test]
+        fn find_all_predicates_accumulate() {
+            let b = bare_all().tag("a").has_attr("href").containing_text("Next");
+            assert_eq!(b.predicates.tag.as_deref(), Some("a"));
+            assert_eq!(b.predicates.attrs.len(), 1);
+            assert_eq!(b.predicates.texts.len(), 1);
         }
     }
 

--- a/crates/zendriver/src/query/mod.rs
+++ b/crates/zendriver/src/query/mod.rs
@@ -25,6 +25,69 @@
 //! `.one()` (errors on empty), `.one_or_none()` (returns `None`). Terminals
 //! on [`FindAllBuilder`]: `.many()` (errors on empty), `.many_or_empty()`
 //! (returns empty `Vec`).
+//!
+//! # Predicate mode (bs4-like combinable matchers)
+//!
+//! Ten predicate methods let you match elements without writing a CSS
+//! selector by hand. All active predicates are AND-ed together:
+//!
+//! | Method | Matches |
+//! |---|---|
+//! | `.tag(name)` | element tag name |
+//! | `.attr(name, value)` | exact attribute value — `[name="value"]` |
+//! | `.attr_contains(name, sub)` | attribute contains substring — `[name*="sub"]` |
+//! | `.attr_starts_with(name, pre)` | attribute value prefix — `[name^="pre"]` |
+//! | `.attr_ends_with(name, suf)` | attribute value suffix — `[name$="suf"]` |
+//! | `.has_attr(name)` | attribute is present — `[name]` |
+//! | `.attr_regex(name, pat)` | attribute value matches JS regex (post-filter) |
+//! | `.containing_text(sub)` | element text contains substring (post-filter) |
+//! | `.text_equals(exact)` | trimmed element text equals string (post-filter) |
+//! | `.text_matches(pat)` | element text matches JS regex (post-filter) |
+//!
+//! Structural predicates (`.tag`, `.attr*`, `.has_attr`) compile to a single
+//! CSS selector that the browser evaluates natively. Regex and text
+//! predicates (`.attr_regex`, `.containing_text`, `.text_equals`,
+//! `.text_matches`) are applied as a JS post-filter over the CSS candidates —
+//! so the browser does the heavy lifting and only the survivors are inspected
+//! in JS.
+//!
+//! **Mixing rule:** predicate methods cannot be combined with single-selector
+//! methods (`.css()`, `.xpath()`, `.text*()`, `.role*()`). Using both on one
+//! builder returns `Err(`[`crate::ZendriverError::ConflictingSelectors`]`)` at
+//! the terminal (`.one()` / `.many()` / etc.).
+//!
+//! ```no_run
+//! # async fn ex() -> zendriver::Result<()> {
+//! # let browser = zendriver::Browser::builder().launch().await?;
+//! # let tab = browser.main_tab();
+//! tab.goto("https://example.com").await?;
+//! // Predicate find: button whose class contains "primary" and text starts with "Buy"
+//! let btn = tab
+//!     .find()
+//!     .tag("button")
+//!     .attr_contains("class", "primary")
+//!     .containing_text("Buy")
+//!     .one()
+//!     .await?;
+//! // CSS convenience alias (equivalent to find().css(…).many())
+//! let links = tab.select_all("nav a").await?;
+//! # let _ = (btn, links);
+//! # Ok(()) }
+//! ```
+//!
+//! # Note: predicate elements are not auto-refreshable
+//!
+//! Elements found through predicate methods carry an *Evaluation* origin
+//! (they are the result of a `Runtime.evaluate` / `callFunctionOn` call that
+//! embeds the full predicate expression). Because the predicate set — especially
+//! the regex and text post-filters — cannot be reduced to a single stored
+//! selector string, the returned [`crate::Element`] handles **cannot be
+//! transparently re-fetched** if the element is detached and the query needs
+//! to be retried.
+//!
+//! Elements found via `.css()`, `.xpath()`, or the other single-selector
+//! kinds are refreshable as before — they carry a stored selector that the
+//! query layer can re-issue against the live DOM.
 
 pub mod actionability;
 pub mod modifiers;

--- a/crates/zendriver/src/query/mod.rs
+++ b/crates/zendriver/src/query/mod.rs
@@ -193,6 +193,93 @@ macro_rules! predicate_methods {
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
+/// `true` when a query mixes a single-selector kind (`.css`/`.xpath`/
+/// `.text*`/`.role*`) with bs4-like predicate methods (`.tag`/`.attr`/…).
+/// The two styles are mutually exclusive; a terminal that sees a conflict
+/// returns [`ZendriverError::ConflictingSelectors`] before dispatching any
+/// CDP call. Extracted as a free function so the rule is unit-testable
+/// without constructing a `Tab`.
+fn has_conflict(selector: &Option<SelectorKind>, predicates: &PredicateSet) -> bool {
+    selector.is_some() && !predicates.is_empty()
+}
+
+/// What a terminal resolves: either a single [`SelectorKind`] (with its
+/// effective `best_match` flag) or a [`PredicateSet`]. Unifying the two
+/// behind one type lets the poll loop, `nth`/`visible_only` pick, the
+/// cross-frame fan-out, and `Element` synthesis be written ONCE — only
+/// the per-scope candidate fetch and the synthesis provenance differ.
+enum Resolver<'a> {
+    /// Single-selector path. `best_match` is the already-resolved
+    /// effective flag (`effective_best_match`), honored only for text
+    /// selectors. Synthesizes elements with full `Query` provenance so
+    /// `Element::refresh` can re-run the selector.
+    Selector {
+        selector: &'a SelectorKind,
+        best_match: bool,
+    },
+    /// Predicate path. Synthesizes elements with `Evaluation` provenance
+    /// (not auto-refreshable): the `Query` origin only carries a
+    /// `SelectorKind`, and compiling a `PredicateSet` down to one would
+    /// silently drop the regex/text post-filters on refresh — returning a
+    /// *different* element. Losing refresh is the honest, correct choice
+    /// over a refresh that re-resolves to the wrong node.
+    Predicate { predicates: &'a PredicateSet },
+}
+
+impl Resolver<'_> {
+    /// Resolve every candidate against `scope` in document order.
+    async fn resolve(&self, scope: &QueryScope<'_>) -> Result<Vec<RemoteRef>> {
+        match self {
+            Resolver::Selector {
+                selector,
+                best_match,
+            } => selector.resolve_many_inner(scope, *best_match).await,
+            Resolver::Predicate { predicates } => {
+                crate::query::selectors::resolve_predicate_many(scope, predicates).await
+            }
+        }
+    }
+
+    /// Wrap a resolved `RemoteRef` into an `Element`, preserving the
+    /// provenance appropriate to this resolver (see the variant docs).
+    fn synthesize(&self, r: RemoteRef, scope: &QueryScope<'_>, nth: usize) -> Element {
+        match self {
+            Resolver::Selector { selector, .. } => {
+                Element::synthesize_query(r, scope, selector, nth)
+            }
+            Resolver::Predicate { .. } => Element::from_jsret(
+                scope.synthesize_tab(),
+                r.backend_node_id,
+                r.remote_object_id,
+            ),
+        }
+    }
+
+    /// Short, log-friendly description for the `ElementNotFound` payload.
+    fn describe(&self) -> String {
+        match self {
+            Resolver::Selector { selector, .. } => describe_selector(selector),
+            Resolver::Predicate { predicates } => describe_predicates(predicates),
+        }
+    }
+
+    /// `Some(selector)` only when this is a text selector with `best_match`
+    /// active — the single case where the cross-frame fan-out runs the
+    /// closest-text-length scoring path (`consider_scope_best` /
+    /// `text_len_of`). Predicate and non-best-match selector resolvers
+    /// return `None`, so they take the cheaper "first hit / concatenate"
+    /// cross-frame branch.
+    fn best_match_selector(&self) -> Option<&SelectorKind> {
+        match self {
+            Resolver::Selector {
+                selector,
+                best_match: true,
+            } => Some(selector),
+            _ => None,
+        }
+    }
+}
+
 /// Chainable single-element query builder.
 ///
 /// Call a selector method, optionally chain modifiers, then terminate with
@@ -677,13 +764,39 @@ impl<'scope> FindBuilder<'scope> {
     /// # Ok(()) }
     /// ```
     pub async fn one(self) -> Result<Element> {
-        let selector = self.selector.ok_or_else(|| {
-            ZendriverError::Navigation(
-                "FindBuilder requires a selector (.css/.xpath/.text/.role/...)".into(),
-            )
-        })?;
+        // Mixing a single-selector kind with predicate methods is a usage
+        // error — reject it before any CDP dispatch.
+        if has_conflict(&self.selector, &self.predicates) {
+            return Err(ZendriverError::ConflictingSelectors);
+        }
+        let predicate_mode = !self.predicates.is_empty();
+        let selector = if predicate_mode {
+            None
+        } else {
+            Some(self.selector.ok_or_else(|| {
+                ZendriverError::Navigation(
+                    "FindBuilder requires a selector (.css/.xpath/.text/.role/...) or a predicate (.tag/.attr/...)"
+                        .into(),
+                )
+            })?)
+        };
+        // `best_match` only applies to text selectors; it is meaningless
+        // (and unset) in predicate mode.
+        let best_match = selector
+            .as_ref()
+            .is_some_and(|s| effective_best_match(self.best_match, s));
+        let resolver = match (&selector, predicate_mode) {
+            (Some(sel), _) => Resolver::Selector {
+                selector: sel,
+                best_match,
+            },
+            (None, true) => Resolver::Predicate {
+                predicates: &self.predicates,
+            },
+            (None, false) => unreachable!("selector is Some whenever predicate_mode is false"),
+        };
+
         let deadline = Instant::now() + self.timeout;
-        let best_match = effective_best_match(self.best_match, &selector);
         let want_nth = self.nth.unwrap_or(0);
 
         // `include_frames` only fans out for a plain Tab-scoped builder.
@@ -695,7 +808,7 @@ impl<'scope> FindBuilder<'scope> {
             && self.frame.is_none();
 
         if let (true, Some(tab)) = (fan_frames, self.tab) {
-            return one_across_frames(tab, &selector, best_match, want_nth, deadline).await;
+            return one_across_frames(tab, &resolver, want_nth, deadline).await;
         }
 
         // Precedence: Element > in_frame override > Frame > Tab.
@@ -718,7 +831,7 @@ impl<'scope> FindBuilder<'scope> {
             }
         };
         loop {
-            let candidates = selector.resolve_many_inner(&scope, best_match).await?;
+            let candidates = resolver.resolve(&scope).await?;
 
             // Visible-only filter: TODO(T16) — depends on
             // `actionability::check_visible`, which depends on
@@ -728,13 +841,11 @@ impl<'scope> FindBuilder<'scope> {
             let filtered = candidates;
 
             if let Some(picked) = filtered.into_iter().nth(want_nth) {
-                return Ok(Element::synthesize_query(
-                    picked, &scope, &selector, want_nth,
-                ));
+                return Ok(resolver.synthesize(picked, &scope, want_nth));
             }
             if Instant::now() >= deadline {
                 return Err(ZendriverError::ElementNotFound {
-                    selector: describe_selector(&selector),
+                    selector: resolver.describe(),
                 });
             }
             tokio::time::sleep(POLL_INTERVAL).await;
@@ -1040,13 +1151,37 @@ impl<'scope> FindAllBuilder<'scope> {
     /// # Ok(()) }
     /// ```
     pub async fn many(self) -> Result<Vec<Element>> {
-        let selector = self.selector.ok_or_else(|| {
-            ZendriverError::Navigation(
-                "FindAllBuilder requires a selector (.css/.xpath/.text/.role/...)".into(),
-            )
-        })?;
+        // Reject mixing single-selector + predicate methods before any
+        // CDP dispatch (see `FindBuilder::one`).
+        if has_conflict(&self.selector, &self.predicates) {
+            return Err(ZendriverError::ConflictingSelectors);
+        }
+        let predicate_mode = !self.predicates.is_empty();
+        let selector = if predicate_mode {
+            None
+        } else {
+            Some(self.selector.ok_or_else(|| {
+                ZendriverError::Navigation(
+                    "FindAllBuilder requires a selector (.css/.xpath/.text/.role/...) or a predicate (.tag/.attr/...)"
+                        .into(),
+                )
+            })?)
+        };
+        let best_match = selector
+            .as_ref()
+            .is_some_and(|s| effective_best_match(self.best_match, s));
+        let resolver = match (&selector, predicate_mode) {
+            (Some(sel), _) => Resolver::Selector {
+                selector: sel,
+                best_match,
+            },
+            (None, true) => Resolver::Predicate {
+                predicates: &self.predicates,
+            },
+            (None, false) => unreachable!("selector is Some whenever predicate_mode is false"),
+        };
+
         let deadline = Instant::now() + self.timeout;
-        let best_match = effective_best_match(self.best_match, &selector);
 
         let fan_frames = self.include_frames
             && self.element.is_none()
@@ -1054,7 +1189,7 @@ impl<'scope> FindAllBuilder<'scope> {
             && self.frame.is_none();
 
         if let (true, Some(tab)) = (fan_frames, self.tab) {
-            return many_across_frames(tab, &selector, best_match, deadline).await;
+            return many_across_frames(tab, &resolver, deadline).await;
         }
 
         // See `FindBuilder::one` for the precedence rationale.
@@ -1070,7 +1205,7 @@ impl<'scope> FindAllBuilder<'scope> {
             }
         };
         loop {
-            let candidates = selector.resolve_many_inner(&scope, best_match).await?;
+            let candidates = resolver.resolve(&scope).await?;
 
             // Visible-only filter: TODO(T16) — depends on
             // `actionability::check_visible`, which depends on
@@ -1084,13 +1219,13 @@ impl<'scope> FindAllBuilder<'scope> {
                 let elements: Vec<Element> = filtered
                     .into_iter()
                     .enumerate()
-                    .map(|(i, r)| Element::synthesize_query(r, &scope, &selector, i))
+                    .map(|(i, r)| resolver.synthesize(r, &scope, i))
                     .collect();
                 return Ok(elements);
             }
             if Instant::now() >= deadline {
                 return Err(ZendriverError::ElementNotFound {
-                    selector: describe_selector(&selector),
+                    selector: resolver.describe(),
                 });
             }
             tokio::time::sleep(POLL_INTERVAL).await;
@@ -1167,20 +1302,20 @@ fn effective_best_match(requested: bool, sel: &SelectorKind) -> bool {
 /// (main before frames, frames in registry order).
 async fn one_across_frames(
     tab: &Tab,
-    selector: &SelectorKind,
-    best_match: bool,
+    resolver: &Resolver<'_>,
     want_nth: usize,
     deadline: Instant,
 ) -> Result<Element> {
     loop {
         let frames = tab.frames().await?;
 
-        if best_match {
+        if let Some(selector) = resolver.best_match_selector() {
             // Gather each scope's nth candidate + its text-length distance
             // to the needle, then pick the global minimum. The per-scope
             // JS sort already puts the closest-length candidate at index
             // `want_nth`; we re-read its raw length here and recompute the
-            // distance to compare *across* scopes.
+            // distance to compare *across* scopes. Only text selectors
+            // with `best_match` reach here (see `best_match_selector`).
             let needle_len = needle_len_of(selector).unwrap_or(0);
             let mut best: Option<(usize, RemoteRef, ScopeTag)> = None;
             let main_scope = QueryScope::Tab(tab);
@@ -1216,30 +1351,26 @@ async fn one_across_frames(
             }
         } else {
             // First hit wins: main first, then frames in registry order.
+            // Covers both plain selectors and the predicate path (which
+            // never uses best_match). `resolver.resolve` dispatches the
+            // per-scope query — predicate or selector — against each scope.
             let main_scope = QueryScope::Tab(tab);
-            let main_hits = selector.resolve_many_inner(&main_scope, false).await?;
+            let main_hits = resolver.resolve(&main_scope).await?;
             if let Some(picked) = main_hits.into_iter().nth(want_nth) {
-                return Ok(Element::synthesize_query(
-                    picked,
-                    &main_scope,
-                    selector,
-                    want_nth,
-                ));
+                return Ok(resolver.synthesize(picked, &main_scope, want_nth));
             }
             for frame in &frames {
                 let scope = QueryScope::Frame(frame);
-                let hits = selector.resolve_many_inner(&scope, false).await?;
+                let hits = resolver.resolve(&scope).await?;
                 if let Some(picked) = hits.into_iter().nth(want_nth) {
-                    return Ok(Element::synthesize_query(
-                        picked, &scope, selector, want_nth,
-                    ));
+                    return Ok(resolver.synthesize(picked, &scope, want_nth));
                 }
             }
         }
 
         if Instant::now() >= deadline {
             return Err(ZendriverError::ElementNotFound {
-                selector: describe_selector(selector),
+                selector: resolver.describe(),
             });
         }
         tokio::time::sleep(POLL_INTERVAL).await;
@@ -1252,8 +1383,7 @@ async fn one_across_frames(
 /// or the deadline passes (mirroring the single-scope `many()` loop).
 async fn many_across_frames(
     tab: &Tab,
-    selector: &SelectorKind,
-    best_match: bool,
+    resolver: &Resolver<'_>,
     deadline: Instant,
 ) -> Result<Vec<Element>> {
     loop {
@@ -1261,23 +1391,13 @@ async fn many_across_frames(
         let mut elements: Vec<Element> = Vec::new();
 
         let main_scope = QueryScope::Tab(tab);
-        for (i, r) in selector
-            .resolve_many_inner(&main_scope, best_match)
-            .await?
-            .into_iter()
-            .enumerate()
-        {
-            elements.push(Element::synthesize_query(r, &main_scope, selector, i));
+        for (i, r) in resolver.resolve(&main_scope).await?.into_iter().enumerate() {
+            elements.push(resolver.synthesize(r, &main_scope, i));
         }
         for frame in &frames {
             let scope = QueryScope::Frame(frame);
-            for (i, r) in selector
-                .resolve_many_inner(&scope, best_match)
-                .await?
-                .into_iter()
-                .enumerate()
-            {
-                elements.push(Element::synthesize_query(r, &scope, selector, i));
+            for (i, r) in resolver.resolve(&scope).await?.into_iter().enumerate() {
+                elements.push(resolver.synthesize(r, &scope, i));
             }
         }
 
@@ -1286,7 +1406,7 @@ async fn many_across_frames(
         }
         if Instant::now() >= deadline {
             return Err(ZendriverError::ElementNotFound {
-                selector: describe_selector(selector),
+                selector: resolver.describe(),
             });
         }
         tokio::time::sleep(POLL_INTERVAL).await;
@@ -1356,6 +1476,19 @@ fn describe_selector(sel: &SelectorKind) -> String {
         SelectorKind::Role(role, Some(name)) => {
             format!("role_named({}, {name})", role.to_css())
         }
+    }
+}
+
+/// Render a short, log-friendly description of a [`PredicateSet`] for the
+/// `ElementNotFound { selector }` payload — the compiled CSS selector,
+/// plus the JS post-filter when any `attr_regex`/text predicate is set.
+fn describe_predicates(pred: &PredicateSet) -> String {
+    let css = pred.to_css_selector();
+    let filter = pred.to_js_filter();
+    if filter == "true" {
+        format!("predicate(css={css})")
+    } else {
+        format!("predicate(css={css}, filter={filter})")
     }
 }
 
@@ -2103,6 +2236,68 @@ mod tests {
             assert_eq!(b.predicates.tag.as_deref(), Some("a"));
             assert_eq!(b.predicates.attrs.len(), 1);
             assert_eq!(b.predicates.texts.len(), 1);
+        }
+
+        // --- T6: conflict guard (unit-testable without a Tab) ----------
+
+        /// A `PredicateSet` carrying a single `tag` — enough to make
+        /// `is_empty()` false for the conflict-guard tests.
+        fn tag_pred(tag: &str) -> PredicateSet {
+            PredicateSet {
+                tag: Some(tag.into()),
+                ..Default::default()
+            }
+        }
+
+        #[test]
+        fn has_conflict_true_when_both_selector_and_predicate_set() {
+            let sel = Some(SelectorKind::Css("div".into()));
+            assert!(has_conflict(&sel, &tag_pred("span")));
+        }
+
+        #[test]
+        fn has_conflict_false_for_selector_only() {
+            let sel = Some(SelectorKind::Css("div".into()));
+            assert!(!has_conflict(&sel, &PredicateSet::default()));
+        }
+
+        #[test]
+        fn has_conflict_false_for_predicate_only() {
+            assert!(!has_conflict(&None, &tag_pred("span")));
+        }
+
+        #[test]
+        fn has_conflict_false_when_neither_set() {
+            assert!(!has_conflict(&None, &PredicateSet::default()));
+        }
+
+        #[test]
+        fn builder_with_css_and_tag_reports_conflict() {
+            // The terminal reads `has_conflict(&self.selector,
+            // &self.predicates)` first; mirror that here so the guard's
+            // builder-level wiring is covered without a browser.
+            let mut b = bare();
+            b.selector = Some(SelectorKind::Css("div".into()));
+            b = b.tag("span");
+            assert!(has_conflict(&b.selector, &b.predicates));
+        }
+
+        #[test]
+        fn describe_predicates_renders_css_and_filter() {
+            // CSS-only (no post-filter) omits the filter clause.
+            assert_eq!(
+                describe_predicates(&tag_pred("button")),
+                "predicate(css=button)"
+            );
+            // Adding a text predicate adds the JS post-filter to the label.
+            let pred = PredicateSet {
+                tag: Some("button".into()),
+                texts: vec![TextPred::Contains("Buy".into())],
+                ..Default::default()
+            };
+            let d = describe_predicates(&pred);
+            assert!(d.starts_with("predicate(css=button, filter="), "{d}");
+            assert!(d.contains("includes"), "{d}");
         }
     }
 

--- a/crates/zendriver/src/query/predicate.rs
+++ b/crates/zendriver/src/query/predicate.rs
@@ -2,6 +2,8 @@
 //! CSS selector (structural parts) + a JS boolean post-filter (regex/text).
 //! Pure — no CDP, fully unit-testable.
 
+#![allow(dead_code)] // types/methods will be consumed in T4-T6 wiring
+
 use serde_json::json;
 
 #[derive(Debug, Clone, Default)]
@@ -54,11 +56,7 @@ impl PredicateSet {
                 AttrPred::Regex(..) => {}
             }
         }
-        if s.is_empty() {
-            "*".to_string()
-        } else {
-            s
-        }
+        if s.is_empty() { "*".to_string() } else { s }
     }
 
     /// Post-filter predicates (`attr_regex` + all text predicates) → a JS

--- a/crates/zendriver/src/query/predicate.rs
+++ b/crates/zendriver/src/query/predicate.rs
@@ -31,20 +31,17 @@ pub(crate) enum TextPred {
 /// Quote a value as a JSON string (`"v"`) — safe for both CSS attribute
 /// values and JS string literals (the selector is later JSON-embedded into
 /// the JS source, double-escaping correctly).
-#[allow(dead_code)] // consumed in T6 (predicate terminal wiring)
 fn q(v: &str) -> String {
     json!(v).to_string()
 }
 
 impl PredicateSet {
-    #[allow(dead_code)] // consumed in T6 (conflict guard at terminal)
     pub(crate) fn is_empty(&self) -> bool {
         self.tag.is_none() && self.attrs.is_empty() && self.texts.is_empty()
     }
 
     /// Structural predicates → a CSS selector. `attr_regex` + text predicates
     /// are post-filters and are NOT emitted here. Empty set → `"*"`.
-    #[allow(dead_code)] // consumed in T6 (resolve_predicate_many)
     pub(crate) fn to_css_selector(&self) -> String {
         let mut s = self.tag.clone().unwrap_or_default();
         for a in &self.attrs {
@@ -63,7 +60,6 @@ impl PredicateSet {
     /// Post-filter predicates (`attr_regex` + all text predicates) → a JS
     /// boolean expression over a bound `el`. Returns `"true"` when there are
     /// no post-filters (so the caller can always `.filter(el => <expr>)`).
-    #[allow(dead_code)] // consumed in T6 (resolve_predicate_many)
     pub(crate) fn to_js_filter(&self) -> String {
         const TXT: &str = r#"(el.innerText||el.textContent||"")"#;
         let mut checks: Vec<String> = Vec::new();

--- a/crates/zendriver/src/query/predicate.rs
+++ b/crates/zendriver/src/query/predicate.rs
@@ -2,8 +2,6 @@
 //! CSS selector (structural parts) + a JS boolean post-filter (regex/text).
 //! Pure — no CDP, fully unit-testable.
 
-#![allow(dead_code)] // types/methods will be consumed in T4-T6 wiring
-
 use serde_json::json;
 
 #[derive(Debug, Clone, Default)]
@@ -33,17 +31,20 @@ pub(crate) enum TextPred {
 /// Quote a value as a JSON string (`"v"`) — safe for both CSS attribute
 /// values and JS string literals (the selector is later JSON-embedded into
 /// the JS source, double-escaping correctly).
+#[allow(dead_code)] // consumed in T6 (predicate terminal wiring)
 fn q(v: &str) -> String {
     json!(v).to_string()
 }
 
 impl PredicateSet {
+    #[allow(dead_code)] // consumed in T6 (conflict guard at terminal)
     pub(crate) fn is_empty(&self) -> bool {
         self.tag.is_none() && self.attrs.is_empty() && self.texts.is_empty()
     }
 
     /// Structural predicates → a CSS selector. `attr_regex` + text predicates
     /// are post-filters and are NOT emitted here. Empty set → `"*"`.
+    #[allow(dead_code)] // consumed in T6 (resolve_predicate_many)
     pub(crate) fn to_css_selector(&self) -> String {
         let mut s = self.tag.clone().unwrap_or_default();
         for a in &self.attrs {
@@ -62,6 +63,7 @@ impl PredicateSet {
     /// Post-filter predicates (`attr_regex` + all text predicates) → a JS
     /// boolean expression over a bound `el`. Returns `"true"` when there are
     /// no post-filters (so the caller can always `.filter(el => <expr>)`).
+    #[allow(dead_code)] // consumed in T6 (resolve_predicate_many)
     pub(crate) fn to_js_filter(&self) -> String {
         const TXT: &str = r#"(el.innerText||el.textContent||"")"#;
         let mut checks: Vec<String> = Vec::new();

--- a/crates/zendriver/src/query/predicate.rs
+++ b/crates/zendriver/src/query/predicate.rs
@@ -1,0 +1,167 @@
+//! bs4-like combinable predicate matchers. A `PredicateSet` compiles to a
+//! CSS selector (structural parts) + a JS boolean post-filter (regex/text).
+//! Pure — no CDP, fully unit-testable.
+
+use serde_json::json;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PredicateSet {
+    pub(crate) tag: Option<String>,
+    pub(crate) attrs: Vec<AttrPred>,
+    pub(crate) texts: Vec<TextPred>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum AttrPred {
+    Exact(String, String),
+    Contains(String, String),
+    StartsWith(String, String),
+    EndsWith(String, String),
+    Has(String),
+    Regex(String, String), // (name, pattern) — JS post-filter, not CSS
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum TextPred {
+    Contains(String),
+    Equals(String),
+    Matches(String), // regex pattern
+}
+
+/// Quote a value as a JSON string (`"v"`) — safe for both CSS attribute
+/// values and JS string literals (the selector is later JSON-embedded into
+/// the JS source, double-escaping correctly).
+fn q(v: &str) -> String {
+    json!(v).to_string()
+}
+
+impl PredicateSet {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.tag.is_none() && self.attrs.is_empty() && self.texts.is_empty()
+    }
+
+    /// Structural predicates → a CSS selector. `attr_regex` + text predicates
+    /// are post-filters and are NOT emitted here. Empty set → `"*"`.
+    pub(crate) fn to_css_selector(&self) -> String {
+        let mut s = self.tag.clone().unwrap_or_default();
+        for a in &self.attrs {
+            match a {
+                AttrPred::Exact(n, v) => s.push_str(&format!("[{n}={}]", q(v))),
+                AttrPred::Contains(n, v) => s.push_str(&format!("[{n}*={}]", q(v))),
+                AttrPred::StartsWith(n, v) => s.push_str(&format!("[{n}^={}]", q(v))),
+                AttrPred::EndsWith(n, v) => s.push_str(&format!("[{n}$={}]", q(v))),
+                AttrPred::Has(n) => s.push_str(&format!("[{n}]")),
+                AttrPred::Regex(..) => {}
+            }
+        }
+        if s.is_empty() {
+            "*".to_string()
+        } else {
+            s
+        }
+    }
+
+    /// Post-filter predicates (`attr_regex` + all text predicates) → a JS
+    /// boolean expression over a bound `el`. Returns `"true"` when there are
+    /// no post-filters (so the caller can always `.filter(el => <expr>)`).
+    pub(crate) fn to_js_filter(&self) -> String {
+        const TXT: &str = r#"(el.innerText||el.textContent||"")"#;
+        let mut checks: Vec<String> = Vec::new();
+        for a in &self.attrs {
+            if let AttrPred::Regex(n, p) = a {
+                checks.push(format!(
+                    "new RegExp({}).test(el.getAttribute({})||\"\")",
+                    q(p),
+                    q(n)
+                ));
+            }
+        }
+        for t in &self.texts {
+            match t {
+                TextPred::Contains(s) => checks.push(format!("{TXT}.includes({})", q(s))),
+                TextPred::Equals(s) => checks.push(format!("{TXT}.trim()==={}", q(s))),
+                TextPred::Matches(p) => checks.push(format!("new RegExp({}).test({TXT})", q(p))),
+            }
+        }
+        if checks.is_empty() {
+            "true".to_string()
+        } else {
+            checks.join("&&")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_set_compiles_to_star() {
+        assert_eq!(PredicateSet::default().to_css_selector(), "*");
+    }
+
+    #[test]
+    fn tag_and_attrs_compile_to_css() {
+        let p = PredicateSet {
+            tag: Some("div".into()),
+            attrs: vec![
+                AttrPred::Exact("data-role".into(), "card".into()),
+                AttrPred::Contains("class".into(), "active".into()),
+                AttrPred::StartsWith("id".into(), "item-".into()),
+                AttrPred::EndsWith("data-x".into(), "-end".into()),
+                AttrPred::Has("data-ready".into()),
+            ],
+            texts: vec![],
+        };
+        assert_eq!(
+            p.to_css_selector(),
+            r#"div[data-role="card"][class*="active"][id^="item-"][data-x$="-end"][data-ready]"#
+        );
+    }
+
+    #[test]
+    fn attr_regex_is_not_in_css() {
+        let p = PredicateSet {
+            tag: Some("a".into()),
+            attrs: vec![AttrPred::Regex("href".into(), r"\d+".into())],
+            texts: vec![],
+        };
+        assert_eq!(p.to_css_selector(), "a");
+    }
+
+    #[test]
+    fn empty_filter_is_true() {
+        assert_eq!(PredicateSet::default().to_js_filter(), "true");
+    }
+
+    #[test]
+    fn regex_and_text_compile_to_js_checks() {
+        let p = PredicateSet {
+            tag: None,
+            attrs: vec![AttrPred::Regex("href".into(), r"\d+".into())],
+            texts: vec![
+                TextPred::Contains("Buy".into()),
+                TextPred::Equals("OK".into()),
+                TextPred::Matches(r"^\$".into()),
+            ],
+        };
+        let f = p.to_js_filter();
+        assert!(
+            f.contains(r#"new RegExp("\\d+").test(el.getAttribute("href")||"")"#),
+            "{f}"
+        );
+        assert!(
+            f.contains(r#"(el.innerText||el.textContent||"").includes("Buy")"#),
+            "{f}"
+        );
+        assert!(
+            f.contains(r#"(el.innerText||el.textContent||"").trim()==="OK""#),
+            "{f}"
+        );
+        assert!(
+            f.contains(r#"new RegExp("^\\$").test((el.innerText||el.textContent||""))"#),
+            "{f}"
+        );
+        assert!(f.contains("&&"), "checks are AND-joined: {f}");
+    }
+}

--- a/crates/zendriver/src/query/predicate.rs
+++ b/crates/zendriver/src/query/predicate.rs
@@ -42,6 +42,14 @@ impl PredicateSet {
 
     /// Structural predicates → a CSS selector. `attr_regex` + text predicates
     /// are post-filters and are NOT emitted here. Empty set → `"*"`.
+    ///
+    /// Attribute *values* are JSON-quoted via [`q`] so a quote/backslash
+    /// can't break the `[name="value"]` literal. Attribute *names* are
+    /// caller-supplied identifiers and are emitted verbatim — a malformed
+    /// name yields a malformed selector, which surfaces as a JS
+    /// `SyntaxError` from `querySelectorAll` (a `JsException`), never an
+    /// escape out of the JS string (the whole selector is JSON-embedded
+    /// before evaluation by the resolver).
     pub(crate) fn to_css_selector(&self) -> String {
         let mut s = self.tag.clone().unwrap_or_default();
         for a in &self.attrs {

--- a/crates/zendriver/src/query/selectors.rs
+++ b/crates/zendriver/src/query/selectors.rs
@@ -328,20 +328,6 @@ pub(crate) async fn resolve_predicate_many(
     extract_array_refs(session, &result["result"]).await
 }
 
-/// Resolve `pred` against `scope` and return the first match (or `None`).
-/// Thin `resolve_predicate_many(...).next()` so the dispatch and JS stay
-/// in one place.
-#[allow(dead_code)] // `.one()` uses resolve_predicate_many directly today; kept for symmetry with the css resolvers.
-pub(crate) async fn resolve_predicate_one(
-    scope: &QueryScope<'_>,
-    pred: &PredicateSet,
-) -> Result<Option<RemoteRef>> {
-    Ok(resolve_predicate_many(scope, pred)
-        .await?
-        .into_iter()
-        .next())
-}
-
 // ---------------------------------------------------------------------
 // XPath
 // ---------------------------------------------------------------------

--- a/crates/zendriver/src/query/selectors.rs
+++ b/crates/zendriver/src/query/selectors.rs
@@ -265,6 +265,84 @@ async fn resolve_css_many(scope: &QueryScope<'_>, selector: &str) -> Result<Vec<
 }
 
 // ---------------------------------------------------------------------
+// Predicate (bs4-like combinable matchers)
+// ---------------------------------------------------------------------
+//
+// A `PredicateSet` compiles to a CSS selector (`tag` + structural attrs)
+// plus a JS boolean post-filter (`attr_regex` + text predicates). The
+// terminal builds ONE `querySelectorAll(css).filter(el => <jsFilter>)`
+// per scope — exactly mirroring `resolve_css_many`'s scope dispatch
+// (`contextId` for frames, `this` for element subtrees) so predicates
+// cross frames the same way CSS does.
+
+use crate::query::predicate::PredicateSet;
+
+/// Resolve `pred` against `scope` and return every match in document
+/// order. Compiles to `Array.from((document|this).querySelectorAll(css))
+/// .filter(el => <jsFilter>)`, with the CSS selector JSON-embedded so a
+/// quote/backslash in an attribute value can't break out of the JS
+/// string literal. Empty `Vec` for no matches (not an error).
+pub(crate) async fn resolve_predicate_many(
+    scope: &QueryScope<'_>,
+    pred: &PredicateSet,
+) -> Result<Vec<RemoteRef>> {
+    let session = scope.session();
+    let ctx = scope.execution_context_id().await?;
+    let css = pred.to_css_selector();
+    let filter = pred.to_js_filter();
+    let result = match scope {
+        QueryScope::Tab(_) | QueryScope::Frame(_) => {
+            let expr = format!(
+                "Array.from(document.querySelectorAll({})).filter(function(el){{return {};}})",
+                json!(css),
+                filter,
+            );
+            let mut params = json!({
+                "expression": expr,
+                "returnByValue": false,
+            });
+            if let Some(id) = ctx {
+                params["contextId"] = json!(id);
+            }
+            session.call("Runtime.evaluate", params).await?
+        }
+        QueryScope::Element(el) => {
+            let object_id = el.remote_object_id_cloned().await?;
+            let func = format!(
+                "function(){{return Array.from(this.querySelectorAll({})).filter(function(el){{return {};}});}}",
+                json!(css),
+                filter,
+            );
+            session
+                .call(
+                    "Runtime.callFunctionOn",
+                    json!({
+                        "objectId": object_id,
+                        "functionDeclaration": func,
+                        "returnByValue": false,
+                    }),
+                )
+                .await?
+        }
+    };
+    extract_array_refs(session, &result["result"]).await
+}
+
+/// Resolve `pred` against `scope` and return the first match (or `None`).
+/// Thin `resolve_predicate_many(...).next()` so the dispatch and JS stay
+/// in one place.
+#[allow(dead_code)] // `.one()` uses resolve_predicate_many directly today; kept for symmetry with the css resolvers.
+pub(crate) async fn resolve_predicate_one(
+    scope: &QueryScope<'_>,
+    pred: &PredicateSet,
+) -> Result<Option<RemoteRef>> {
+    Ok(resolve_predicate_many(scope, pred)
+        .await?
+        .into_iter()
+        .next())
+}
+
+// ---------------------------------------------------------------------
 // XPath
 // ---------------------------------------------------------------------
 

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -2189,6 +2189,51 @@ impl Tab {
         crate::query::FindAllBuilder::new_for_tab(self)
     }
 
+    /// Find one element by CSS selector. Python-parity convenience for
+    /// `find().css(sel).one()`. For modifiers (frames / nth / timeout) use the
+    /// builder directly.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZendriverError::ElementNotFound`] if no element matches.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn ex() -> zendriver::Result<()> {
+    /// # let browser = zendriver::Browser::builder().launch().await?;
+    /// # let tab = browser.main_tab();
+    /// tab.goto("https://example.com").await?;
+    /// let h1 = tab.select("h1").await?;
+    /// # let _ = h1;
+    /// # Ok(()) }
+    /// ```
+    pub async fn select(&self, css: &str) -> crate::error::Result<crate::Element> {
+        self.find().css(css).one().await
+    }
+
+    /// Find all elements by CSS selector. Python-parity convenience for
+    /// `find_all().css(sel).many()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZendriverError::ElementNotFound`] if no elements match.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn ex() -> zendriver::Result<()> {
+    /// # let browser = zendriver::Browser::builder().launch().await?;
+    /// # let tab = browser.main_tab();
+    /// tab.goto("https://example.com").await?;
+    /// let links = tab.select_all("a").await?;
+    /// println!("{} links", links.len());
+    /// # Ok(()) }
+    /// ```
+    pub async fn select_all(&self, css: &str) -> crate::error::Result<Vec<crate::Element>> {
+        self.find_all().css(css).many().await
+    }
+
     /// Collect every linked URL on the page — the `href` of `[href]` elements
     /// (`<a>`, `<link>`, `<area>`, …) and the `src` of `[src]` elements
     /// (`<img>`, `<script>`, `<iframe>`, …).

--- a/crates/zendriver/tests/find_predicate_iframe.rs
+++ b/crates/zendriver/tests/find_predicate_iframe.rs
@@ -1,0 +1,217 @@
+//! Nested-iframe traversal + predicate finder integration tests.
+//!
+//! Gated behind the `integration-tests` feature; CI exercises these on the
+//! integration job where a real Chrome binary is available.
+//!
+//! The fixture/server pattern mirrors `integration_phase4.rs` exactly:
+//! wiremock serves HTML at `/`, and additional paths are mounted inline when
+//! a test needs multiple routes.
+
+#![cfg(feature = "integration-tests")]
+#![allow(clippy::panic, clippy::unwrap_used)]
+
+use std::time::Duration;
+
+use serial_test::serial;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+use zendriver::Browser;
+
+/// Spin up a mock HTTP server that returns `html` at `/`.
+async fn fixture_with_html(html: &str) -> MockServer {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(html.as_bytes().to_vec(), "text/html"),
+        )
+        .mount(&mock)
+        .await;
+    mock
+}
+
+// ---------------------------------------------------------------------------
+// T8: Nested-iframe traversal
+// ---------------------------------------------------------------------------
+
+/// Verify that `find().css(sel).include_frames().one()` crosses two levels of
+/// same-origin iframes to locate an element nested inside an iframe inside
+/// another iframe.
+///
+/// Fixture layout:
+///   `/` (outer) → embeds `/mid` via `<iframe src="/mid">`
+///   `/mid`      → embeds `/inner` via `<iframe src="/inner">`
+///   `/inner`    → contains `<div id="deep">found</div>`
+///
+/// All three pages are served from the same wiremock origin so Chrome keeps
+/// them same-origin (single CDP session, no OOPIF).
+#[tokio::test]
+#[serial]
+#[ignore] // headful; run on the integration job or locally with Chrome
+async fn include_frames_finds_element_two_iframes_deep() {
+    let mock = MockServer::start().await;
+
+    // Innermost page — holds the target element.
+    Mock::given(method("GET"))
+        .and(path("/inner"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            br#"<!doctype html><html><body><div id="deep">found</div></body></html>"#.to_vec(),
+            "text/html",
+        ))
+        .mount(&mock)
+        .await;
+
+    // Middle page — embeds inner.
+    Mock::given(method("GET"))
+        .and(path("/mid"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            br#"<!doctype html><html><body><iframe src="/inner"></iframe></body></html>"#.to_vec(),
+            "text/html",
+        ))
+        .mount(&mock)
+        .await;
+
+    // Outer page — embeds mid.
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            br#"<!doctype html><html><body><iframe id="mid" src="/mid"></iframe></body></html>"#
+                .to_vec(),
+            "text/html",
+        ))
+        .mount(&mock)
+        .await;
+
+    let browser = Browser::builder().headless(true).launch().await.unwrap();
+    let tab = browser.main_tab();
+    tab.goto(&mock.uri()).await.unwrap();
+    tab.wait_for_load().await.unwrap();
+
+    // Wait until at least two child frames register (mid + inner).
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let frames = tab.frames().await.unwrap();
+        let child_count = frames.iter().filter(|f| !f.is_main()).count();
+        if child_count >= 2 {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "expected at least 2 child frames within 10s; saw {} (total {})",
+                child_count,
+                frames.len()
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    let el = tab
+        .find()
+        .css("#deep")
+        .include_frames()
+        .one()
+        .await
+        .expect("element nested two iframes deep must be found with include_frames()");
+    assert_eq!(
+        el.inner_text().await.unwrap(),
+        "found",
+        "#deep should contain 'found'"
+    );
+
+    let all = tab
+        .find_all()
+        .css("#deep")
+        .include_frames()
+        .many()
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 1, "exactly one #deep element across all frames");
+
+    browser.close().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// T9: Predicate finds + select_all + mixing guard
+// ---------------------------------------------------------------------------
+
+/// Find an element using a combination of tag, attr, attr_regex, and text
+/// predicates. Fixture: `<button class="primary active" data-id="4821">Buy now</button>`.
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn predicate_finds_by_tag_attr_text() {
+    let mock = fixture_with_html(
+        r#"<!doctype html><html><body>
+          <button class="primary active" data-id="4821">Buy now</button>
+        </body></html>"#,
+    )
+    .await;
+    let browser = Browser::builder().headless(true).launch().await.unwrap();
+    let tab = browser.main_tab();
+    tab.goto(&mock.uri()).await.unwrap();
+    tab.wait_for_load().await.unwrap();
+
+    let el = tab
+        .find()
+        .tag("button")
+        .attr_contains("class", "active")
+        .attr_regex("data-id", r"^\d{4}$")
+        .containing_text("Buy")
+        .one()
+        .await
+        .unwrap();
+    assert!(
+        el.inner_text().await.unwrap().contains("Buy"),
+        "button text should contain 'Buy'"
+    );
+
+    browser.close().await.unwrap();
+}
+
+/// Verify that `select_all` returns all matching elements.
+/// Fixture: a `<ul>` with exactly 3 `<li>` items.
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn select_all_returns_all_matches() {
+    let mock = fixture_with_html(
+        r#"<!doctype html><html><body>
+          <ul id="list">
+            <li>one</li>
+            <li>two</li>
+            <li>three</li>
+          </ul>
+        </body></html>"#,
+    )
+    .await;
+    let browser = Browser::builder().headless(true).launch().await.unwrap();
+    let tab = browser.main_tab();
+    tab.goto(&mock.uri()).await.unwrap();
+    tab.wait_for_load().await.unwrap();
+
+    let items = tab.select_all("ul li").await.unwrap();
+    assert_eq!(items.len(), 3, "expected 3 <li> elements");
+
+    browser.close().await.unwrap();
+}
+
+/// Mixing `.css()` and a predicate method on the same query must return
+/// `Err(ZendriverError::ConflictingSelectors)`.
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn mixing_predicate_and_css_errors() {
+    let mock = fixture_with_html(r#"<!doctype html><html><body><div>x</div></body></html>"#).await;
+    let browser = Browser::builder().headless(true).launch().await.unwrap();
+    let tab = browser.main_tab();
+    tab.goto(&mock.uri()).await.unwrap();
+    tab.wait_for_load().await.unwrap();
+
+    let err = tab.find().css("div").tag("span").one().await.unwrap_err();
+    assert!(
+        matches!(err, zendriver::ZendriverError::ConflictingSelectors),
+        "expected ConflictingSelectors, got {err:?}"
+    );
+
+    browser.close().await.unwrap();
+}

--- a/docs/book/src/error-reference.md
+++ b/docs/book/src/error-reference.md
@@ -20,6 +20,7 @@ new variants may land in minor releases.
 | `Transport(TransportError)` | WebSocket failure (Chrome crashed, socket reset). | Retry the operation; if recurring, check Chrome's stderr for crash dumps. |
 | `Cdp { code, message, data }` | Chrome returned a CDP RPC error. | Inspect `message` — `Invalid params` usually means a stale `RemoteObjectId` or wrong type signature. |
 | `ElementNotFound { selector }` | Query selector matched zero elements within the timeout. | Confirm the page actually rendered the element (`tab.wait_for_load()` / `wait_for_idle()`); check the selector with `tab.find().css(...).count()`. |
+| `ConflictingSelectors` | A query mixed a single-selector method (`.css`/`.xpath`/`.text`/`.role`) with bs4-like predicate methods (`.tag`/`.attr*`/`.containing_text`/…). | Use one selector style per query — either a single selector *or* combinable predicates, not both. |
 | `Timeout(Duration)` | Generic operation timeout. | Increase the timeout via the builder, or address the underlying slow operation. |
 | `Navigation(String)` | Page navigation failed (DNS, refused, crashed) **or** an in-flight call lost its context to a navigation. | Check the URL / DNS / network; for the context-lost case, sequence the action after `tab.wait_for_load()`. |
 | `JsException(String)` | A JS expression in `evaluate()` raised an exception. | Wrap the JS in `try { ... } catch (e) { return null; }` if you want a soft failure; otherwise fix the JS. |

--- a/docs/book/src/quickstart.md
+++ b/docs/book/src/quickstart.md
@@ -97,6 +97,12 @@ chain encodes both the selector and any modifiers:
 - `.xpath("//div[@id='main']")` — XPath escape hatch.
 - `.role(AriaRole::Button)` — ARIA-role + accessible-name match
   (Playwright-style).
+- `.tag("button").attr_contains("class", "primary").containing_text("Buy")`
+  — bs4-like combinable *predicate* finders (`tag`, `attr`, `attr_contains`,
+  `attr_starts_with`, `attr_ends_with`, `has_attr`, `attr_regex`,
+  `containing_text`, `text_equals`, `text_matches`), all AND-ed together.
+  Predicate methods can't be mixed with the single-selector methods above on
+  one query (doing so errors with `ConflictingSelectors`).
 - `.nth(2)` — pick the 2nd match.
 - `.visible_only()` — skip `display:none` / zero-bbox elements.
 - `.timeout(Duration::from_secs(5))` — override the default 30s wait.
@@ -105,6 +111,11 @@ A terminal method (`one`, `first`, `many`, `many_or_empty`, `count`,
 `exists`) consumes the builder and dispatches. `.one()` waits for
 exactly one match — errors with `ElementNotUnique` if there are zero or
 more than one — making it perfect for queries that should be deterministic.
+
+For the common CSS case, `tab.select("h1")` / `tab.select_all("nav a")` are
+Python-parity convenience aliases for `find().css(...).one()` /
+`find_all().css(...).many()`. The same pair exists on `Frame` and `Element`
+(`Element::select` scopes to that element's subtree).
 
 [`Tab::find()`]: https://docs.rs/zendriver/latest/zendriver/struct.Tab.html#method.find
 [`FindBuilder`]: https://docs.rs/zendriver/latest/zendriver/struct.FindBuilder.html

--- a/docs/superpowers/plans/2026-06-02-find-dom-predicates-iframe.md
+++ b/docs/superpowers/plans/2026-06-02-find-dom-predicates-iframe.md
@@ -1,0 +1,727 @@
+# Find/DOM — Predicate Builder + Nested-iframe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add bs4-like combinable predicate matchers (tag/attr/text) to `FindBuilder`/`FindAllBuilder`, plus `select`/`select_all` aliases, and verify+lock nested-iframe traversal.
+
+**Architecture:** Predicates accumulate in a new `PredicateSet` (pure, unit-tested compilation to a CSS selector + a JS post-filter). The terminal compiles to ONE `Runtime.evaluate`/`callFunctionOn` per scope, reusing the existing `QueryScope` dispatch + `execution_context_id` (so it crosses frames) + `extract_array_refs`. Single-selector vs predicate mixing is a runtime error at the terminal (1A). Nested-iframe is verify-first: a test drives whether any fix is needed.
+
+**Tech Stack:** Rust, `serde_json::json!` for safe JS-string embedding, CDP `Runtime.evaluate`/`callFunctionOn`, existing `QueryScope`/`RemoteRef`/`extract_array_refs` helpers in `query/selectors.rs`.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-find-dom-predicates-iframe-design.md`
+
+---
+
+## File Structure
+
+- **Create** `crates/zendriver/src/query/predicate.rs` — `PredicateSet`, `AttrPred`, `TextPred`, `to_css_selector()`, `to_js_filter()`. Pure, no I/O, fully unit-tested.
+- **Modify** `crates/zendriver/src/query/mod.rs` — add `predicates: PredicateSet` field + a `predicate_methods!` macro (10 methods) invoked on both builders; terminal conflict check + predicate dispatch.
+- **Modify** `crates/zendriver/src/query/selectors.rs` — `resolve_predicate_one` / `resolve_predicate_many`.
+- **Modify** `crates/zendriver/src/error.rs` — `ConflictingSelectors` variant.
+- **Modify** `crates/zendriver/src/tab.rs`, `crates/zendriver/src/frame/mod.rs`, `crates/zendriver/src/element/mod.rs` — `select` / `select_all`.
+- **Create** `crates/zendriver/tests/find_predicate_iframe.rs` — gated headful integration tests.
+- **Modify** `CHANGELOG.md`.
+
+---
+
+## Task 1: `PredicateSet` types + CSS compilation
+
+**Files:**
+- Create: `crates/zendriver/src/query/predicate.rs`
+- Modify: `crates/zendriver/src/query/mod.rs` (add `pub(crate) mod predicate;`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `crates/zendriver/src/query/predicate.rs`:
+```rust
+//! bs4-like combinable predicate matchers. A `PredicateSet` compiles to a
+//! CSS selector (structural parts) + a JS boolean post-filter (regex/text).
+//! Pure — no CDP, fully unit-testable.
+
+use serde_json::json;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PredicateSet {
+    pub(crate) tag: Option<String>,
+    pub(crate) attrs: Vec<AttrPred>,
+    pub(crate) texts: Vec<TextPred>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum AttrPred {
+    Exact(String, String),
+    Contains(String, String),
+    StartsWith(String, String),
+    EndsWith(String, String),
+    Has(String),
+    Regex(String, String), // (name, pattern) — JS post-filter, not CSS
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum TextPred {
+    Contains(String),
+    Equals(String),
+    Matches(String), // regex pattern
+}
+
+/// Quote a value as a JSON string (`"v"`) — safe for both CSS attribute
+/// values and JS string literals (the selector is later JSON-embedded into
+/// the JS source, double-escaping correctly).
+fn q(v: &str) -> String {
+    json!(v).to_string()
+}
+
+impl PredicateSet {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.tag.is_none() && self.attrs.is_empty() && self.texts.is_empty()
+    }
+
+    /// Structural predicates → a CSS selector. `attr_regex` + text predicates
+    /// are post-filters and are NOT emitted here. Empty set → `"*"`.
+    pub(crate) fn to_css_selector(&self) -> String {
+        let mut s = self.tag.clone().unwrap_or_default();
+        for a in &self.attrs {
+            match a {
+                AttrPred::Exact(n, v) => s.push_str(&format!("[{n}={}]", q(v))),
+                AttrPred::Contains(n, v) => s.push_str(&format!("[{n}*={}]", q(v))),
+                AttrPred::StartsWith(n, v) => s.push_str(&format!("[{n}^={}]", q(v))),
+                AttrPred::EndsWith(n, v) => s.push_str(&format!("[{n}$={}]", q(v))),
+                AttrPred::Has(n) => s.push_str(&format!("[{n}]")),
+                AttrPred::Regex(..) => {}
+            }
+        }
+        if s.is_empty() { "*".to_string() } else { s }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_set_compiles_to_star() {
+        assert_eq!(PredicateSet::default().to_css_selector(), "*");
+    }
+
+    #[test]
+    fn tag_and_attrs_compile_to_css() {
+        let p = PredicateSet {
+            tag: Some("div".into()),
+            attrs: vec![
+                AttrPred::Exact("data-role".into(), "card".into()),
+                AttrPred::Contains("class".into(), "active".into()),
+                AttrPred::StartsWith("id".into(), "item-".into()),
+                AttrPred::EndsWith("data-x".into(), "-end".into()),
+                AttrPred::Has("data-ready".into()),
+            ],
+            texts: vec![],
+        };
+        assert_eq!(
+            p.to_css_selector(),
+            r#"div[data-role="card"][class*="active"][id^="item-"][data-x$="-end"][data-ready]"#
+        );
+    }
+
+    #[test]
+    fn attr_regex_is_not_in_css() {
+        let p = PredicateSet {
+            tag: Some("a".into()),
+            attrs: vec![AttrPred::Regex("href".into(), r"\d+".into())],
+            texts: vec![],
+        };
+        assert_eq!(p.to_css_selector(), "a");
+    }
+}
+```
+
+Add to `crates/zendriver/src/query/mod.rs` near the other `pub mod` lines (around line 29):
+```rust
+pub(crate) mod predicate;
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cargo test -p zendriver predicate::tests`
+Expected: 3 passed.
+
+- [ ] **Step 3: Commit**
+```bash
+git add crates/zendriver/src/query/predicate.rs crates/zendriver/src/query/mod.rs
+git commit -m "feat(query): PredicateSet types + CSS compilation"
+```
+
+---
+
+## Task 2: JS post-filter compilation
+
+**Files:**
+- Modify: `crates/zendriver/src/query/predicate.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `predicate.rs` `tests` mod:
+```rust
+#[test]
+fn empty_filter_is_true() {
+    assert_eq!(PredicateSet::default().to_js_filter(), "true");
+}
+
+#[test]
+fn regex_and_text_compile_to_js_checks() {
+    let p = PredicateSet {
+        tag: None,
+        attrs: vec![AttrPred::Regex("href".into(), r"\d+".into())],
+        texts: vec![
+            TextPred::Contains("Buy".into()),
+            TextPred::Equals("OK".into()),
+            TextPred::Matches(r"^\$".into()),
+        ],
+    };
+    let f = p.to_js_filter();
+    assert!(f.contains(r#"new RegExp("\\d+").test(el.getAttribute("href")||"")"#), "{f}");
+    assert!(f.contains(r#"(el.innerText||el.textContent||"").includes("Buy")"#), "{f}");
+    assert!(f.contains(r#"(el.innerText||el.textContent||"").trim()==="OK""#), "{f}");
+    assert!(f.contains(r#"new RegExp("^\\$").test((el.innerText||el.textContent||""))"#), "{f}");
+    assert!(f.contains("&&"), "checks are AND-joined: {f}");
+}
+```
+
+- [ ] **Step 2: Implement**
+
+Add to `impl PredicateSet` in `predicate.rs`:
+```rust
+    /// Post-filter predicates (`attr_regex` + all text predicates) → a JS
+    /// boolean expression over a bound `el`. Returns `"true"` when there are
+    /// no post-filters (so the caller can always `.filter(el => <expr>)`).
+    pub(crate) fn to_js_filter(&self) -> String {
+        const TXT: &str = r#"(el.innerText||el.textContent||"")"#;
+        let mut checks: Vec<String> = Vec::new();
+        for a in &self.attrs {
+            if let AttrPred::Regex(n, p) = a {
+                checks.push(format!(
+                    "new RegExp({}).test(el.getAttribute({})||\"\")",
+                    q(p), q(n)
+                ));
+            }
+        }
+        for t in &self.texts {
+            match t {
+                TextPred::Contains(s) => checks.push(format!("{TXT}.includes({})", q(s))),
+                TextPred::Equals(s) => checks.push(format!("{TXT}.trim()==={}", q(s))),
+                TextPred::Matches(p) => checks.push(format!("new RegExp({}).test({TXT})", q(p))),
+            }
+        }
+        if checks.is_empty() { "true".to_string() } else { checks.join("&&") }
+    }
+```
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test -p zendriver predicate::tests`
+Expected: 5 passed.
+```bash
+git add crates/zendriver/src/query/predicate.rs
+git commit -m "feat(query): predicate JS post-filter compilation"
+```
+
+---
+
+## Task 3: `ConflictingSelectors` error variant
+
+**Files:**
+- Modify: `crates/zendriver/src/error.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crates/zendriver/src/error.rs` (in or after the existing `#[cfg(test)]` mod; if none, add one):
+```rust
+#[test]
+fn conflicting_selectors_message() {
+    let e = ZendriverError::ConflictingSelectors;
+    assert!(e.to_string().contains("predicate"));
+    assert!(e.to_string().contains("css"));
+}
+```
+
+- [ ] **Step 2: Implement**
+
+Add a variant to `pub enum ZendriverError` (after the `ElementNotFound` variant near line 68):
+```rust
+    /// A predicate method (`.tag`/`.attr`/`.containing_text`/…) was combined
+    /// with a single-selector method (`.css`/`.xpath`/`.text`/`.role`) on one
+    /// query. Use one selector style per query.
+    #[error("predicate methods (.tag/.attr/…) cannot be combined with .css()/.xpath()/.text()/.role(); use one selector style per query")]
+    ConflictingSelectors,
+```
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test -p zendriver conflicting_selectors_message`
+Expected: PASS.
+```bash
+git add crates/zendriver/src/error.rs
+git commit -m "feat(error): ConflictingSelectors variant"
+```
+
+---
+
+## Task 4: Predicate methods on `FindBuilder` (+ shared macro)
+
+**Files:**
+- Modify: `crates/zendriver/src/query/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a unit test to `mod.rs` (in a `#[cfg(test)] mod predicate_builder_tests`):
+```rust
+#[cfg(test)]
+mod predicate_builder_tests {
+    use super::*;
+    use crate::query::predicate::{AttrPred, TextPred};
+
+    // A builder with no Tab is fine for inspecting accumulated predicates;
+    // we never call a terminal here.
+    fn bare() -> FindBuilder<'static> {
+        FindBuilder {
+            tab: None, element: None, frame: None,
+            selector: None, predicates: Default::default(),
+            timeout: DEFAULT_TIMEOUT, nth: None, visible_only: false,
+            in_frame: None, include_frames: false, best_match: false,
+        }
+    }
+
+    #[test]
+    fn predicate_methods_accumulate() {
+        let b = bare().tag("div").attr("data-x", "y").attr_contains("class", "z")
+            .has_attr("ready").attr_regex("id", r"\d+").containing_text("Buy")
+            .text_equals("OK").text_matches(r"^\$");
+        assert_eq!(b.predicates.tag.as_deref(), Some("div"));
+        assert_eq!(b.predicates.attrs.len(), 4);
+        assert_eq!(b.predicates.texts.len(), 3);
+        assert!(matches!(b.predicates.attrs[0], AttrPred::Exact(_, _)));
+        assert!(matches!(b.predicates.texts[2], TextPred::Matches(_)));
+    }
+}
+```
+
+- [ ] **Step 2: Implement**
+
+In `mod.rs`: add the field to the `FindBuilder` struct (after `selector`):
+```rust
+    pub(crate) selector: Option<SelectorKind>,
+    /// Accumulated bs4-like predicates. Mutually exclusive with `selector`
+    /// (enforced at the terminal — see `one`/`one_or_none`).
+    pub(crate) predicates: crate::query::predicate::PredicateSet,
+```
+Add `predicates: Default::default(),` to all three constructors (`new_for_tab`, `new_for_element`, `new_for_frame`).
+
+Define the shared macro once (top of `mod.rs`, after imports) — internal code-gen, not a user DSL:
+```rust
+use crate::query::predicate::{AttrPred, PredicateSet, TextPred};
+
+/// Generates the 10 predicate setters shared by FindBuilder + FindAllBuilder.
+/// Both structs have a `predicates: PredicateSet` field.
+macro_rules! predicate_methods {
+    () => {
+        /// Match by tag name (compiles into the CSS selector). Predicate mode.
+        #[must_use] pub fn tag(mut self, name: impl Into<String>) -> Self {
+            self.predicates.tag = Some(name.into()); self
+        }
+        /// Match an exact attribute value `[name="value"]`.
+        #[must_use] pub fn attr(mut self, name: &str, value: &str) -> Self {
+            self.predicates.attrs.push(AttrPred::Exact(name.into(), value.into())); self
+        }
+        /// Match a substring of an attribute value `[name*="sub"]`.
+        #[must_use] pub fn attr_contains(mut self, name: &str, sub: &str) -> Self {
+            self.predicates.attrs.push(AttrPred::Contains(name.into(), sub.into())); self
+        }
+        /// Match an attribute value prefix `[name^="pre"]`.
+        #[must_use] pub fn attr_starts_with(mut self, name: &str, pre: &str) -> Self {
+            self.predicates.attrs.push(AttrPred::StartsWith(name.into(), pre.into())); self
+        }
+        /// Match an attribute value suffix `[name$="suf"]`.
+        #[must_use] pub fn attr_ends_with(mut self, name: &str, suf: &str) -> Self {
+            self.predicates.attrs.push(AttrPred::EndsWith(name.into(), suf.into())); self
+        }
+        /// Require the attribute be present `[name]`.
+        #[must_use] pub fn has_attr(mut self, name: &str) -> Self {
+            self.predicates.attrs.push(AttrPred::Has(name.into())); self
+        }
+        /// Match an attribute value against a JS regex (post-filter).
+        #[must_use] pub fn attr_regex(mut self, name: &str, pattern: &str) -> Self {
+            self.predicates.attrs.push(AttrPred::Regex(name.into(), pattern.into())); self
+        }
+        /// Match elements whose text contains `sub` (post-filter).
+        #[must_use] pub fn containing_text(mut self, sub: &str) -> Self {
+            self.predicates.texts.push(TextPred::Contains(sub.into())); self
+        }
+        /// Match elements whose trimmed text equals `exact` (post-filter).
+        #[must_use] pub fn text_equals(mut self, exact: &str) -> Self {
+            self.predicates.texts.push(TextPred::Equals(exact.into())); self
+        }
+        /// Match elements whose text matches a JS regex `pattern` (post-filter).
+        #[must_use] pub fn text_matches(mut self, pattern: &str) -> Self {
+            self.predicates.texts.push(TextPred::Matches(pattern.into())); self
+        }
+    };
+}
+```
+Invoke it inside `impl<'scope> FindBuilder<'scope>` (alongside the existing selector methods):
+```rust
+impl<'scope> FindBuilder<'scope> {
+    predicate_methods!{}
+    // ... existing methods ...
+}
+```
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test -p zendriver predicate_builder_tests`
+Expected: PASS.
+```bash
+git add crates/zendriver/src/query/mod.rs
+git commit -m "feat(query): predicate methods on FindBuilder"
+```
+
+---
+
+## Task 5: Predicate methods on `FindAllBuilder`
+
+**Files:**
+- Modify: `crates/zendriver/src/query/mod.rs`
+
+- [ ] **Step 1: Implement (the macro makes this mechanical)**
+
+Add the same field to the `FindAllBuilder` struct:
+```rust
+    pub(crate) predicates: crate::query::predicate::PredicateSet,
+```
+Add `predicates: Default::default(),` to its three constructors (`new_for_tab`/`new_for_element`/`new_for_frame` for `FindAllBuilder`).
+Invoke the macro in its impl:
+```rust
+impl<'scope> FindAllBuilder<'scope> {
+    predicate_methods!{}
+    // ... existing methods ...
+}
+```
+
+- [ ] **Step 2: Write + run the test**
+
+Add to `predicate_builder_tests`:
+```rust
+fn bare_all() -> FindAllBuilder<'static> {
+    FindAllBuilder {
+        tab: None, element: None, frame: None,
+        selector: None, predicates: Default::default(),
+        timeout: DEFAULT_TIMEOUT, visible_only: false,
+        in_frame: None, include_frames: false, best_match: false,
+    }
+}
+#[test]
+fn find_all_predicates_accumulate() {
+    let b = bare_all().tag("a").has_attr("href").containing_text("Next");
+    assert_eq!(b.predicates.tag.as_deref(), Some("a"));
+    assert_eq!(b.predicates.attrs.len(), 1);
+    assert_eq!(b.predicates.texts.len(), 1);
+}
+```
+> Adapt `bare_all()`'s field list to the real `FindAllBuilder` struct fields (it lacks `nth`; confirm against mod.rs:697+).
+
+Run: `cargo test -p zendriver predicate_builder_tests`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+```bash
+git add crates/zendriver/src/query/mod.rs
+git commit -m "feat(query): predicate methods on FindAllBuilder"
+```
+
+---
+
+## Task 6: Predicate resolution + terminal wiring (conflict guard)
+
+**Files:**
+- Modify: `crates/zendriver/src/query/selectors.rs` (add resolvers)
+- Modify: `crates/zendriver/src/query/mod.rs` (terminal dispatch + conflict check)
+
+- [ ] **Step 1: Implement the resolvers** in `selectors.rs` (model on `resolve_css_many`, selectors.rs:232):
+```rust
+use crate::query::predicate::PredicateSet;
+
+pub(crate) async fn resolve_predicate_many(
+    scope: &QueryScope<'_>,
+    pred: &PredicateSet,
+) -> Result<Vec<RemoteRef>> {
+    let session = scope.session();
+    let ctx = scope.execution_context_id().await?;
+    let css = pred.to_css_selector();
+    let filter = pred.to_js_filter();
+    let result = match scope {
+        QueryScope::Tab(_) | QueryScope::Frame(_) => {
+            let expr = format!(
+                "Array.from(document.querySelectorAll({})).filter(function(el){{return {};}})",
+                json!(css), filter
+            );
+            let mut params = json!({ "expression": expr, "returnByValue": false });
+            if let Some(id) = ctx { params["contextId"] = json!(id); }
+            session.call("Runtime.evaluate", params).await?
+        }
+        QueryScope::Element(el) => {
+            let object_id = el.remote_object_id_cloned().await?;
+            let func = format!(
+                "function(){{return Array.from(this.querySelectorAll({})).filter(function(el){{return {};}});}}",
+                json!(css), filter
+            );
+            session.call("Runtime.callFunctionOn", json!({
+                "objectId": object_id,
+                "functionDeclaration": func,
+                "returnByValue": false,
+            })).await?
+        }
+    };
+    extract_array_refs(session, &result["result"]).await
+}
+
+pub(crate) async fn resolve_predicate_one(
+    scope: &QueryScope<'_>,
+    pred: &PredicateSet,
+) -> Result<Option<RemoteRef>> {
+    Ok(resolve_predicate_many(scope, pred).await?.into_iter().next())
+}
+```
+> Confirm `extract_array_refs` + `remote_object_id_cloned` signatures match the css resolver's usage (selectors.rs:264, :214). Reuse verbatim.
+
+- [ ] **Step 2: Wire the terminal + conflict guard** in `mod.rs`. In `FindBuilder::one_or_none` (the resolution core; find the existing body that builds a `QueryScope` and calls `selector.resolve_one(...)`), add at the top, before selector resolution:
+```rust
+        if self.selector.is_some() && !self.predicates.is_empty() {
+            return Err(ZendriverError::ConflictingSelectors);
+        }
+        if !self.predicates.is_empty() {
+            // predicate path — mirror the selector path's scope construction,
+            // nth/visible_only/timeout handling, and Element synthesis.
+            // (Reuse the same QueryScope + poll loop; swap resolve_one for
+            //  crate::query::selectors::resolve_predicate_one(&scope, &self.predicates).)
+        }
+```
+> The existing `one_or_none`/`one` already build a `QueryScope`, run a timeout poll loop, apply `nth`/`visible_only`, and synthesize `Element`s from `RemoteRef`s. Refactor that resolution body so it accepts EITHER `selector.resolve_one`/`resolve_many` OR `resolve_predicate_one`/`many` — e.g. extract the candidate-fetch into a closure/match on `(selector, predicates)`. Do the SAME in `include_frames` fan-out (`one_across_frames`) so predicates work across frames. Keep `nth`/`visible_only`/`best_match`/`timeout` applied identically.
+
+- [ ] **Step 3: Write the conflict test** (`predicate_builder_tests`, needs a Tab — use the existing mock/integration harness if a unit Tab isn't constructible; otherwise assert via a thin helper that calls the guard). Minimal guard unit test that doesn't need a browser:
+```rust
+// If a no-browser Tab can't be built, assert the guard by calling the
+// extracted check function directly:
+#[test]
+fn mixing_selector_and_predicate_is_conflict() {
+    let mut b = bare();
+    b.selector = Some(SelectorKind::Css("div".into()));
+    b = b.tag("span");
+    assert!(b.selector.is_some() && !b.predicates.is_empty());
+    // resolve_conflict(&b) -> Err(ConflictingSelectors)   (extract this helper)
+}
+```
+> Prefer extracting a tiny `fn has_conflict(sel: &Option<SelectorKind>, pred: &PredicateSet) -> bool` so it's unit-testable without a Tab; assert it returns true here and false for either-alone.
+
+- [ ] **Step 4: Run + commit**
+
+Run: `cargo test -p zendriver query::` and `cargo build -p zendriver`
+Expected: green (unit + build).
+```bash
+git add crates/zendriver/src/query/
+git commit -m "feat(query): predicate resolution + mixing guard at terminal"
+```
+
+---
+
+## Task 7: `select` / `select_all` aliases
+
+**Files:**
+- Modify: `crates/zendriver/src/tab.rs`, `crates/zendriver/src/frame/mod.rs`, `crates/zendriver/src/element/mod.rs`
+
+- [ ] **Step 1: Implement** (Tab shown; Frame + Element are identical with their own `find`/`find_all`):
+```rust
+// in impl Tab (and impl Frame, impl Element)
+/// Find one element by CSS selector. Python-parity convenience for
+/// `find().css(sel).one()`. For modifiers (frames/nth/timeout) use the builder.
+pub async fn select(&self, css: &str) -> Result<Element> {
+    self.find().css(css).one().await
+}
+/// Find all elements by CSS selector. Python-parity convenience for
+/// `find_all().css(sel).many()`.
+pub async fn select_all(&self, css: &str) -> Result<Vec<Element>> {
+    self.find_all().css(css).many().await
+}
+```
+> Confirm each type exposes `find()`/`find_all()` returning the builders (Tab:2166, Frame/mod.rs:458, Element traversal.rs:88). For `Element`, `select_all` scopes to its subtree (correct).
+
+- [ ] **Step 2: Build + a doctest**
+
+Add a `no_run` doctest on `Tab::select` mirroring the existing doctest style (module example at mod.rs:6). Run:
+`cargo test -p zendriver --doc select`
+Expected: compiles/passes.
+
+- [ ] **Step 3: Commit**
+```bash
+git add crates/zendriver/src/tab.rs crates/zendriver/src/frame/mod.rs crates/zendriver/src/element/mod.rs
+git commit -m "feat: select/select_all CSS aliases on Tab/Frame/Element"
+```
+
+---
+
+## Task 8: Nested-iframe verify (TDD) — fix only if red
+
+**Files:**
+- Create: `crates/zendriver/tests/find_predicate_iframe.rs`
+
+- [ ] **Step 1: Write the iframe-in-iframe test** (gate exactly like `crates/zendriver/tests/integration_phase4.rs` — copy its `#![cfg(feature = "integration-tests")]` / `#[tokio::test]` / `#[serial]` / serving pattern):
+```rust
+// Serve: outer.html embeds mid.html (iframe) which embeds inner.html (iframe)
+// containing <div id="deep">found</div>. Use the same local-server helper the
+// other integration tests use (see integration_phase4.rs for the fixture/server).
+#[tokio::test]
+#[ignore] // headful; run on the integration job
+async fn include_frames_finds_element_two_iframes_deep() {
+    // ... launch, goto outer, wait for frames ...
+    let el = tab.find().css("#deep").include_frames().one().await
+        .expect("element nested two iframes deep must be found");
+    assert_eq!(el.text().await.unwrap(), "found");
+
+    let all = tab.find_all().css("#deep").include_frames().many().await.unwrap();
+    assert_eq!(all.len(), 1);
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test -p zendriver --features integration-tests --test find_predicate_iframe -- --ignored include_frames_finds_element_two`
+- **PASS** → architecture already crosses nested frames. Skip to Step 4 (lock + commit).
+- **FAIL** → Step 3.
+
+- [ ] **Step 3 (only if red): fix the gap**
+
+Inspect frame registration: `crates/zendriver/src/tab.rs` (frame registry / `Tab::frames`) + the `Page.frameAttached` / frame-tree handler. Ensure frames are registered at ALL depths (a nested iframe's `frameAttached` fires with a `parentId`; confirm the handler adds it). If same-process nested frames are NOT separate query scopes, add the fallback content_document walk to `resolve_css_*`/`resolve_predicate_*`: walk `document.querySelectorAll('iframe,frame')`, recurse into each `el.contentDocument` (guard `=== null` for cross-origin), collect matches. Add a unit test for the walk's null-guard if you add JS.
+
+- [ ] **Step 4: Commit**
+```bash
+git add crates/zendriver/tests/find_predicate_iframe.rs  # + any fix
+git commit -m "test: nested-iframe include_frames traversal (verify + lock)"
+```
+
+---
+
+## Task 9: Predicate + select_all integration tests
+
+**Files:**
+- Modify: `crates/zendriver/tests/find_predicate_iframe.rs`
+
+- [ ] **Step 1: Add tests** against a fixture page with known elements:
+```rust
+#[tokio::test]
+#[ignore]
+async fn predicate_finds_by_tag_attr_text() {
+    // fixture: <button class="primary active" data-id="4821">Buy now</button>
+    let el = tab.find()
+        .tag("button").attr_contains("class", "active")
+        .attr_regex("data-id", r"^\d{4}$").containing_text("Buy")
+        .one().await.unwrap();
+    assert!(el.text().await.unwrap().contains("Buy"));
+}
+
+#[tokio::test]
+#[ignore]
+async fn select_all_returns_all_matches() {
+    let items = tab.select_all("ul li").await.unwrap();
+    assert_eq!(items.len(), 3);
+}
+
+#[tokio::test]
+#[ignore]
+async fn mixing_predicate_and_css_errors() {
+    let err = tab.find().css("div").tag("span").one().await.unwrap_err();
+    assert!(matches!(err, zendriver::ZendriverError::ConflictingSelectors));
+}
+```
+> Reuse the fixture/server helper from the iframe test. Adapt `el.text()` to the real accessor.
+
+- [ ] **Step 2: Compile-check (defer headful run to CI)**
+
+Run: `cargo test -p zendriver --features integration-tests --test find_predicate_iframe --no-run`
+Expected: compiles.
+
+- [ ] **Step 3: Commit**
+```bash
+git add crates/zendriver/tests/find_predicate_iframe.rs
+git commit -m "test: predicate finds + select_all + mixing-guard integration"
+```
+
+---
+
+## Task 10: Docs + CHANGELOG
+
+**Files:**
+- Modify: `crates/zendriver/src/query/mod.rs` (module docs), `CHANGELOG.md`
+
+- [ ] **Step 1: Update module docs** — extend the `query/mod.rs` header doc (lines 22-27) to document predicate mode + the mixing rule:
+```rust
+//! Predicate mode (combinable, AND-ed): `.tag`, `.attr`, `.attr_contains`,
+//! `.attr_starts_with`, `.attr_ends_with`, `.has_attr`, `.attr_regex`,
+//! `.containing_text`, `.text_equals`, `.text_matches`. Predicate methods
+//! cannot be combined with the single-selector kinds (`.css`/`.xpath`/
+//! `.text*`/`.role*`) — doing so errors at the terminal with
+//! `ConflictingSelectors`.
+```
+Add a `no_run` doctest showing a predicate find + a `select_all` call.
+
+- [ ] **Step 2: CHANGELOG**
+
+Add under `[Unreleased]` in `CHANGELOG.md`:
+```markdown
+### Added
+- bs4-like combinable predicate finders on `find()`/`find_all()`: `tag`,
+  `attr`, `attr_contains`, `attr_starts_with`, `attr_ends_with`, `has_attr`,
+  `attr_regex`, `containing_text`, `text_equals`, `text_matches` (#55).
+- `select`/`select_all` CSS convenience aliases on `Tab`/`Frame`/`Element`.
+- Verified `include_frames()` finds elements in nested iframes (#239).
+```
+
+- [ ] **Step 3: Commit**
+```bash
+git add crates/zendriver/src/query/mod.rs CHANGELOG.md
+git commit -m "docs: predicate finders + select aliases"
+```
+
+---
+
+## Task 11: Gates + PR
+
+- [ ] **Step 1: Format + clippy (per CLAUDE.md)**
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --locked --fix --allow-dirty --allow-staged
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+```
+Expected: clean. (Predicate/query code is default-feature; no extra feature clippy needed unless you touched gated code.)
+
+- [ ] **Step 2: Tests**
+```bash
+cargo test --workspace --locked
+cargo test -p zendriver --features integration-tests --test find_predicate_iframe --no-run
+```
+Expected: unit/doctests green; integration compiles. (Headful `--ignored` tests run on the integration job / locally with Chrome.)
+
+- [ ] **Step 3: Commit + PR**
+```bash
+git add -A && git commit -m "chore: fmt + clippy for find/DOM predicates"
+gh pr create --base main \
+  --title "feat: bs4-like predicate finders + select_all + nested-iframe (#55, #239)" \
+  --body "PR2 Group A. See docs/superpowers/specs/2026-06-02-find-dom-predicates-iframe-design.md"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:** §3 predicate API → T1/T2/T4/T5; §3 mixing guard 1A → T3/T6; §4 compilation → T1/T2/T6; §5 modifier composition → T6 (terminal refactor reuses nth/visible_only/include_frames); §6 nested-iframe verify → T8; §6 select/select_all → T7; §7 testing → T1/T2/T4/T6 (unit) + T8/T9 (integration); §8 out-of-scope honored (no macro DSL, no type-state). Covered.
+
+**Placeholders:** the verify-fork in T8 (pass→lock / fail→fix) is intentional + bounded, not a placeholder. The T6 terminal refactor is described against the real existing `one_or_none`/`one_across_frames` bodies (reuse, not invent). Adapt-points flagged inline (real struct fields for `bare_all()`, `extract_array_refs`/`remote_object_id_cloned` signatures, `find()`/`text()` accessor names, integration-test gating/server helper).
+
+**Type consistency:** `PredicateSet`/`AttrPred`/`TextPred`, `to_css_selector`/`to_js_filter`, `resolve_predicate_one`/`many`, `predicates` field, `ConflictingSelectors`, the 10 method names, `select`/`select_all` — used consistently across tasks and matching the spec.

--- a/docs/superpowers/specs/2026-06-02-find-dom-predicates-iframe-design.md
+++ b/docs/superpowers/specs/2026-06-02-find-dom-predicates-iframe-design.md
@@ -1,0 +1,162 @@
+# Find/DOM — Predicate Builder + Nested-iframe — Design (PR2 / Group A)
+
+- **Date:** 2026-06-02
+- **Status:** Approved (brainstorming), pending implementation plan
+- **Upstream drivers:** zendriver #55 (bs4-like find), #239 + PR #246 (nested-iframe select_all)
+- **Scope:** Group A of the PR2 batch (the 7 upstream TODOs split into ~4 cohesive sub-PRs). This spec covers **Find/DOM only**. Groups B (network), C (robustness), D (datadome) are separate spec→plan→PR cycles.
+
+---
+
+## 1. Context
+
+The port already has rich finders ([`crates/zendriver/src/query/mod.rs`](../../../crates/zendriver/src/query/mod.rs)):
+
+- `FindBuilder` (single) + `FindAllBuilder` (multi), each with **8 mutually-exclusive selector kinds** (`css`, `xpath`, `text`, `text_exact`, `text_regex`, `text_regex_with_flags`, `role`, `role_named`) plus modifiers (`nth`, `visible_only`, `in_frame`, `include_frames`, `best_match`, `timeout`) and terminals (`one`/`one_or_none`, `many`/`many_or_empty`).
+- Queries run through `Runtime.evaluate` / `Runtime.callFunctionOn` of JS `querySelectorAll` (document-bound), **not** CDP `DOM.querySelectorAll`.
+- Cross-frame `include_frames()` (`one_across_frames`) iterates the `Tab::frames()` registry, querying each frame in **its own session / execution context** — architecturally different from Python zendriver's single-document query.
+- No `select`/`select_all` aliases.
+
+Two gaps this sub-PR closes:
+
+1. **#55 (bs4-like):** find by *any combination* of tag + attributes + text. Today the selector kinds are mutually exclusive — you cannot AND css + text in one query.
+2. **#239/#246 (nested iframe):** ensure `find`/`find_all` with `include_frames()` reach elements in arbitrarily-nested iframes. Python's bug is `querySelectorAll` not crossing `content_document` boundaries; Rust's per-frame-context architecture *may already cover this* — so the work is **verify-first**, not a blind port.
+
+---
+
+## 2. Decisions locked in brainstorming
+
+- **Mixing guard: 1A — runtime error** (not compile-time type-state). One `FindBuilder` type; mixing a predicate method with a single-selector method is rejected at the terminal with a clear error. (Type-state 1B rejected for this domain — it is hostile to runtime-chosen selectors, the common scraping case; see §8.)
+- **Predicate API: combinable builder methods** directly on `FindBuilder`/`FindAllBuilder`.
+- **Matchers in scope:** `tag`, `attr`, `attr_contains`, `attr_starts_with`, `attr_ends_with`, `has_attr`, `attr_regex`, `containing_text`, `text_equals`, `text_matches`. (Case-insensitive variants deferred.)
+- **Predicate-text names: 3A** — `containing_text` / `text_equals` / `text_matches` (distinct from the standalone `text`/`text_exact`/`text_regex` modes to avoid collision).
+- **`select`/`select_all` aliases: IN, minimal** (no-modifier CSS conveniences for Python migration parity).
+- **Nested-iframe: verify-first** (test → fix only the gap → content_document walk is a fallback only if needed).
+
+---
+
+## 3. Predicate builder — public API
+
+New combinable methods on **both** `FindBuilder` and `FindAllBuilder` (all AND-ed):
+
+```rust
+// structural — compile into the CSS selector
+pub fn tag(self, name: impl Into<String>) -> Self;            // div
+pub fn attr(self, name: &str, value: &str) -> Self;          // [name="value"]
+pub fn attr_contains(self, name: &str, sub: &str) -> Self;   // [name*="sub"]
+pub fn attr_starts_with(self, name: &str, pre: &str) -> Self;// [name^="pre"]
+pub fn attr_ends_with(self, name: &str, suf: &str) -> Self;  // [name$="suf"]
+pub fn has_attr(self, name: &str) -> Self;                   // [name]
+
+// post-filters — applied to the candidate set in the same JS pass
+pub fn attr_regex(self, name: &str, pattern: &str) -> Self;  // RegExp(pattern).test(getAttribute(name))
+pub fn containing_text(self, sub: &str) -> Self;             // (innerText||textContent).includes(sub)
+pub fn text_equals(self, exact: &str) -> Self;               // trimmed text === exact
+pub fn text_matches(self, pattern: &str) -> Self;            // RegExp(pattern).test(text)
+```
+
+Usage:
+```rust
+let card = tab.find()
+    .tag("div")
+    .attr("data-role", "card")
+    .attr_contains("class", "active")
+    .has_attr("data-ready")
+    .containing_text("Buy")
+    .one().await?;
+```
+
+Composes with all existing modifiers (`nth`, `visible_only`, `include_frames`, `best_match`, `timeout`) and all scopes (`tab.find()`, `frame.find()`, `element.find()`).
+
+### Coexistence + mixing guard (1A)
+
+The builder tracks an internal selector spec:
+
+```rust
+enum SelectorSpec {
+    None,
+    Single(SingleSelector),   // css | xpath | text* | role*
+    Predicate(PredicateSet),  // accumulated predicates above
+}
+```
+
+- Single-selector setters and predicate setters target different variants. If both groups get touched, a `conflict` flag is set.
+- The terminal (`one`/`one_or_none`/`many`/`many_or_empty`) returns `Err(ZendriverError::ConflictingSelectors)` with message: *"predicate methods (.tag/.attr/.containing_text/…) cannot be combined with .css()/.xpath()/.text()/.role(); use one selector style per query."*
+- Within the predicate group, methods accumulate (AND). Within the single group, last-wins (unchanged from today).
+- Empty spec at terminal → existing `Err(..NoSelector)` (unchanged).
+
+---
+
+## 4. Compilation (one CDP round-trip)
+
+A predicate set compiles to a **single JS function**, evaluated once per scope via the existing `Runtime.evaluate` / `Runtime.callFunctionOn` path in [`query/selectors.rs`](../../../crates/zendriver/src/query/selectors.rs):
+
+1. **CSS-expressible parts** → one selector string. `tag` + `attr*`/`has_attr` →
+   `div[data-role="card"][class*="active"][data-ready]`. (No structural predicate → `*`.)
+2. `Array.from((scope).querySelectorAll(sel))` — `scope` is `document` (tab/frame) or `this` (element), matching the existing scope dispatch.
+3. **Post-filters** applied in the same function, no extra round-trip:
+   - `attr_regex(name, p)` → `new RegExp(p).test(el.getAttribute(name) ?? "")`
+   - `containing_text` / `text_equals` / `text_matches` → against `el.innerText || el.textContent`, reusing the existing text-engine semantics (`text_matches` uses JS `RegExp`, consistent with the current `text_regex_with_flags`).
+4. Return the filtered node array (FindAll) or first match (Find), reusing the existing `Runtime.getProperties` enumeration → `Element` wrapping.
+
+Attribute values and patterns are JSON-escaped into the JS source (reuse the existing escaping helper used by the current selectors). This keeps predicate queries to the **same one round-trip per scope** as today's finders.
+
+---
+
+## 5. Composition with modifiers & scopes
+
+Predicate resolution produces a candidate `Vec<Element>` (or first match); existing modifiers apply unchanged on top:
+
+- `nth(i)` — index into candidates; `visible_only(true)` — filter by the existing visibility check; `timeout(d)` — existing poll loop; `best_match()` — existing text-length heuristic (meaningful when a text predicate is present).
+- `include_frames()` — fans out the predicate query across the frame registry exactly as the single-selector path does (the compiled JS runs per scope/frame).
+- Available identically on `FindBuilder` (`one`/`one_or_none`) and `FindAllBuilder` (`many`/`many_or_empty`), and for tab/frame/element scopes.
+
+---
+
+## 6. Nested-iframe (#239/#246) — verify-first
+
+Rust's `include_frames()` queries each registered frame in its own context, unlike Python's document-bound query. So:
+
+1. **Verify (TDD, first):** add a headful integration test — an element nested **two iframes deep** — and assert `tab.find().css(sel).include_frames().one()` and `find_all(...).many()` locate it.
+   - **If it passes:** the architecture already crosses nested boundaries. Lock it with the test; done. No content_document walk.
+   - **If it fails:** fix the gap in this order:
+     a. Ensure the frame registry captures **nested same-process frames** (confirm `Page.frameAttached`/frame-tree handling registers frames at all depths), and that each resolves in its execution context.
+     b. **Fallback only if (a) cannot cover same-process nested frames:** add a `content_document` DOM-walk (the #246 approach) for frames not represented as separate query scopes — walking the tree, collecting each iframe's `content_document`, querying each, guarding cross-origin `content_document === null`.
+2. **`select` / `select_all` parity aliases** — thin CSS conveniences on `Tab`, `Frame`, `Element`:
+   ```rust
+   /// One element by CSS selector. Convenience for `find().css(sel).one()`.
+   pub async fn select(&self, css: &str) -> Result<Element>;
+   /// All elements by CSS selector. Convenience for `find_all().css(sel).many()`.
+   pub async fn select_all(&self, css: &str) -> Result<Vec<Element>>;
+   ```
+   No-modifier by design; callers needing `include_frames`/`nth`/`timeout` use the builder. Eases Python→Rust migration (#239/#246 are framed around `select_all`).
+
+---
+
+## 7. Testing
+
+- **Unit (no browser):**
+  - Predicate → CSS-selector string compilation (assert generated selector for representative predicate sets; empty → `*`).
+  - Predicate → JS function generation (snapshot/string-contains: `querySelectorAll`, the regex/text post-filters, escaping).
+  - Mixing guard: predicate + `.css()` → `ConflictingSelectors` at terminal; empty → `NoSelector`.
+- **Integration (gated headful, mirror `integration_phase4.rs` gating):**
+  - **iframe-in-iframe** find/find_all across frames (§6 verify).
+  - Predicate finds against a fixture page: tag+attr combos, `attr_contains`/`starts_with`/`ends_with`/`has_attr`, `attr_regex`, `containing_text`/`text_equals`/`text_matches`, and composition with `nth`/`visible_only`.
+  - `select` / `select_all` (incl. across frames via the builder for the include_frames case).
+
+---
+
+## 8. Out of scope (future / other PRs)
+
+- **`find!` DSL macro** — a terse `macro_rules!`/proc-macro query DSL (`find!(tab, tag="div", class*="x", text~"Buy")`). Real terseness value but adds a DSL + a second way to do one thing. Revisit if users ask. **Future.**
+- **Type-state builders (1B)** — compile-time enforcement of the single-vs-predicate split via a `FindBuilder<Mode>` type parameter. Rejected for this domain: it is hostile to runtime-chosen selectors (each branch is a distinct type → cannot unify without erasure), the common scraping pattern. If revisited, it is its own deliberate API initiative across all builders (~1–2 wk), not part of Group A. **Future, separate.**
+- **Case-insensitive matchers** (`[a="v" i]`, lowercased text compare). **Deferred.**
+- **XPath predicate compilation** — predicates compile to CSS + JS filter only; `.xpath()` remains its own single-selector mode.
+- **Groups B (network monitor #223 / browser-context HTTP #189), C (CDP freshness / popup flags), D (datadome #20)** — separate sub-PRs.
+
+---
+
+## 9. Open questions for the plan stage
+
+- Confirm the exact existing escaping helper + scope-dispatch functions in `selectors.rs` to reuse for predicate JS generation.
+- Confirm whether the frame registry already enumerates nested same-process frames (drives whether §6 step 2a/2b is needed) — resolved empirically by the §6 verify test at implementation time.
+- Exact `ConflictingSelectors` error variant placement in the `ZendriverError` hierarchy.


### PR DESCRIPTION
**PR2 Group A** (Find/DOM) of the upstream-TODO batch. Independent of PR1 (#24). Implements zendriver #55 (bs4-like find) and #239/#246 (nested-iframe find).

## What's included

**Combinable predicate finders (#55)** — new AND-ed matchers on `find()`/`find_all()`, usable on `Tab`/`Frame`/`Element`:
```rust
let card = tab.find()
    .tag("div").attr_contains("class", "active")
    .attr_regex("data-id", r"^\d{4}$").containing_text("Buy")
    .one().await?;
```
Full set: `tag`, `attr`, `attr_contains`, `attr_starts_with`, `attr_ends_with`, `has_attr`, `attr_regex`, `containing_text`, `text_equals`, `text_matches`. CSS-expressible parts compile into one selector; regex/text are post-filters — **one CDP round-trip per scope**, same as existing finders. Composes with all modifiers (`nth`/`visible_only`/`include_frames`/`timeout`/`best_match`).

**Mixing guard (1A)** — combining a predicate method with `.css()`/`.xpath()`/`.text*()`/`.role*()` returns `ZendriverError::ConflictingSelectors` at the terminal (checked before any CDP dispatch). One selector style per query.

**`select`/`select_all`** — Python-parity CSS convenience aliases on `Tab`/`Frame`/`Element`.

**Nested-iframe (#239/#246) — verified, no fix needed.** Unlike Python zendriver (whose `querySelectorAll` can't cross `content_document` boundaries), this port queries each frame in its own execution context. A new iframe-in-iframe integration test confirms `include_frames()` already finds elements nested two iframes deep — so we **locked it with a regression test** instead of porting #246's content_document walk.

## Architecture
A `Resolver` enum routes both single-selector and predicate finders through the *same* poll-loop / `nth` / `visible_only` / `Element`-synthesis path, so existing finder behavior is byte-identical (all prior `query::` tests stay green). Predicate compilation lives in a focused, pure, unit-tested `query/predicate.rs`.

## Limitation (documented)
Elements found via predicate methods are **not auto-refreshable** (Evaluation origin) — a predicate set with regex/text post-filters can't be re-resolved from a single stored selector. `.css()`/`.xpath()` elements remain refreshable. A predicate-carrying refreshable origin is a possible follow-up (touches `element/`).

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean
- [x] `cargo test --workspace --locked` green (254 `zendriver` lib + doctests; predicate compilation, mixing guard, accumulation all unit-tested)
- [x] iframe-in-iframe integration test **ran headful against real Chrome and PASSED** (frame traversal already crosses nested iframes)
- [x] predicate / `select_all` / mixing-guard integration tests compile (`--features integration-tests`, `#[ignore]`-gated for the nightly job)

Spec: `docs/superpowers/specs/2026-06-02-find-dom-predicates-iframe-design.md`
Plan: `docs/superpowers/plans/2026-06-02-find-dom-predicates-iframe.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)