### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.4", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.5", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.3" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.2.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.1.4" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.2.0" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.2" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.2.3" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.2.4" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.1.3" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.1.1" }
 

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.4] - 2026-06-02
+
+
 ## [0.2.3] - 2026-06-02
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-06-02
+
+
 ## [0.2.4] - 2026-06-02
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `zendriver-mcp`: 0.2.3 -> 0.2.4

<details><summary><i><b>Changelog</b></i></summary><p>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).