### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3418,7 +3418,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,15 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.5", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.6", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.3" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.2.0" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.2.1" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.1.4" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.2.0" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.2" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.2.4" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.3.0" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.1.3" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.1.1" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.1.2" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.2] - 2026-06-02
+
+
 ## [0.1.1] - 2026-06-02
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.0] - 2026-06-02
+
+### Added
+
+- AttrOp/AttrPredicate types + predicate-mode Selector
+- Thread AttrOp/AttrPredicate predicates through resolve bridge
+- Browser_open preferences + persona
+- Browser_request tool
+- Browser_fingerprint_generate (fingerprints feature)
+- Monitor feature + SessionState monitor handles
+- Browser_monitor_start/read/stop tools
+
+### Changed
+
+- Collapse find.rs selector-bridge duplication
+
+### Fixed
+
+- Stop monitors on browser_close + RAII MonitorState Drop
+
+
 ## [0.2.4] - 2026-06-02
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.2.4"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.1] - 2026-06-02
+
+
 ## [0.2.0] - 2026-06-02
 
 ### Added

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-06-02
+
+
 ## [0.2.5] - 2026-06-02
 
 

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `zendriver`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `zendriver-mcp`: 0.2.4 -> 0.3.0 (⚠ API breaking changes)
* `zendriver-fingerprints`: 0.1.1 -> 0.1.2

### ⚠ `zendriver-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field OpenInput.preferences in /tmp/.tmpIfgbnR/zendriver-rs/crates/zendriver-mcp/src/tools/lifecycle.rs:39
  field OpenInput.persona in /tmp/.tmpIfgbnR/zendriver-rs/crates/zendriver-mcp/src/tools/lifecycle.rs:43
  field Selector.tag in /tmp/.tmpIfgbnR/zendriver-rs/crates/zendriver-mcp/src/selectors.rs:80
  field Selector.attrs in /tmp/.tmpIfgbnR/zendriver-rs/crates/zendriver-mcp/src/selectors.rs:83
  field SessionState.monitors in /tmp/.tmpIfgbnR/zendriver-rs/crates/zendriver-mcp/src/state.rs:125

--- failure enum_discriminants_undefined_non_unit_variant: enum's variants no longer have defined discriminants due to non-unit variant ---

Description:
An enum's variants no longer have well-defined discriminant values due to a tuple or struct variant in the enum. This breaks downstream code that accesses discriminants via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_discriminants_undefined_non_unit_variant.ron

Failed in:
  enum SelectorError in /tmp/.tmpIfgbnR/zendriver-rs/crates/zendriver-mcp/src/selectors.rs:104

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant SelectorError:PredicateConflict in /tmp/.tmpIfgbnR/zendriver-rs/crates/zendriver-mcp/src/selectors.rs:118
  variant SelectorError:AttrValueRequired in /tmp/.tmpIfgbnR/zendriver-rs/crates/zendriver-mcp/src/selectors.rs:122
```

<details><summary><i><b>Changelog</b></i></summary><p>



## `zendriver-mcp`

<blockquote>

## [0.3.0] - 2026-06-02

### Added

- AttrOp/AttrPredicate types + predicate-mode Selector
- Thread AttrOp/AttrPredicate predicates through resolve bridge
- Browser_open preferences + persona
- Browser_request tool
- Browser_fingerprint_generate (fingerprints feature)
- Monitor feature + SessionState monitor handles
- Browser_monitor_start/read/stop tools

### Changed

- Collapse find.rs selector-bridge duplication

### Fixed

- Stop monitors on browser_close + RAII MonitorState Drop
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).