### PR TITLE
feat: zendriver-datadome bypass crate + WebGPU coherence + unified anti-bot result model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,35 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SEMVER.md].
   (reese84, legacy Incapsula, CAPTCHA surfaces). Opt-in Fetch-domain
   fast-path and opt-in CAPTCHA solver callback. `Tab::imperva()`
   convenience method gated by the `imperva` cargo feature.
+- **Group D — DataDome bypass + WebGPU coherence (#20):**
+  - `zendriver-datadome` crate: passive bypass for DataDome-protected sites.
+    Detects device-check / captcha / block surfaces via a single
+    `window.dd`-reading probe, polls until the `datadome` clearance cookie
+    lands, and escalates a CAPTCHA surface to a caller-supplied async solver
+    (returns the `datadome` cookie, not a form-field token). Opt-in
+    Fetch-domain fast-path. `Tab::datadome()` convenience method gated by
+    the `datadome` cargo feature. MCP tool `browser_solve_datadome` added
+    with `cleared / challenge_gone / already_clear / blocked / timeout`
+    outcomes.
+  - `Surface::Webgpu` in `zendriver-stealth`: coherence patch for
+    `navigator.gpu.requestAdapter()`. Derives `GPUAdapterInfo`
+    (`vendor` / `architecture` / `description`) from the spoofed WebGL
+    renderer string and overrides `requestAdapter` so the WebGPU adapter
+    info agrees with WebGL. Closes the `navigator.gpu` fingerprint leak
+    from issue #20. Included in `StealthProfile::spoofed()` with no
+    extra configuration.
+
+- **Breaking (imperva + cloudflare):** Flow-terminal conditions
+  `Timeout`, `NoChallenge`, and `ClearanceTimeout` have moved from
+  `Error` variants to `ClearanceOutcome` variants, unifying the result
+  model across all three anti-bot crates (cloudflare, imperva,
+  datadome). `ImpervaError::Timeout` is removed; the new variant is
+  `ImpervaClearanceOutcome::TimedOut { last_surface }`.
+  `CloudflareError::NoChallenge` and `CloudflareError::ClearanceTimeout`
+  are removed; the new variant is `ClearanceOutcome::TimedOut {
+  saw_challenge }`. Callers who matched on `Err(ImpervaError::Timeout
+  { .. })` or `Err(CloudflareError::ClearanceTimeout)` must update to
+  match on `Ok(ClearanceOutcome::TimedOut { .. })`.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3325,6 +3325,7 @@ dependencies = [
  "url",
  "wiremock",
  "zendriver-cloudflare",
+ "zendriver-datadome",
  "zendriver-fetcher",
  "zendriver-imperva",
  "zendriver-interception",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3347,6 +3347,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "zendriver-datadome"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-test",
+ "tokio-util",
+ "tracing",
+ "zendriver-interception",
+ "zendriver-transport",
+]
+
+[[package]]
 name = "zendriver-fetcher"
 version = "0.1.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/zendriver-fetcher",
     "crates/zendriver-mcp",
     "crates/zendriver-imperva",
+    "crates/zendriver-datadome",
     "crates/zendriver-fingerprints",
 ]
 
@@ -29,6 +30,7 @@ zendriver-interception  = { path = "crates/zendriver-interception", version = "0
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.2" }
 zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.3.0" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.1.3" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.0" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.1.2" }
 
 # MCP server

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ More working examples in [`crates/zendriver/examples/`](crates/zendriver/example
 | `expect`       | no       | Playwright-style `expect_response()` / `expect_request()`     | (in-tree, no extra crate)             |
 | `cloudflare`   | no       | Solve Cloudflare Turnstile challenges                         | `zendriver-cloudflare`                |
 | `imperva`      | no       | Imperva WAF / Incapsula bypass (reese84 / legacy / CAPTCHA)   | `zendriver-imperva`                   |
+| `datadome`     | no       | DataDome bypass (device-check / CAPTCHA / block) + `Surface::Webgpu` coherence | `zendriver-datadome` |
 | `fetcher`      | no       | Auto-download a pinned Chrome for Testing build               | `zendriver-fetcher` + `reqwest`/`zip` |
 
 Separate binary crate (not a feature on `zendriver`):
@@ -83,10 +84,10 @@ Same as above — only spell out the feature if you want it visible in `Cargo.to
 **Everything:**
 
 ```bash
-cargo add zendriver --features "interception expect cloudflare imperva fetcher"
+cargo add zendriver --features "interception expect cloudflare imperva datadome fetcher"
 ```
 
-Adds request interception, `expect()` matchers, Cloudflare Turnstile bypass, Imperva WAF / Incapsula bypass, and the Chrome for Testing fetcher.
+Adds request interception, `expect()` matchers, Cloudflare Turnstile bypass, Imperva WAF / Incapsula bypass, DataDome bypass, and the Chrome for Testing fetcher.
 
 ## Drive a stealth browser from your AI agent
 
@@ -116,6 +117,7 @@ cargo install zendriver-mcp
 - **Stateful primitives** agents need for real work — `browser_cookies_persist` for save/load auth, full `browser_storage_*`, multi-tab management, frame traversal
 - **Anti-bot superpowers** (gated cargo features, on by default for the published binary):
   - `browser_solve_turnstile` — Cloudflare Turnstile bypass without a CAPTCHA-solving service
+  - `browser_solve_datadome` — DataDome device-check / CAPTCHA / block bypass (with `Surface::Webgpu` coherence)
   - `browser_intercept_*` — block/redirect/respond/modify requests via CDP `Fetch.*`
   - `browser_expect_register / _await` — Playwright-style "wait for response/dialog/download" matchers, split across MCP calls so the agent can act in between
   - `browser_install_chrome` — pull a pinned Chrome-for-Testing build on demand

--- a/crates/zendriver-cloudflare/src/bypass.rs
+++ b/crates/zendriver-cloudflare/src/bypass.rs
@@ -22,11 +22,11 @@
 //! 4. If we previously observed an iframe + clicked, and the iframe is now
 //!    gone without a token, resolves to [`ClearanceOutcome::ChallengeGone`]
 //!    (clearance-cookie shortcut).
-//! 5. Errors with [`CloudflareError::ClearanceTimeout`] on deadline when
-//!    challenge markers were seen but never resolved, or
-//!    [`CloudflareError::NoChallenge`] when the entire timeout window
-//!    elapsed without observing any challenge markers — the caller likely
-//!    invoked the bypass on a page that has no Cloudflare gate at all.
+//! 5. Resolves to [`ClearanceOutcome::TimedOut`] on deadline, carrying
+//!    `saw_challenge` — `true` when challenge markers were seen but never
+//!    resolved, `false` when the entire timeout window elapsed without
+//!    observing any challenge markers (the caller likely invoked the bypass
+//!    on a page that has no Cloudflare gate at all).
 
 use std::time::Duration;
 
@@ -46,6 +46,13 @@ pub enum ClearanceOutcome {
     TokenAcquired(String),
     /// The challenge container disappeared without yielding a token.
     ChallengeGone,
+    /// Deadline elapsed without a terminal clearance state. `saw_challenge`
+    /// is `true` if any challenge marker (container, hidden input, or live
+    /// iframe) was ever observed; `false` if none ever appeared — the caller
+    /// likely invoked the bypass on a page that has no Cloudflare gate at all.
+    /// Not a fault: a deadline in a bot-management flow is a normal "didn't
+    /// finish, retry or give up" terminal.
+    TimedOut { saw_challenge: bool },
 }
 
 /// Default poll interval for `wait_for_clearance`.
@@ -95,14 +102,14 @@ impl<'a> CloudflareBypass<'a> {
     ///   present, we clicked it, and the challenge container then
     ///   disappeared without yielding a token (e.g. a clearance cookie
     ///   shortcut).
+    /// - `Ok(ClearanceOutcome::TimedOut { saw_challenge })` — `timeout`
+    ///   elapsed without a terminal clearance state. `saw_challenge` is
+    ///   `true` if challenge markers were observed (markers present but
+    ///   never resolved); `false` if none ever appeared (the caller likely
+    ///   invoked the bypass on a page that has no Cloudflare gate). Not a
+    ///   fault — a deadline here is a normal "retry or give up" signal.
     ///
     /// # Errors
-    /// - [`CloudflareError::NoChallenge`] — `timeout` elapsed without any
-    ///   challenge markers ever being observed on the page (no container,
-    ///   no hidden input, no iframe). The caller likely invoked the bypass
-    ///   on a page that has no Cloudflare gate.
-    /// - [`CloudflareError::ClearanceTimeout`] — `timeout` elapsed with
-    ///   challenge markers present but neither success state observed.
     /// - [`CloudflareError::Call`] / [`CloudflareError::JsError`] — CDP or
     ///   in-page evaluator failure.
     ///
@@ -165,10 +172,8 @@ impl<'a> CloudflareBypass<'a> {
             }
 
             if Instant::now() >= deadline {
-                return Err(if ever_seen_markers {
-                    CloudflareError::ClearanceTimeout
-                } else {
-                    CloudflareError::NoChallenge
+                return Ok(ClearanceOutcome::TimedOut {
+                    saw_challenge: ever_seen_markers,
                 });
             }
 

--- a/crates/zendriver-cloudflare/src/error.rs
+++ b/crates/zendriver-cloudflare/src/error.rs
@@ -3,12 +3,6 @@
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum CloudflareError {
-    #[error("no Turnstile challenge detected")]
-    NoChallenge,
-
-    #[error("clearance timed out")]
-    ClearanceTimeout,
-
     #[error("call failed: {0}")]
     Call(#[from] zendriver_transport::CallError),
 
@@ -22,14 +16,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn display_no_challenge() {
-        let e = CloudflareError::NoChallenge;
-        assert_eq!(e.to_string(), "no Turnstile challenge detected");
-    }
-
-    #[test]
-    fn display_clearance_timeout() {
-        let e = CloudflareError::ClearanceTimeout;
-        assert_eq!(e.to_string(), "clearance timed out");
+    fn display_js_error_passthrough() {
+        let e = CloudflareError::JsError("bad payload".into());
+        assert_eq!(e.to_string(), "JS error: bad payload");
     }
 }

--- a/crates/zendriver-cloudflare/src/lib.rs
+++ b/crates/zendriver-cloudflare/src/lib.rs
@@ -33,6 +33,9 @@
 //! match outcome {
 //!     ClearanceOutcome::TokenAcquired(token) => println!("got token: {token}"),
 //!     ClearanceOutcome::ChallengeGone => println!("challenge cleared"),
+//!     ClearanceOutcome::TimedOut { saw_challenge } => {
+//!         println!("timed out; saw_challenge = {saw_challenge}")
+//!     }
 //! }
 //! # Ok(()) }
 //! ```

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "zendriver-datadome"
+description = "DataDome anti-bot bypass for zendriver"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme = "../../README.md"
+homepage = "https://github.com/TurtIeSocks/zendriver-rs"
+documentation = "https://docs.rs/zendriver-datadome"
+keywords = ["datadome", "anti-bot", "bypass", "browser", "zendriver"]
+categories = ["web-programming"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true
+
+[dependencies]
+zendriver-transport.workspace    = true
+zendriver-interception.workspace = true
+tokio.workspace                  = true
+tokio-util.workspace             = true
+futures.workspace                = true
+serde.workspace                  = true
+serde_json.workspace             = true
+thiserror.workspace              = true
+tracing.workspace                = true
+
+[dev-dependencies]
+tokio-test.workspace = true
+zendriver-transport  = { workspace = true, features = ["testing"] }

--- a/crates/zendriver-datadome/src/bypass.rs
+++ b/crates/zendriver-datadome/src/bypass.rs
@@ -1,0 +1,452 @@
+//! DataDome bypass driver.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::time::Instant;
+use zendriver_transport::SessionHandle;
+
+use crate::captcha::CaptchaSolver;
+use crate::detection::{DataDomeSurface, DetectionSnapshot};
+use crate::error::DataDomeError;
+
+pub(crate) const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Terminal outcome of a clearance attempt. All flow-terminals are `Ok`;
+/// only genuine faults are [`DataDomeError`].
+#[derive(Debug, Clone)]
+pub enum ClearanceOutcome {
+    /// datadome cookie acquired AND challenge markers gone.
+    Cleared { datadome: String },
+    /// Markers cleared but no datadome cookie observed (rare / legacy path).
+    ChallengeGone,
+    /// No DataDome surface present at call time. Fast path; no waiting.
+    AlreadyClear,
+    /// window.dd.t == 'bv' — IP banned. Nothing in-browser can clear this;
+    /// the caller must change IP (e.g. residential proxy).
+    Blocked,
+    /// Deadline elapsed without reaching a terminal state.
+    TimedOut {
+        last_surface: Option<DataDomeSurface>,
+    },
+}
+
+/// Drives a DataDome clearance flow against a single tab's session.
+///
+/// Constructed via `Tab::datadome()`.
+pub struct DataDomeBypass<'tab> {
+    pub(crate) session: &'tab SessionHandle,
+    pub(crate) poll_interval: Duration,
+    pub(crate) timeout: Duration,
+    pub(crate) on_captcha: Option<Arc<CaptchaSolver>>,
+    pub(crate) interception_enabled: bool,
+}
+
+impl std::fmt::Debug for DataDomeBypass<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DataDomeBypass")
+            .field("poll_interval", &self.poll_interval)
+            .field("timeout", &self.timeout)
+            .field("on_captcha", &self.on_captcha.as_ref().map(|_| "..."))
+            .field("interception_enabled", &self.interception_enabled)
+            .finish()
+    }
+}
+
+impl<'tab> DataDomeBypass<'tab> {
+    /// New driver with default 250ms poll interval + 30s timeout.
+    pub fn new(session: &'tab SessionHandle) -> Self {
+        Self {
+            session,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            timeout: DEFAULT_TIMEOUT,
+            on_captcha: None,
+            interception_enabled: false,
+        }
+    }
+
+    /// Override the default 30s overall timeout.
+    #[must_use]
+    pub fn timeout(mut self, dur: Duration) -> Self {
+        self.timeout = dur;
+        self
+    }
+
+    /// Override the default 250ms poll interval.
+    #[must_use]
+    pub fn poll_interval(mut self, dur: Duration) -> Self {
+        self.poll_interval = dur;
+        self
+    }
+
+    /// Enable the Fetch-domain fast-path (see [`crate::interception`]).
+    #[must_use]
+    pub fn with_interception(mut self) -> Self {
+        self.interception_enabled = true;
+        self
+    }
+
+    /// Register a caller-supplied async CAPTCHA solver. Without it, a CAPTCHA
+    /// surface yields [`DataDomeError::CaptchaRequired`].
+    ///
+    /// The solver receives a [`DataDomeChallenge`] (captcha URL, page URL, UA,
+    /// cid, hash) and returns a [`DataDomeSolution`] carrying the solved
+    /// `datadome` cookie — wire it to a service like 2captcha / capsolver.
+    ///
+    /// [`DataDomeChallenge`]: crate::captcha::DataDomeChallenge
+    /// [`DataDomeSolution`]: crate::captcha::DataDomeSolution
+    #[must_use]
+    pub fn on_captcha<F, Fut>(mut self, f: F) -> Self
+    where
+        F: Fn(crate::captcha::DataDomeChallenge) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<
+                Output = Result<
+                    crate::captcha::DataDomeSolution,
+                    Box<dyn std::error::Error + Send + Sync>,
+                >,
+            > + Send
+            + 'static,
+    {
+        self.on_captcha = Some(crate::captcha::arc_solver(f));
+        self
+    }
+
+    /// Run the surface-aware poll loop until clearance, block, or timeout.
+    ///
+    /// # Returns
+    /// - `Cleared { datadome }` — cookie landed and markers gone.
+    /// - `ChallengeGone` — markers gone, no cookie observed.
+    /// - `AlreadyClear` — no surface at call time.
+    /// - `Blocked` — `window.dd.t == 'bv'` (IP banned).
+    /// - `TimedOut { last_surface }` — deadline elapsed.
+    ///
+    /// # Errors
+    /// - [`DataDomeError::CaptchaRequired`] — captcha surface, no solver.
+    /// - [`DataDomeError::CaptchaSolver`] — registered solver errored.
+    /// - [`DataDomeError::Interception`] / [`DataDomeError::Call`] /
+    ///   [`DataDomeError::JsError`].
+    pub async fn wait_for_clearance(self) -> Result<ClearanceOutcome, DataDomeError> {
+        let deadline = Instant::now() + self.timeout;
+
+        let snapshot = self.probe(deadline).await?;
+
+        match snapshot.surface {
+            DataDomeSurface::None if snapshot.body_clean => {
+                return Ok(ClearanceOutcome::AlreadyClear);
+            }
+            DataDomeSurface::Block => return Ok(ClearanceOutcome::Blocked),
+            _ => {}
+        }
+
+        // Pre-loop captcha escalation.
+        if snapshot.surface == DataDomeSurface::Captcha {
+            let Some(solver) = self.on_captcha.clone() else {
+                return Err(DataDomeError::CaptchaRequired);
+            };
+            let challenge = crate::captcha::build_challenge(self.session, &snapshot).await?;
+            let site_url = challenge.site_url.clone();
+            let solution = solver(challenge)
+                .await
+                .map_err(DataDomeError::CaptchaSolver)?;
+            crate::captcha::apply_solution(self.session, &solution, &site_url).await?;
+            // Page reloaded — discard the stale snapshot, force a re-probe.
+            return self.poll_loop(deadline, None).await;
+        }
+
+        // Interception fast-path is wired in Task 4.1.
+        self.poll_loop(deadline, Some(snapshot)).await
+    }
+
+    /// One detect probe. The pre-loop probe is a single fast `detect.js` eval;
+    /// the loop's own deadline check + `sleep_until` arm bound total time.
+    async fn probe(&self, _deadline: Instant) -> Result<DetectionSnapshot, DataDomeError> {
+        crate::detection::detect_snapshot(self.session).await
+    }
+
+    pub(crate) async fn poll_loop(
+        self,
+        deadline: Instant,
+        mut next_snapshot: Option<DetectionSnapshot>,
+    ) -> Result<ClearanceOutcome, DataDomeError> {
+        use tokio::time::{Interval, MissedTickBehavior};
+
+        let mut ticker: Interval = tokio::time::interval(self.poll_interval);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        // First iter always either returns or writes `last_surface` before
+        // any read, but the deadline-check branches keep a read path alive.
+        #[allow(unused_assignments)]
+        let mut last_surface: Option<DataDomeSurface> = None;
+
+        loop {
+            let snap = match next_snapshot.take() {
+                Some(s) => s,
+                None => crate::detection::detect_snapshot(self.session).await?,
+            };
+
+            let cookie = snap.datadome.as_ref().filter(|v| !v.is_empty());
+            match (cookie, snap.body_clean) {
+                (Some(c), true) => {
+                    return Ok(ClearanceOutcome::Cleared {
+                        datadome: c.clone(),
+                    });
+                }
+                (None, true) if snap.surface == DataDomeSurface::None => {
+                    return Ok(ClearanceOutcome::ChallengeGone);
+                }
+                _ => last_surface = Some(snap.surface),
+            }
+
+            if Instant::now() >= deadline {
+                return Ok(ClearanceOutcome::TimedOut { last_surface });
+            }
+
+            tokio::select! {
+                _ = ticker.tick() => {}
+                () = tokio::time::sleep_until(deadline) => {
+                    return Ok(ClearanceOutcome::TimedOut { last_surface });
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use zendriver_transport::testing::MockConnection;
+
+    #[tokio::test]
+    async fn builder_defaults_and_overrides() {
+        let (_, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let b = DataDomeBypass::new(&sess);
+        assert_eq!(b.poll_interval, DEFAULT_POLL_INTERVAL);
+        assert_eq!(b.timeout, DEFAULT_TIMEOUT);
+        assert!(b.on_captcha.is_none());
+        assert!(!b.interception_enabled);
+
+        let b = b
+            .timeout(std::time::Duration::from_secs(45))
+            .poll_interval(std::time::Duration::from_millis(100))
+            .with_interception();
+        assert_eq!(b.timeout, std::time::Duration::from_secs(45));
+        assert_eq!(b.poll_interval, std::time::Duration::from_millis(100));
+        assert!(b.interception_enabled);
+        conn.shutdown();
+    }
+
+    use crate::detection::DataDomeSurface;
+    use serde_json::json;
+
+    fn snap_reply(v: serde_json::Value) -> serde_json::Value {
+        json!({ "result": { "type": "object", "value": v } })
+    }
+
+    #[tokio::test]
+    async fn already_clear_on_clean_page() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move { DataDomeBypass::new(&s).wait_for_clearance().await }
+        });
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id,
+            snap_reply(
+                json!({"surface":"none","datadome":"DD","dd":null,"captcha_url":null,"body_clean":true}),
+            ),
+        )
+        .await;
+        assert!(matches!(
+            fut.await.unwrap().unwrap(),
+            ClearanceOutcome::AlreadyClear
+        ));
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn block_is_immediate_terminal() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move { DataDomeBypass::new(&s).wait_for_clearance().await }
+        });
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id,
+            snap_reply(
+                json!({"surface":"block","datadome":null,"dd":{"cid":"C","hsh":"H","t":"bv","host":"h"},"captcha_url":null,"body_clean":false}),
+            ),
+        )
+        .await;
+        assert!(matches!(
+            fut.await.unwrap().unwrap(),
+            ClearanceOutcome::Blocked
+        ));
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn device_check_clears_when_cookie_lands_and_body_clean() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+        // Probe 1: device-check, no cookie.
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id1,
+            snap_reply(
+                json!({"surface":"device_check","datadome":null,"dd":{"cid":"C","hsh":"H","t":"fe","host":"h"},"captcha_url":null,"body_clean":false}),
+            ),
+        )
+        .await;
+        // Probe 2: cleared.
+        let id2 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id2,
+            snap_reply(
+                json!({"surface":"none","datadome":"COOKIE_OK","dd":null,"captcha_url":null,"body_clean":true}),
+            ),
+        )
+        .await;
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::Cleared { datadome } => assert_eq!(datadome, "COOKIE_OK"),
+            other => panic!("expected Cleared, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn times_out_when_device_check_never_clears() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .timeout(Duration::from_millis(40))
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+        for _ in 0..50 {
+            let Ok(id) = tokio::time::timeout(
+                Duration::from_millis(80),
+                mock.expect_cmd("Runtime.evaluate"),
+            )
+            .await
+            else {
+                break;
+            };
+            mock.reply(
+                id,
+                snap_reply(
+                    json!({"surface":"device_check","datadome":null,"dd":{"cid":"C","hsh":"H","t":"fe","host":"h"},"captcha_url":null,"body_clean":false}),
+                ),
+            )
+            .await;
+        }
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::TimedOut { last_surface } => {
+                assert_eq!(last_surface, Some(DataDomeSurface::DeviceCheck));
+            }
+            other => panic!("expected TimedOut, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn captcha_with_solver_applies_cookie_then_clears() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .on_captcha(|ch| async move {
+                        assert!(ch.captcha_url.contains("captcha-delivery.com"));
+                        Ok(crate::captcha::DataDomeSolution {
+                            datadome_cookie: "FROM_SOLVER".into(),
+                        })
+                    })
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        // Pre-loop probe: captcha surface.
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id1,
+            snap_reply(
+                json!({"surface":"captcha","datadome":"OLD","dd":{"cid":"C","hsh":"H","t":"fe","host":"h"},"captcha_url":"https://geo.captcha-delivery.com/captcha/?cid=C","body_clean":false}),
+            ),
+        )
+        .await;
+        // build_challenge eval (url + ua).
+        let id_ctx = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id_ctx,
+            json!({"result":{"type":"object","value":{"url":"https://shop.example.com/p","ua":"Mozilla/5.0"}}}),
+        )
+        .await;
+        // apply_solution: setCookie + reload.
+        let id_cookie = mock.expect_cmd("Network.setCookie").await;
+        mock.reply(id_cookie, json!({"success":true})).await;
+        let id_reload = mock.expect_cmd("Page.reload").await;
+        mock.reply(id_reload, json!({})).await;
+        // Post-reload poll: cleared.
+        let id_poll = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id_poll,
+            snap_reply(
+                json!({"surface":"none","datadome":"FROM_SOLVER","dd":null,"captcha_url":null,"body_clean":true}),
+            ),
+        )
+        .await;
+
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::Cleared { datadome } => assert_eq!(datadome, "FROM_SOLVER"),
+            other => panic!("expected Cleared, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn captcha_without_solver_errors() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move { DataDomeBypass::new(&s).wait_for_clearance().await }
+        });
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id,
+            snap_reply(
+                json!({"surface":"captcha","datadome":null,"dd":null,"captcha_url":"https://geo.captcha-delivery.com/captcha/?cid=C","body_clean":false}),
+            ),
+        )
+        .await;
+        assert!(matches!(
+            fut.await.unwrap().unwrap_err(),
+            DataDomeError::CaptchaRequired
+        ));
+        conn.shutdown();
+    }
+}

--- a/crates/zendriver-datadome/src/bypass.rs
+++ b/crates/zendriver-datadome/src/bypass.rs
@@ -202,7 +202,15 @@ impl<'tab> DataDomeBypass<'tab> {
         loop {
             let snap = match next_snapshot.take() {
                 Some(s) => s,
-                None => crate::detection::detect_snapshot(self.session).await?,
+                None => match tokio::time::timeout_at(
+                    deadline,
+                    crate::detection::detect_snapshot(self.session),
+                )
+                .await
+                {
+                    Ok(res) => res?,
+                    Err(_) => return Ok(ClearanceOutcome::TimedOut { last_surface }),
+                },
             };
 
             let cookie = snap.datadome.as_ref().filter(|v| !v.is_empty());
@@ -502,6 +510,28 @@ mod tests {
             fut.await.unwrap().unwrap_err(),
             DataDomeError::CaptchaRequired
         ));
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn poll_loop_probe_hang_respects_deadline() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .poll_loop(Instant::now() + Duration::from_millis(30), None, None, None)
+                    .await
+            }
+        });
+        // First in-loop probe is received but NEVER answered → deadline fires.
+        let _id = mock.expect_cmd("Runtime.evaluate").await;
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::TimedOut { .. } => {}
+            other => panic!("expected TimedOut, got {other:?}"),
+        }
         conn.shutdown();
     }
 

--- a/crates/zendriver-datadome/src/bypass.rs
+++ b/crates/zendriver-datadome/src/bypass.rs
@@ -129,7 +129,15 @@ impl<'tab> DataDomeBypass<'tab> {
     pub async fn wait_for_clearance(self) -> Result<ClearanceOutcome, DataDomeError> {
         let deadline = Instant::now() + self.timeout;
 
-        let snapshot = self.probe(deadline).await?;
+        let snapshot = match tokio::time::timeout_at(
+            deadline,
+            crate::detection::detect_snapshot(self.session),
+        )
+        .await
+        {
+            Ok(res) => res?,
+            Err(_) => return Ok(ClearanceOutcome::TimedOut { last_surface: None }),
+        };
 
         match snapshot.surface {
             DataDomeSurface::None if snapshot.body_clean => {
@@ -156,12 +164,6 @@ impl<'tab> DataDomeBypass<'tab> {
 
         // Interception fast-path is wired in Task 4.1.
         self.poll_loop(deadline, Some(snapshot)).await
-    }
-
-    /// One detect probe. The pre-loop probe is a single fast `detect.js` eval;
-    /// the loop's own deadline check + `sleep_until` arm bound total time.
-    async fn probe(&self, _deadline: Instant) -> Result<DetectionSnapshot, DataDomeError> {
-        crate::detection::detect_snapshot(self.session).await
     }
 
     pub(crate) async fn poll_loop(
@@ -423,6 +425,28 @@ mod tests {
         match fut.await.unwrap().unwrap() {
             ClearanceOutcome::Cleared { datadome } => assert_eq!(datadome, "FROM_SOLVER"),
             other => panic!("expected Cleared, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn pre_loop_probe_respects_timeout() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .timeout(Duration::from_millis(30))
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+        // Receive the probe command but NEVER reply → the timeout must fire.
+        let _id = mock.expect_cmd("Runtime.evaluate").await;
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::TimedOut { last_surface } => assert_eq!(last_surface, None),
+            other => panic!("expected TimedOut, got {other:?}"),
         }
         conn.shutdown();
     }

--- a/crates/zendriver-datadome/src/bypass.rs
+++ b/crates/zendriver-datadome/src/bypass.rs
@@ -159,17 +159,33 @@ impl<'tab> DataDomeBypass<'tab> {
                 .map_err(DataDomeError::CaptchaSolver)?;
             crate::captcha::apply_solution(self.session, &solution, &site_url).await?;
             // Page reloaded — discard the stale snapshot, force a re-probe.
-            return self.poll_loop(deadline, None).await;
+            return self.poll_loop(deadline, None, None, None).await;
         }
 
-        // Interception fast-path is wired in Task 4.1.
-        self.poll_loop(deadline, Some(snapshot)).await
+        // Optional Fetch-domain fast-path. The guard's `Drop` cooperatively
+        // cancels the spawned task (token check at every loop boundary)
+        // with `abort()` as a backstop.
+        let (interception_rx, interception_guard) = if self.interception_enabled {
+            let (rx, guard) = crate::interception::spawn_signal(self.session);
+            (Some(rx), Some(guard))
+        } else {
+            (None, None)
+        };
+        self.poll_loop(
+            deadline,
+            Some(snapshot),
+            interception_rx,
+            interception_guard,
+        )
+        .await
     }
 
     pub(crate) async fn poll_loop(
         self,
         deadline: Instant,
         mut next_snapshot: Option<DetectionSnapshot>,
+        mut interception_rx: Option<tokio::sync::oneshot::Receiver<()>>,
+        _interception_guard: Option<crate::interception::InterceptionGuard>,
     ) -> Result<ClearanceOutcome, DataDomeError> {
         use tokio::time::{Interval, MissedTickBehavior};
 
@@ -208,6 +224,19 @@ impl<'tab> DataDomeBypass<'tab> {
                 _ = ticker.tick() => {}
                 () = tokio::time::sleep_until(deadline) => {
                     return Ok(ClearanceOutcome::TimedOut { last_surface });
+                }
+                Ok(()) = async {
+                    match interception_rx.as_mut() {
+                        Some(rx) => rx.await,
+                        // Never-resolves fallback keeps this arm inert when
+                        // interception is disabled; `select!` polls the
+                        // remaining arms unaffected.
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    // Drop the receiver so we don't re-await a closed channel
+                    // on the next iteration; loop body re-probes immediately.
+                    interception_rx = None;
                 }
             }
         }
@@ -471,6 +500,42 @@ mod tests {
             fut.await.unwrap().unwrap_err(),
             DataDomeError::CaptchaRequired
         ));
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn interception_signal_triggers_reprobe() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tx.send(()).unwrap(); // signal already fired
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_secs(10))
+                    .poll_loop(
+                        Instant::now() + Duration::from_secs(5),
+                        None,
+                        Some(rx),
+                        None,
+                    )
+                    .await
+            }
+        });
+        // The signal arm fires immediately → one detect probe → cleared.
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id,
+            snap_reply(
+                json!({"surface":"none","datadome":"DD","dd":null,"captcha_url":null,"body_clean":true}),
+            ),
+        )
+        .await;
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::Cleared { datadome } => assert_eq!(datadome, "DD"),
+            other => panic!("expected Cleared, got {other:?}"),
+        }
         conn.shutdown();
     }
 }

--- a/crates/zendriver-datadome/src/bypass.rs
+++ b/crates/zendriver-datadome/src/bypass.rs
@@ -80,7 +80,9 @@ impl<'tab> DataDomeBypass<'tab> {
         self
     }
 
-    /// Enable the Fetch-domain fast-path (see [`crate::interception`]).
+    /// Enable the Fetch-domain fast-path. Spawns a `Fetch` subscription that
+    /// signals on first 2xx response to `captcha-delivery.com` or any
+    /// `datadome*` URL, waking the poll loop immediately.
     #[must_use]
     pub fn with_interception(mut self) -> Self {
         self.interception_enabled = true;

--- a/crates/zendriver-datadome/src/captcha.rs
+++ b/crates/zendriver-datadome/src/captcha.rs
@@ -1,0 +1,188 @@
+//! CAPTCHA escalation: types handed to / returned from the caller-supplied
+//! solver, plus the CDP helpers that build the challenge descriptor and apply
+//! the solved `datadome` cookie. DataDome's solution is a COOKIE (it
+//! whitelists the browser), not a form-field token — the structural delta from
+//! imperva.
+
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+use serde_json::json;
+use zendriver_transport::SessionHandle;
+
+use crate::detection::DetectionSnapshot;
+use crate::error::DataDomeError;
+
+/// CAPTCHA escalation handed to a caller-supplied solver.
+#[derive(Debug, Clone)]
+pub struct DataDomeChallenge {
+    /// captcha-delivery iframe URL, e.g.
+    /// `https://geo.captcha-delivery.com/captcha/?initialCid=…&hash=…&cid=…&t=fe`.
+    pub captcha_url: String,
+    /// URL of the page presenting the CAPTCHA.
+    pub site_url: String,
+    /// Browser UA — MUST match the page's UA (solver-service requirement).
+    pub user_agent: String,
+    /// datadome cookie / `dd.cid`, when known.
+    pub cid: Option<String>,
+    /// `dd.hsh`, when known.
+    pub hash: Option<String>,
+}
+
+/// Token returned by a caller-supplied solver. For DataDome this is the solved
+/// `datadome` COOKIE value.
+#[derive(Debug, Clone)]
+pub struct DataDomeSolution {
+    pub datadome_cookie: String,
+}
+
+/// Erased solver closure, stored behind `Arc<dyn ...>` on [`DataDomeBypass`].
+///
+/// [`DataDomeBypass`]: crate::bypass::DataDomeBypass
+pub(crate) type CaptchaSolver = dyn Fn(
+        DataDomeChallenge,
+    )
+        -> BoxFuture<'static, Result<DataDomeSolution, Box<dyn std::error::Error + Send + Sync>>>
+    + Send
+    + Sync;
+
+/// Wrap a typed closure into the stored `Arc<dyn CaptchaSolver>` shape.
+pub(crate) fn arc_solver<F, Fut>(f: F) -> Arc<CaptchaSolver>
+where
+    F: Fn(DataDomeChallenge) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<
+            Output = Result<DataDomeSolution, Box<dyn std::error::Error + Send + Sync>>,
+        > + Send
+        + 'static,
+{
+    Arc::new(move |challenge| Box::pin(f(challenge)))
+}
+
+/// Build a [`DataDomeChallenge`] from a detection snapshot + the live page URL
+/// + UA (read via CDP).
+pub(crate) async fn build_challenge(
+    session: &SessionHandle,
+    snap: &DetectionSnapshot,
+) -> Result<DataDomeChallenge, DataDomeError> {
+    // Read location.href + navigator.userAgent in one eval.
+    let res = session
+        .call(
+            "Runtime.evaluate",
+            json!({
+                "expression": "({ url: location.href, ua: navigator.userAgent })",
+                "returnByValue": true,
+            }),
+        )
+        .await?;
+    let v = res
+        .get("result")
+        .and_then(|r| r.get("value"))
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let site_url = v
+        .get("url")
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .to_string();
+    let user_agent = v
+        .get("ua")
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    Ok(DataDomeChallenge {
+        captcha_url: snap.captcha_url.clone().unwrap_or_default(),
+        site_url,
+        user_agent,
+        cid: snap
+            .dd
+            .as_ref()
+            .and_then(|d| d.cid.clone())
+            .or_else(|| snap.datadome.clone()),
+        hash: snap.dd.as_ref().and_then(|d| d.hsh.clone()),
+    })
+}
+
+/// Apply the solved `datadome` cookie via `Network.setCookie`, scoped to the
+/// registrable parent domain of `site_url` (DataDome sets the cookie on the
+/// eTLD+1 so it covers subdomains), then reload the page.
+pub(crate) async fn apply_solution(
+    session: &SessionHandle,
+    solution: &DataDomeSolution,
+    site_url: &str,
+) -> Result<(), DataDomeError> {
+    let domain = cookie_domain(site_url);
+    session
+        .call(
+            "Network.setCookie",
+            json!({
+                "name": "datadome",
+                "value": solution.datadome_cookie,
+                "domain": domain,
+                "path": "/",
+                "secure": true,
+                "sameSite": "Lax",
+            }),
+        )
+        .await?;
+    session.call("Page.reload", json!({})).await?;
+    Ok(())
+}
+
+/// Derive the `.eTLD+1` cookie domain from a URL. Best-effort: take the host,
+/// drop the leftmost label when there are ≥3 labels, prefix with `.`.
+/// (`shop.example.com` → `.example.com`; `example.com` → `.example.com`.)
+fn cookie_domain(site_url: &str) -> String {
+    let host = site_url
+        .split("://")
+        .nth(1)
+        .unwrap_or(site_url)
+        .split('/')
+        .next()
+        .unwrap_or("")
+        .split(':')
+        .next()
+        .unwrap_or("");
+    let labels: Vec<&str> = host.split('.').collect();
+    if labels.len() >= 3 {
+        format!(".{}", labels[labels.len() - 2..].join("."))
+    } else if labels.len() == 2 {
+        format!(".{host}")
+    } else {
+        host.to_string()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use zendriver_transport::testing::MockConnection;
+
+    #[tokio::test]
+    async fn apply_solution_sets_cookie_then_reloads() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let sol = DataDomeSolution {
+            datadome_cookie: "SOLVED_DD".into(),
+        };
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move { apply_solution(&s, &sol, "https://shop.example.com/x").await }
+        });
+
+        let id_cookie = mock.expect_cmd("Network.setCookie").await;
+        let sent = mock.last_sent();
+        assert_eq!(sent["params"]["name"], "datadome");
+        assert_eq!(sent["params"]["value"], "SOLVED_DD");
+        assert_eq!(sent["params"]["domain"], ".example.com");
+        mock.reply(id_cookie, json!({ "success": true })).await;
+
+        let id_reload = mock.expect_cmd("Page.reload").await;
+        mock.reply(id_reload, json!({})).await;
+
+        fut.await.unwrap().unwrap();
+        conn.shutdown();
+    }
+}

--- a/crates/zendriver-datadome/src/captcha.rs
+++ b/crates/zendriver-datadome/src/captcha.rs
@@ -118,7 +118,7 @@ pub(crate) async fn apply_solution(
     site_url: &str,
 ) -> Result<(), DataDomeError> {
     let domain = cookie_domain(site_url);
-    session
+    let res = session
         .call(
             "Network.setCookie",
             json!({
@@ -131,6 +131,12 @@ pub(crate) async fn apply_solution(
             }),
         )
         .await?;
+    if res.get("success").and_then(|s| s.as_bool()) == Some(false) {
+        tracing::warn!(
+            domain = %domain,
+            "datadome: Network.setCookie reported success=false — the solved cookie was rejected (bad domain?); clearance will likely time out"
+        );
+    }
     session.call("Page.reload", json!({})).await?;
     Ok(())
 }
@@ -165,6 +171,47 @@ mod tests {
     use super::*;
     use serde_json::json;
     use zendriver_transport::testing::MockConnection;
+
+    #[test]
+    fn cookie_domain_derives_etld_plus_one() {
+        assert_eq!(cookie_domain("https://shop.example.com/x"), ".example.com");
+        assert_eq!(cookie_domain("https://example.com/"), ".example.com");
+        assert_eq!(
+            cookie_domain("https://a.b.example.com/p?q=1"),
+            ".example.com"
+        );
+        assert_eq!(cookie_domain("http://localhost:8080/"), "localhost");
+        // Known v1 limitation: no public-suffix list, so multi-label TLDs
+        // degrade to the wrong parent (documented). Must never panic.
+        assert_eq!(cookie_domain("https://shop.example.co.uk/"), ".co.uk");
+    }
+
+    #[tokio::test]
+    async fn build_challenge_handles_null_eval_without_panicking() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let snap = crate::detection::DetectionSnapshot {
+            surface: crate::detection::DataDomeSurface::Captcha,
+            datadome: Some("CID".into()),
+            dd: None,
+            captcha_url: Some("https://geo.captcha-delivery.com/captcha/?cid=CID".into()),
+            body_clean: false,
+        };
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move { build_challenge(&s, &snap).await }
+        });
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id, json!({"result":{"type":"undefined"}})).await; // no value field
+        let ch = fut.await.unwrap().unwrap();
+        assert_eq!(
+            ch.captcha_url,
+            "https://geo.captcha-delivery.com/captcha/?cid=CID"
+        );
+        assert_eq!(ch.cid.as_deref(), Some("CID")); // falls back to snap.datadome
+        assert!(ch.site_url.is_empty() && ch.user_agent.is_empty());
+        conn.shutdown();
+    }
 
     #[tokio::test]
     async fn apply_solution_sets_cookie_then_reloads() {

--- a/crates/zendriver-datadome/src/captcha.rs
+++ b/crates/zendriver-datadome/src/captcha.rs
@@ -90,6 +90,12 @@ pub(crate) async fn build_challenge(
         .unwrap_or("")
         .to_string();
 
+    if site_url.is_empty() || user_agent.is_empty() {
+        tracing::warn!(
+            "datadome: build_challenge read empty url/ua — solver may receive an incomplete challenge"
+        );
+    }
+
     Ok(DataDomeChallenge {
         captcha_url: snap.captcha_url.clone().unwrap_or_default(),
         site_url,

--- a/crates/zendriver-datadome/src/detect.js
+++ b/crates/zendriver-datadome/src/detect.js
@@ -1,0 +1,40 @@
+(function () {
+  function readCookie(name) {
+    var m = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+    return m ? decodeURIComponent(m[1]) : null;
+  }
+  function findCaptchaUrl(root) {
+    var iframes = root.querySelectorAll ? root.querySelectorAll('iframe') : [];
+    for (var i = 0; i < iframes.length; i++) {
+      var f = iframes[i];
+      if (f.src && f.src.indexOf('captcha-delivery.com') !== -1) return f.src;
+    }
+    var all = root.querySelectorAll ? root.querySelectorAll('*') : [];
+    for (var j = 0; j < all.length; j++) {
+      if (all[j].shadowRoot) {
+        var sub = findCaptchaUrl(all[j].shadowRoot);
+        if (sub) return sub;
+      }
+    }
+    return null;
+  }
+  var dd = (typeof window.dd === 'object' && window.dd) ? window.dd : null;
+  var captchaUrl = findCaptchaUrl(document);
+  var datadome = readCookie('datadome');
+  var surface = 'none';
+  if (dd && String(dd.t) === 'bv') {
+    surface = 'block';
+  } else if (captchaUrl) {
+    surface = 'captcha';
+  } else if (dd) {
+    surface = 'device_check';
+  }
+  var bodyClean = !dd && !captchaUrl;
+  return {
+    surface: surface,
+    datadome: datadome,
+    dd: dd ? { cid: dd.cid || null, hsh: dd.hsh || null, t: dd.t || null, host: dd.host || null } : null,
+    captcha_url: captchaUrl,
+    body_clean: bodyClean
+  };
+})()

--- a/crates/zendriver-datadome/src/detection.rs
+++ b/crates/zendriver-datadome/src/detection.rs
@@ -1,0 +1,164 @@
+//! DataDome surface detection. One `Runtime.evaluate` round-trip bundles the
+//! cookie read, `window.dd` parse, and captcha-delivery iframe walk.
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+use zendriver_transport::SessionHandle;
+
+use crate::error::DataDomeError;
+
+/// Which DataDome surface a tab is currently showing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataDomeSurface {
+    /// window.dd.t == 'fe' device-check / interstitial — invisible JS
+    /// interrogation; also covers the auto-resolving "please wait" page.
+    DeviceCheck,
+    /// captcha-delivery.com iframe present (slider / puzzle / press-hold).
+    Captcha,
+    /// window.dd.t == 'bv' — IP banned; unsolvable in-browser.
+    Block,
+    /// No DataDome surface detected; the datadome cookie may already be valid.
+    None,
+}
+
+/// Parsed `window.dd` challenge descriptor.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct DdConfig {
+    pub cid: Option<String>,
+    pub hsh: Option<String>,
+    pub t: Option<String>,
+    pub host: Option<String>,
+}
+
+/// Snapshot of one `detect.js` round-trip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetectionSnapshot {
+    pub surface: DataDomeSurface,
+    pub datadome: Option<String>,
+    pub dd: Option<DdConfig>,
+    pub captcha_url: Option<String>,
+    pub body_clean: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSnapshot {
+    surface: String,
+    #[serde(default)]
+    datadome: Option<String>,
+    #[serde(default)]
+    dd: Option<DdConfig>,
+    #[serde(default)]
+    captcha_url: Option<String>,
+    body_clean: bool,
+}
+
+impl From<RawSnapshot> for DetectionSnapshot {
+    fn from(r: RawSnapshot) -> Self {
+        let surface = match r.surface.as_str() {
+            "device_check" => DataDomeSurface::DeviceCheck,
+            "captcha" => DataDomeSurface::Captcha,
+            "block" => DataDomeSurface::Block,
+            _ => DataDomeSurface::None,
+        };
+        Self {
+            surface,
+            datadome: r.datadome,
+            dd: r.dd,
+            captcha_url: r.captcha_url,
+            body_clean: r.body_clean,
+        }
+    }
+}
+
+/// Run a single `detect.js` probe against `session`'s main world.
+pub(crate) async fn detect_snapshot(
+    session: &SessionHandle,
+) -> Result<DetectionSnapshot, DataDomeError> {
+    let res = session
+        .call(
+            "Runtime.evaluate",
+            json!({
+                "expression": include_str!("detect.js"),
+                "returnByValue": true,
+                "awaitPromise": true,
+            }),
+        )
+        .await?;
+
+    if let Some(details) = res.get("exceptionDetails") {
+        let msg = details
+            .get("exception")
+            .and_then(|e| e.get("description"))
+            .and_then(|d| d.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        return Err(DataDomeError::JsError(msg));
+    }
+
+    let value = res
+        .get("result")
+        .and_then(|r| r.get("value"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    let raw: RawSnapshot = serde_json::from_value(value)
+        .map_err(|e| DataDomeError::JsError(format!("invalid detect.js payload: {e}")))?;
+    Ok(raw.into())
+}
+
+/// Surface-only probe. Convenience for "which surface am I on" without driving
+/// a bypass.
+pub async fn detect_surface(session: &SessionHandle) -> Result<DataDomeSurface, DataDomeError> {
+    Ok(detect_snapshot(session).await?.surface)
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use zendriver_transport::testing::MockConnection;
+
+    fn reply(v: serde_json::Value) -> serde_json::Value {
+        json!({ "result": { "type": "object", "value": v } })
+    }
+
+    #[tokio::test]
+    async fn detect_surface_classifies_each_surface() {
+        for (payload, expected) in [
+            (
+                json!({"surface":"device_check","datadome":null,"dd":{"cid":"C","hsh":"H","t":"fe","host":"geo.captcha-delivery.com"},"captcha_url":null,"body_clean":false}),
+                DataDomeSurface::DeviceCheck,
+            ),
+            (
+                json!({"surface":"captcha","datadome":"DD","dd":{"cid":"C","hsh":"H","t":"fe","host":"geo.captcha-delivery.com"},"captcha_url":"https://geo.captcha-delivery.com/captcha/?cid=C","body_clean":false}),
+                DataDomeSurface::Captcha,
+            ),
+            (
+                json!({"surface":"block","datadome":null,"dd":{"cid":"C","hsh":"H","t":"bv","host":"geo.captcha-delivery.com"},"captcha_url":null,"body_clean":false}),
+                DataDomeSurface::Block,
+            ),
+            (
+                json!({"surface":"none","datadome":"DD","dd":null,"captcha_url":null,"body_clean":true}),
+                DataDomeSurface::None,
+            ),
+        ] {
+            let (mut mock, conn) = MockConnection::pair();
+            let sess = SessionHandle::new(conn.clone(), "S1");
+            let fut = tokio::spawn({
+                let s = sess.clone();
+                async move { detect_surface(&s).await }
+            });
+            let id = mock.expect_cmd("Runtime.evaluate").await;
+            assert!(
+                mock.last_sent()["params"]["expression"]
+                    .as_str()
+                    .unwrap()
+                    .contains("captcha-delivery.com")
+            );
+            mock.reply(id, reply(payload)).await;
+            assert_eq!(fut.await.unwrap().unwrap(), expected);
+            conn.shutdown();
+        }
+    }
+}

--- a/crates/zendriver-datadome/src/error.rs
+++ b/crates/zendriver-datadome/src/error.rs
@@ -1,0 +1,56 @@
+//! DataDome-bypass errors.
+
+use zendriver_interception::InterceptionError;
+use zendriver_transport::CallError;
+
+/// Error returned by [`DataDomeBypass`] operations. Faults only — flow
+/// terminals (cleared / blocked / timed-out / already-clear) are
+/// [`ClearanceOutcome`] variants, not errors.
+///
+/// [`DataDomeBypass`]: crate::bypass::DataDomeBypass
+/// [`ClearanceOutcome`]: crate::bypass::ClearanceOutcome
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum DataDomeError {
+    /// CAPTCHA surface detected, but no `on_captcha` solver was registered.
+    #[error("CAPTCHA surface detected but no solver registered")]
+    CaptchaRequired,
+
+    /// User-supplied CAPTCHA solver returned an error.
+    #[error("CAPTCHA solver failed: {0}")]
+    CaptchaSolver(Box<dyn std::error::Error + Send + Sync>),
+
+    /// Fetch-domain interception hook failed at startup.
+    #[error("interception hook error: {0}")]
+    Interception(#[from] InterceptionError),
+
+    /// CDP transport / call error.
+    #[error("call failed: {0}")]
+    Call(#[from] CallError),
+
+    /// In-page evaluator raised or returned an unexpected payload shape.
+    #[error("JS error: {0}")]
+    JsError(String),
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_captcha_required() {
+        assert_eq!(
+            DataDomeError::CaptchaRequired.to_string(),
+            "CAPTCHA surface detected but no solver registered"
+        );
+    }
+
+    #[test]
+    fn display_js_error_passthrough() {
+        assert_eq!(
+            DataDomeError::JsError("bad payload".into()).to_string(),
+            "JS error: bad payload"
+        );
+    }
+}

--- a/crates/zendriver-datadome/src/interception.rs
+++ b/crates/zendriver-datadome/src/interception.rs
@@ -1,0 +1,101 @@
+//! Fetch-domain fast-path for DataDome clearance detection.
+//!
+//! Opt-in via [`DataDomeBypass::with_interception`]. Subscribes to
+//! Fetch responses matching `captcha-delivery.com` or `datadome` URL
+//! patterns; signals the waiter via a oneshot when a 2xx is observed.
+//! Polling continues in parallel — first signal wins.
+//!
+//! [`DataDomeBypass::with_interception`]: crate::bypass::DataDomeBypass::with_interception
+
+use futures::StreamExt;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+use zendriver_interception::InterceptBuilder;
+use zendriver_transport::SessionHandle;
+
+/// Spawn a background task that signals on first 2xx DataDome-sensor
+/// response and returns the receiver half of a oneshot.
+///
+/// Infallible: the `InterceptBuilder` chain used here (`new` → `pattern` →
+/// `at_response` → `subscribe`) is pure sync setup with no `Result`-returning
+/// step. The actual `Fetch.enable` CDP round-trip is fire-and-forget inside
+/// `subscribe()`; transport errors there are surfaced as a warn log + an
+/// empty stream, not as a `spawn_signal` failure. Treating this as `-> _`
+/// rather than `Result<_, DataDomeError>` avoids the
+/// `clippy::result_large_err` warning that `DataDomeError`'s 136-byte
+/// `CallError` variant would otherwise trip for a tiny `Ok` payload.
+///
+/// Caller must keep the returned [`InterceptionGuard`] alive until they are
+/// done with the receiver. Dropping the guard cancels the spawned task
+/// cooperatively via a `CancellationToken` checked at every loop boundary,
+/// then aborts it as a backstop. Cooperative cancel is preferred over a
+/// bare `abort()` because abort is asynchronous: the task may run one more
+/// `paused.continue_().await` after the abort signal lands — harmless, but
+/// the token lets the loop exit cleanly between events instead.
+pub(crate) fn spawn_signal(session: &SessionHandle) -> (oneshot::Receiver<()>, InterceptionGuard) {
+    let (tx, rx) = oneshot::channel();
+    let cancel = CancellationToken::new();
+    let task_cancel = cancel.clone();
+
+    // `subscribe()` is sync and returns `impl Stream<Item = PausedRequest>`.
+    // `pattern()` returns `Self` (not a `Result`), so no `?` needed on chain.
+    let stream = InterceptBuilder::new(session)
+        .pattern("*captcha-delivery.com*")
+        .at_response()
+        .pattern("*datadome*")
+        .at_response()
+        .subscribe();
+
+    let handle = tokio::spawn(async move {
+        let mut stream = Box::pin(stream);
+        let mut tx = Some(tx);
+        loop {
+            tokio::select! {
+                biased;
+                () = task_cancel.cancelled() => break,
+                next = stream.next() => {
+                    let Some(paused) = next else { break };
+                    let is_2xx = paused
+                        .response
+                        .as_ref()
+                        .map(|r| (200..300).contains(&r.status))
+                        .unwrap_or(false);
+                    // Always release the pause so the page keeps loading.
+                    let _ = paused.continue_().await;
+                    if is_2xx {
+                        if let Some(t) = tx.take() {
+                            let _ = t.send(());
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    (
+        rx,
+        InterceptionGuard {
+            cancel,
+            handle: Some(handle),
+        },
+    )
+}
+
+/// Guard for the background interception task. On drop, signals
+/// cooperative cancellation first (clean exit between events) and then
+/// aborts as a backstop in case the task is parked on a non-cancellable
+/// future.
+pub(crate) struct InterceptionGuard {
+    cancel: CancellationToken,
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for InterceptionGuard {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        if let Some(h) = self.handle.take() {
+            h.abort();
+        }
+    }
+}

--- a/crates/zendriver-datadome/src/lib.rs
+++ b/crates/zendriver-datadome/src/lib.rs
@@ -30,6 +30,7 @@ pub mod bypass;
 pub mod captcha;
 pub mod detection;
 pub mod error;
+mod interception;
 
 pub use bypass::{ClearanceOutcome, DataDomeBypass};
 pub use captcha::{DataDomeChallenge, DataDomeSolution};

--- a/crates/zendriver-datadome/src/lib.rs
+++ b/crates/zendriver-datadome/src/lib.rs
@@ -26,8 +26,12 @@
 //!
 //! [`BrowserBuilder::stealth`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.stealth
 
+pub mod bypass;
+pub mod captcha;
 pub mod detection;
 pub mod error;
 
+pub use bypass::{ClearanceOutcome, DataDomeBypass};
+pub use captcha::{DataDomeChallenge, DataDomeSolution};
 pub use detection::{DataDomeSurface, DdConfig, DetectionSnapshot, detect_surface};
 pub use error::DataDomeError;

--- a/crates/zendriver-datadome/src/lib.rs
+++ b/crates/zendriver-datadome/src/lib.rs
@@ -26,8 +26,8 @@
 //!
 //! [`BrowserBuilder::stealth`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.stealth
 
+pub mod detection;
 pub mod error;
 
+pub use detection::{DataDomeSurface, DdConfig, DetectionSnapshot, detect_surface};
 pub use error::DataDomeError;
-
-// Additional modules land in later tasks.

--- a/crates/zendriver-datadome/src/lib.rs
+++ b/crates/zendriver-datadome/src/lib.rs
@@ -26,4 +26,8 @@
 //!
 //! [`BrowserBuilder::stealth`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.stealth
 
-// Modules land in later tasks.
+pub mod error;
+
+pub use error::DataDomeError;
+
+// Additional modules land in later tasks.

--- a/crates/zendriver-datadome/src/lib.rs
+++ b/crates/zendriver-datadome/src/lib.rs
@@ -1,0 +1,29 @@
+//! DataDome anti-bot bypass for `zendriver`.
+//!
+//! This crate is a sibling to `zendriver-cloudflare` and `zendriver-imperva`.
+//! It detects which DataDome surface a tab is currently showing, observes the
+//! page until the `datadome` clearance cookie lands (on device-check surfaces
+//! the invisible JS interrogation resolves on its own), and escalates a CAPTCHA
+//! surface (slider / puzzle / press-hold) to a caller-supplied solver callback.
+//!
+//! # Limitations
+//!
+//! A successful clearance means the `datadome` cookie landed in the browser —
+//! it does **not** guarantee every subsequent request will be accepted.
+//! DataDome runs an invisible device-check that scores the fingerprint the
+//! browser emitted during the interstitial. If that score falls below
+//! threshold the next request returns a fresh challenge regardless of the
+//! cookie value.
+//!
+//! The most common root cause of a repeated challenge after apparent clearance
+//! is the **WebGL / WebGPU fingerprint leak** (issue #20): an un-shimmed
+//! `UNMASKED_RENDERER_WEBGL` extension string or `GPUAdapterInfo.device` field
+//! exposes the real GPU and flags the session as a headless browser.
+//!
+//! Run with [`BrowserBuilder::stealth`] enabled to minimize fingerprint
+//! surface. Without stealth the bypass will succeed locally but fail on
+//! real DataDome-protected sites under scoring.
+//!
+//! [`BrowserBuilder::stealth`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.stealth
+
+// Modules land in later tasks.

--- a/crates/zendriver-imperva/src/bypass.rs
+++ b/crates/zendriver-imperva/src/bypass.rs
@@ -18,32 +18,20 @@ use crate::captcha::{
     CaptchaChallenge, CaptchaSolution, CaptchaSolver, arc_solver, extract_captcha_site_key,
     inject_captcha_solution,
 };
-use crate::detection::{DetectionSnapshot, ImpervaSurface};
+use crate::detection::DetectionSnapshot;
 use crate::error::ImpervaError;
 
-/// Budget passed to [`probe_with_deadline`]: the absolute deadline the
-/// select races against, the original timeout duration for error reporting,
-/// and the most-recently-observed surface for `Timeout` diagnostics.
-#[derive(Debug, Clone, Copy)]
-struct ProbeBudget {
-    deadline: Instant,
-    timeout: Duration,
-    last_surface: Option<ImpervaSurface>,
-}
-
 /// Probe `detect_snapshot` against `session`, racing against the overall
-/// `deadline`. Returns `ImpervaError::Timeout` if the deadline wins so that
-/// no probe — including the pre-loop one — can outlive the caller's budget.
+/// `deadline`. Returns `Ok(None)` if the deadline wins so that no probe —
+/// including the pre-loop one — can outlive the caller's budget; the caller
+/// maps that sentinel to a [`ClearanceOutcome::TimedOut`].
 async fn probe_with_deadline(
     session: &SessionHandle,
-    budget: ProbeBudget,
-) -> Result<DetectionSnapshot, ImpervaError> {
+    deadline: Instant,
+) -> Result<Option<DetectionSnapshot>, ImpervaError> {
     tokio::select! {
-        res = crate::detection::detect_snapshot(session) => res,
-        () = tokio::time::sleep_until(budget.deadline) => Err(ImpervaError::Timeout {
-            timeout: budget.timeout,
-            last_surface: budget.last_surface,
-        }),
+        res = crate::detection::detect_snapshot(session) => res.map(Some),
+        () = tokio::time::sleep_until(deadline) => Ok(None),
     }
 }
 
@@ -64,6 +52,12 @@ pub enum ClearanceOutcome {
     ChallengeGone,
     /// No Imperva surface present at call time. Fast path; no waiting.
     AlreadyClear,
+    /// Deadline elapsed without clearance. `last_surface` is the most recent
+    /// surface the poll loop observed (`None` if the deadline won before the
+    /// first probe completed).
+    TimedOut {
+        last_surface: Option<crate::detection::ImpervaSurface>,
+    },
 }
 
 /// Drives an Imperva clearance flow against a single tab's session.
@@ -185,10 +179,12 @@ impl<'tab> ImpervaBypass<'tab> {
     ///   Imperva challenge markers (hybrid AND signal).
     /// - `Ok(ClearanceOutcome::ChallengeGone)` — body markers cleared but
     ///   no reese84 token was ever observed (e.g., legacy Incapsula).
+    /// - `Ok(ClearanceOutcome::TimedOut { last_surface })` — overall timeout
+    ///   elapsed before clearance. `last_surface` carries the most-recent
+    ///   observed surface. Not a fault: a deadline in a bot-management flow
+    ///   is a normal "didn't finish, retry or give up" terminal.
     ///
     /// # Errors
-    /// - [`ImpervaError::Timeout`] — overall timeout elapsed before
-    ///   clearance. `last_surface` carries the most-recent observed surface.
     /// - [`ImpervaError::CaptchaRequired`] — CAPTCHA surface detected
     ///   but no `on_captcha` solver was registered.
     /// - [`ImpervaError::CaptchaSolver`] — registered solver returned an
@@ -214,19 +210,13 @@ impl<'tab> ImpervaBypass<'tab> {
     /// ```
     pub async fn wait_for_clearance(self) -> Result<ClearanceOutcome, ImpervaError> {
         let deadline = Instant::now() + self.timeout;
-        let timeout = self.timeout;
 
         // Every probe — including the first — is raced against the deadline.
         // A hung CDP call cannot exceed the caller's stated timeout budget.
-        let snapshot = probe_with_deadline(
-            self.session,
-            ProbeBudget {
-                deadline,
-                timeout,
-                last_surface: None,
-            },
-        )
-        .await?;
+        // `None` means the deadline won before the first probe resolved.
+        let Some(snapshot) = probe_with_deadline(self.session, deadline).await? else {
+            return Ok(ClearanceOutcome::TimedOut { last_surface: None });
+        };
 
         // Fast path: nothing to clear.
         if matches!(snapshot.surface, crate::detection::ImpervaSurface::None) && snapshot.body_clean
@@ -270,14 +260,8 @@ impl<'tab> ImpervaBypass<'tab> {
             (None, None)
         };
 
-        self.poll_loop(
-            deadline,
-            timeout,
-            next_snapshot,
-            interception_rx,
-            interception_guard,
-        )
-        .await
+        self.poll_loop(deadline, next_snapshot, interception_rx, interception_guard)
+            .await
     }
 
     /// Core poll loop, factored out so unit tests can drive it with a
@@ -290,7 +274,6 @@ impl<'tab> ImpervaBypass<'tab> {
     pub(crate) async fn poll_loop(
         self,
         deadline: Instant,
-        timeout: Duration,
         mut next_snapshot: Option<DetectionSnapshot>,
         mut interception_rx: Option<tokio::sync::oneshot::Receiver<()>>,
         _interception_guard: Option<crate::interception::InterceptionGuard>,
@@ -314,17 +297,12 @@ impl<'tab> ImpervaBypass<'tab> {
         loop {
             let snap = match next_snapshot.take() {
                 Some(s) => s,
-                None => {
-                    probe_with_deadline(
-                        self.session,
-                        ProbeBudget {
-                            deadline,
-                            timeout,
-                            last_surface,
-                        },
-                    )
-                    .await?
-                }
+                None => match probe_with_deadline(self.session, deadline).await? {
+                    Some(s) => s,
+                    // Deadline won the probe race — terminate with the
+                    // most-recent surface observed so far.
+                    None => return Ok(ClearanceOutcome::TimedOut { last_surface }),
+                },
             };
 
             let token = snap.reese84.as_ref().filter(|v| !v.is_empty());
@@ -362,19 +340,13 @@ impl<'tab> ImpervaBypass<'tab> {
             }
 
             if Instant::now() >= deadline {
-                return Err(ImpervaError::Timeout {
-                    timeout,
-                    last_surface,
-                });
+                return Ok(ClearanceOutcome::TimedOut { last_surface });
             }
 
             tokio::select! {
                 _ = ticker.tick() => {}
                 () = tokio::time::sleep_until(deadline) => {
-                    return Err(ImpervaError::Timeout {
-                        timeout,
-                        last_surface,
-                    });
+                    return Ok(ClearanceOutcome::TimedOut { last_surface });
                 }
                 Ok(()) = async {
                     match interception_rx.as_mut() {
@@ -576,12 +548,12 @@ mod tests {
             .await;
         }
 
-        let err = fut.await.unwrap().unwrap_err();
-        match err {
-            ImpervaError::Timeout { last_surface, .. } => {
+        let outcome = fut.await.unwrap().unwrap();
+        match outcome {
+            ClearanceOutcome::TimedOut { last_surface } => {
                 assert_eq!(last_surface, Some(ImpervaSurface::Reese84));
             }
-            other => panic!("expected Timeout, got {other:?}"),
+            other => panic!("expected TimedOut, got {other:?}"),
         }
         conn.shutdown();
     }
@@ -888,9 +860,7 @@ mod tests {
             async move {
                 let bypass = ImpervaBypass::new(&s).poll_interval(Duration::from_secs(1));
                 let deadline = Instant::now() + Duration::from_secs(5);
-                bypass
-                    .poll_loop(deadline, Duration::from_secs(5), None, Some(rx), None)
-                    .await
+                bypass.poll_loop(deadline, None, Some(rx), None).await
             }
         });
 

--- a/crates/zendriver-imperva/src/error.rs
+++ b/crates/zendriver-imperva/src/error.rs
@@ -1,10 +1,9 @@
 //! Imperva-bypass errors.
 
-use std::time::Duration;
 use zendriver_interception::InterceptionError;
 use zendriver_transport::CallError;
 
-use crate::detection::{CaptchaKind, ImpervaSurface};
+use crate::detection::CaptchaKind;
 
 /// Error returned by [`ImpervaBypass`] operations.
 ///
@@ -12,14 +11,6 @@ use crate::detection::{CaptchaKind, ImpervaSurface};
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum ImpervaError {
-    /// `wait_for_clearance` exceeded the configured timeout.
-    /// `last_surface` is the most recent surface observed by the poll loop.
-    #[error("clearance not achieved within {timeout:?}")]
-    Timeout {
-        timeout: Duration,
-        last_surface: Option<ImpervaSurface>,
-    },
-
     /// CAPTCHA detected, but no `on_captcha` solver was registered.
     #[error("CAPTCHA required but no solver registered: {kind:?}")]
     CaptchaRequired { kind: CaptchaKind },
@@ -48,15 +39,6 @@ pub enum ImpervaError {
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn display_timeout_includes_duration() {
-        let e = ImpervaError::Timeout {
-            timeout: Duration::from_secs(30),
-            last_surface: Some(ImpervaSurface::Reese84),
-        };
-        assert_eq!(e.to_string(), "clearance not achieved within 30s");
-    }
 
     #[test]
     fn display_captcha_required_includes_kind() {

--- a/crates/zendriver-imperva/src/lib.rs
+++ b/crates/zendriver-imperva/src/lib.rs
@@ -54,6 +54,9 @@
 //!     }
 //!     ClearanceOutcome::ChallengeGone => println!("legacy cleared"),
 //!     ClearanceOutcome::AlreadyClear => println!("no challenge present"),
+//!     ClearanceOutcome::TimedOut { last_surface } => {
+//!         println!("timed out; last_surface = {last_surface:?}")
+//!     }
 //! }
 //! # Ok(()) }
 //! ```

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -21,12 +21,13 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [features]
-default = ["interception", "expect", "cloudflare", "imperva", "fetcher", "monitor"]
+default = ["interception", "expect", "cloudflare", "imperva", "datadome", "fetcher", "monitor"]
 interception  = ["zendriver/interception", "dep:uuid"]
 expect        = ["zendriver/expect", "dep:uuid"]
 monitor       = ["zendriver/monitor", "dep:uuid", "dep:futures"]
 cloudflare    = ["zendriver/cloudflare"]
 imperva       = ["zendriver/imperva"]
+datadome      = ["zendriver/datadome"]
 fetcher       = ["zendriver/fetcher"]
 fingerprints      = ["dep:zendriver-fingerprints"]
 integration-tests = []

--- a/crates/zendriver-mcp/mcp-coverage-ledger.toml
+++ b/crates/zendriver-mcp/mcp-coverage-ledger.toml
@@ -330,3 +330,52 @@ covered = "browser_monitor_start"
 [[entry]]
 api = "zendriver::NetworkEvent"
 covered = "browser_monitor_read"
+
+# ── Group D: DataDome bypass crate + WebGPU surface ─────────────────────────
+[[entry]]
+api = "zendriver::tab::Tab::datadome"
+covered = "browser_solve_datadome"
+
+[[entry]]
+api = "zendriver::DataDomeBypass"
+covered = "browser_solve_datadome"
+
+[[entry]]
+api = "zendriver::DataDomeClearanceOutcome"
+covered = "browser_solve_datadome"
+
+[[entry]]
+api = "zendriver::DataDomeSurface"
+excluded = "diagnostic enum surfaced via browser_solve_datadome.outcome; the standalone datadome_detect_surface fn is a Rust convenience"
+
+[[entry]]
+api = "zendriver::DataDomeError"
+excluded = "error type surfaced through browser_solve_datadome MCP errors"
+
+[[entry]]
+api = "zendriver::DataDomeChallenge"
+excluded = "captcha-solver callback type; the on_captcha hook is a documented MCP non-goal (same as imperva CaptchaChallenge)"
+
+[[entry]]
+api = "zendriver::DataDomeSolution"
+excluded = "captcha-solver callback type; on_captcha hook is a documented MCP non-goal"
+
+[[entry]]
+api = "zendriver::datadome_detect_surface"
+excluded = "Rust convenience probe; surface is reported via browser_solve_datadome.outcome"
+
+# `ZendriverError::DataDome` + its `From<DataDomeError>` impl are how the lib
+# folds datadome faults into the unified error enum; surfaced over MCP as
+# `browser_solve_datadome` errors (same routing as the Imperva/Cloudflare
+# variants). Both the short and module-qualified paths are emitted.
+[[entry]]
+api = "zendriver::ZendriverError::DataDome"
+covered = "browser_solve_datadome"
+
+[[entry]]
+api = "zendriver::error::ZendriverError::DataDome"
+covered = "browser_solve_datadome"
+
+[[entry]]
+api = "zendriver::error::ZendriverError::from"
+excluded = "blanket From<DataDomeError> conversion into the unified error enum; the resulting variant is covered above and surfaced via browser_solve_datadome errors"

--- a/crates/zendriver-mcp/public-api-baseline.txt
+++ b/crates/zendriver-mcp/public-api-baseline.txt
@@ -9,6 +9,12 @@ pub use zendriver::CloudflareBypass
 pub use zendriver::CloudflareError
 pub use zendriver::Connection
 pub use zendriver::CookieSnapshot
+pub use zendriver::DataDomeBypass
+pub use zendriver::DataDomeChallenge
+pub use zendriver::DataDomeClearanceOutcome
+pub use zendriver::DataDomeError
+pub use zendriver::DataDomeSolution
+pub use zendriver::DataDomeSurface
 pub use zendriver::DetectionSnapshot
 pub use zendriver::Fetcher
 pub use zendriver::FetcherChannel
@@ -38,6 +44,7 @@ pub use zendriver::Strategy
 pub use zendriver::Surface
 pub use zendriver::TransportError
 pub use zendriver::VersionSpec
+pub use zendriver::datadome_detect_surface
 pub use zendriver::detect_surface
 pub mod zendriver::browser
 pub enum zendriver::browser::Channel
@@ -887,6 +894,7 @@ pub zendriver::error::ZendriverError::Cdp::message: alloc::string::String
 pub zendriver::error::ZendriverError::Cloudflare(alloc::boxed::Box<zendriver_cloudflare::error::CloudflareError>)
 pub zendriver::error::ZendriverError::ConflictingSelectors
 pub zendriver::error::ZendriverError::Cookie(alloc::string::String)
+pub zendriver::error::ZendriverError::DataDome(alloc::boxed::Box<zendriver_datadome::error::DataDomeError>)
 pub zendriver::error::ZendriverError::Disconnected
 pub zendriver::error::ZendriverError::ElementNotFound
 pub zendriver::error::ZendriverError::ElementNotFound::selector: alloc::string::String
@@ -917,6 +925,8 @@ impl core::convert::From<zendriver::error::BrowserError> for zendriver::error::Z
 pub fn zendriver::error::ZendriverError::from(zendriver::error::BrowserError) -> Self
 impl core::convert::From<zendriver_cloudflare::error::CloudflareError> for zendriver::error::ZendriverError
 pub fn zendriver::error::ZendriverError::from(zendriver_cloudflare::error::CloudflareError) -> Self
+impl core::convert::From<zendriver_datadome::error::DataDomeError> for zendriver::error::ZendriverError
+pub fn zendriver::error::ZendriverError::from(zendriver_datadome::error::DataDomeError) -> Self
 impl core::convert::From<zendriver_fetcher::error::FetcherError> for zendriver::error::ZendriverError
 pub fn zendriver::error::ZendriverError::from(zendriver_fetcher::error::FetcherError) -> Self
 impl core::convert::From<zendriver_imperva::error::ImpervaError> for zendriver::error::ZendriverError
@@ -3885,6 +3895,8 @@ pub async fn zendriver::tab::Tab::wait_for_ready_state(&self, zendriver::tab::Re
 impl zendriver::tab::Tab
 pub fn zendriver::tab::Tab::cloudflare(&self) -> zendriver_cloudflare::bypass::CloudflareBypass<'_>
 impl zendriver::tab::Tab
+pub fn zendriver::tab::Tab::datadome(&self) -> zendriver_datadome::bypass::DataDomeBypass<'_>
+impl zendriver::tab::Tab
 pub async fn zendriver::tab::Tab::download_file(&self, impl core::convert::Into<alloc::string::String>, core::option::Option<std::path::PathBuf>) -> zendriver::error::Result<()>
 pub fn zendriver::tab::Tab::find(&self) -> zendriver::query::FindBuilder<'_>
 pub fn zendriver::tab::Tab::find_all(&self) -> zendriver::query::FindAllBuilder<'_>
@@ -5299,6 +5311,7 @@ pub zendriver::ZendriverError::Cdp::message: alloc::string::String
 pub zendriver::ZendriverError::Cloudflare(alloc::boxed::Box<zendriver_cloudflare::error::CloudflareError>)
 pub zendriver::ZendriverError::ConflictingSelectors
 pub zendriver::ZendriverError::Cookie(alloc::string::String)
+pub zendriver::ZendriverError::DataDome(alloc::boxed::Box<zendriver_datadome::error::DataDomeError>)
 pub zendriver::ZendriverError::Disconnected
 pub zendriver::ZendriverError::ElementNotFound
 pub zendriver::ZendriverError::ElementNotFound::selector: alloc::string::String
@@ -5329,6 +5342,8 @@ impl core::convert::From<zendriver::error::BrowserError> for zendriver::error::Z
 pub fn zendriver::error::ZendriverError::from(zendriver::error::BrowserError) -> Self
 impl core::convert::From<zendriver_cloudflare::error::CloudflareError> for zendriver::error::ZendriverError
 pub fn zendriver::error::ZendriverError::from(zendriver_cloudflare::error::CloudflareError) -> Self
+impl core::convert::From<zendriver_datadome::error::DataDomeError> for zendriver::error::ZendriverError
+pub fn zendriver::error::ZendriverError::from(zendriver_datadome::error::DataDomeError) -> Self
 impl core::convert::From<zendriver_fetcher::error::FetcherError> for zendriver::error::ZendriverError
 pub fn zendriver::error::ZendriverError::from(zendriver_fetcher::error::FetcherError) -> Self
 impl core::convert::From<zendriver_imperva::error::ImpervaError> for zendriver::error::ZendriverError
@@ -7348,6 +7363,8 @@ pub async fn zendriver::tab::Tab::wait_for_load(&self) -> zendriver::error::Resu
 pub async fn zendriver::tab::Tab::wait_for_ready_state(&self, zendriver::tab::ReadyState) -> zendriver::error::Result<()>
 impl zendriver::tab::Tab
 pub fn zendriver::tab::Tab::cloudflare(&self) -> zendriver_cloudflare::bypass::CloudflareBypass<'_>
+impl zendriver::tab::Tab
+pub fn zendriver::tab::Tab::datadome(&self) -> zendriver_datadome::bypass::DataDomeBypass<'_>
 impl zendriver::tab::Tab
 pub async fn zendriver::tab::Tab::download_file(&self, impl core::convert::Into<alloc::string::String>, core::option::Option<std::path::PathBuf>) -> zendriver::error::Result<()>
 pub fn zendriver::tab::Tab::find(&self) -> zendriver::query::FindBuilder<'_>

--- a/crates/zendriver-mcp/src/server.rs
+++ b/crates/zendriver-mcp/src/server.rs
@@ -31,6 +31,8 @@ use crate::state::SessionState;
 #[cfg(feature = "cloudflare")]
 use crate::tools::cloudflare;
 use crate::tools::common::EmptyInput;
+#[cfg(feature = "datadome")]
+use crate::tools::datadome;
 #[cfg(feature = "expect")]
 use crate::tools::expect;
 #[cfg(feature = "fetcher")]
@@ -992,6 +994,29 @@ impl ZendriverServer {
     }
 }
 
+// ---------- datadome (gated) ---------------------------------------------
+//
+// Same split pattern as the cloudflare / imperva blocks — own impl block so
+// the `tool_router` macro can cfg-gate the whole thing.
+
+#[cfg(feature = "datadome")]
+#[tool_router(router = datadome_tool_router, vis = "pub")]
+impl ZendriverServer {
+    /// Drive the DataDome clearance flow on the current tab.
+    #[tool(
+        name = "browser_solve_datadome",
+        description = "Detect the active DataDome surface and poll until the datadome clearance cookie lands. Detects the active surface (invisible device-check, captcha-delivery interstitial, or `bv` IP-block) and polls every `poll_interval_ms` until one of five terminal states is reached, bounded by `timeout_ms` (default 30_000 = 30s): `cleared` (datadome cookie captured — returned in `datadome`), `challenge_gone` (markers cleared without a cookie), `already_clear` (no surface present at call time — fast path), `blocked` (`window.dd.t == 'bv'`, IP banned — caller must change IP), or `timeout` (deadline elapsed — not an error, retry or fall back). Set `with_interception: true` for the Fetch-domain fast-path. A captcha surface without a registered solver errors (handle out-of-band). Requires stealth (on by default)."
+    )]
+    pub async fn browser_solve_datadome(
+        &self,
+        Parameters(input): Parameters<datadome::SolveDataDomeInput>,
+    ) -> Result<Json<datadome::SolveDataDomeOutput>, ErrorData> {
+        datadome::solve_datadome(self.state.clone(), input)
+            .await
+            .map(Json)
+    }
+}
+
 // ---------- fetcher (gated) ----------------------------------------------
 //
 // Same split pattern as the other gated blocks. `browser_install_chrome`
@@ -1101,6 +1126,8 @@ impl ZendriverServer {
         let router = router + Self::cloudflare_tool_router();
         #[cfg(feature = "imperva")]
         let router = router + Self::imperva_tool_router();
+        #[cfg(feature = "datadome")]
+        let router = router + Self::datadome_tool_router();
         #[cfg(feature = "fetcher")]
         let router = router + Self::fetcher_tool_router();
         #[cfg(feature = "fingerprints")]

--- a/crates/zendriver-mcp/src/tools/cloudflare.rs
+++ b/crates/zendriver-mcp/src/tools/cloudflare.rs
@@ -10,16 +10,15 @@
 //!   `cf-turnstile-response` input picked up a token.
 //! - `Ok(ClearanceOutcome::ChallengeGone)` — the challenge container
 //!   vanished without a token (e.g. clearance cookie shortcut).
-//! - `Err(CloudflareError::ClearanceTimeout)` — the per-call deadline
-//!   elapsed.
+//! - `Ok(ClearanceOutcome::TimedOut { saw_challenge })` — the per-call
+//!   deadline elapsed (whether or not a challenge was ever seen).
 //!
 //! Agents typically want all three lumped into a single discriminated
 //! union of *expected* outcomes — a timeout in turnstile flow is a normal
 //! "didn't finish, try again or give up" signal, not a server error. So
-//! the MCP layer collapses `ClearanceTimeout` from the `Err` arm into a
-//! third [`Outcome::Timeout`] variant on the `Ok` side, and keeps every
-//! other `CloudflareError` (network failure, JS error, no challenge
-//! present at all) as a real MCP error.
+//! the MCP layer collapses `TimedOut` into a third [`Outcome::Timeout`]
+//! variant, and keeps every `CloudflareError` (network failure, JS error)
+//! as a real MCP error.
 //!
 //! [`CloudflareBypass::wait_for_clearance`]: zendriver_cloudflare::CloudflareBypass::wait_for_clearance
 
@@ -32,7 +31,7 @@ use rmcp::ErrorData;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
-use zendriver::{ClearanceOutcome, CloudflareError, ZendriverError};
+use zendriver::{ClearanceOutcome, ZendriverError};
 
 use crate::errors::{McpServerError, map_error};
 use crate::state::SessionState;
@@ -121,14 +120,16 @@ pub async fn solve_turnstile(
             outcome: Outcome::ChallengeGone,
             token: None,
         }),
-        // ClearanceTimeout collapses into the success channel — see
-        // module docs for the rationale.
-        Err(CloudflareError::ClearanceTimeout) => Ok(SolveOutput {
+        // TimedOut is a lib-side success terminal; collapse it into the
+        // success-channel `Outcome::Timeout` — see module docs. The old
+        // `NoChallenge` error used to fall into the `Err` arm below; it is
+        // now folded into this outcome (with `saw_challenge: false`).
+        Ok(ClearanceOutcome::TimedOut { .. }) => Ok(SolveOutput {
             outcome: Outcome::Timeout,
             token: None,
         }),
-        // Everything else (no challenge, CDP call failed, JS error) is a
-        // real error the agent should surface. Route through the lib's
+        // Everything else (CDP call failed, JS error) is a real error the
+        // agent should surface. Route through the lib's
         // `From<CloudflareError> for ZendriverError` so the existing
         // `map_error` knows how to format it.
         Err(other) => Err(map_error(McpServerError::from(ZendriverError::from(other)))),

--- a/crates/zendriver-mcp/src/tools/cloudflare.rs
+++ b/crates/zendriver-mcp/src/tools/cloudflare.rs
@@ -62,9 +62,10 @@ fn default_timeout() -> u64 {
 /// Terminal outcome of a turnstile bypass attempt.
 ///
 /// `Solved` and `ChallengeGone` mirror the lib's `ClearanceOutcome`
-/// variants. `Timeout` is the MCP layer's collapse of
-/// `CloudflareError::ClearanceTimeout` into the success channel — agents
-/// can branch on `outcome` without try/catch around a timeout.
+/// variants. `Timeout` mirrors the lib's `ClearanceOutcome::TimedOut` — a
+/// deadline in a turnstile flow is a normal outcome, not an error —
+/// surfacing it on the success channel so agents can branch on `outcome`
+/// without try/catch around a timeout.
 #[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Outcome {

--- a/crates/zendriver-mcp/src/tools/datadome.rs
+++ b/crates/zendriver-mcp/src/tools/datadome.rs
@@ -1,0 +1,145 @@
+//! DataDome bypass tool — `browser_solve_datadome`. Gated behind the
+//! `datadome` feature. Mirrors `tools/imperva.rs`: all flow-terminals
+//! (cleared / challenge_gone / already_clear / blocked / timed_out) are
+//! success-channel outcomes; only genuine faults (captcha-without-solver, CDP,
+//! JS) are MCP errors. The `on_captcha` solver hook is intentionally not wired
+//! over MCP (documented non-goal, same as imperva): a captcha surface without
+//! a solver surfaces as a `CaptchaRequired` error the agent handles
+//! out-of-band.
+
+#![cfg(feature = "datadome")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rmcp::ErrorData;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use zendriver::{DataDomeClearanceOutcome, ZendriverError};
+
+use crate::errors::{McpServerError, map_error};
+use crate::state::SessionState;
+use crate::tools::common::current_tab;
+
+/// Input for `browser_solve_datadome`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SolveDataDomeInput {
+    /// Maximum total wait for a terminal outcome, in milliseconds. Default
+    /// 30_000 (30s).
+    #[serde(default = "default_timeout")]
+    pub timeout_ms: u64,
+    /// Override the bypass driver's internal poll cadence, in milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub poll_interval_ms: Option<u64>,
+    /// Enable the Fetch-domain interception fast-path. Default `false`.
+    #[serde(default)]
+    pub with_interception: bool,
+}
+
+fn default_timeout() -> u64 {
+    30_000
+}
+
+/// Terminal outcome of a DataDome bypass attempt.
+#[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Outcome {
+    /// datadome cookie acquired (value in [`SolveDataDomeOutput::datadome`]).
+    Cleared,
+    /// Body markers cleared without a datadome cookie.
+    ChallengeGone,
+    /// No DataDome surface present at call time (fast path).
+    AlreadyClear,
+    /// `window.dd.t == 'bv'` — IP banned. Caller must change IP.
+    Blocked,
+    /// `timeout_ms` elapsed without a terminal state. Not a hard error.
+    Timeout,
+}
+
+/// Output of `browser_solve_datadome`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct SolveDataDomeOutput {
+    /// Which terminal state the bypass reached.
+    pub outcome: Outcome,
+    /// datadome cookie value. Populated only when `outcome == cleared`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub datadome: Option<String>,
+}
+
+/// Drive the DataDome clearance flow on the current tab, returning the
+/// terminal outcome within `timeout_ms`.
+///
+/// See module-level docs for outcome semantics.
+pub async fn solve_datadome(
+    state: Arc<Mutex<SessionState>>,
+    input: SolveDataDomeInput,
+) -> Result<SolveDataDomeOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    let mut bypass = tab
+        .datadome()
+        .timeout(Duration::from_millis(input.timeout_ms));
+    if let Some(p) = input.poll_interval_ms {
+        bypass = bypass.poll_interval(Duration::from_millis(p));
+    }
+    if input.with_interception {
+        bypass = bypass.with_interception();
+    }
+    match bypass.wait_for_clearance().await {
+        Ok(DataDomeClearanceOutcome::Cleared { datadome }) => Ok(SolveDataDomeOutput {
+            outcome: Outcome::Cleared,
+            datadome: Some(datadome),
+        }),
+        Ok(DataDomeClearanceOutcome::ChallengeGone) => Ok(SolveDataDomeOutput {
+            outcome: Outcome::ChallengeGone,
+            datadome: None,
+        }),
+        Ok(DataDomeClearanceOutcome::AlreadyClear) => Ok(SolveDataDomeOutput {
+            outcome: Outcome::AlreadyClear,
+            datadome: None,
+        }),
+        Ok(DataDomeClearanceOutcome::Blocked) => Ok(SolveDataDomeOutput {
+            outcome: Outcome::Blocked,
+            datadome: None,
+        }),
+        // TimedOut is a lib-side success terminal; collapse it into the
+        // success-channel `Outcome::Timeout` — see module docs.
+        Ok(DataDomeClearanceOutcome::TimedOut { .. }) => Ok(SolveDataDomeOutput {
+            outcome: Outcome::Timeout,
+            datadome: None,
+        }),
+        // Everything else (CAPTCHA-without-solver, CDP failure, JS error) is a
+        // real error. Route through `From<DataDomeError> for ZendriverError` so
+        // the existing `map_error` knows how to format it.
+        Err(other) => Err(map_error(McpServerError::from(ZendriverError::from(other)))),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    //! No-browser unit coverage. The bypass flow itself needs a live Chrome +
+    //! a DataDome-protected page — exercised in the integration test gated
+    //! behind `integration-tests + datadome`. Here we cover the only branch
+    //! reachable without a browser: no browser open surfaces `BrowserNotOpen`.
+
+    use super::*;
+
+    #[tokio::test]
+    async fn solve_datadome_with_no_browser_errors() {
+        let state = Arc::new(Mutex::new(SessionState::new()));
+        let err = solve_datadome(
+            state,
+            SolveDataDomeInput {
+                timeout_ms: 100,
+                poll_interval_ms: None,
+                with_interception: false,
+            },
+        )
+        .await
+        .expect_err("expected BrowserNotOpen");
+        assert!(err.message.contains("Browser not open"));
+    }
+}

--- a/crates/zendriver-mcp/src/tools/imperva.rs
+++ b/crates/zendriver-mcp/src/tools/imperva.rs
@@ -69,9 +69,10 @@ fn default_timeout() -> u64 {
 /// Terminal outcome of an Imperva bypass attempt.
 ///
 /// `TokenAcquired` / `ChallengeGone` / `AlreadyClear` mirror the lib's
-/// [`ImpervaClearanceOutcome`] variants. `Timeout` is the MCP layer's
-/// collapse of [`ImpervaError::Timeout`] into the success channel — agents
-/// branch on `outcome` without try/catch around a timeout.
+/// [`ImpervaClearanceOutcome`] variants. `Timeout` mirrors the lib's
+/// [`ImpervaClearanceOutcome::TimedOut`] — a deadline in a bot-management
+/// flow is a normal outcome, not an error — surfacing it on the success
+/// channel so agents branch on `outcome` without try/catch around a timeout.
 #[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Outcome {

--- a/crates/zendriver-mcp/src/tools/imperva.rs
+++ b/crates/zendriver-mcp/src/tools/imperva.rs
@@ -4,10 +4,10 @@
 //! Mirrors [`tools/cloudflare.rs`][crate::tools::cloudflare]: the lib's
 //! [`ImpervaBypass::wait_for_clearance`] models its terminal state as
 //! `Result<ImpervaClearanceOutcome, ImpervaError>`. The MCP layer collapses
-//! the [`ImpervaError::Timeout`] arm into a non-error
-//! [`Outcome::Timeout`] — a deadline in a bot-management flow is a normal
-//! "didn't finish, retry or give up" signal, not a server error — and keeps
-//! every other `ImpervaError` (CAPTCHA-without-solver, CDP failure, JS error)
+//! the lib-side [`ImpervaClearanceOutcome::TimedOut`] terminal into a
+//! non-error [`Outcome::Timeout`] — a deadline in a bot-management flow is a
+//! normal "didn't finish, retry or give up" signal, not a server error — and
+//! keeps every `ImpervaError` (CAPTCHA-without-solver, CDP failure, JS error)
 //! as a real MCP error.
 //!
 //! Unlike Cloudflare's three states, Imperva reports a fourth —
@@ -31,7 +31,7 @@ use rmcp::ErrorData;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
-use zendriver::{ImpervaClearanceOutcome, ImpervaError, ZendriverError};
+use zendriver::{ImpervaClearanceOutcome, ZendriverError};
 
 use crate::errors::{McpServerError, map_error};
 use crate::state::SessionState;
@@ -134,8 +134,9 @@ pub async fn solve_imperva(
             outcome: Outcome::AlreadyClear,
             reese84: None,
         }),
-        // Timeout collapses into the success channel — see module docs.
-        Err(ImpervaError::Timeout { .. }) => Ok(SolveImpervaOutput {
+        // TimedOut is a lib-side success terminal; collapse it into the
+        // success-channel `Outcome::Timeout` — see module docs.
+        Ok(ImpervaClearanceOutcome::TimedOut { .. }) => Ok(SolveImpervaOutput {
             outcome: Outcome::Timeout,
             reese84: None,
         }),

--- a/crates/zendriver-mcp/src/tools/mod.rs
+++ b/crates/zendriver-mcp/src/tools/mod.rs
@@ -13,6 +13,8 @@ pub mod actions;
 pub mod cloudflare;
 pub mod common;
 pub mod cookies;
+#[cfg(feature = "datadome")]
+pub mod datadome;
 pub mod download;
 pub mod eval;
 #[cfg(feature = "expect")]

--- a/crates/zendriver-mcp/tests/schema_snapshots.rs
+++ b/crates/zendriver-mcp/tests/schema_snapshots.rs
@@ -277,6 +277,17 @@ mod imperva_snaps {
     schema_snap!(imperva_solve_out, tools::imperva::SolveImpervaOutput);
 }
 
+// ---------- datadome (feature-gated) --------------------------------------
+
+#[cfg(feature = "datadome")]
+mod datadome_snaps {
+    use super::*;
+
+    schema_snap!(datadome_solve_in, tools::datadome::SolveDataDomeInput);
+    schema_snap!(datadome_outcome, tools::datadome::Outcome);
+    schema_snap!(datadome_solve_out, tools::datadome::SolveDataDomeOutput);
+}
+
 // ---------- fetcher (feature-gated) ---------------------------------------
 
 #[cfg(feature = "fetcher")]

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__cloudflare_snaps__cloudflare_outcome.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__cloudflare_snaps__cloudflare_outcome.snap
@@ -4,7 +4,7 @@ expression: "schema_for! (tools::cloudflare::Outcome)"
 ---
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: Outcome
-description: "Terminal outcome of a turnstile bypass attempt.\n\n`Solved` and `ChallengeGone` mirror the lib's `ClearanceOutcome`\nvariants. `Timeout` is the MCP layer's collapse of\n`CloudflareError::ClearanceTimeout` into the success channel — agents\ncan branch on `outcome` without try/catch around a timeout."
+description: "Terminal outcome of a turnstile bypass attempt.\n\n`Solved` and `ChallengeGone` mirror the lib's `ClearanceOutcome`\nvariants. `Timeout` mirrors the lib's `ClearanceOutcome::TimedOut` — a\ndeadline in a turnstile flow is a normal outcome, not an error —\nsurfacing it on the success channel so agents can branch on `outcome`\nwithout try/catch around a timeout."
 oneOf:
   - description: "Turnstile produced a token (value of `cf-turnstile-response`). The\ntoken is available in [`SolveOutput::token`]."
     type: string

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__cloudflare_snaps__cloudflare_solve_out.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__cloudflare_snaps__cloudflare_solve_out.snap
@@ -19,7 +19,7 @@ required:
   - outcome
 $defs:
   Outcome:
-    description: "Terminal outcome of a turnstile bypass attempt.\n\n`Solved` and `ChallengeGone` mirror the lib's `ClearanceOutcome`\nvariants. `Timeout` is the MCP layer's collapse of\n`CloudflareError::ClearanceTimeout` into the success channel — agents\ncan branch on `outcome` without try/catch around a timeout."
+    description: "Terminal outcome of a turnstile bypass attempt.\n\n`Solved` and `ChallengeGone` mirror the lib's `ClearanceOutcome`\nvariants. `Timeout` mirrors the lib's `ClearanceOutcome::TimedOut` — a\ndeadline in a turnstile flow is a normal outcome, not an error —\nsurfacing it on the success channel so agents can branch on `outcome`\nwithout try/catch around a timeout."
     oneOf:
       - description: "Turnstile produced a token (value of `cf-turnstile-response`). The\ntoken is available in [`SolveOutput::token`]."
         type: string

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__datadome_snaps__datadome_outcome.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__datadome_snaps__datadome_outcome.snap
@@ -1,0 +1,23 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::datadome::Outcome)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: Outcome
+description: Terminal outcome of a DataDome bypass attempt.
+oneOf:
+  - description: "datadome cookie acquired (value in [`SolveDataDomeOutput::datadome`])."
+    type: string
+    const: cleared
+  - description: Body markers cleared without a datadome cookie.
+    type: string
+    const: challenge_gone
+  - description: No DataDome surface present at call time (fast path).
+    type: string
+    const: already_clear
+  - description: "`window.dd.t == 'bv'` — IP banned. Caller must change IP."
+    type: string
+    const: blocked
+  - description: "`timeout_ms` elapsed without a terminal state. Not a hard error."
+    type: string
+    const: timeout

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__datadome_snaps__datadome_solve_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__datadome_snaps__datadome_solve_in.snap
@@ -1,0 +1,27 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::datadome::SolveDataDomeInput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: SolveDataDomeInput
+description: "Input for `browser_solve_datadome`."
+type: object
+properties:
+  poll_interval_ms:
+    description: "Override the bypass driver's internal poll cadence, in milliseconds."
+    type:
+      - integer
+      - "null"
+    format: uint64
+    minimum: 0
+  timeout_ms:
+    description: "Maximum total wait for a terminal outcome, in milliseconds. Default\n30_000 (30s)."
+    type: integer
+    format: uint64
+    default: 30000
+    minimum: 0
+  with_interception:
+    description: "Enable the Fetch-domain interception fast-path. Default `false`."
+    type: boolean
+    default: false
+additionalProperties: false

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__datadome_snaps__datadome_solve_out.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__datadome_snaps__datadome_solve_out.snap
@@ -1,0 +1,38 @@
+---
+source: crates/zendriver-mcp/tests/schema_snapshots.rs
+expression: "schema_for! (tools::datadome::SolveDataDomeOutput)"
+---
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: SolveDataDomeOutput
+description: "Output of `browser_solve_datadome`."
+type: object
+properties:
+  datadome:
+    description: "datadome cookie value. Populated only when `outcome == cleared`."
+    type:
+      - string
+      - "null"
+  outcome:
+    description: Which terminal state the bypass reached.
+    $ref: "#/$defs/Outcome"
+required:
+  - outcome
+$defs:
+  Outcome:
+    description: Terminal outcome of a DataDome bypass attempt.
+    oneOf:
+      - description: "datadome cookie acquired (value in [`SolveDataDomeOutput::datadome`])."
+        type: string
+        const: cleared
+      - description: Body markers cleared without a datadome cookie.
+        type: string
+        const: challenge_gone
+      - description: No DataDome surface present at call time (fast path).
+        type: string
+        const: already_clear
+      - description: "`window.dd.t == 'bv'` — IP banned. Caller must change IP."
+        type: string
+        const: blocked
+      - description: "`timeout_ms` elapsed without a terminal state. Not a hard error."
+        type: string
+        const: timeout

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__imperva_snaps__imperva_outcome.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__imperva_snaps__imperva_outcome.snap
@@ -4,7 +4,7 @@ expression: "schema_for! (tools::imperva::Outcome)"
 ---
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: Outcome
-description: "Terminal outcome of an Imperva bypass attempt.\n\n`TokenAcquired` / `ChallengeGone` / `AlreadyClear` mirror the lib's\n[`ImpervaClearanceOutcome`] variants. `Timeout` is the MCP layer's\ncollapse of [`ImpervaError::Timeout`] into the success channel — agents\nbranch on `outcome` without try/catch around a timeout."
+description: "Terminal outcome of an Imperva bypass attempt.\n\n`TokenAcquired` / `ChallengeGone` / `AlreadyClear` mirror the lib's\n[`ImpervaClearanceOutcome`] variants. `Timeout` mirrors the lib's\n[`ImpervaClearanceOutcome::TimedOut`] — a deadline in a bot-management\nflow is a normal outcome, not an error — surfacing it on the success\nchannel so agents branch on `outcome` without try/catch around a timeout."
 oneOf:
   - description: "reese84 token acquired (value in [`SolveImpervaOutput::reese84`])."
     type: string

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__imperva_snaps__imperva_solve_out.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__imperva_snaps__imperva_solve_out.snap
@@ -19,7 +19,7 @@ required:
   - outcome
 $defs:
   Outcome:
-    description: "Terminal outcome of an Imperva bypass attempt.\n\n`TokenAcquired` / `ChallengeGone` / `AlreadyClear` mirror the lib's\n[`ImpervaClearanceOutcome`] variants. `Timeout` is the MCP layer's\ncollapse of [`ImpervaError::Timeout`] into the success channel — agents\nbranch on `outcome` without try/catch around a timeout."
+    description: "Terminal outcome of an Imperva bypass attempt.\n\n`TokenAcquired` / `ChallengeGone` / `AlreadyClear` mirror the lib's\n[`ImpervaClearanceOutcome`] variants. `Timeout` mirrors the lib's\n[`ImpervaClearanceOutcome::TimedOut`] — a deadline in a bot-management\nflow is a normal outcome, not an error — surfacing it on the success\nchannel so agents branch on `outcome` without try/catch around a timeout."
     oneOf:
       - description: "reese84 token acquired (value in [`SolveImpervaOutput::reese84`])."
         type: string

--- a/crates/zendriver-stealth/src/patches.rs
+++ b/crates/zendriver-stealth/src/patches.rs
@@ -198,18 +198,16 @@ fn push_webgpu(out: &mut String, cfg: Option<&SurfaceCfg>, webgl: Option<&WebglS
     use crate::persona::webgpu_adapter::adapter_for_renderer;
     let strat = Surface::Webgpu.resolve_strategy(cfg.and_then(|c| c.strategy));
     if strat == Strategy::Native {
-        return; // leave the real navigator.gpu untouched
+        return;
     }
-    // Default coherent renderer must match webgl.js's hardcoded fallback.
     const DEFAULT_RENDERER: &str =
         "ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)";
     let renderer = webgl
         .and_then(|w| w.unmasked_renderer.as_deref())
         .unwrap_or(DEFAULT_RENDERER);
     let adapter = adapter_for_renderer(renderer);
-    let (vendor, arch, desc, mode) = if strat == Strategy::Block {
+    let (vendor, arch, mode) = if strat == Strategy::Block {
         (
-            "null".to_string(),
             "null".to_string(),
             "null".to_string(),
             "\"block\"".to_string(),
@@ -218,7 +216,6 @@ fn push_webgpu(out: &mut String, cfg: Option<&SurfaceCfg>, webgl: Option<&WebglS
         (
             serde_json::to_string(&adapter.vendor).unwrap_or_else(|_| "null".into()),
             serde_json::to_string(&adapter.architecture).unwrap_or_else(|_| "null".into()),
-            serde_json::to_string(&adapter.description).unwrap_or_else(|_| "null".into()),
             "\"value\"".to_string(),
         )
     };
@@ -227,7 +224,6 @@ fn push_webgpu(out: &mut String, cfg: Option<&SurfaceCfg>, webgl: Option<&WebglS
         &WEBGPU
             .replace("WEBGPU_VENDOR", &vendor)
             .replace("WEBGPU_ARCHITECTURE", &arch)
-            .replace("WEBGPU_DESCRIPTION", &desc)
             .replace("WEBGPU_MODE", &mode),
     );
 }
@@ -635,10 +631,9 @@ mod tests {
         let p = Persona {
             webgl: Some(WebglSpec {
                 strategy: Some(Strategy::Value),
-                unmasked_vendor: Some("Google Inc. (NVIDIA)".into()),
+                unmasked_vendor: Some("Google Inc. (Apple)".into()),
                 unmasked_renderer: Some(
-                    "ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 Direct3D11 vs_5_0 ps_5_0, D3D11)"
-                        .into(),
+                    "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)".into(),
                 ),
             }),
             ..Persona::default()
@@ -649,12 +644,12 @@ mod tests {
             "webgpu patch emitted by default (Value)"
         );
         assert!(
-            s.contains("\"nvidia\""),
+            s.contains("\"apple\""),
             "coherent vendor derived from renderer"
         );
         assert!(
-            s.contains("ada-lovelace"),
-            "coherent architecture derived from renderer"
+            s.contains("\"metal-3\""),
+            "validated architecture for Apple Metal (real Chrome probe)"
         );
     }
 
@@ -742,7 +737,6 @@ mod tests {
             "HW_VOICES",
             "WEBGPU_VENDOR",
             "WEBGPU_ARCHITECTURE",
-            "WEBGPU_DESCRIPTION",
             "WEBGPU_MODE",
         ] {
             assert!(

--- a/crates/zendriver-stealth/src/patches.rs
+++ b/crates/zendriver-stealth/src/patches.rs
@@ -645,7 +645,7 @@ mod tests {
         };
         let s = bootstrap_script(&p, &mock_identity());
         assert!(
-            s.contains("requestAdapter"),
+            s.contains("GPUAdapter.prototype"),
             "webgpu patch emitted by default (Value)"
         );
         assert!(
@@ -668,6 +668,10 @@ mod tests {
         };
         let s = bootstrap_script(&p, &mock_identity());
         assert!(s.contains("\"block\""), "block mode token substituted");
+        assert!(
+            s.contains("navigator, 'gpu'"),
+            "block mode shadows navigator.gpu"
+        );
     }
 
     #[test]
@@ -682,7 +686,7 @@ mod tests {
         // Native → no webgpu patch emitted at all.
         assert!(!s.contains("WEBGPU_VENDOR"), "no unsubstituted token");
         assert!(
-            !s.contains("requestAdapter"),
+            !s.contains("GPUAdapter.prototype"),
             "Native webgpu omits the patch"
         );
     }

--- a/crates/zendriver-stealth/src/patches.rs
+++ b/crates/zendriver-stealth/src/patches.rs
@@ -42,6 +42,7 @@ const CLIENT_RECTS: &str = include_str!("patches/client_rects.js");
 const FONTS: &str = include_str!("patches/fonts.js");
 const WEBRTC: &str = include_str!("patches/webrtc.js");
 const HARDWARE: &str = include_str!("patches/hardware.js");
+const WEBGPU: &str = include_str!("patches/webgpu.js");
 
 /// Build the bootstrap script for the spoofed profile.
 ///
@@ -88,6 +89,7 @@ pub fn bootstrap_script(persona: &Persona, identity: &Fingerprint) -> String {
     );
 
     push_webgl(&mut out, persona.webgl.as_ref());
+    push_webgpu(&mut out, persona.webgpu.as_ref(), persona.webgl.as_ref());
     push_fonts(&mut out, persona.fonts.as_ref(), seed);
     push_hardware(&mut out, persona.hardware.as_ref());
     push_webrtc(&mut out, persona.webrtc.as_ref());
@@ -186,6 +188,47 @@ fn push_webgl(out: &mut String, spec: Option<&WebglSpec>) {
         &WEBGL
             .replace("WEBGL_VENDOR", &vendor)
             .replace("WEBGL_RENDERER", &renderer),
+    );
+}
+
+/// Append the WebGPU coherence patch. The adapter info is derived from the
+/// persona's WebGL renderer (or the hardcoded Intel default the webgl block
+/// falls back to), so navigator.gpu agrees with WebGL. Omitted under `Native`.
+fn push_webgpu(out: &mut String, cfg: Option<&SurfaceCfg>, webgl: Option<&WebglSpec>) {
+    use crate::persona::webgpu_adapter::adapter_for_renderer;
+    let strat = Surface::Webgpu.resolve_strategy(cfg.and_then(|c| c.strategy));
+    if strat == Strategy::Native {
+        return; // leave the real navigator.gpu untouched
+    }
+    // Default coherent renderer must match webgl.js's hardcoded fallback.
+    const DEFAULT_RENDERER: &str =
+        "ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)";
+    let renderer = webgl
+        .and_then(|w| w.unmasked_renderer.as_deref())
+        .unwrap_or(DEFAULT_RENDERER);
+    let adapter = adapter_for_renderer(renderer);
+    let (vendor, arch, desc, mode) = if strat == Strategy::Block {
+        (
+            "null".to_string(),
+            "null".to_string(),
+            "null".to_string(),
+            "\"block\"".to_string(),
+        )
+    } else {
+        (
+            serde_json::to_string(&adapter.vendor).unwrap_or_else(|_| "null".into()),
+            serde_json::to_string(&adapter.architecture).unwrap_or_else(|_| "null".into()),
+            serde_json::to_string(&adapter.description).unwrap_or_else(|_| "null".into()),
+            "\"value\"".to_string(),
+        )
+    };
+    out.push('\n');
+    out.push_str(
+        &WEBGPU
+            .replace("WEBGPU_VENDOR", &vendor)
+            .replace("WEBGPU_ARCHITECTURE", &arch)
+            .replace("WEBGPU_DESCRIPTION", &desc)
+            .replace("WEBGPU_MODE", &mode),
     );
 }
 
@@ -588,6 +631,63 @@ mod tests {
     }
 
     #[test]
+    fn webgpu_value_substitutes_coherent_adapter_from_renderer() {
+        let p = Persona {
+            webgl: Some(WebglSpec {
+                strategy: Some(Strategy::Value),
+                unmasked_vendor: Some("Google Inc. (NVIDIA)".into()),
+                unmasked_renderer: Some(
+                    "ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 Direct3D11 vs_5_0 ps_5_0, D3D11)"
+                        .into(),
+                ),
+            }),
+            ..Persona::default()
+        };
+        let s = bootstrap_script(&p, &mock_identity());
+        assert!(
+            s.contains("requestAdapter"),
+            "webgpu patch emitted by default (Value)"
+        );
+        assert!(
+            s.contains("\"nvidia\""),
+            "coherent vendor derived from renderer"
+        );
+        assert!(
+            s.contains("ada-lovelace"),
+            "coherent architecture derived from renderer"
+        );
+    }
+
+    #[test]
+    fn webgpu_block_deletes_navigator_gpu() {
+        let p = Persona {
+            webgpu: Some(SurfaceCfg {
+                strategy: Some(Strategy::Block),
+            }),
+            ..Persona::default()
+        };
+        let s = bootstrap_script(&p, &mock_identity());
+        assert!(s.contains("\"block\""), "block mode token substituted");
+    }
+
+    #[test]
+    fn webgpu_native_passes_null_vendor() {
+        let p = Persona {
+            webgpu: Some(SurfaceCfg {
+                strategy: Some(Strategy::Native),
+            }),
+            ..Persona::default()
+        };
+        let s = bootstrap_script(&p, &mock_identity());
+        // Native → no webgpu patch emitted at all.
+        assert!(!s.contains("WEBGPU_VENDOR"), "no unsubstituted token");
+        assert!(
+            !s.contains("requestAdapter"),
+            "Native webgpu omits the patch"
+        );
+    }
+
+    #[test]
     fn no_unsubstituted_tokens_remain() {
         // Exercise every surface so all token-bearing patches are emitted.
         let p = Persona {
@@ -619,6 +719,9 @@ mod tests {
                 media_devices: Some(2),
                 speech_voices: Some(vec!["A".into()]),
             }),
+            webgpu: Some(SurfaceCfg {
+                strategy: Some(Strategy::Value),
+            }),
             seed: Some(Seed::from_u64(9)),
             ..Persona::default()
         };
@@ -633,6 +736,10 @@ mod tests {
             "HW_BATTERY",
             "HW_MEDIA_DEVICES",
             "HW_VOICES",
+            "WEBGPU_VENDOR",
+            "WEBGPU_ARCHITECTURE",
+            "WEBGPU_DESCRIPTION",
+            "WEBGPU_MODE",
         ] {
             assert!(
                 !script.contains(tok),

--- a/crates/zendriver-stealth/src/patches/webgpu.js
+++ b/crates/zendriver-stealth/src/patches/webgpu.js
@@ -1,0 +1,32 @@
+// Coherent WebGPU adapter. Defeats DataDome's navigator.gpu.requestAdapter()
+// inconsistency check (upstream #20). Values are dataset-derived from the
+// spoofed WebGL renderer (never randomized).
+(function (vendor, architecture, description, mode) {
+  if (!('gpu' in navigator)) return;            // nothing to patch
+  if (mode === 'block') {
+    try { Object.defineProperty(navigator, 'gpu', { get: () => undefined }); } catch (e) {}
+    return;
+  }
+  if (vendor === null) return;                  // Native → leave real gpu in place
+
+  const info = { vendor: vendor, architecture: architecture, device: '', description: description };
+  const realGpu = navigator.gpu;
+  const realRequest = realGpu && realGpu.requestAdapter ? realGpu.requestAdapter.bind(realGpu) : null;
+
+  async function requestAdapter(opts) {
+    let adapter = realRequest ? await realRequest(opts) : null;
+    if (!adapter) return adapter;               // headless w/o gpu: don't fabricate a whole adapter
+    try {
+      Object.defineProperty(adapter, 'info', { get: () => info, configurable: true });
+      if (adapter.requestAdapterInfo) {
+        adapter.requestAdapterInfo = async () => info;
+      }
+    } catch (e) {}
+    return adapter;
+  }
+  try {
+    Object.defineProperty(navigator.gpu, 'requestAdapter', {
+      value: requestAdapter, writable: true, configurable: true,
+    });
+  } catch (e) {}
+})(WEBGPU_VENDOR, WEBGPU_ARCHITECTURE, WEBGPU_DESCRIPTION, WEBGPU_MODE);

--- a/crates/zendriver-stealth/src/patches/webgpu.js
+++ b/crates/zendriver-stealth/src/patches/webgpu.js
@@ -1,32 +1,31 @@
-// Coherent WebGPU adapter. Defeats DataDome's navigator.gpu.requestAdapter()
-// inconsistency check (upstream #20). Values are dataset-derived from the
-// spoofed WebGL renderer (never randomized).
+// Coherent WebGPU adapter info. Defeats DataDome's navigator.gpu.requestAdapter()
+// inconsistency check (upstream #20). Values are dataset-derived from the spoofed
+// WebGL renderer (never randomized). Overrides the GPUAdapter.prototype `info`
+// getter — matching how real Chrome exposes it (a prototype accessor, NOT an own
+// property), so Object.getOwnPropertyDescriptor(adapter,'info') stays undefined
+// like a genuine adapter.
+//
+// Known v1 limitations (acceptable per scope; validated/iterated via the nightly
+// coherence test): the returned info is a plain object, not a real GPUAdapterInfo
+// instance (an `instanceof GPUAdapterInfo` check would tell); the Block path can
+// only shadow navigator.gpu, it cannot make `'gpu' in navigator` false.
 (function (vendor, architecture, description, mode) {
-  if (!('gpu' in navigator)) return;            // nothing to patch
+  if (!('gpu' in navigator)) return;                 // no WebGPU → nothing to do
   if (mode === 'block') {
-    try { Object.defineProperty(navigator, 'gpu', { get: () => undefined }); } catch (e) {}
+    try { Object.defineProperty(navigator, 'gpu', { get: function () { return undefined; }, configurable: true }); } catch (e) {}
     return;
   }
-  if (vendor === null) return;                  // Native → leave real gpu in place
-
-  const info = { vendor: vendor, architecture: architecture, device: '', description: description };
-  const realGpu = navigator.gpu;
-  const realRequest = realGpu && realGpu.requestAdapter ? realGpu.requestAdapter.bind(realGpu) : null;
-
-  async function requestAdapter(opts) {
-    let adapter = realRequest ? await realRequest(opts) : null;
-    if (!adapter) return adapter;               // headless w/o gpu: don't fabricate a whole adapter
-    try {
-      Object.defineProperty(adapter, 'info', { get: () => info, configurable: true });
-      if (adapter.requestAdapterInfo) {
-        adapter.requestAdapterInfo = async () => info;
-      }
-    } catch (e) {}
-    return adapter;
-  }
+  if (vendor === null) return;                       // Native → leave real gpu in place
+  if (typeof GPUAdapter === 'undefined' || !GPUAdapter.prototype) return;
+  var info = { vendor: vendor, architecture: architecture, device: '', description: description };
   try {
-    Object.defineProperty(navigator.gpu, 'requestAdapter', {
-      value: requestAdapter, writable: true, configurable: true,
-    });
+    var d = Object.getOwnPropertyDescriptor(GPUAdapter.prototype, 'info');
+    if (d && typeof d.get === 'function') {
+      Object.defineProperty(GPUAdapter.prototype, 'info', {
+        get: function () { return info; },
+        configurable: true,
+        enumerable: d.enumerable,
+      });
+    }
   } catch (e) {}
 })(WEBGPU_VENDOR, WEBGPU_ARCHITECTURE, WEBGPU_DESCRIPTION, WEBGPU_MODE);

--- a/crates/zendriver-stealth/src/patches/webgpu.js
+++ b/crates/zendriver-stealth/src/patches/webgpu.js
@@ -5,19 +5,23 @@
 // property), so Object.getOwnPropertyDescriptor(adapter,'info') stays undefined
 // like a genuine adapter.
 //
-// Known v1 limitations (acceptable per scope; validated/iterated via the nightly
-// coherence test): the returned info is a plain object, not a real GPUAdapterInfo
-// instance (an `instanceof GPUAdapterInfo` check would tell); the Block path can
-// only shadow navigator.gpu, it cannot make `'gpu' in navigator` false.
-(function (vendor, architecture, description, mode) {
-  if (!('gpu' in navigator)) return;                 // no WebGPU → nothing to do
+// Validated against native Chrome (Apple M4 Pro): info = { vendor, architecture,
+// device:"", description:"" } — Chrome masks device + description, so we emit
+// them empty. `isFallbackAdapter:false` mirrors a real hardware adapter.
+//
+// Known v1 limitations (acceptable per scope): the returned info is a plain
+// object, not a real GPUAdapterInfo instance (an `instanceof` check would tell);
+// it omits subgroupMinSize/subgroupMaxSize; the Block path can only shadow
+// navigator.gpu, it cannot make `'gpu' in navigator` false.
+(function (vendor, architecture, mode) {
+  if (!('gpu' in navigator)) return;
   if (mode === 'block') {
     try { Object.defineProperty(navigator, 'gpu', { get: function () { return undefined; }, configurable: true }); } catch (e) {}
     return;
   }
-  if (vendor === null) return;                       // Native → leave real gpu in place
+  if (vendor === null) return;
   if (typeof GPUAdapter === 'undefined' || !GPUAdapter.prototype) return;
-  var info = { vendor: vendor, architecture: architecture, device: '', description: description };
+  var info = { vendor: vendor, architecture: architecture, device: '', description: '', isFallbackAdapter: false };
   try {
     var d = Object.getOwnPropertyDescriptor(GPUAdapter.prototype, 'info');
     if (d && typeof d.get === 'function') {
@@ -28,4 +32,4 @@
       });
     }
   } catch (e) {}
-})(WEBGPU_VENDOR, WEBGPU_ARCHITECTURE, WEBGPU_DESCRIPTION, WEBGPU_MODE);
+})(WEBGPU_VENDOR, WEBGPU_ARCHITECTURE, WEBGPU_MODE);

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -3,6 +3,7 @@
 pub mod seed;
 pub mod specs;
 pub mod surface;
+pub(crate) mod webgpu_adapter;
 
 pub use seed::Seed;
 pub use specs::{FontSpec, HardwareSpec, SurfaceCfg, UaSpec, WebglSpec, WebrtcSpec};

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -25,6 +25,7 @@ pub struct Persona {
     pub timezone: Option<String>,
     pub locale: Option<String>,
     pub webgl: Option<WebglSpec>,
+    pub webgpu: Option<SurfaceCfg>,
     pub canvas: Option<SurfaceCfg>,
     pub audio: Option<SurfaceCfg>,
     pub fonts: Option<FontSpec>,
@@ -96,6 +97,7 @@ impl Persona {
             timezone: over.timezone.or(self.timezone),
             locale: over.locale.or(self.locale),
             webgl: over.webgl.or(self.webgl),
+            webgpu: over.webgpu.or(self.webgpu),
             canvas: over.canvas.or(self.canvas),
             audio: over.audio.or(self.audio),
             fonts: over.fonts.or(self.fonts),
@@ -143,6 +145,9 @@ impl Persona {
             }
             Surface::Hardware => {
                 self.hardware.get_or_insert_with(Default::default).strategy = Some(strategy)
+            }
+            Surface::Webgpu => {
+                self.webgpu.get_or_insert_with(Default::default).strategy = Some(strategy)
             }
         }
     }
@@ -411,6 +416,17 @@ mod persona_tests {
         let webgl = p.webgl.as_ref().unwrap();
         assert_eq!(webgl.strategy, Some(Strategy::Value));
         assert_eq!(webgl.unmasked_renderer.as_deref(), Some("ANGLE (x)"));
+    }
+
+    #[test]
+    fn apply_surface_override_webgpu() {
+        use crate::{Strategy, Surface};
+        let mut p = Persona::default();
+        p.apply_surface_override(Surface::Webgpu, Strategy::Block);
+        assert_eq!(
+            p.webgpu.as_ref().and_then(|c| c.strategy),
+            Some(Strategy::Block)
+        );
     }
 
     #[test]

--- a/crates/zendriver-stealth/src/persona/surface.rs
+++ b/crates/zendriver-stealth/src/persona/surface.rs
@@ -12,6 +12,7 @@ pub enum Surface {
     ClientRects,
     Webrtc,
     Hardware,
+    Webgpu,
 }
 
 /// How a resolved persona is applied to a surface in the page.
@@ -36,7 +37,9 @@ impl Surface {
     pub fn kind(self) -> SurfaceKind {
         match self {
             Surface::Canvas | Surface::Audio | Surface::ClientRects => SurfaceKind::Noise,
-            Surface::Webgl | Surface::Fonts | Surface::Hardware => SurfaceKind::Value,
+            Surface::Webgl | Surface::Fonts | Surface::Hardware | Surface::Webgpu => {
+                SurfaceKind::Value
+            }
             Surface::Webrtc => SurfaceKind::Policy,
         }
     }
@@ -112,5 +115,19 @@ mod tests {
     #[test]
     fn webrtc_default_is_block() {
         assert_eq!(Surface::Webrtc.resolve_strategy(None), Strategy::Block);
+    }
+
+    #[test]
+    fn webgpu_is_value_kind_default_value() {
+        assert_eq!(Surface::Webgpu.kind(), SurfaceKind::Value);
+        assert_eq!(Surface::Webgpu.resolve_strategy(None), Strategy::Value);
+    }
+
+    #[test]
+    fn webgpu_block_passes() {
+        assert_eq!(
+            Surface::Webgpu.resolve_strategy(Some(Strategy::Block)),
+            Strategy::Block
+        );
     }
 }

--- a/crates/zendriver-stealth/src/persona/webgpu_adapter.rs
+++ b/crates/zendriver-stealth/src/persona/webgpu_adapter.rs
@@ -13,6 +13,13 @@ pub(crate) struct GpuAdapterInfo {
 
 /// Map a WebGL `UNMASKED_RENDERER` string to a coherent adapter. Falls back to
 /// a stable Intel integrated-GPU adapter for unrecognized renderers.
+// NOTE: `vendor` is the load-bearing coherence field for the #20 fix (it must
+// agree with the WebGL renderer's vendor). The `architecture` tokens
+// (ada-lovelace / ampere / turing / rdna-3 / gen-12lp / common-3) are
+// best-effort, dataset-style values; their exact match to what Chrome's Dawn
+// backend reports is validated by the nightly `webgpu_adapter_coheres_with_webgl_renderer`
+// integration test (Phase 9) and may be refined in a fast-follow. They are
+// never randomized — a random value reads as an unknown device to a WAF.
 pub(crate) fn adapter_for_renderer(renderer: &str) -> GpuAdapterInfo {
     let r = renderer.to_ascii_lowercase();
     // Order matters: check discrete vendors before the Intel fallback.

--- a/crates/zendriver-stealth/src/persona/webgpu_adapter.rs
+++ b/crates/zendriver-stealth/src/persona/webgpu_adapter.rs
@@ -1,91 +1,46 @@
-//! Derive a coherent WebGPU `GPUAdapterInfo` from the spoofed WebGL renderer
-//! string. Dataset-mapped, deterministic — NEVER randomized (DataDome and
-//! other WAFs hash the WebGPU fingerprint and compare against a device dataset;
-//! a random adapter reads as an unknown device).
+//! Derive a coherent WebGPU adapter (vendor + architecture) from the spoofed
+//! WebGL renderer string. Dataset-mapped, deterministic — NEVER randomized
+//! (WAFs hash the WebGPU fingerprint; a random/unknown value reads as a bot).
+//!
+//! Validated against native Chrome (Apple M4 Pro, 2026-06): `requestAdapter().info`
+//! = `{ vendor: "apple", architecture: "metal-3", device: "", description: "" }`.
+//! Chrome MASKS `device` + `description` to "" (the patch emits them empty);
+//! `vendor` + `architecture` are exposed. `vendor` is the load-bearing #20
+//! coherence field (must agree with the WebGL renderer). `architecture` is
+//! emitted only where validated against real Chrome (Apple → "metal-3");
+//! unvalidated vendors get "" — emitting a WRONG token is a worse tell than
+//! an empty one. Add NVIDIA/AMD/Intel tokens here as they are confirmed on
+//! real hardware.
 
-/// Minimal `GPUAdapterInfo` triple the patch substitutes into `navigator.gpu`.
+/// vendor + architecture for the spoofed WebGPU adapter. `device` and
+/// `description` are always emitted empty by the patch (Chrome masks them).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GpuAdapterInfo {
     pub vendor: String,
     pub architecture: String,
-    pub description: String,
 }
 
-/// Map a WebGL `UNMASKED_RENDERER` string to a coherent adapter. Falls back to
-/// a stable Intel integrated-GPU adapter for unrecognized renderers.
-// NOTE: `vendor` is the load-bearing coherence field for the #20 fix (it must
-// agree with the WebGL renderer's vendor). The `architecture` tokens
-// (ada-lovelace / ampere / turing / rdna-3 / gen-12lp / common-3) are
-// best-effort, dataset-style values; their exact match to what Chrome's Dawn
-// backend reports is validated by the nightly `webgpu_adapter_coheres_with_webgl_renderer`
-// integration test (Phase 9) and may be refined in a fast-follow. They are
-// never randomized — a random value reads as an unknown device to a WAF.
+/// Map a WebGL `UNMASKED_RENDERER` string to a coherent WebGPU adapter.
+/// Unrecognized renderers fall back to Intel (the common integrated default).
 pub(crate) fn adapter_for_renderer(renderer: &str) -> GpuAdapterInfo {
     let r = renderer.to_ascii_lowercase();
-    // Order matters: check discrete vendors before the Intel fallback.
-    if r.contains("nvidia") || r.contains("geforce") || r.contains("rtx") || r.contains("gtx") {
-        let arch = if r.contains("rtx 40") || r.contains("ada") {
-            "ada-lovelace"
-        } else if r.contains("rtx 30") {
-            "ampere"
-        } else if r.contains("rtx 20") {
-            "turing"
-        } else {
-            "ampere"
-        };
-        return GpuAdapterInfo {
-            vendor: "nvidia".into(),
-            architecture: arch.into(),
-            description: extract_model(renderer, "NVIDIA"),
-        };
-    }
-    if r.contains("amd") || r.contains("radeon") {
-        return GpuAdapterInfo {
-            vendor: "amd".into(),
-            architecture: "rdna-3".into(),
-            description: extract_model(renderer, "AMD"),
-        };
-    }
-    if r.contains("apple") {
-        return GpuAdapterInfo {
-            vendor: "apple".into(),
-            architecture: "common-3".into(),
-            description: extract_model(renderer, "Apple"),
-        };
-    }
-    // Intel + everything unrecognized → coherent Intel integrated default.
+    let (vendor, architecture) = if r.contains("nvidia")
+        || r.contains("geforce")
+        || r.contains("rtx")
+        || r.contains("gtx")
+    {
+        ("nvidia", "")
+    } else if r.contains("amd") || r.contains("radeon") {
+        ("amd", "")
+    } else if r.contains("apple") {
+        ("apple", "metal-3")
+    } else {
+        ("intel", "")
+    };
     GpuAdapterInfo {
-        vendor: "intel".into(),
-        architecture: "gen-12lp".into(),
-        description: if r.contains("intel") {
-            extract_model(renderer, "Intel")
-        } else {
-            "Intel(R) UHD Graphics 630".into()
-        },
+        vendor: vendor.into(),
+        architecture: architecture.into(),
     }
-}
-
-/// Pull a human-readable model substring out of the ANGLE renderer string,
-/// or fall back to a vendor-generic description.
-fn extract_model(renderer: &str, vendor: &str) -> String {
-    // ANGLE strings look like "ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 Direct3D11 ...)".
-    // Take the middle segment after the first comma, trimmed of the D3D suffix.
-    if let Some(inner) = renderer.split('(').nth(1).and_then(|s| s.split(')').next()) {
-        if let Some(mid) = inner.split(',').nth(1) {
-            let model = mid
-                .split(" Direct3D")
-                .next()
-                .unwrap_or(mid)
-                .split(" vs_")
-                .next()
-                .unwrap_or(mid)
-                .trim();
-            if !model.is_empty() {
-                return model.to_string();
-            }
-        }
-    }
-    format!("{vendor} Graphics")
 }
 
 #[cfg(test)]
@@ -93,71 +48,41 @@ mod tests {
     use super::*;
 
     #[test]
-    fn nvidia_renderer_maps_to_nvidia_adapter() {
+    fn nvidia_vendor_arch_empty_until_validated() {
         let a = adapter_for_renderer(
             "ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 Direct3D11 vs_5_0 ps_5_0, D3D11)",
         );
         assert_eq!(a.vendor, "nvidia");
-        assert_eq!(a.architecture, "ada-lovelace");
-        assert!(a.description.contains("RTX 4090"));
+        assert_eq!(a.architecture, "");
     }
-
     #[test]
-    fn intel_renderer_maps_to_intel_adapter() {
-        let a = adapter_for_renderer(
-            "ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)",
-        );
-        assert_eq!(a.vendor, "intel");
-        assert_eq!(a.architecture, "gen-12lp");
-    }
-
-    #[test]
-    fn unknown_renderer_falls_back_to_coherent_intel() {
-        let a = adapter_for_renderer("Mesa OffScreen");
-        // Never panics, never randomizes: a stable coherent default.
-        assert_eq!(a.vendor, "intel");
-    }
-
-    #[test]
-    fn amd_renderer_maps_to_amd_adapter() {
+    fn amd_vendor_arch_empty_until_validated() {
         let a = adapter_for_renderer(
             "ANGLE (AMD, AMD Radeon RX 7900 XT Direct3D11 vs_5_0 ps_5_0, D3D11)",
         );
         assert_eq!(a.vendor, "amd");
-        assert_eq!(a.architecture, "rdna-3");
-        assert!(a.description.contains("Radeon"));
+        assert_eq!(a.architecture, "");
     }
-
     #[test]
-    fn apple_renderer_maps_to_apple_adapter() {
-        let a =
-            adapter_for_renderer("ANGLE (Apple, ANGLE Metal Renderer: Apple M1 Pro, Unspecified)");
+    fn apple_arch_is_metal3_validated_against_real_chrome() {
+        let a = adapter_for_renderer(
+            "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
+        );
         assert_eq!(a.vendor, "apple");
-        assert_eq!(a.architecture, "common-3");
+        assert_eq!(a.architecture, "metal-3");
     }
-
     #[test]
-    fn nvidia_arch_by_generation() {
-        assert_eq!(
-            adapter_for_renderer("NVIDIA GeForce RTX 3080").architecture,
-            "ampere"
+    fn intel_vendor_arch_empty() {
+        let a = adapter_for_renderer(
+            "ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)",
         );
-        assert_eq!(
-            adapter_for_renderer("NVIDIA GeForce RTX 2070").architecture,
-            "turing"
-        );
-        // generic nvidia (no recognized generation) → ampere default
-        assert_eq!(
-            adapter_for_renderer("NVIDIA GeForce GTX 1080").architecture,
-            "ampere"
-        );
+        assert_eq!(a.vendor, "intel");
+        assert_eq!(a.architecture, "");
     }
-
     #[test]
-    fn extract_model_falls_back_when_no_parens() {
-        // A vendor-matching renderer with no ANGLE "(...)" → "{Vendor} Graphics".
-        let a = adapter_for_renderer("nvidia geforce");
-        assert_eq!(a.vendor, "nvidia");
-        assert_eq!(a.description, "NVIDIA Graphics");
+    fn unknown_renderer_falls_back_to_intel() {
+        let a = adapter_for_renderer("Mesa OffScreen");
+        assert_eq!(a.vendor, "intel");
+        assert_eq!(a.architecture, "");
     }
 }

--- a/crates/zendriver-stealth/src/persona/webgpu_adapter.rs
+++ b/crates/zendriver-stealth/src/persona/webgpu_adapter.rs
@@ -2,15 +2,13 @@
 //! WebGL renderer string. Dataset-mapped, deterministic — NEVER randomized
 //! (WAFs hash the WebGPU fingerprint; a random/unknown value reads as a bot).
 //!
-//! Validated against native Chrome (Apple M4 Pro, 2026-06): `requestAdapter().info`
-//! = `{ vendor: "apple", architecture: "metal-3", device: "", description: "" }`.
-//! Chrome MASKS `device` + `description` to "" (the patch emits them empty);
-//! `vendor` + `architecture` are exposed. `vendor` is the load-bearing #20
-//! coherence field (must agree with the WebGL renderer). `architecture` is
-//! emitted only where validated against real Chrome (Apple → "metal-3");
-//! unvalidated vendors get "" — emitting a WRONG token is a worse tell than
-//! an empty one. Add NVIDIA/AMD/Intel tokens here as they are confirmed on
-//! real hardware.
+//! Architecture tokens come from Dawn's `gpu_info.json`, normalized
+//! (lowercase, spaces→hyphens) — the scheme Chrome's WebGPU backend uses for
+//! `GPUAdapterInfo.architecture`. Validated: Apple M4 Pro → "metal-3";
+//! NVIDIA Turing → "turing" (MDN). Only confident model→µarch mappings emit a
+//! token; unrecognized models get "" — Chrome legitimately returns "" for
+//! unclassified GPUs, so empty is coherent and safe. A WRONG token reads as an
+//! unknown device to a fingerprinting WAF.
 
 /// vendor + architecture for the spoofed WebGPU adapter. `device` and
 /// `description` are always emitted empty by the patch (Chrome masks them).
@@ -20,26 +18,85 @@ pub(crate) struct GpuAdapterInfo {
     pub architecture: String,
 }
 
-/// Map a WebGL `UNMASKED_RENDERER` string to a coherent WebGPU adapter.
-/// Unrecognized renderers fall back to Intel (the common integrated default).
+/// Map a WebGL `UNMASKED_RENDERER` string to a coherent WebGPU adapter
+/// (vendor + architecture). Architecture tokens are Dawn's `gpu_info.json`
+/// names normalized (lowercase, spaces→hyphens) — the scheme Chrome's WebGPU
+/// backend uses for `GPUAdapterInfo.architecture` (validated: Apple M4 Pro →
+/// "metal-3"; NVIDIA Turing → "turing" per MDN). Only confident model→µarch
+/// mappings emit a token; unrecognized models get "" (Chrome legitimately
+/// returns "" for unclassified GPUs, so empty is coherent and safe — a WRONG
+/// token reads as an unknown device to a fingerprinting WAF). Add families
+/// here as they're confirmed.
 pub(crate) fn adapter_for_renderer(renderer: &str) -> GpuAdapterInfo {
     let r = renderer.to_ascii_lowercase();
-    let (vendor, architecture) = if r.contains("nvidia")
-        || r.contains("geforce")
-        || r.contains("rtx")
-        || r.contains("gtx")
+
+    if r.contains("nvidia") || r.contains("geforce") || r.contains("rtx") || r.contains("gtx") {
+        let arch = if r.contains("rtx 50") || r.contains("rtx50") {
+            "blackwell"
+        } else if r.contains("rtx 40") || r.contains("rtx40") {
+            "lovelace"
+        } else if r.contains("rtx 30") || r.contains("rtx30") {
+            "ampere"
+        } else if r.contains("rtx 20")
+            || r.contains("rtx20")
+            || r.contains("rtx 16")
+            || r.contains("gtx 16")
+            || r.contains("gtx16")
+        {
+            "turing"
+        } else if r.contains("gtx 10") || r.contains("gtx10") {
+            "pascal"
+        } else if r.contains("titan v") {
+            "volta"
+        } else {
+            ""
+        };
+        return GpuAdapterInfo {
+            vendor: "nvidia".into(),
+            architecture: arch.into(),
+        };
+    }
+
+    if r.contains("amd") || r.contains("radeon") {
+        let arch = if r.contains("rx 9") || r.contains("rx9") {
+            "rdna-4"
+        } else if r.contains("rx 7") || r.contains("rx7") {
+            "rdna-3"
+        } else if r.contains("rx 6") || r.contains("rx6") {
+            "rdna-2"
+        } else if r.contains("rx 5700") || r.contains("rx 5600") || r.contains("rx 5500") {
+            "rdna-1"
+        } else {
+            ""
+        };
+        return GpuAdapterInfo {
+            vendor: "amd".into(),
+            architecture: arch.into(),
+        };
+    }
+
+    if r.contains("apple") {
+        return GpuAdapterInfo {
+            vendor: "apple".into(),
+            architecture: "metal-3".into(),
+        };
+    }
+
+    // Intel + everything unrecognized → Intel (the common integrated default).
+    let arch = if r.contains("iris xe") || r.contains("xe graphics") {
+        "gen-12-lp"
+    } else if r.contains("uhd graphics 6")
+        || r.contains("hd graphics 6")
+        || r.contains("uhd graphics 5")
+        || r.contains("hd graphics 5")
     {
-        ("nvidia", "")
-    } else if r.contains("amd") || r.contains("radeon") {
-        ("amd", "")
-    } else if r.contains("apple") {
-        ("apple", "metal-3")
+        "gen-9"
     } else {
-        ("intel", "")
+        ""
     };
     GpuAdapterInfo {
-        vendor: vendor.into(),
-        architecture: architecture.into(),
+        vendor: "intel".into(),
+        architecture: arch.into(),
     }
 }
 
@@ -48,39 +105,83 @@ mod tests {
     use super::*;
 
     #[test]
-    fn nvidia_vendor_arch_empty_until_validated() {
-        let a = adapter_for_renderer(
-            "ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 Direct3D11 vs_5_0 ps_5_0, D3D11)",
+    fn nvidia_rtx_generations() {
+        assert_eq!(
+            adapter_for_renderer(
+                "ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 Direct3D11 vs_5_0 ps_5_0, D3D11)"
+            )
+            .architecture,
+            "lovelace"
         );
+        assert_eq!(
+            adapter_for_renderer("NVIDIA GeForce RTX 3080").architecture,
+            "ampere"
+        );
+        assert_eq!(
+            adapter_for_renderer("NVIDIA GeForce RTX 2070 SUPER").architecture,
+            "turing"
+        );
+        assert_eq!(
+            adapter_for_renderer("NVIDIA GeForce GTX 1080 Ti").architecture,
+            "pascal"
+        );
+        let a = adapter_for_renderer("NVIDIA GeForce RTX 4090");
         assert_eq!(a.vendor, "nvidia");
-        assert_eq!(a.architecture, "");
     }
+
     #[test]
-    fn amd_vendor_arch_empty_until_validated() {
-        let a = adapter_for_renderer(
-            "ANGLE (AMD, AMD Radeon RX 7900 XT Direct3D11 vs_5_0 ps_5_0, D3D11)",
+    fn nvidia_unknown_generation_is_empty() {
+        // Vendor still nvidia, but an unrecognized model → empty arch (safe).
+        assert_eq!(adapter_for_renderer("NVIDIA Quadro K2200").architecture, "");
+    }
+
+    #[test]
+    fn amd_rx_generations() {
+        assert_eq!(
+            adapter_for_renderer("ANGLE (AMD, AMD Radeon RX 7900 XT, D3D11)").architecture,
+            "rdna-3"
         );
-        assert_eq!(a.vendor, "amd");
-        assert_eq!(a.architecture, "");
+        assert_eq!(
+            adapter_for_renderer("AMD Radeon RX 6800 XT").architecture,
+            "rdna-2"
+        );
+        assert_eq!(
+            adapter_for_renderer("AMD Radeon RX 5700 XT").architecture,
+            "rdna-1"
+        );
+        assert_eq!(adapter_for_renderer("AMD Radeon RX 7900 XT").vendor, "amd");
     }
+
     #[test]
-    fn apple_arch_is_metal3_validated_against_real_chrome() {
+    fn apple_is_metal3() {
         let a = adapter_for_renderer(
             "ANGLE (Apple, ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version)",
         );
         assert_eq!(a.vendor, "apple");
         assert_eq!(a.architecture, "metal-3");
     }
+
     #[test]
-    fn intel_vendor_arch_empty() {
-        let a = adapter_for_renderer(
-            "ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)",
+    fn intel_integrated_generations() {
+        assert_eq!(
+            adapter_for_renderer(
+                "ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)"
+            )
+            .architecture,
+            "gen-9"
         );
-        assert_eq!(a.vendor, "intel");
-        assert_eq!(a.architecture, "");
+        assert_eq!(
+            adapter_for_renderer("ANGLE (Intel, Intel(R) Iris(R) Xe Graphics, D3D11)").architecture,
+            "gen-12-lp"
+        );
+        assert_eq!(
+            adapter_for_renderer("Intel(R) UHD Graphics 630").vendor,
+            "intel"
+        );
     }
+
     #[test]
-    fn unknown_renderer_falls_back_to_intel() {
+    fn unknown_renderer_falls_back_to_intel_empty_arch() {
         let a = adapter_for_renderer("Mesa OffScreen");
         assert_eq!(a.vendor, "intel");
         assert_eq!(a.architecture, "");

--- a/crates/zendriver-stealth/src/persona/webgpu_adapter.rs
+++ b/crates/zendriver-stealth/src/persona/webgpu_adapter.rs
@@ -1,0 +1,113 @@
+//! Derive a coherent WebGPU `GPUAdapterInfo` from the spoofed WebGL renderer
+//! string. Dataset-mapped, deterministic — NEVER randomized (DataDome and
+//! other WAFs hash the WebGPU fingerprint and compare against a device dataset;
+//! a random adapter reads as an unknown device).
+
+/// Minimal `GPUAdapterInfo` triple the patch substitutes into `navigator.gpu`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GpuAdapterInfo {
+    pub vendor: String,
+    pub architecture: String,
+    pub description: String,
+}
+
+/// Map a WebGL `UNMASKED_RENDERER` string to a coherent adapter. Falls back to
+/// a stable Intel integrated-GPU adapter for unrecognized renderers.
+pub(crate) fn adapter_for_renderer(renderer: &str) -> GpuAdapterInfo {
+    let r = renderer.to_ascii_lowercase();
+    // Order matters: check discrete vendors before the Intel fallback.
+    if r.contains("nvidia") || r.contains("geforce") || r.contains("rtx") || r.contains("gtx") {
+        let arch = if r.contains("rtx 40") || r.contains("ada") {
+            "ada-lovelace"
+        } else if r.contains("rtx 30") {
+            "ampere"
+        } else if r.contains("rtx 20") {
+            "turing"
+        } else {
+            "ampere"
+        };
+        return GpuAdapterInfo {
+            vendor: "nvidia".into(),
+            architecture: arch.into(),
+            description: extract_model(renderer, "NVIDIA"),
+        };
+    }
+    if r.contains("amd") || r.contains("radeon") {
+        return GpuAdapterInfo {
+            vendor: "amd".into(),
+            architecture: "rdna-3".into(),
+            description: extract_model(renderer, "AMD"),
+        };
+    }
+    if r.contains("apple") {
+        return GpuAdapterInfo {
+            vendor: "apple".into(),
+            architecture: "common-3".into(),
+            description: extract_model(renderer, "Apple"),
+        };
+    }
+    // Intel + everything unrecognized → coherent Intel integrated default.
+    GpuAdapterInfo {
+        vendor: "intel".into(),
+        architecture: "gen-12lp".into(),
+        description: if r.contains("intel") {
+            extract_model(renderer, "Intel")
+        } else {
+            "Intel(R) UHD Graphics 630".into()
+        },
+    }
+}
+
+/// Pull a human-readable model substring out of the ANGLE renderer string,
+/// or fall back to a vendor-generic description.
+fn extract_model(renderer: &str, vendor: &str) -> String {
+    // ANGLE strings look like "ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 Direct3D11 ...)".
+    // Take the middle segment after the first comma, trimmed of the D3D suffix.
+    if let Some(inner) = renderer.split('(').nth(1).and_then(|s| s.split(')').next()) {
+        if let Some(mid) = inner.split(',').nth(1) {
+            let model = mid
+                .split(" Direct3D")
+                .next()
+                .unwrap_or(mid)
+                .split(" vs_")
+                .next()
+                .unwrap_or(mid)
+                .trim();
+            if !model.is_empty() {
+                return model.to_string();
+            }
+        }
+    }
+    format!("{vendor} Graphics")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nvidia_renderer_maps_to_nvidia_adapter() {
+        let a = adapter_for_renderer(
+            "ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 Direct3D11 vs_5_0 ps_5_0, D3D11)",
+        );
+        assert_eq!(a.vendor, "nvidia");
+        assert_eq!(a.architecture, "ada-lovelace");
+        assert!(a.description.contains("RTX 4090"));
+    }
+
+    #[test]
+    fn intel_renderer_maps_to_intel_adapter() {
+        let a = adapter_for_renderer(
+            "ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)",
+        );
+        assert_eq!(a.vendor, "intel");
+        assert_eq!(a.architecture, "gen-12lp");
+    }
+
+    #[test]
+    fn unknown_renderer_falls_back_to_coherent_intel() {
+        let a = adapter_for_renderer("Mesa OffScreen");
+        // Never panics, never randomizes: a stable coherent default.
+        assert_eq!(a.vendor, "intel");
+    }
+}

--- a/crates/zendriver-stealth/src/persona/webgpu_adapter.rs
+++ b/crates/zendriver-stealth/src/persona/webgpu_adapter.rs
@@ -117,4 +117,47 @@ mod tests {
         // Never panics, never randomizes: a stable coherent default.
         assert_eq!(a.vendor, "intel");
     }
+
+    #[test]
+    fn amd_renderer_maps_to_amd_adapter() {
+        let a = adapter_for_renderer(
+            "ANGLE (AMD, AMD Radeon RX 7900 XT Direct3D11 vs_5_0 ps_5_0, D3D11)",
+        );
+        assert_eq!(a.vendor, "amd");
+        assert_eq!(a.architecture, "rdna-3");
+        assert!(a.description.contains("Radeon"));
+    }
+
+    #[test]
+    fn apple_renderer_maps_to_apple_adapter() {
+        let a =
+            adapter_for_renderer("ANGLE (Apple, ANGLE Metal Renderer: Apple M1 Pro, Unspecified)");
+        assert_eq!(a.vendor, "apple");
+        assert_eq!(a.architecture, "common-3");
+    }
+
+    #[test]
+    fn nvidia_arch_by_generation() {
+        assert_eq!(
+            adapter_for_renderer("NVIDIA GeForce RTX 3080").architecture,
+            "ampere"
+        );
+        assert_eq!(
+            adapter_for_renderer("NVIDIA GeForce RTX 2070").architecture,
+            "turing"
+        );
+        // generic nvidia (no recognized generation) → ampere default
+        assert_eq!(
+            adapter_for_renderer("NVIDIA GeForce GTX 1080").architecture,
+            "ampere"
+        );
+    }
+
+    #[test]
+    fn extract_model_falls_back_when_no_parens() {
+        // A vendor-matching renderer with no ANGLE "(...)" → "{Vendor} Graphics".
+        let a = adapter_for_renderer("nvidia geforce");
+        assert_eq!(a.vendor, "nvidia");
+        assert_eq!(a.description, "NVIDIA Graphics");
+    }
 }

--- a/crates/zendriver-stealth/tests/snapshots/persona_snapshot__persona_full_wire_shape.snap
+++ b/crates/zendriver-stealth/tests/snapshots/persona_snapshot__persona_full_wire_shape.snap
@@ -10,6 +10,7 @@ expression: p
   "timezone": "UTC",
   "locale": null,
   "webgl": null,
+  "webgpu": null,
   "canvas": null,
   "audio": null,
   "fonts": null,

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -23,7 +23,7 @@ workspace = true
 [features]
 default = []
 # Enables real-Chrome integration tests (requires Chrome installed on $PATH).
-integration-tests = ["dep:wiremock", "dep:serial_test", "interception", "expect", "cloudflare", "imperva", "monitor"]
+integration-tests = ["dep:wiremock", "dep:serial_test", "interception", "expect", "cloudflare", "imperva", "datadome", "monitor"]
 # Nightly stealth tests against external sites (sannysoft, areyouheadless).
 # Separate from integration-tests because external sites flake.
 stealth-tests = ["integration-tests"]
@@ -42,6 +42,10 @@ cloudflare = ["interception", "dep:zendriver-cloudflare"]
 imperva = ["interception", "dep:zendriver-imperva"]
 # Network-touching Imperva nightly tests (real protected sites).
 imperva-tests = ["imperva", "integration-tests"]
+# DataDome anti-bot bypass; pulls in interception.
+datadome = ["interception", "dep:zendriver-datadome"]
+# Network-touching DataDome nightly tests (real protected sites).
+datadome-tests = ["datadome", "integration-tests"]
 # Chrome for Testing binary downloader.
 fetcher = ["dep:zendriver-fetcher"]
 # Network-touching fetcher tests (CfT manifest, real downloads).
@@ -55,6 +59,7 @@ zendriver-stealth.workspace   = true
 zendriver-interception        = { workspace = true, optional = true }
 zendriver-cloudflare          = { workspace = true, optional = true }
 zendriver-imperva             = { workspace = true, optional = true }
+zendriver-datadome            = { workspace = true, optional = true }
 zendriver-fetcher             = { workspace = true, optional = true }
 async-trait.workspace         = true
 chromiumoxide_cdp.workspace   = true
@@ -87,6 +92,10 @@ tokio-test.workspace          = true
 insta.workspace               = true
 tracing-subscriber.workspace  = true
 zendriver-transport = { workspace = true, features = ["testing"] }
+
+[[test]]
+name = "datadome_v0"
+required-features = ["datadome"]
 
 [[example]]
 name = "hello"

--- a/crates/zendriver/examples/cloudflare_bypass.rs
+++ b/crates/zendriver/examples/cloudflare_bypass.rs
@@ -23,19 +23,19 @@
 //!   - `ChallengeGone` — the interactive iframe was clicked and the
 //!     challenge container then disappeared without a token (e.g.
 //!     clearance-cookie shortcut).
-//!   - `Err(NoChallenge)` — the full timeout window elapsed without any
-//!     challenge markers ever being observed (no container, no hidden
-//!     input, no iframe). The page likely has no Cloudflare gate; not a
-//!     failure.
-//!   - `Err(ClearanceTimeout)` — 30s elapsed with markers present but
-//!     neither success state observed.
+//!   - `TimedOut { saw_challenge: false }` — the full timeout window
+//!     elapsed without any challenge markers ever being observed (no
+//!     container, no hidden input, no iframe). The page likely has no
+//!     Cloudflare gate; not a failure.
+//!   - `TimedOut { saw_challenge: true }` — 30s elapsed with markers
+//!     present but neither success state observed.
 //!
 //! Requires the `cloudflare` cargo feature:
 //! `cargo run --example cloudflare_bypass --features cloudflare`.
 
 use std::time::Duration;
 
-use zendriver::{Browser, CloudflareError};
+use zendriver::{Browser, ClearanceOutcome};
 
 #[tokio::main]
 #[allow(clippy::result_large_err)] // example boundary; users wrap in their own Error
@@ -53,13 +53,17 @@ async fn main() -> zendriver::Result<()> {
         .wait_for_clearance(Duration::from_secs(30))
         .await
     {
-        Ok(outcome) => println!("cleared: {outcome:?}"),
-        Err(CloudflareError::NoChallenge) => {
+        Ok(ClearanceOutcome::TimedOut {
+            saw_challenge: false,
+        }) => {
             println!("no challenge detected (page already cleared or no CF gate present)");
         }
-        Err(CloudflareError::ClearanceTimeout) => {
+        Ok(ClearanceOutcome::TimedOut {
+            saw_challenge: true,
+        }) => {
             println!("clearance timed out within 30s");
         }
+        Ok(outcome) => println!("cleared: {outcome:?}"),
         Err(e) => return Err(e.into()),
     }
 

--- a/crates/zendriver/examples/imperva_bypass.rs
+++ b/crates/zendriver/examples/imperva_bypass.rs
@@ -29,7 +29,7 @@
 use std::time::Duration;
 
 use zendriver::stealth::StealthProfile;
-use zendriver::{Browser, ImpervaError};
+use zendriver::{Browser, ImpervaClearanceOutcome, ImpervaError};
 
 #[tokio::main]
 #[allow(clippy::result_large_err)]
@@ -55,12 +55,12 @@ async fn main() -> zendriver::Result<()> {
         .wait_for_clearance()
         .await
     {
+        Ok(ImpervaClearanceOutcome::TimedOut { last_surface }) => {
+            println!("clearance timed out; last_surface = {last_surface:?}");
+        }
         Ok(outcome) => println!("cleared: {outcome:?}"),
         Err(ImpervaError::CaptchaRequired { kind }) => {
             println!("captcha required ({kind:?}); register .on_captcha(...) to solve");
-        }
-        Err(ImpervaError::Timeout { last_surface, .. }) => {
-            println!("clearance timed out; last_surface = {last_surface:?}");
         }
         Err(e) => return Err(e.into()),
     }

--- a/crates/zendriver/src/error.rs
+++ b/crates/zendriver/src/error.rs
@@ -153,6 +153,11 @@ pub enum ZendriverError {
     #[error("imperva: {0}")]
     Imperva(Box<zendriver_imperva::ImpervaError>),
 
+    /// DataDome bypass sub-crate error. Gated by feature `datadome`.
+    #[cfg(feature = "datadome")]
+    #[error("datadome: {0}")]
+    DataDome(Box<zendriver_datadome::DataDomeError>),
+
     /// Chrome-for-Testing fetcher error. Gated by feature `fetcher`.
     #[cfg(feature = "fetcher")]
     #[error("fetcher: {0}")]
@@ -197,6 +202,13 @@ impl From<zendriver_cloudflare::CloudflareError> for ZendriverError {
 impl From<zendriver_imperva::ImpervaError> for ZendriverError {
     fn from(e: zendriver_imperva::ImpervaError) -> Self {
         Self::Imperva(Box::new(e))
+    }
+}
+
+#[cfg(feature = "datadome")]
+impl From<zendriver_datadome::DataDomeError> for ZendriverError {
+    fn from(e: zendriver_datadome::DataDomeError) -> Self {
+        Self::DataDome(Box::new(e))
     }
 }
 

--- a/crates/zendriver/src/lib.rs
+++ b/crates/zendriver/src/lib.rs
@@ -160,6 +160,18 @@ pub use zendriver_imperva::{
 #[cfg(feature = "imperva")]
 pub use zendriver_imperva::ClearanceOutcome as ImpervaClearanceOutcome;
 
+/// DataDome bypass surface re-exports. Gated by the `datadome` cargo feature.
+#[cfg(feature = "datadome")]
+pub use zendriver_datadome::{
+    DataDomeBypass, DataDomeChallenge, DataDomeError, DataDomeSolution, DataDomeSurface,
+    detect_surface as datadome_detect_surface,
+};
+
+/// DataDome clearance outcome (aliased to avoid colliding with the cloudflare
+/// and imperva `ClearanceOutcome`).
+#[cfg(feature = "datadome")]
+pub use zendriver_datadome::ClearanceOutcome as DataDomeClearanceOutcome;
+
 /// Re-export the shared `UrlMatcher` used by `expect_*` and `monitor`.
 pub use url_matcher::UrlMatcher;
 
@@ -354,6 +366,18 @@ mod auto_trait_assertions {
         assert_send_sync::<CookieSnapshot>();
         assert_send_sync::<DetectionSnapshot>();
         assert_send_sync::<ImpervaClearanceOutcome>();
+    }
+
+    #[cfg(feature = "datadome")]
+    #[allow(unused_imports)]
+    use crate::{DataDomeBypass, DataDomeClearanceOutcome, DataDomeError, DataDomeSurface};
+    #[cfg(feature = "datadome")]
+    #[test]
+    fn datadome_surface_is_send_sync() {
+        assert_send_sync::<DataDomeBypass<'_>>();
+        assert_send_sync::<DataDomeError>();
+        assert_send_sync::<DataDomeSurface>();
+        assert_send_sync::<DataDomeClearanceOutcome>();
     }
 
     #[cfg(feature = "fetcher")]

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -2717,6 +2717,27 @@ impl Tab {
     }
 }
 
+#[cfg(feature = "datadome")]
+impl Tab {
+    /// Construct a [`DataDomeBypass`](zendriver_datadome::DataDomeBypass) bound
+    /// to this tab's session.
+    ///
+    /// Chain `timeout` / `poll_interval` / `with_interception` / `on_captcha`,
+    /// then `wait_for_clearance` to detect the active DataDome surface
+    /// (device-check, captcha, or block) and poll until the `datadome`
+    /// clearance cookie lands.
+    ///
+    /// **Stealth strongly recommended.** DataDome's device-check scores the
+    /// browser fingerprint; without `BrowserBuilder::stealth` (including the
+    /// `Surface::Webgpu` coherence patch) the device-check will not clear.
+    ///
+    /// Gated by the `datadome` cargo feature.
+    #[must_use]
+    pub fn datadome(&self) -> zendriver_datadome::DataDomeBypass<'_> {
+        zendriver_datadome::DataDomeBypass::new(self.session())
+    }
+}
+
 #[cfg(feature = "interception")]
 impl Tab {
     /// Construct a fluent

--- a/crates/zendriver/tests/datadome_v0.rs
+++ b/crates/zendriver/tests/datadome_v0.rs
@@ -1,1 +1,132 @@
+//! Integration tests for `tab.datadome()` against a synthetic DataDome fixture.
+//!
+//! Gated behind `integration-tests` + `datadome`, `#[ignore]` (needs a real
+//! Chrome). Run:
+//! ```bash
+//! cargo test -p zendriver --features datadome-tests --test datadome_v0 -- --ignored
+//! ```
 #![cfg(all(feature = "integration-tests", feature = "datadome"))]
+#![allow(clippy::panic, clippy::unwrap_used)]
+
+use std::time::Duration;
+
+use serial_test::serial;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+use zendriver::stealth::StealthProfile;
+use zendriver::{Browser, DataDomeClearanceOutcome};
+
+/// A challenge page carrying a `var dd` config (device-check, t='fe').
+const CHALLENGE_HTML: &str = r#"<!doctype html><html><head>
+<script>var dd={'rt':'c','cid':'CID123','hsh':'HSH456','t':'fe','s':1,'host':'geo.captcha-delivery.com'};</script>
+</head><body>verifying…</body></html>"#;
+
+const CLEAN_HTML: &str = r#"<!doctype html><html><body>welcome</body></html>"#;
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn datadome_device_check_clears_when_cookie_set() {
+    let mock = MockServer::start().await;
+    // Serve a challenge page (window.dd present, device-check surface).
+    // No datadome cookie is ever set by the server, so the poll loop observes
+    // device-check markers and times out — proving detection works against a
+    // real Chrome.
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(CHALLENGE_HTML.as_bytes().to_vec(), "text/html"),
+        )
+        .mount(&mock)
+        .await;
+
+    let browser = Browser::builder().headless(true).launch().await.unwrap();
+    let tab = browser.main_tab();
+    tab.goto(&mock.uri()).await.unwrap();
+    tab.wait_for_load().await.ok();
+
+    // No datadome cookie + device-check markers → times out (markers never clear).
+    let outcome = tab
+        .datadome()
+        .timeout(Duration::from_millis(800))
+        .poll_interval(Duration::from_millis(100))
+        .wait_for_clearance()
+        .await
+        .unwrap();
+    assert!(
+        matches!(outcome, DataDomeClearanceOutcome::TimedOut { .. }),
+        "expected TimedOut, got {outcome:?}"
+    );
+
+    browser.close().await.ok();
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn datadome_already_clear_on_plain_page() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(CLEAN_HTML.as_bytes().to_vec(), "text/html"),
+        )
+        .mount(&mock)
+        .await;
+
+    let browser = Browser::builder().headless(true).launch().await.unwrap();
+    let tab = browser.main_tab();
+    tab.goto(&mock.uri()).await.unwrap();
+    tab.wait_for_load().await.ok();
+
+    let outcome = tab
+        .datadome()
+        .timeout(Duration::from_secs(2))
+        .wait_for_clearance()
+        .await
+        .unwrap();
+    assert!(
+        matches!(outcome, DataDomeClearanceOutcome::AlreadyClear),
+        "expected AlreadyClear, got {outcome:?}"
+    );
+
+    browser.close().await.ok();
+}
+
+/// Drift probe against a known DataDome-protected surface. Best-effort: skips
+/// (does not fail) on network errors. Run only in the nightly job.
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn datadome_real_site_drift_probe() {
+    let browser = match Browser::builder()
+        .stealth(StealthProfile::spoofed())
+        .headless(true)
+        .launch()
+        .await
+    {
+        Ok(b) => b,
+        Err(_) => return,
+    };
+    // deviceandbrowserinfo.com/are_you_a_bot is the surface the #20 reporter used.
+    let tab = browser.main_tab();
+    if tab
+        .goto("https://deviceandbrowserinfo.com/are_you_a_bot")
+        .await
+        .is_err()
+    {
+        browser.close().await.ok();
+        return;
+    }
+    tab.wait_for_load().await.ok();
+    // We don't assert pass/fail (sites change); we assert the bypass RUNS and
+    // returns a terminal without panicking.
+    let outcome = tab
+        .datadome()
+        .timeout(Duration::from_secs(20))
+        .wait_for_clearance()
+        .await;
+    eprintln!("datadome real-site outcome: {outcome:?}");
+    browser.close().await.ok();
+}

--- a/crates/zendriver/tests/datadome_v0.rs
+++ b/crates/zendriver/tests/datadome_v0.rs
@@ -1,0 +1,1 @@
+#![cfg(all(feature = "integration-tests", feature = "datadome"))]

--- a/crates/zendriver/tests/stealth_phase2.rs
+++ b/crates/zendriver/tests/stealth_phase2.rs
@@ -179,3 +179,53 @@ async fn native_fails_sannysoft_navigator_webdriver_but_passes_user_agent() {
 
     browser.close().await.expect("close");
 }
+
+/// Assert that the WebGPU adapter vendor reported by `navigator.gpu` coheres
+/// with the spoofed WebGL renderer. If the platform has no GPU, the test is a
+/// no-op pass (both values null). This validates the `Surface::Webgpu`
+/// coherence patch ships correctly with `stealth()`.
+#[tokio::test]
+#[serial]
+async fn webgpu_adapter_coheres_with_webgl_renderer() {
+    let browser = Browser::builder()
+        .stealth(StealthProfile::spoofed())
+        .headless(true)
+        .launch()
+        .await
+        .expect("launch");
+    let tab = browser.main_tab();
+    tab.goto("about:blank").await.expect("goto");
+    tab.wait_for_load().await.ok();
+
+    let v: serde_json::Value = tab
+        .evaluate_main(
+            r#"(async () => {
+            const a = navigator.gpu && await navigator.gpu.requestAdapter();
+            const c = document.createElement('canvas').getContext('webgl');
+            const dbg = c && c.getExtension('WEBGL_debug_renderer_info');
+            return {
+              gpuVendor: a && a.info ? a.info.vendor : null,
+              webglRenderer: dbg ? c.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : null,
+            };
+        })()"#,
+        )
+        .await
+        .expect("eval");
+
+    // If WebGPU is available, its vendor must be substring-consistent with
+    // the WebGL renderer (both nvidia / both intel / etc.). If gpuVendor is
+    // null (no GPU in this env), the test is a no-op pass.
+    if let Some(vendor) = v.get("gpuVendor").and_then(|x| x.as_str()) {
+        let renderer = v
+            .get("webglRenderer")
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .to_lowercase();
+        assert!(
+            renderer.contains(vendor) || (vendor == "intel" && renderer.contains("intel")),
+            "webgpu vendor {vendor} must cohere with webgl renderer {renderer}"
+        );
+    }
+
+    browser.close().await.expect("close");
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -14,6 +14,7 @@
 - [Network monitor & HTTP](./network.md)
 - [Cloudflare](./cloudflare.md)
 - [Imperva WAF / Incapsula](./imperva.md)
+- [DataDome](./datadome.md)
 - [Fetcher](./fetcher.md)
 - [MCP server](./mcp.md)
 - [Migration from Playwright](./migration-playwright.md)

--- a/docs/book/src/datadome.md
+++ b/docs/book/src/datadome.md
@@ -1,0 +1,185 @@
+# DataDome
+
+The `datadome` cargo feature (sub-crate: `zendriver-datadome`) provides a
+passive bypass driver for sites protected by DataDome. It detects the active
+DataDome surface (`device_check`, `captcha`, or `block`), then polls the page
+until the `datadome` clearance cookie lands, optionally escalating a CAPTCHA
+surface to a caller-supplied async solver.
+
+> **Stealth strongly recommended.** DataDome's dominant surface is an
+> **invisible device-check** that scores the browser fingerprint. Without
+> `BrowserBuilder::stealth` the device-check will not clear on the vast
+> majority of real DataDome-protected sites. The `stealth()` profile now
+> includes the `Surface::Webgpu` coherence patch (issue #20) which aligns
+> `navigator.gpu` adapter info with the spoofed WebGL renderer — a DataDome
+> signal previously unmasked.
+
+## Enabling the feature
+
+```toml
+[dependencies]
+zendriver = { version = "*", features = ["datadome"] }
+```
+
+To run the integration test suite against a real Chrome:
+
+```bash
+cargo test -p zendriver --features datadome-tests --test datadome_v0 -- --ignored
+```
+
+## Quick start
+
+```rust,no_run
+use std::time::Duration;
+use zendriver::stealth::StealthProfile;
+use zendriver::{Browser, DataDomeClearanceOutcome};
+
+#[tokio::main]
+async fn main() -> zendriver::Result<()> {
+    let browser = Browser::builder()
+        .stealth(StealthProfile::spoofed())
+        .launch()
+        .await?;
+    let tab = browser.main_tab();
+    tab.goto("https://protected.example.com").await?;
+    tab.wait_for_load().await?;
+
+    let outcome = tab
+        .datadome()
+        .timeout(Duration::from_secs(60))
+        .wait_for_clearance()
+        .await?;
+
+    match outcome {
+        DataDomeClearanceOutcome::Cleared { datadome } => {
+            println!("cleared — datadome cookie: {datadome}")
+        }
+        DataDomeClearanceOutcome::AlreadyClear => println!("no DataDome surface"),
+        DataDomeClearanceOutcome::Blocked => println!("IP banned — change your proxy"),
+        DataDomeClearanceOutcome::TimedOut { .. } => println!("timed out"),
+        DataDomeClearanceOutcome::ChallengeGone => println!("challenge cleared without cookie"),
+    }
+
+    browser.close().await?;
+    Ok(())
+}
+```
+
+## `tab.datadome()` builder
+
+| Method | Default | Description |
+|---|---|---|
+| `.timeout(Duration)` | 30 s | Maximum total wait for a terminal outcome. |
+| `.poll_interval(Duration)` | 250 ms | How often to re-probe the page during the poll loop. |
+| `.with_interception()` | off | Enable Fetch-domain fast-path: signals on first 2xx response from `captcha-delivery.com` or any `datadome*` URL. |
+| `.on_captcha(solver)` | none | Register an async CAPTCHA solver. Without it, a CAPTCHA surface returns `DataDomeError::CaptchaRequired`. |
+
+Call `.wait_for_clearance().await` to start the drive.
+
+## Surface variants
+
+| Variant | What it is | How it's detected |
+|---|---|---|
+| `DeviceCheck` | Invisible JS interrogation (`window.dd.t == 'fe'`). Scores the browser fingerprint. | `window.dd` present + no captcha-delivery iframe. |
+| `Captcha` | Slider / puzzle / press-hold via `captcha-delivery.com` iframe. | `captcha-delivery.com` iframe src present. |
+| `Block` | IP banned (`window.dd.t == 'bv'`). Nothing in-browser clears this. | `window.dd.t == 'bv'`. |
+| `None` | No DataDome surface. Fast `AlreadyClear` path. | Default — `window.dd` absent + no iframe. |
+
+Detection precedence: **Block > Captcha > DeviceCheck > None**.
+
+## Clearance signal
+
+`Cleared` requires *both*:
+
+1. The `datadome` cookie is present and non-empty.
+2. `window.dd` is absent and no `captcha-delivery.com` iframe is present (`body_clean`).
+
+`ChallengeGone` fires when body markers clear but no `datadome` cookie is
+observed (rare / legacy path). Legacy flows that never set the cookie use this
+path.
+
+## CAPTCHA handling
+
+Without an `on_captcha` callback, a CAPTCHA surface returns
+`DataDomeError::CaptchaRequired` immediately (no waiting). Plug in your
+solver:
+
+```rust,no_run
+# use zendriver_datadome::{DataDomeSolution, DataDomeBypass};
+# async fn ex(tab: &zendriver_transport::SessionHandle) -> Result<(), zendriver_datadome::DataDomeError> {
+let _ = DataDomeBypass::new(tab)
+    .on_captcha(|challenge| async move {
+        // challenge.captcha_url — the captcha-delivery.com iframe URL.
+        // challenge.user_agent — must match the page UA (solver requirement).
+        // Wire to 2captcha / capsolver / your own service:
+        let cookie = call_my_service(&challenge.captcha_url, &challenge.user_agent).await?;
+        Ok(DataDomeSolution { datadome_cookie: cookie })
+    })
+    .wait_for_clearance()
+    .await?;
+# Ok(()) }
+# async fn call_my_service(_: &str, _: &str) -> Result<String, Box<dyn std::error::Error + Send + Sync>> { Ok(String::new()) }
+```
+
+**The solver returns the `datadome` COOKIE value** — DataDome whitelists the
+browser by setting this cookie (not a form-field token like hCaptcha/reCAPTCHA).
+The driver applies it via `Network.setCookie` scoped to the registrable domain
+and reloads the page.
+
+`DataDomeChallenge` carries: `captcha_url`, `site_url`, `user_agent`, `cid`
+(DataDome challenge ID), and `hash`. `DataDomeSolution` holds
+`datadome_cookie`.
+
+## `Blocked` / `TimedOut` outcomes
+
+- **`Blocked`** — `window.dd.t == 'bv'` means DataDome has banned the IP at
+  the edge. Nothing the browser does will clear this. Change your proxy to a
+  residential IP, or wait out the ban.
+- **`TimedOut { last_surface }`** — the deadline elapsed without reaching a
+  terminal state. `last_surface` records the most recent surface the poll loop
+  observed. Common causes: fingerprint scoring failure (see stealth note),
+  IP reputation, or a CAPTCHA with no solver registered.
+
+## Fetch-domain fast path
+
+`.with_interception()` spawns a `Fetch` subscription that signals on first
+2xx response to `captcha-delivery.com` or any `datadome*` URL. Polling
+continues in parallel; the first signal wins. Useful on sites where the cookie
+is set faster than the default 250 ms poll cadence.
+
+```rust,no_run
+# use zendriver_datadome::DataDomeBypass;
+# async fn ex(tab: &zendriver_transport::SessionHandle) -> Result<(), zendriver_datadome::DataDomeError> {
+let _ = DataDomeBypass::new(tab)
+    .with_interception()
+    .wait_for_clearance()
+    .await?;
+# Ok(()) }
+```
+
+## WebGPU / issue #20 stealth note
+
+DataDome's device-check probes `navigator.gpu.requestAdapter()` and compares
+the reported `GPUAdapterInfo.vendor` + `architecture` against its device
+dataset. Before the `Surface::Webgpu` patch (issue #20), Chrome running under
+`zendriver` leaked the platform's real GPU adapter info even when the WebGL
+renderer was spoofed — the inconsistency read as a bot signal.
+
+`Surface::Webgpu` (shipped with `zendriver-stealth`) derives a coherent
+`GPUAdapterInfo` from the spoofed WebGL renderer string and overrides
+`navigator.gpu.requestAdapter()` so both surfaces report the same hardware.
+This patch is included in `BrowserBuilder::stealth(StealthProfile::spoofed())`
+with no extra configuration required.
+
+**Containers / CI:** WebGPU requires a real GPU. In GPU-less containers,
+`requestAdapter()` returns `null` both before and after the patch — which is
+itself coherent (no GPU present). The patch does not fabricate adapters in
+GPU-less environments.
+
+## Active sensor reverse-engineering — out of scope
+
+Computing DataDome's invisible device-check score in pure Rust (outside of a
+real browser) is not in scope for this crate. DataDome updates its obfuscated
+JS sensor frequently; maintaining a pure-HTTP solver alongside a
+browser-automation library is a poor fit. If you need pure-HTTP DataDome bypass
+for high-throughput scraping, build that as a separate crate.

--- a/docs/superpowers/plans/2026-06-02-datadome-bypass.md
+++ b/docs/superpowers/plans/2026-06-02-datadome-bypass.md
@@ -1,0 +1,2262 @@
+# Group D — DataDome bypass crate + WebGPU coherence — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a feature-gated `zendriver-datadome` bypass crate (detect → observe-and-wait → opt-in CAPTCHA-solver callback), an 8th `Surface::Webgpu` coherence farble in `zendriver-stealth` that closes upstream #20's `navigator.gpu` leak, and a cross-crate retrofit unifying all three anti-bot crates on a single-channel result model.
+
+**Architecture:** The crate mirrors `zendriver-imperva` file-for-file (bypass / detection / captcha / interception / error / lib + a `detect.js`). It detects the DataDome surface from `window.dd` + the `datadome` cookie + a `captcha-delivery.com` iframe, polls until the clearance cookie lands, and escalates a CAPTCHA surface to a caller-supplied async solver whose returned **cookie** is applied via `Network.setCookie` + reload. The WebGPU surface plugs into the existing `Persona`/`bootstrap_script` token-substitution machinery, deriving a coherent `GPUAdapter` from the already-spoofed WebGL renderer. The retrofit moves timeout/no-challenge terminals from `Error` to `Outcome` across imperva + cloudflare.
+
+**Tech Stack:** Rust 2024, tokio, `zendriver-transport` (CDP actor + `MockConnection` test harness), `zendriver-interception` (Fetch domain), `thiserror`, `serde_json`, `rmcp` (MCP), `wiremock` (fixture tests), `insta` (schema snapshots).
+
+**Spec:** `docs/superpowers/specs/2026-06-02-datadome-bypass-design.md`
+
+**Branch:** `claude/group-d-datadome` (off main @ 704c4c4). Worktree: this checkout.
+
+---
+
+## Reference patterns (read before starting)
+
+The implementer should open these as live templates — the plan references them rather than reproducing every boilerplate line:
+
+- `crates/zendriver-imperva/src/{lib,bypass,detection,captcha,interception,error}.rs` — the crate template.
+- `crates/zendriver-imperva/src/detect.js` — the detection-script template (bundled one-round-trip probe).
+- `crates/zendriver-cloudflare/src/{bypass,detection,click}.rs` — the shadow-DOM iframe walk (`findBbox`) to reuse for the captcha-delivery iframe.
+- `crates/zendriver-stealth/src/patches.rs` + `src/patches/webgl.js` — the token-substitution machinery the WebGPU surface joins.
+- `crates/zendriver-mcp/src/tools/{imperva,cloudflare}.rs` + `src/server.rs` (`imperva_tool_router` @ ~978, `combined_tool_router` @ ~1094) — the MCP tool template.
+- `crates/zendriver/tests/network_monitor_http.rs` — the `wiremock` + real-Chrome integration-test harness (`fixture_with_html`, `#[serial]`, `#[ignore]`).
+
+**Gates after every phase that touches Rust** (the repo CLAUDE.md requires this before any push; run locally, do not rely on CI):
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --locked --fix --allow-dirty --allow-staged
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings   # feature-gated code touched
+```
+
+---
+
+## Phase 0 — Crate scaffold
+
+### Task 0.1: Create the `zendriver-datadome` crate skeleton
+
+**Files:**
+- Create: `crates/zendriver-datadome/Cargo.toml`
+- Create: `crates/zendriver-datadome/src/lib.rs`
+- Modify: `Cargo.toml` (workspace root) — `members` + `[workspace.dependencies]`
+
+- [ ] **Step 1: Write `Cargo.toml`** (copy `crates/zendriver-imperva/Cargo.toml`, change name/description/keywords; it needs the interception + tokio-util + futures deps because the Fetch fast-path mirrors imperva):
+
+```toml
+[package]
+name = "zendriver-datadome"
+description = "DataDome anti-bot bypass for zendriver"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme = "../../README.md"
+homepage = "https://github.com/TurtIeSocks/zendriver-rs"
+documentation = "https://docs.rs/zendriver-datadome"
+keywords = ["datadome", "anti-bot", "bypass", "browser", "zendriver"]
+categories = ["web-programming"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true
+
+[dependencies]
+zendriver-transport.workspace    = true
+zendriver-interception.workspace = true
+tokio.workspace                  = true
+tokio-util.workspace             = true
+futures.workspace                = true
+serde.workspace                  = true
+serde_json.workspace             = true
+thiserror.workspace              = true
+tracing.workspace                = true
+
+[dev-dependencies]
+tokio-test.workspace = true
+zendriver-transport  = { workspace = true, features = ["testing"] }
+```
+
+- [ ] **Step 2: Write a minimal `src/lib.rs`** so the crate compiles before the modules exist:
+
+```rust
+//! DataDome anti-bot bypass for `zendriver`.
+//!
+//! Sibling to `zendriver-cloudflare` / `zendriver-imperva`. Detects the active
+//! DataDome surface, observes the page until the `datadome` clearance cookie
+//! lands, and escalates a CAPTCHA surface to a caller-supplied solver.
+//!
+//! # Limitations
+//!
+//! Clearance ≠ acceptance. DataDome's dominant surface is an **invisible
+//! device-check** that scores the browser fingerprint; a `Cleared` result
+//! means the `datadome` cookie landed, not that the fingerprint passed. The
+//! single most common cause of a stuck device-check is the WebGL / WebGPU
+//! fingerprint leak from upstream issue #20 — run with
+//! `BrowserBuilder::stealth` (which now includes the `Surface::Webgpu`
+//! coherence patch) and, in containers, ensure GPU support. IP reputation and
+//! UA-vs-binary drift are the other upstream causes.
+
+// Modules land in later tasks.
+```
+
+- [ ] **Step 3: Add the crate to the workspace.** In the root `Cargo.toml`, add `"crates/zendriver-datadome"` to `members` (after the `zendriver-imperva` line) and this to `[workspace.dependencies]` (after the `zendriver-imperva` line, aligned):
+
+```toml
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.0" }
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo build -p zendriver-datadome`
+Expected: builds clean (empty lib).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/zendriver-datadome Cargo.toml
+git commit -m "feat(datadome): scaffold zendriver-datadome crate"
+```
+
+---
+
+## Phase 1 — Errors + surface detection
+
+### Task 1.1: `DataDomeError`
+
+**Files:**
+- Create: `crates/zendriver-datadome/src/error.rs`
+- Modify: `crates/zendriver-datadome/src/lib.rs` (add `pub mod error;` + re-export)
+
+- [ ] **Step 1: Write the failing test** (append to `error.rs`):
+
+```rust
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_captcha_required() {
+        assert_eq!(
+            DataDomeError::CaptchaRequired.to_string(),
+            "CAPTCHA surface detected but no solver registered"
+        );
+    }
+
+    #[test]
+    fn display_js_error_passthrough() {
+        assert_eq!(
+            DataDomeError::JsError("bad payload".into()).to_string(),
+            "JS error: bad payload"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Write `error.rs`** (mirror `zendriver-imperva/src/error.rs`; faults only — no `Timeout`/`Block`, those are outcomes):
+
+```rust
+//! DataDome-bypass errors.
+
+use zendriver_interception::InterceptionError;
+use zendriver_transport::CallError;
+
+/// Error returned by [`DataDomeBypass`] operations. Faults only — flow
+/// terminals (cleared / blocked / timed-out / already-clear) are
+/// [`ClearanceOutcome`] variants, not errors.
+///
+/// [`DataDomeBypass`]: crate::bypass::DataDomeBypass
+/// [`ClearanceOutcome`]: crate::bypass::ClearanceOutcome
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum DataDomeError {
+    /// CAPTCHA surface detected, but no `on_captcha` solver was registered.
+    #[error("CAPTCHA surface detected but no solver registered")]
+    CaptchaRequired,
+
+    /// User-supplied CAPTCHA solver returned an error.
+    #[error("CAPTCHA solver failed: {0}")]
+    CaptchaSolver(Box<dyn std::error::Error + Send + Sync>),
+
+    /// Fetch-domain interception hook failed at startup (only when
+    /// [`DataDomeBypass::with_interception`] was set).
+    ///
+    /// [`DataDomeBypass::with_interception`]: crate::bypass::DataDomeBypass::with_interception
+    #[error("interception hook error: {0}")]
+    Interception(#[from] InterceptionError),
+
+    /// CDP transport / call error.
+    #[error("call failed: {0}")]
+    Call(#[from] CallError),
+
+    /// In-page evaluator raised or returned an unexpected payload shape.
+    #[error("JS error: {0}")]
+    JsError(String),
+}
+```
+
+- [ ] **Step 3: Wire into `lib.rs`** — add `pub mod error;` and `pub use error::DataDomeError;`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p zendriver-datadome error::`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/zendriver-datadome/src
+git commit -m "feat(datadome): DataDomeError (faults-only)"
+```
+
+### Task 1.2: `DataDomeSurface` + `detect_surface` + `detect.js`
+
+**Files:**
+- Create: `crates/zendriver-datadome/src/detection.rs`
+- Create: `crates/zendriver-datadome/src/detect.js`
+- Modify: `crates/zendriver-datadome/src/lib.rs`
+
+**Detection contract:** `detect.js` returns one JSON object:
+```js
+{ surface: "device_check" | "captcha" | "block" | "none",
+  datadome: "<cookie value>" | null,   // the `datadome` cookie
+  dd: { cid, hsh, t, host } | null,     // parsed window.dd, when present
+  captcha_url: "<...>" | null,          // captcha-delivery iframe src, when present
+  body_clean: true | false }            // no dd config / challenge markers in DOM
+```
+
+- [ ] **Step 1: Write `detect.js`** — reads cookie, `window.dd`, and walks (incl. shadow roots) for a `captcha-delivery.com` iframe:
+
+```js
+(function () {
+  function readCookie(name) {
+    var m = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+    return m ? decodeURIComponent(m[1]) : null;
+  }
+  // Recursive shadow-DOM-aware walk for the captcha-delivery iframe src.
+  function findCaptchaUrl(root) {
+    var iframes = root.querySelectorAll ? root.querySelectorAll('iframe') : [];
+    for (var i = 0; i < iframes.length; i++) {
+      var f = iframes[i];
+      if (f.src && f.src.indexOf('captcha-delivery.com') !== -1) return f.src;
+    }
+    var all = root.querySelectorAll ? root.querySelectorAll('*') : [];
+    for (var j = 0; j < all.length; j++) {
+      if (all[j].shadowRoot) {
+        var sub = findCaptchaUrl(all[j].shadowRoot);
+        if (sub) return sub;
+      }
+    }
+    return null;
+  }
+  var dd = (typeof window.dd === 'object' && window.dd) ? window.dd : null;
+  var captchaUrl = findCaptchaUrl(document);
+  var datadome = readCookie('datadome');
+
+  // Classify. window.dd.t drives the challenge type: 'bv' => banned/block,
+  // 'fe' => front-end challenge (device-check or captcha). A captcha-delivery
+  // iframe is the captcha tell; otherwise dd present => device-check.
+  var surface = 'none';
+  if (dd && String(dd.t) === 'bv') {
+    surface = 'block';
+  } else if (captchaUrl) {
+    surface = 'captcha';
+  } else if (dd) {
+    surface = 'device_check';
+  }
+
+  var bodyClean = !dd && !captchaUrl;
+  return {
+    surface: surface,
+    datadome: datadome,
+    dd: dd ? { cid: dd.cid || null, hsh: dd.hsh || null, t: dd.t || null, host: dd.host || null } : null,
+    captcha_url: captchaUrl,
+    body_clean: bodyClean
+  };
+})()
+```
+
+- [ ] **Step 2: Write the failing test** (append to `detection.rs`):
+
+```rust
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use zendriver_transport::testing::MockConnection;
+
+    fn reply(v: serde_json::Value) -> serde_json::Value {
+        json!({ "result": { "type": "object", "value": v } })
+    }
+
+    #[tokio::test]
+    async fn detect_surface_classifies_each_surface() {
+        for (payload, expected) in [
+            (json!({"surface":"device_check","datadome":null,"dd":{"cid":"C","hsh":"H","t":"fe","host":"geo.captcha-delivery.com"},"captcha_url":null,"body_clean":false}), DataDomeSurface::DeviceCheck),
+            (json!({"surface":"captcha","datadome":"DD","dd":{"cid":"C","hsh":"H","t":"fe","host":"geo.captcha-delivery.com"},"captcha_url":"https://geo.captcha-delivery.com/captcha/?cid=C","body_clean":false}), DataDomeSurface::Captcha),
+            (json!({"surface":"block","datadome":null,"dd":{"cid":"C","hsh":"H","t":"bv","host":"geo.captcha-delivery.com"},"captcha_url":null,"body_clean":false}), DataDomeSurface::Block),
+            (json!({"surface":"none","datadome":"DD","dd":null,"captcha_url":null,"body_clean":true}), DataDomeSurface::None),
+        ] {
+            let (mut mock, conn) = MockConnection::pair();
+            let sess = SessionHandle::new(conn.clone(), "S1");
+            let fut = tokio::spawn({ let s = sess.clone(); async move { detect_surface(&s).await } });
+            let id = mock.expect_cmd("Runtime.evaluate").await;
+            assert!(mock.last_sent()["params"]["expression"].as_str().unwrap().contains("captcha-delivery.com"));
+            mock.reply(id, reply(payload)).await;
+            assert_eq!(fut.await.unwrap().unwrap(), expected);
+            conn.shutdown();
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cargo test -p zendriver-datadome detection::`
+Expected: FAIL ("cannot find ... DataDomeSurface").
+
+- [ ] **Step 4: Write `detection.rs`** (mirror `zendriver-imperva/src/detection.rs`'s structure — `RawSnapshot` deserialize + `detect_snapshot` one-round-trip + a `detect_surface` convenience):
+
+```rust
+//! DataDome surface detection. One `Runtime.evaluate` round-trip bundles the
+//! cookie read, `window.dd` parse, and captcha-delivery iframe walk.
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+use zendriver_transport::SessionHandle;
+
+use crate::error::DataDomeError;
+
+/// Which DataDome surface a tab is currently showing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataDomeSurface {
+    /// window.dd.t == 'fe' device-check / interstitial — invisible JS
+    /// interrogation; also covers the auto-resolving "please wait" page.
+    DeviceCheck,
+    /// captcha-delivery.com iframe present (slider / puzzle / press-hold).
+    Captcha,
+    /// window.dd.t == 'bv' — IP banned; unsolvable in-browser.
+    Block,
+    /// No DataDome surface detected; the datadome cookie may already be valid.
+    None,
+}
+
+/// Parsed `window.dd` challenge descriptor.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct DdConfig {
+    pub cid: Option<String>,
+    pub hsh: Option<String>,
+    pub t: Option<String>,
+    pub host: Option<String>,
+}
+
+/// Snapshot of one `detect.js` round-trip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetectionSnapshot {
+    pub surface: DataDomeSurface,
+    pub datadome: Option<String>,
+    pub dd: Option<DdConfig>,
+    pub captcha_url: Option<String>,
+    pub body_clean: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSnapshot {
+    surface: String,
+    #[serde(default)]
+    datadome: Option<String>,
+    #[serde(default)]
+    dd: Option<DdConfig>,
+    #[serde(default)]
+    captcha_url: Option<String>,
+    body_clean: bool,
+}
+
+impl From<RawSnapshot> for DetectionSnapshot {
+    fn from(r: RawSnapshot) -> Self {
+        let surface = match r.surface.as_str() {
+            "device_check" => DataDomeSurface::DeviceCheck,
+            "captcha" => DataDomeSurface::Captcha,
+            "block" => DataDomeSurface::Block,
+            _ => DataDomeSurface::None,
+        };
+        Self {
+            surface,
+            datadome: r.datadome,
+            dd: r.dd,
+            captcha_url: r.captcha_url,
+            body_clean: r.body_clean,
+        }
+    }
+}
+
+/// Run a single `detect.js` probe against `session`'s main world.
+pub(crate) async fn detect_snapshot(
+    session: &SessionHandle,
+) -> Result<DetectionSnapshot, DataDomeError> {
+    let res = session
+        .call(
+            "Runtime.evaluate",
+            json!({
+                "expression": include_str!("detect.js"),
+                "returnByValue": true,
+                "awaitPromise": true,
+            }),
+        )
+        .await?;
+
+    if let Some(details) = res.get("exceptionDetails") {
+        let msg = details
+            .get("exception")
+            .and_then(|e| e.get("description"))
+            .and_then(|d| d.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        return Err(DataDomeError::JsError(msg));
+    }
+
+    let value = res
+        .get("result")
+        .and_then(|r| r.get("value"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    let raw: RawSnapshot = serde_json::from_value(value)
+        .map_err(|e| DataDomeError::JsError(format!("invalid detect.js payload: {e}")))?;
+    Ok(raw.into())
+}
+
+/// Surface-only probe. Convenience for "which surface am I on" without driving
+/// a bypass.
+///
+/// ```no_run
+/// # async fn ex(tab: &zendriver_transport::SessionHandle)
+/// #   -> Result<(), zendriver_datadome::DataDomeError> {
+/// use zendriver_datadome::{DataDomeSurface, detect_surface};
+/// match detect_surface(tab).await? {
+///     DataDomeSurface::None => println!("clean"),
+///     other => println!("datadome surface: {other:?}"),
+/// }
+/// # Ok(()) }
+/// ```
+pub async fn detect_surface(session: &SessionHandle) -> Result<DataDomeSurface, DataDomeError> {
+    Ok(detect_snapshot(session).await?.surface)
+}
+```
+
+- [ ] **Step 5: Wire into `lib.rs`** — `pub mod detection;` + `pub use detection::{DataDomeSurface, DetectionSnapshot, DdConfig, detect_surface};`.
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test -p zendriver-datadome detection::`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/zendriver-datadome/src
+git commit -m "feat(datadome): surface detection (detect.js + DataDomeSurface)"
+```
+
+---
+
+## Phase 2 — Result model + driver core (no captcha/interception yet)
+
+### Task 2.1: `ClearanceOutcome` + `DataDomeBypass` builder
+
+**Files:**
+- Create: `crates/zendriver-datadome/src/bypass.rs`
+- Modify: `crates/zendriver-datadome/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test** (append to `bypass.rs`):
+
+```rust
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use zendriver_transport::testing::MockConnection;
+
+    #[tokio::test]
+    async fn builder_defaults_and_overrides() {
+        let (_, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let b = DataDomeBypass::new(&sess);
+        assert_eq!(b.poll_interval, DEFAULT_POLL_INTERVAL);
+        assert_eq!(b.timeout, DEFAULT_TIMEOUT);
+        assert!(b.on_captcha.is_none());
+        assert!(!b.interception_enabled);
+
+        let b = b
+            .timeout(std::time::Duration::from_secs(45))
+            .poll_interval(std::time::Duration::from_millis(100))
+            .with_interception();
+        assert_eq!(b.timeout, std::time::Duration::from_secs(45));
+        assert_eq!(b.poll_interval, std::time::Duration::from_millis(100));
+        assert!(b.interception_enabled);
+        conn.shutdown();
+    }
+}
+```
+
+- [ ] **Step 2: Write the `bypass.rs` head** (types + builder; mirror `zendriver-imperva/src/bypass.rs` lines 50–175 — same `Arc<dyn solver>` + custom `Debug`). The `wait_for_clearance` body lands in Task 2.2 (use a `todo!()`-free stub that the next task replaces):
+
+```rust
+//! DataDome bypass driver.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::time::Instant;
+use zendriver_transport::SessionHandle;
+
+use crate::captcha::CaptchaSolver;
+use crate::detection::{DataDomeSurface, DetectionSnapshot};
+use crate::error::DataDomeError;
+
+pub(crate) const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Terminal outcome of a clearance attempt. All flow-terminals are `Ok`;
+/// only genuine faults are [`DataDomeError`].
+#[derive(Debug, Clone)]
+pub enum ClearanceOutcome {
+    /// datadome cookie acquired AND challenge markers gone.
+    Cleared { datadome: String },
+    /// Markers cleared but no datadome cookie observed (rare / legacy path).
+    ChallengeGone,
+    /// No DataDome surface present at call time. Fast path; no waiting.
+    AlreadyClear,
+    /// window.dd.t == 'bv' — IP banned. Nothing in-browser can clear this;
+    /// the caller must change IP (e.g. residential proxy).
+    Blocked,
+    /// Deadline elapsed without reaching a terminal state.
+    TimedOut { last_surface: Option<DataDomeSurface> },
+}
+
+/// Drives a DataDome clearance flow against a single tab's session.
+///
+/// Constructed via `Tab::datadome()`.
+pub struct DataDomeBypass<'tab> {
+    pub(crate) session: &'tab SessionHandle,
+    pub(crate) poll_interval: Duration,
+    pub(crate) timeout: Duration,
+    pub(crate) on_captcha: Option<Arc<CaptchaSolver>>,
+    pub(crate) interception_enabled: bool,
+}
+
+impl std::fmt::Debug for DataDomeBypass<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DataDomeBypass")
+            .field("poll_interval", &self.poll_interval)
+            .field("timeout", &self.timeout)
+            .field("on_captcha", &self.on_captcha.as_ref().map(|_| "..."))
+            .field("interception_enabled", &self.interception_enabled)
+            .finish()
+    }
+}
+
+impl<'tab> DataDomeBypass<'tab> {
+    /// New driver with default 250ms poll interval + 30s timeout.
+    pub fn new(session: &'tab SessionHandle) -> Self {
+        Self {
+            session,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            timeout: DEFAULT_TIMEOUT,
+            on_captcha: None,
+            interception_enabled: false,
+        }
+    }
+
+    /// Override the default 30s overall timeout.
+    #[must_use]
+    pub fn timeout(mut self, dur: Duration) -> Self {
+        self.timeout = dur;
+        self
+    }
+
+    /// Override the default 250ms poll interval.
+    #[must_use]
+    pub fn poll_interval(mut self, dur: Duration) -> Self {
+        self.poll_interval = dur;
+        self
+    }
+
+    /// Enable the Fetch-domain fast-path (see [`crate::interception`]).
+    #[must_use]
+    pub fn with_interception(mut self) -> Self {
+        self.interception_enabled = true;
+        self
+    }
+}
+```
+
+> Note: `bypass.rs` won't compile until `captcha.rs` defines `CaptchaSolver` (Task 3.1). To keep Phase 2 green, do Task 3.1 **before** building 2.1, OR temporarily stub `pub(crate) type CaptchaSolver = dyn std::fmt::Debug + Send + Sync;` and the `on_captcha` field, then replace in Task 3.1. The plan orders 2.1 → 2.2 → 3.1; the implementer should write the `captcha.rs` solver-type alias (Task 3.1 Step 2, the `CaptchaSolver` + `arc_solver` block only) first so the type resolves. Mark this dependency.
+
+- [ ] **Step 3: Add `pub mod bypass;` + `pub mod captcha;` to `lib.rs`** and re-export `pub use bypass::{ClearanceOutcome, DataDomeBypass};`.
+
+- [ ] **Step 4: Run test**
+
+Run: `cargo test -p zendriver-datadome bypass::builder_defaults_and_overrides`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/zendriver-datadome/src
+git commit -m "feat(datadome): ClearanceOutcome + DataDomeBypass builder"
+```
+
+### Task 2.2: `wait_for_clearance` core poll loop (device-check / block / already-clear / timeout)
+
+**Files:**
+- Modify: `crates/zendriver-datadome/src/bypass.rs`
+
+This mirrors imperva's `wait_for_clearance` + `poll_loop` (bypass.rs lines 215–406) with DataDome's terminal rules. The captcha + interception branches are stubbed here (added in Tasks 3.2 / 4.1).
+
+- [ ] **Step 1: Write the failing tests** (append to the `bypass.rs` test module):
+
+```rust
+    use crate::detection::DataDomeSurface;
+    use serde_json::json;
+
+    fn snap_reply(v: serde_json::Value) -> serde_json::Value {
+        json!({ "result": { "type": "object", "value": v } })
+    }
+
+    #[tokio::test]
+    async fn already_clear_on_clean_page() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({ let s = sess.clone(); async move {
+            DataDomeBypass::new(&s).wait_for_clearance().await
+        }});
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id, snap_reply(json!({"surface":"none","datadome":"DD","dd":null,"captcha_url":null,"body_clean":true}))).await;
+        assert!(matches!(fut.await.unwrap().unwrap(), ClearanceOutcome::AlreadyClear));
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn block_is_immediate_terminal() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({ let s = sess.clone(); async move {
+            DataDomeBypass::new(&s).wait_for_clearance().await
+        }});
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id, snap_reply(json!({"surface":"block","datadome":null,"dd":{"cid":"C","hsh":"H","t":"bv","host":"h"},"captcha_url":null,"body_clean":false}))).await;
+        assert!(matches!(fut.await.unwrap().unwrap(), ClearanceOutcome::Blocked));
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn device_check_clears_when_cookie_lands_and_body_clean() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({ let s = sess.clone(); async move {
+            DataDomeBypass::new(&s).poll_interval(Duration::from_millis(1)).wait_for_clearance().await
+        }});
+        // Probe 1: device-check, no cookie.
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id1, snap_reply(json!({"surface":"device_check","datadome":null,"dd":{"cid":"C","hsh":"H","t":"fe","host":"h"},"captcha_url":null,"body_clean":false}))).await;
+        // Probe 2: cleared.
+        let id2 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id2, snap_reply(json!({"surface":"none","datadome":"COOKIE_OK","dd":null,"captcha_url":null,"body_clean":true}))).await;
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::Cleared { datadome } => assert_eq!(datadome, "COOKIE_OK"),
+            other => panic!("expected Cleared, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn times_out_when_device_check_never_clears() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({ let s = sess.clone(); async move {
+            DataDomeBypass::new(&s).poll_interval(Duration::from_millis(1)).timeout(Duration::from_millis(40)).wait_for_clearance().await
+        }});
+        for _ in 0..50 {
+            let Ok(id) = tokio::time::timeout(Duration::from_millis(80), mock.expect_cmd("Runtime.evaluate")).await else { break };
+            mock.reply(id, snap_reply(json!({"surface":"device_check","datadome":null,"dd":{"cid":"C","hsh":"H","t":"fe","host":"h"},"captcha_url":null,"body_clean":false}))).await;
+        }
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::TimedOut { last_surface } => assert_eq!(last_surface, Some(DataDomeSurface::DeviceCheck)),
+            other => panic!("expected TimedOut, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+```
+
+- [ ] **Step 2: Implement `wait_for_clearance` + a factored `poll_loop`** in the `impl` block. The clearance rule: `Cleared` when the `datadome` cookie is present AND `body_clean`; `ChallengeGone` when `body_clean` but no cookie (defensive). `Block` short-circuits. The captcha + interception integration points are marked and filled in later tasks:
+
+```rust
+    /// Run the surface-aware poll loop until clearance, block, or timeout.
+    ///
+    /// # Returns
+    /// - `Cleared { datadome }` — cookie landed and markers gone.
+    /// - `ChallengeGone` — markers gone, no cookie observed.
+    /// - `AlreadyClear` — no surface at call time.
+    /// - `Blocked` — `window.dd.t == 'bv'` (IP banned).
+    /// - `TimedOut { last_surface }` — deadline elapsed.
+    ///
+    /// # Errors
+    /// - [`DataDomeError::CaptchaRequired`] — captcha surface, no solver.
+    /// - [`DataDomeError::CaptchaSolver`] — registered solver errored.
+    /// - [`DataDomeError::Interception`] / [`DataDomeError::Call`] /
+    ///   [`DataDomeError::JsError`].
+    pub async fn wait_for_clearance(self) -> Result<ClearanceOutcome, DataDomeError> {
+        let deadline = Instant::now() + self.timeout;
+
+        let snapshot = self.probe(deadline).await?;
+
+        match snapshot.surface {
+            DataDomeSurface::None if snapshot.body_clean => {
+                return Ok(ClearanceOutcome::AlreadyClear);
+            }
+            DataDomeSurface::Block => return Ok(ClearanceOutcome::Blocked),
+            DataDomeSurface::Captcha => {
+                // Captcha escalation lands in Task 3.2. Until then:
+                return Err(DataDomeError::CaptchaRequired);
+            }
+            _ => {}
+        }
+
+        // Interception fast-path is wired in Task 4.1.
+        self.poll_loop(deadline, Some(snapshot)).await
+    }
+
+    /// One detect probe, raced against `deadline` so no probe outlives the
+    /// caller's budget. Returns `TimedOut`-as-Ok via the loop, but here a
+    /// deadline hit maps to a sentinel the loop converts; simplest is to
+    /// return the snapshot or, on deadline, a synthetic `None`/clean snapshot
+    /// that the loop treats as timeout. To keep terminals explicit we instead
+    /// surface the deadline through `poll_loop`'s own check — so `probe`
+    /// simply awaits `detect_snapshot` (the pre-loop probe is fast).
+    async fn probe(&self, _deadline: Instant) -> Result<DetectionSnapshot, DataDomeError> {
+        crate::detection::detect_snapshot(self.session).await
+    }
+
+    pub(crate) async fn poll_loop(
+        self,
+        deadline: Instant,
+        mut next_snapshot: Option<DetectionSnapshot>,
+    ) -> Result<ClearanceOutcome, DataDomeError> {
+        use tokio::time::{Interval, MissedTickBehavior};
+
+        let mut ticker: Interval = tokio::time::interval(self.poll_interval);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        let mut last_surface: Option<DataDomeSurface> = None;
+
+        loop {
+            let snap = match next_snapshot.take() {
+                Some(s) => s,
+                None => crate::detection::detect_snapshot(self.session).await?,
+            };
+
+            let cookie = snap.datadome.as_ref().filter(|v| !v.is_empty());
+            match (cookie, snap.body_clean) {
+                (Some(c), true) => return Ok(ClearanceOutcome::Cleared { datadome: c.clone() }),
+                (None, true) if snap.surface == DataDomeSurface::None => {
+                    return Ok(ClearanceOutcome::ChallengeGone);
+                }
+                _ => last_surface = Some(snap.surface),
+            }
+
+            if Instant::now() >= deadline {
+                return Ok(ClearanceOutcome::TimedOut { last_surface });
+            }
+
+            tokio::select! {
+                _ = ticker.tick() => {}
+                () = tokio::time::sleep_until(deadline) => {
+                    return Ok(ClearanceOutcome::TimedOut { last_surface });
+                }
+            }
+        }
+    }
+```
+
+> Decision note: unlike imperva (which makes the pre-loop probe race the deadline via `probe_with_deadline`), DataDome's pre-loop probe is a single fast `detect.js` eval; the loop's own deadline check + `sleep_until` arm bound total time. If a hung CDP call is a concern, wrap `probe` in `tokio::time::timeout(self.timeout, …)` mapping elapsed → `Ok(TimedOut{last_surface:None})`. Keep it simple unless an integration test shows a hang.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p zendriver-datadome bypass::`
+Expected: PASS (all four terminal tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/zendriver-datadome/src/bypass.rs
+git commit -m "feat(datadome): core poll loop (cleared/blocked/already-clear/timeout)"
+```
+
+---
+
+## Phase 3 — CAPTCHA escalation
+
+### Task 3.1: `captcha.rs` — solver type, challenge extraction, cookie application
+
+**Files:**
+- Create: `crates/zendriver-datadome/src/captcha.rs`
+- Modify: `crates/zendriver-datadome/src/lib.rs`, `crates/zendriver-datadome/src/bypass.rs` (`on_captcha` builder method)
+
+- [ ] **Step 1: Write the failing test** (append to `captcha.rs`):
+
+```rust
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use zendriver_transport::testing::MockConnection;
+
+    #[tokio::test]
+    async fn apply_solution_sets_cookie_then_reloads() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let sol = DataDomeSolution { datadome_cookie: "SOLVED_DD".into() };
+        let fut = tokio::spawn({ let s = sess.clone(); async move {
+            apply_solution(&s, &sol, "https://shop.example.com/x").await
+        }});
+
+        let id_cookie = mock.expect_cmd("Network.setCookie").await;
+        let sent = mock.last_sent();
+        assert_eq!(sent["params"]["name"], "datadome");
+        assert_eq!(sent["params"]["value"], "SOLVED_DD");
+        assert_eq!(sent["params"]["domain"], ".example.com");
+        mock.reply(id_cookie, json!({ "success": true })).await;
+
+        let id_reload = mock.expect_cmd("Page.reload").await;
+        mock.reply(id_reload, json!({})).await;
+
+        fut.await.unwrap().unwrap();
+        conn.shutdown();
+    }
+}
+```
+
+- [ ] **Step 2: Write `captcha.rs`** (solver type + `arc_solver` mirror imperva exactly; the challenge/solution types + `build_challenge` + `apply_solution` are DataDome-specific — cookie, not form field):
+
+```rust
+//! CAPTCHA escalation: types handed to / returned from the caller-supplied
+//! solver, plus the CDP helpers that build the challenge descriptor and apply
+//! the solved `datadome` cookie. DataDome's solution is a COOKIE (it
+//! whitelists the browser), not a form-field token — the structural delta from
+//! imperva.
+
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+use serde_json::json;
+use zendriver_transport::SessionHandle;
+
+use crate::detection::DetectionSnapshot;
+use crate::error::DataDomeError;
+
+/// CAPTCHA escalation handed to a caller-supplied solver.
+#[derive(Debug, Clone)]
+pub struct DataDomeChallenge {
+    /// captcha-delivery iframe URL, e.g.
+    /// `https://geo.captcha-delivery.com/captcha/?initialCid=…&hash=…&cid=…&t=fe`.
+    pub captcha_url: String,
+    /// URL of the page presenting the CAPTCHA.
+    pub site_url: String,
+    /// Browser UA — MUST match the page's UA (solver-service requirement).
+    pub user_agent: String,
+    /// datadome cookie / `dd.cid`, when known.
+    pub cid: Option<String>,
+    /// `dd.hsh`, when known.
+    pub hash: Option<String>,
+}
+
+/// Token returned by a caller-supplied solver. For DataDome this is the solved
+/// `datadome` COOKIE value.
+#[derive(Debug, Clone)]
+pub struct DataDomeSolution {
+    pub datadome_cookie: String,
+}
+
+/// Erased solver closure, stored behind `Arc<dyn ...>` on [`DataDomeBypass`].
+///
+/// [`DataDomeBypass`]: crate::bypass::DataDomeBypass
+pub(crate) type CaptchaSolver = dyn Fn(
+        DataDomeChallenge,
+    )
+        -> BoxFuture<'static, Result<DataDomeSolution, Box<dyn std::error::Error + Send + Sync>>>
+    + Send
+    + Sync;
+
+/// Wrap a typed closure into the stored `Arc<dyn CaptchaSolver>` shape.
+pub(crate) fn arc_solver<F, Fut>(f: F) -> Arc<CaptchaSolver>
+where
+    F: Fn(DataDomeChallenge) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<
+            Output = Result<DataDomeSolution, Box<dyn std::error::Error + Send + Sync>>,
+        > + Send
+        + 'static,
+{
+    Arc::new(move |challenge| Box::pin(f(challenge)))
+}
+
+/// Build a [`DataDomeChallenge`] from a detection snapshot + the live page URL
+/// + UA (read via CDP).
+pub(crate) async fn build_challenge(
+    session: &SessionHandle,
+    snap: &DetectionSnapshot,
+) -> Result<DataDomeChallenge, DataDomeError> {
+    // Read location.href + navigator.userAgent in one eval.
+    let res = session
+        .call(
+            "Runtime.evaluate",
+            json!({
+                "expression": "({ url: location.href, ua: navigator.userAgent })",
+                "returnByValue": true,
+            }),
+        )
+        .await?;
+    let v = res
+        .get("result")
+        .and_then(|r| r.get("value"))
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let site_url = v.get("url").and_then(|x| x.as_str()).unwrap_or("").to_string();
+    let user_agent = v.get("ua").and_then(|x| x.as_str()).unwrap_or("").to_string();
+
+    Ok(DataDomeChallenge {
+        captcha_url: snap.captcha_url.clone().unwrap_or_default(),
+        site_url,
+        user_agent,
+        cid: snap.dd.as_ref().and_then(|d| d.cid.clone()).or_else(|| snap.datadome.clone()),
+        hash: snap.dd.as_ref().and_then(|d| d.hsh.clone()),
+    })
+}
+
+/// Apply the solved `datadome` cookie via `Network.setCookie`, scoped to the
+/// registrable parent domain of `site_url` (DataDome sets the cookie on the
+/// eTLD+1 so it covers subdomains), then reload the page.
+pub(crate) async fn apply_solution(
+    session: &SessionHandle,
+    solution: &DataDomeSolution,
+    site_url: &str,
+) -> Result<(), DataDomeError> {
+    let domain = cookie_domain(site_url);
+    session
+        .call(
+            "Network.setCookie",
+            json!({
+                "name": "datadome",
+                "value": solution.datadome_cookie,
+                "domain": domain,
+                "path": "/",
+                "secure": true,
+                "sameSite": "Lax",
+            }),
+        )
+        .await?;
+    session.call("Page.reload", json!({})).await?;
+    Ok(())
+}
+
+/// Derive the `.eTLD+1` cookie domain from a URL. Best-effort: take the host,
+/// drop the leftmost label when there are ≥3 labels, prefix with `.`.
+/// (`shop.example.com` → `.example.com`; `example.com` → `.example.com`.)
+fn cookie_domain(site_url: &str) -> String {
+    let host = site_url
+        .split("://")
+        .nth(1)
+        .unwrap_or(site_url)
+        .split('/')
+        .next()
+        .unwrap_or("")
+        .split(':')
+        .next()
+        .unwrap_or("");
+    let labels: Vec<&str> = host.split('.').collect();
+    if labels.len() >= 3 {
+        format!(".{}", labels[labels.len() - 2..].join("."))
+    } else if labels.len() == 2 {
+        format!(".{host}")
+    } else {
+        host.to_string()
+    }
+}
+```
+
+> Note on `cookie_domain`: this is a deliberately simple heuristic (no public-suffix list) — it fails on multi-label TLDs like `co.uk`. v1 accepts this; a follow-up can pull in `publicsuffix` if real sites need it. Document the limitation in the crate docs.
+
+- [ ] **Step 3: Add the `on_captcha` builder method** to `bypass.rs` (mirror imperva bypass.rs lines 139–150):
+
+```rust
+    /// Register a caller-supplied async CAPTCHA solver. Without it, a CAPTCHA
+    /// surface yields [`DataDomeError::CaptchaRequired`].
+    ///
+    /// The solver receives a [`DataDomeChallenge`] (captcha URL, page URL, UA,
+    /// cid, hash) and returns a [`DataDomeSolution`] carrying the solved
+    /// `datadome` cookie — wire it to a service like 2captcha / capsolver.
+    #[must_use]
+    pub fn on_captcha<F, Fut>(mut self, f: F) -> Self
+    where
+        F: Fn(crate::captcha::DataDomeChallenge) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<
+                Output = Result<
+                    crate::captcha::DataDomeSolution,
+                    Box<dyn std::error::Error + Send + Sync>,
+                >,
+            > + Send
+            + 'static,
+    {
+        self.on_captcha = Some(crate::captcha::arc_solver(f));
+        self
+    }
+```
+
+- [ ] **Step 4: Wire into `lib.rs`** — `pub use captcha::{DataDomeChallenge, DataDomeSolution};` (and `pub mod captcha;` already added in 2.1).
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p zendriver-datadome captcha::`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/zendriver-datadome/src
+git commit -m "feat(datadome): captcha challenge extraction + cookie application"
+```
+
+### Task 3.2: Wire captcha escalation into `wait_for_clearance`
+
+**Files:**
+- Modify: `crates/zendriver-datadome/src/bypass.rs`
+
+- [ ] **Step 1: Write the failing test** (append to `bypass.rs` tests):
+
+```rust
+    #[tokio::test]
+    async fn captcha_with_solver_applies_cookie_then_clears() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({ let s = sess.clone(); async move {
+            DataDomeBypass::new(&s)
+                .poll_interval(Duration::from_millis(1))
+                .on_captcha(|ch| async move {
+                    assert!(ch.captcha_url.contains("captcha-delivery.com"));
+                    Ok(crate::captcha::DataDomeSolution { datadome_cookie: "FROM_SOLVER".into() })
+                })
+                .wait_for_clearance().await
+        }});
+
+        // Pre-loop probe: captcha surface.
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id1, snap_reply(json!({"surface":"captcha","datadome":"OLD","dd":{"cid":"C","hsh":"H","t":"fe","host":"h"},"captcha_url":"https://geo.captcha-delivery.com/captcha/?cid=C","body_clean":false}))).await;
+        // build_challenge eval (url + ua).
+        let id_ctx = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id_ctx, json!({"result":{"type":"object","value":{"url":"https://shop.example.com/p","ua":"Mozilla/5.0"}}})).await;
+        // apply_solution: setCookie + reload.
+        let id_cookie = mock.expect_cmd("Network.setCookie").await;
+        mock.reply(id_cookie, json!({"success":true})).await;
+        let id_reload = mock.expect_cmd("Page.reload").await;
+        mock.reply(id_reload, json!({})).await;
+        // Post-reload poll: cleared.
+        let id_poll = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id_poll, snap_reply(json!({"surface":"none","datadome":"FROM_SOLVER","dd":null,"captcha_url":null,"body_clean":true}))).await;
+
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::Cleared { datadome } => assert_eq!(datadome, "FROM_SOLVER"),
+            other => panic!("expected Cleared, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn captcha_without_solver_errors() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({ let s = sess.clone(); async move {
+            DataDomeBypass::new(&s).wait_for_clearance().await
+        }});
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id, snap_reply(json!({"surface":"captcha","datadome":null,"dd":null,"captcha_url":"https://geo.captcha-delivery.com/captcha/?cid=C","body_clean":false}))).await;
+        assert!(matches!(fut.await.unwrap().unwrap_err(), DataDomeError::CaptchaRequired));
+        conn.shutdown();
+    }
+```
+
+- [ ] **Step 2: Replace the captcha arm** in `wait_for_clearance` (the `DataDomeSurface::Captcha => return Err(CaptchaRequired)` stub from Task 2.2) with the escalation logic. Because the page mutates after the solver runs, force the loop to re-probe (`next_snapshot = None`):
+
+```rust
+        // Pre-loop captcha escalation.
+        if snapshot.surface == DataDomeSurface::Captcha {
+            let Some(solver) = self.on_captcha.clone() else {
+                return Err(DataDomeError::CaptchaRequired);
+            };
+            let challenge = crate::captcha::build_challenge(self.session, &snapshot).await?;
+            let site_url = challenge.site_url.clone();
+            let solution = solver(challenge).await.map_err(DataDomeError::CaptchaSolver)?;
+            crate::captcha::apply_solution(self.session, &solution, &site_url).await?;
+            // Page reloaded — discard the stale snapshot, force a re-probe.
+            return self.poll_loop(deadline, None).await;
+        }
+```
+
+Adjust the `match snapshot.surface { ... }` block from Task 2.2: remove the `Captcha` arm there (it's now handled by this dedicated block placed *before* the `poll_loop` call), keeping `None`/`Block` short-circuits. Final control flow:
+
+```rust
+        match snapshot.surface {
+            DataDomeSurface::None if snapshot.body_clean => return Ok(ClearanceOutcome::AlreadyClear),
+            DataDomeSurface::Block => return Ok(ClearanceOutcome::Blocked),
+            _ => {}
+        }
+        if snapshot.surface == DataDomeSurface::Captcha {
+            // ... escalation block above ...
+        }
+        self.poll_loop(deadline, Some(snapshot)).await
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p zendriver-datadome bypass::`
+Expected: PASS (captcha-with-solver + captcha-without-solver + the Task 2.2 four).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/zendriver-datadome/src/bypass.rs
+git commit -m "feat(datadome): wire captcha solver escalation into wait_for_clearance"
+```
+
+---
+
+## Phase 4 — Opt-in interception fast-path
+
+### Task 4.1: `interception.rs` + race into the poll loop
+
+**Files:**
+- Create: `crates/zendriver-datadome/src/interception.rs`
+- Modify: `crates/zendriver-datadome/src/bypass.rs` (thread `interception_rx` + guard through `poll_loop`), `crates/zendriver-datadome/src/lib.rs` (`mod interception;`)
+
+- [ ] **Step 1: Write `interception.rs`** — **identical** to `zendriver-imperva/src/interception.rs` except the two `pattern(...)` strings. Copy that file verbatim, then change:
+  - module doc: "Imperva" → "DataDome"; pattern examples → `*captcha-delivery.com*`.
+  - the subscribe chain to:
+
+```rust
+    let stream = InterceptBuilder::new(session)
+        .pattern("*captcha-delivery.com*")
+        .at_response()
+        .pattern("*datadome*")
+        .at_response()
+        .subscribe();
+```
+
+  The 2xx-detection + `InterceptionGuard` (CancellationToken + JoinHandle, `Drop` cancels then aborts) stay byte-for-byte identical.
+
+- [ ] **Step 2: Thread the receiver through `poll_loop`** (mirror imperva bypass.rs lines 263–392). Change `poll_loop`'s signature to accept `mut interception_rx: Option<tokio::sync::oneshot::Receiver<()>>` + `_guard: Option<crate::interception::InterceptionGuard>`, and add the third `select!` arm:
+
+```rust
+                Ok(()) = async {
+                    match interception_rx.as_mut() {
+                        Some(rx) => rx.await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    interception_rx = None; // re-probe immediately next iteration
+                }
+```
+
+In `wait_for_clearance`, before calling `poll_loop`, construct the signal when enabled (mirror imperva lines 266–271):
+
+```rust
+        let (interception_rx, interception_guard) = if self.interception_enabled {
+            let (rx, guard) = crate::interception::spawn_signal(self.session);
+            (Some(rx), Some(guard))
+        } else {
+            (None, None)
+        };
+        self.poll_loop(deadline, Some(snapshot), interception_rx, interception_guard).await
+```
+
+(and the captcha-escalation path passes `None, None, …` since it re-probes synchronously after reload, OR also constructs the signal — keep it simple: pass `None, None` there).
+
+- [ ] **Step 2b: Add an interception unit test** (mirror imperva's `poll_loop`-driven test — drive `poll_loop` directly with a pre-fired oneshot to assert the signal arm triggers a re-probe that returns `Cleared`). Place in `bypass.rs` tests:
+
+```rust
+    #[tokio::test]
+    async fn interception_signal_triggers_reprobe() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tx.send(()).unwrap(); // signal already fired
+        let fut = tokio::spawn({ let s = sess.clone(); async move {
+            DataDomeBypass::new(&s).poll_interval(Duration::from_secs(10))
+                .poll_loop(Instant::now() + Duration::from_secs(5), None, Some(rx), None).await
+        }});
+        // The signal arm fires immediately → one detect probe → cleared.
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id, snap_reply(json!({"surface":"none","datadome":"DD","dd":null,"captcha_url":null,"body_clean":true}))).await;
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::Cleared { datadome } => assert_eq!(datadome, "DD"),
+            other => panic!("expected Cleared, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p zendriver-datadome`
+Expected: PASS (all crate tests).
+
+- [ ] **Step 4: Gates + commit**
+
+```bash
+cargo fmt --all && cargo clippy -p zendriver-datadome --all-targets -- -D warnings
+git add crates/zendriver-datadome/src
+git commit -m "feat(datadome): opt-in Fetch interception fast-path"
+```
+
+---
+
+## Phase 5 — `zendriver` crate wiring
+
+### Task 5.1: feature flag, `Tab::datadome()`, re-exports, error `From`
+
+**Files:**
+- Modify: `crates/zendriver/Cargo.toml`, `crates/zendriver/src/tab.rs`, `crates/zendriver/src/lib.rs`, `crates/zendriver/src/error.rs`
+
+- [ ] **Step 1: `Cargo.toml`** — add the optional dep + features (mirror the imperva lines):
+
+```toml
+# in [dependencies]
+zendriver-datadome            = { workspace = true, optional = true }
+
+# in [features]
+datadome = ["interception", "dep:zendriver-datadome"]
+datadome-tests = ["datadome", "integration-tests"]
+```
+Also add `"datadome"` to the `integration-tests` feature list (next to `"imperva"`), and add a `[[test]]` entry:
+```toml
+[[test]]
+name = "datadome_v0"
+required-features = ["datadome"]
+```
+
+- [ ] **Step 2: `tab.rs`** — add (mirror the `#[cfg(feature="imperva")] impl Tab` block at lines 2694–2718):
+
+```rust
+#[cfg(feature = "datadome")]
+impl Tab {
+    /// Construct a [`DataDomeBypass`](zendriver_datadome::DataDomeBypass) bound
+    /// to this tab's session.
+    ///
+    /// Chain `timeout` / `poll_interval` / `with_interception` / `on_captcha`,
+    /// then `wait_for_clearance` to detect the active DataDome surface
+    /// (device-check, captcha, or block) and poll until the `datadome`
+    /// clearance cookie lands.
+    ///
+    /// **Stealth strongly recommended.** DataDome's device-check scores the
+    /// browser fingerprint; without `BrowserBuilder::stealth` (including the
+    /// `Surface::Webgpu` coherence patch) the device-check will not clear.
+    ///
+    /// Gated by the `datadome` cargo feature.
+    #[must_use]
+    pub fn datadome(&self) -> zendriver_datadome::DataDomeBypass<'_> {
+        zendriver_datadome::DataDomeBypass::new(self.session())
+    }
+}
+```
+
+- [ ] **Step 3: `lib.rs`** — add re-exports (mirror imperva lines 146–161). `ClearanceOutcome` collides with cloudflare/imperva, so alias it:
+
+```rust
+/// DataDome bypass surface re-exports. Gated by the `datadome` cargo feature.
+#[cfg(feature = "datadome")]
+pub use zendriver_datadome::{
+    DataDomeBypass, DataDomeChallenge, DataDomeError, DataDomeSolution, DataDomeSurface,
+    detect_surface as datadome_detect_surface,
+};
+
+/// DataDome clearance outcome (aliased to avoid colliding with the cloudflare
+/// and imperva `ClearanceOutcome`).
+#[cfg(feature = "datadome")]
+pub use zendriver_datadome::ClearanceOutcome as DataDomeClearanceOutcome;
+```
+
+> Note: imperva already exports `detect_surface` unaliased. DataDome's `detect_surface` collides, so re-export it as `datadome_detect_surface`. (Adjust imperva's similarly only if a name clash surfaces at compile time — `cargo build --features imperva,datadome` will tell you.)
+
+- [ ] **Step 4: Add the send_sync compile test** in `lib.rs` (mirror lines 339–356):
+
+```rust
+    #[cfg(feature = "datadome")]
+    #[allow(unused_imports)]
+    use crate::{
+        DataDomeBypass, DataDomeClearanceOutcome, DataDomeError, DataDomeSurface,
+    };
+    #[cfg(feature = "datadome")]
+    #[test]
+    fn datadome_surface_is_send_sync() {
+        assert_send_sync::<DataDomeBypass<'_>>();
+        assert_send_sync::<DataDomeError>();
+        assert_send_sync::<DataDomeSurface>();
+        assert_send_sync::<DataDomeClearanceOutcome>();
+    }
+```
+
+- [ ] **Step 5: `error.rs`** — add the `ZendriverError` variant (mirror lines 151–154) + `From` (mirror lines 196–200):
+
+```rust
+    /// DataDome bypass sub-crate error. Gated by feature `datadome`.
+    #[cfg(feature = "datadome")]
+    #[error("datadome: {0}")]
+    DataDome(Box<zendriver_datadome::DataDomeError>),
+```
+```rust
+#[cfg(feature = "datadome")]
+impl From<zendriver_datadome::DataDomeError> for ZendriverError {
+    fn from(e: zendriver_datadome::DataDomeError) -> Self {
+        Self::DataDome(Box::new(e))
+    }
+}
+```
+
+- [ ] **Step 6: Verify**
+
+Run: `cargo build -p zendriver --features datadome && cargo test -p zendriver --features datadome --lib datadome`
+Expected: builds; send_sync test passes.
+
+- [ ] **Step 7: Gates + commit**
+
+```bash
+cargo fmt --all && cargo clippy -p zendriver --features datadome --all-targets -- -D warnings
+git add crates/zendriver/Cargo.toml crates/zendriver/src
+git commit -m "feat(datadome): wire Tab::datadome() + re-exports + error mapping behind the datadome feature"
+```
+
+---
+
+## Phase 6 — WebGPU coherence surface (`zendriver-stealth`)
+
+### Task 6.1: `Surface::Webgpu` enum + Persona field + override plumbing
+
+**Files:**
+- Modify: `crates/zendriver-stealth/src/persona/surface.rs`, `crates/zendriver-stealth/src/persona/mod.rs`
+
+- [ ] **Step 1: Write the failing tests** (append to `surface.rs` tests):
+
+```rust
+    #[test]
+    fn webgpu_is_value_kind_default_value() {
+        assert_eq!(Surface::Webgpu.kind(), SurfaceKind::Value);
+        assert_eq!(Surface::Webgpu.resolve_strategy(None), Strategy::Value);
+    }
+
+    #[test]
+    fn webgpu_block_passes() {
+        assert_eq!(
+            Surface::Webgpu.resolve_strategy(Some(Strategy::Block)),
+            Strategy::Block
+        );
+    }
+```
+
+- [ ] **Step 2: Add `Webgpu` to the `Surface` enum** (surface.rs line 7–15) and the `kind()` match (line 38–41): add `Surface::Webgpu` to the `SurfaceKind::Value` arm alongside `Webgl | Fonts | Hardware`.
+
+- [ ] **Step 3: Add the Persona field + plumbing** in `mod.rs`:
+  - `Persona` struct: add `pub webgpu: Option<SurfaceCfg>,` (after `webgl`).
+  - `overlay`: add `webgpu: over.webgpu.or(self.webgpu),`.
+  - `apply_surface_override`: add the arm:
+    ```rust
+            Surface::Webgpu => {
+                self.webgpu.get_or_insert_with(Default::default).strategy = Some(strategy)
+            }
+    ```
+
+- [ ] **Step 4: Add a Persona override test** (append to `mod.rs` persona_tests):
+
+```rust
+    #[test]
+    fn apply_surface_override_webgpu() {
+        use crate::{Strategy, Surface};
+        let mut p = Persona::default();
+        p.apply_surface_override(Surface::Webgpu, Strategy::Block);
+        assert_eq!(p.webgpu.as_ref().and_then(|c| c.strategy), Some(Strategy::Block));
+    }
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p zendriver-stealth persona::`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/zendriver-stealth/src/persona
+git commit -m "feat(stealth): add Surface::Webgpu (Value kind) + Persona.webgpu plumbing"
+```
+
+### Task 6.2: renderer → GPUAdapter derivation (Rust, dataset-mapped)
+
+**Files:**
+- Create: `crates/zendriver-stealth/src/persona/webgpu_adapter.rs`
+- Modify: `crates/zendriver-stealth/src/persona/mod.rs` (`mod webgpu_adapter;`)
+
+The coherence rule: derive a `GPUAdapterInfo` `{ vendor, architecture, description }` from the WebGL `UNMASKED_RENDERER` string, drawn from a fixed dataset (never randomized).
+
+- [ ] **Step 1: Write the failing test** (in `webgpu_adapter.rs`):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nvidia_renderer_maps_to_nvidia_adapter() {
+        let a = adapter_for_renderer("ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 Direct3D11 vs_5_0 ps_5_0, D3D11)");
+        assert_eq!(a.vendor, "nvidia");
+        assert_eq!(a.architecture, "ada-lovelace");
+        assert!(a.description.contains("RTX 4090"));
+    }
+
+    #[test]
+    fn intel_renderer_maps_to_intel_adapter() {
+        let a = adapter_for_renderer("ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)");
+        assert_eq!(a.vendor, "intel");
+        assert_eq!(a.architecture, "gen-12lp");
+    }
+
+    #[test]
+    fn unknown_renderer_falls_back_to_coherent_intel() {
+        let a = adapter_for_renderer("Mesa OffScreen");
+        // Never panics, never randomizes: a stable coherent default.
+        assert_eq!(a.vendor, "intel");
+    }
+}
+```
+
+- [ ] **Step 2: Implement `webgpu_adapter.rs`:**
+
+```rust
+//! Derive a coherent WebGPU `GPUAdapterInfo` from the spoofed WebGL renderer
+//! string. Dataset-mapped, deterministic — NEVER randomized (DataDome and
+//! other WAFs hash the WebGPU fingerprint and compare against a device dataset;
+//! a random adapter reads as an unknown device).
+
+/// Minimal `GPUAdapterInfo` triple the patch substitutes into `navigator.gpu`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GpuAdapterInfo {
+    pub vendor: String,
+    pub architecture: String,
+    pub description: String,
+}
+
+/// Map a WebGL `UNMASKED_RENDERER` string to a coherent adapter. Falls back to
+/// a stable Intel integrated-GPU adapter for unrecognized renderers.
+pub(crate) fn adapter_for_renderer(renderer: &str) -> GpuAdapterInfo {
+    let r = renderer.to_ascii_lowercase();
+    // Order matters: check discrete vendors before the Intel fallback.
+    if r.contains("nvidia") || r.contains("geforce") || r.contains("rtx") || r.contains("gtx") {
+        let arch = if r.contains("rtx 40") || r.contains("ada") {
+            "ada-lovelace"
+        } else if r.contains("rtx 30") {
+            "ampere"
+        } else if r.contains("rtx 20") {
+            "turing"
+        } else {
+            "ampere"
+        };
+        return GpuAdapterInfo {
+            vendor: "nvidia".into(),
+            architecture: arch.into(),
+            description: extract_model(renderer, "NVIDIA"),
+        };
+    }
+    if r.contains("amd") || r.contains("radeon") {
+        return GpuAdapterInfo {
+            vendor: "amd".into(),
+            architecture: "rdna-3".into(),
+            description: extract_model(renderer, "AMD"),
+        };
+    }
+    if r.contains("apple") {
+        return GpuAdapterInfo {
+            vendor: "apple".into(),
+            architecture: "common-3".into(),
+            description: extract_model(renderer, "Apple"),
+        };
+    }
+    // Intel + everything unrecognized → coherent Intel integrated default.
+    GpuAdapterInfo {
+        vendor: "intel".into(),
+        architecture: "gen-12lp".into(),
+        description: if r.contains("intel") {
+            extract_model(renderer, "Intel")
+        } else {
+            "Intel(R) UHD Graphics 630".into()
+        },
+    }
+}
+
+/// Pull a human-readable model substring out of the ANGLE renderer string,
+/// or fall back to a vendor-generic description.
+fn extract_model(renderer: &str, vendor: &str) -> String {
+    // ANGLE strings look like "ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 Direct3D11 ...)".
+    // Take the middle segment after the first comma, trimmed of the D3D suffix.
+    if let Some(inner) = renderer.split('(').nth(1).and_then(|s| s.split(')').next()) {
+        if let Some(mid) = inner.split(',').nth(1) {
+            let model = mid
+                .split(" Direct3D")
+                .next()
+                .unwrap_or(mid)
+                .split(" vs_")
+                .next()
+                .unwrap_or(mid)
+                .trim();
+            if !model.is_empty() {
+                return model.to_string();
+            }
+        }
+    }
+    format!("{vendor} Graphics")
+}
+```
+
+- [ ] **Step 3: Register the module** — add `mod webgpu_adapter;` to `mod.rs` (private; used by `patches.rs`). Make it `pub(crate)`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p zendriver-stealth webgpu_adapter`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/zendriver-stealth/src/persona
+git commit -m "feat(stealth): renderer->GPUAdapter coherence map for WebGPU"
+```
+
+### Task 6.3: `webgpu.js` patch + `push_webgpu` bootstrap wiring
+
+**Files:**
+- Create: `crates/zendriver-stealth/src/patches/webgpu.js`
+- Modify: `crates/zendriver-stealth/src/patches.rs`
+
+The patch overrides `navigator.gpu.requestAdapter()` to resolve a `GPUAdapter` whose `.info` matches the substituted tokens, plus a coherent standard `.features` set + `.limits`. `Block` strategy deletes `navigator.gpu`.
+
+- [ ] **Step 1: Write `webgpu.js`** (token placeholders `WEBGPU_VENDOR` / `WEBGPU_ARCHITECTURE` / `WEBGPU_DESCRIPTION` / `WEBGPU_MODE`):
+
+```js
+// Coherent WebGPU adapter. Defeats DataDome's navigator.gpu.requestAdapter()
+// inconsistency check (upstream #20). Values are dataset-derived from the
+// spoofed WebGL renderer (never randomized).
+(function (vendor, architecture, description, mode) {
+  if (!('gpu' in navigator)) return;            // nothing to patch
+  if (mode === 'block') {
+    try { Object.defineProperty(navigator, 'gpu', { get: () => undefined }); } catch (e) {}
+    return;
+  }
+  if (vendor === null) return;                  // Native → leave real gpu in place
+
+  const info = { vendor: vendor, architecture: architecture, device: '', description: description };
+  const realGpu = navigator.gpu;
+  const realRequest = realGpu && realGpu.requestAdapter ? realGpu.requestAdapter.bind(realGpu) : null;
+
+  async function requestAdapter(opts) {
+    let adapter = realRequest ? await realRequest(opts) : null;
+    if (!adapter) return adapter;               // headless w/o gpu: don't fabricate a whole adapter
+    try {
+      Object.defineProperty(adapter, 'info', { get: () => info, configurable: true });
+      if (adapter.requestAdapterInfo) {
+        adapter.requestAdapterInfo = async () => info;
+      }
+    } catch (e) {}
+    return adapter;
+  }
+  try {
+    Object.defineProperty(navigator.gpu, 'requestAdapter', {
+      value: requestAdapter, writable: true, configurable: true,
+    });
+  } catch (e) {}
+})(WEBGPU_VENDOR, WEBGPU_ARCHITECTURE, WEBGPU_DESCRIPTION, WEBGPU_MODE);
+```
+
+> Coherence note: the patch only decorates a real adapter's `info` (it does not fabricate a full `GPUAdapter` when the platform has none — fabricating `requestDevice`/`limits` coherently is brittle and out of v1 scope). On a GPU-capable Chrome (the common case, incl. most CI + desktop), this makes `requestAdapter().info` match the WebGL renderer. In a GPU-less container, `requestAdapter()` returns null both before and after — which is itself coherent for "no GPU". The container-GPU case is the upstream maintainer's `zendriver-docker` concern (spec §15 non-goal).
+
+- [ ] **Step 2: Write the failing test** (append to `patches.rs` tests):
+
+```rust
+    #[test]
+    fn webgpu_value_substitutes_coherent_adapter_from_renderer() {
+        let p = Persona {
+            webgl: Some(WebglSpec {
+                strategy: Some(Strategy::Value),
+                unmasked_vendor: Some("Google Inc. (NVIDIA)".into()),
+                unmasked_renderer: Some("ANGLE (NVIDIA, NVIDIA GeForce RTX 4090 Direct3D11 vs_5_0 ps_5_0, D3D11)".into()),
+            }),
+            ..Persona::default()
+        };
+        let s = bootstrap_script(&p, &mock_identity());
+        assert!(s.contains("requestAdapter"), "webgpu patch emitted by default (Value)");
+        assert!(s.contains("\"nvidia\""), "coherent vendor derived from renderer");
+        assert!(s.contains("ada-lovelace"), "coherent architecture derived from renderer");
+    }
+
+    #[test]
+    fn webgpu_block_deletes_navigator_gpu() {
+        let p = Persona {
+            webgpu: Some(SurfaceCfg { strategy: Some(Strategy::Block) }),
+            ..Persona::default()
+        };
+        let s = bootstrap_script(&p, &mock_identity());
+        assert!(s.contains("\"block\""), "block mode token substituted");
+    }
+
+    #[test]
+    fn webgpu_native_passes_null_vendor() {
+        let p = Persona {
+            webgpu: Some(SurfaceCfg { strategy: Some(Strategy::Native) }),
+            ..Persona::default()
+        };
+        let s = bootstrap_script(&p, &mock_identity());
+        // Native → no webgpu patch emitted at all.
+        assert!(!s.contains("WEBGPU_VENDOR"), "no unsubstituted token");
+        assert!(!s.contains("requestAdapter"), "Native webgpu omits the patch");
+    }
+```
+
+- [ ] **Step 3: Add the `WEBGPU` const + `push_webgpu`** to `patches.rs`. Register the const near the other surface patches (line ~44) and call `push_webgpu` in `bootstrap_script` after `push_webgl` (so the renderer it derives from is consistent with the webgl block just emitted):
+
+```rust
+const WEBGPU: &str = include_str!("patches/webgpu.js");
+```
+```rust
+// in bootstrap_script, after push_webgl(...):
+    push_webgpu(&mut out, persona.webgpu.as_ref(), persona.webgl.as_ref());
+```
+```rust
+/// Append the WebGPU coherence patch. The adapter info is derived from the
+/// persona's WebGL renderer (or the hardcoded Intel default the webgl block
+/// falls back to), so navigator.gpu agrees with WebGL. Omitted under `Native`.
+fn push_webgpu(out: &mut String, cfg: Option<&SurfaceCfg>, webgl: Option<&WebglSpec>) {
+    use crate::persona::webgpu_adapter::adapter_for_renderer;
+    let strat = Surface::Webgpu.resolve_strategy(cfg.and_then(|c| c.strategy));
+    if strat == Strategy::Native {
+        return; // leave the real navigator.gpu untouched
+    }
+    // Default coherent renderer must match webgl.js's hardcoded fallback.
+    const DEFAULT_RENDERER: &str =
+        "ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)";
+    let renderer = webgl
+        .and_then(|w| w.unmasked_renderer.as_deref())
+        .unwrap_or(DEFAULT_RENDERER);
+    let adapter = adapter_for_renderer(renderer);
+    let (vendor, arch, desc, mode) = if strat == Strategy::Block {
+        ("null".to_string(), "null".to_string(), "null".to_string(), "\"block\"".to_string())
+    } else {
+        (
+            serde_json::to_string(&adapter.vendor).unwrap_or_else(|_| "null".into()),
+            serde_json::to_string(&adapter.architecture).unwrap_or_else(|_| "null".into()),
+            serde_json::to_string(&adapter.description).unwrap_or_else(|_| "null".into()),
+            "\"value\"".to_string(),
+        )
+    };
+    out.push('\n');
+    out.push_str(
+        &WEBGPU
+            .replace("WEBGPU_VENDOR", &vendor)
+            .replace("WEBGPU_ARCHITECTURE", &arch)
+            .replace("WEBGPU_DESCRIPTION", &desc)
+            .replace("WEBGPU_MODE", &mode),
+    );
+}
+```
+
+- [ ] **Step 4: Extend the `no_unsubstituted_tokens_remain` test** — add `"WEBGPU_VENDOR"`, `"WEBGPU_ARCHITECTURE"`, `"WEBGPU_DESCRIPTION"`, `"WEBGPU_MODE"` to its token list, and add `webgpu: Some(SurfaceCfg { strategy: Some(Strategy::Value) })` to its exercised persona.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p zendriver-stealth patches::`
+Expected: PASS.
+
+- [ ] **Step 6: Gates + commit**
+
+```bash
+cargo fmt --all && cargo clippy -p zendriver-stealth --all-targets -- -D warnings
+git add crates/zendriver-stealth/src
+git commit -m "feat(stealth): WebGPU coherence patch (navigator.gpu adapter from WebGL renderer)"
+```
+
+---
+
+## Phase 7 — Cross-crate result-model retrofit
+
+### Task 7.1: imperva — `Timeout` Error → `TimedOut` Outcome
+
+**Files:**
+- Modify: `crates/zendriver-imperva/src/bypass.rs`, `crates/zendriver-imperva/src/error.rs`, `crates/zendriver-mcp/src/tools/imperva.rs`
+
+- [ ] **Step 1: Update the `ClearanceOutcome` enum** (bypass.rs ~line 56) — add:
+
+```rust
+    /// Deadline elapsed without clearance. `last_surface` is the most recent
+    /// surface the poll loop observed.
+    TimedOut { last_surface: Option<crate::detection::ImpervaSurface> },
+```
+
+- [ ] **Step 2: Replace `Err(ImpervaError::Timeout { … })` with `Ok(ClearanceOutcome::TimedOut { … })`** at the three return sites in `bypass.rs` (the pre-loop `probe_with_deadline` Err, and the two loop deadline returns at ~365 and ~374). `probe_with_deadline` currently returns `Result<DetectionSnapshot, ImpervaError>` with `Err(Timeout)` on deadline — change the loop to detect that sentinel. Simplest: keep `probe_with_deadline` returning the snapshot, and have its deadline arm return a new `ProbeOutcome::TimedOut` instead. **Concretely:** change the three `return Err(ImpervaError::Timeout { timeout, last_surface })` to `return Ok(ClearanceOutcome::TimedOut { last_surface })`, and for the pre-loop probe (`probe_with_deadline` returning Err on deadline) convert that Err arm at the call site in `wait_for_clearance` into an early `Ok(ClearanceOutcome::TimedOut { last_surface: None })`.
+
+- [ ] **Step 3: Remove `Timeout` from `ImpervaError`** (error.rs ~lines 16–22) and its `display_timeout_includes_duration` test. Remove the now-unused `Duration` import if it becomes dead.
+
+- [ ] **Step 4: Update `tools/imperva.rs`** — replace the `Err(ImpervaError::Timeout { .. }) => Ok(Outcome::Timeout)` arm (lines ~138–141) with a new `Ok` arm:
+
+```rust
+        Ok(ImpervaClearanceOutcome::TimedOut { .. }) => Ok(SolveImpervaOutput {
+            outcome: Outcome::Timeout,
+            reese84: None,
+        }),
+```
+Keep the MCP wire `Outcome::Timeout` variant as-is (snapshot unchanged).
+
+- [ ] **Step 5: Fix the imperva unit tests** that asserted `ImpervaError::Timeout` (e.g. `wait_for_clearance_holds_when_cookie_only_no_body_clean` near bypass.rs:541) — change the expected terminal from `Err(Timeout)` to `Ok(ClearanceOutcome::TimedOut { .. })`.
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test -p zendriver-imperva && cargo test -p zendriver-mcp --features imperva imperva`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/zendriver-imperva crates/zendriver-mcp/src/tools/imperva.rs
+git commit -m "refactor(imperva): TimedOut is an Outcome, not an Error (unify result model)"
+```
+
+### Task 7.2: cloudflare — `NoChallenge` + `ClearanceTimeout` Errors → `TimedOut` Outcome
+
+**Files:**
+- Modify: `crates/zendriver-cloudflare/src/bypass.rs`, `crates/zendriver-cloudflare/src/error.rs`, `crates/zendriver-mcp/src/tools/cloudflare.rs`
+
+- [ ] **Step 1: Update the `ClearanceOutcome` enum** (cloudflare bypass.rs ~line 44) — add a single `TimedOut` carrying the diagnostic that distinguished the two old errors:
+
+```rust
+    /// Deadline elapsed. `saw_challenge` is true if challenge markers were
+    /// observed (the old `ClearanceTimeout`); false if none ever appeared
+    /// (the old `NoChallenge`).
+    TimedOut { saw_challenge: bool },
+```
+
+- [ ] **Step 2: Replace the two `Err(...)` returns** at the deadline check (bypass.rs ~lines 167–173) with:
+
+```rust
+            if Instant::now() >= deadline {
+                return Ok(ClearanceOutcome::TimedOut { saw_challenge: ever_seen_markers });
+            }
+```
+
+- [ ] **Step 3: Remove `NoChallenge` + `ClearanceTimeout` from `CloudflareError`** (error.rs lines 6–10) and their two display tests.
+
+- [ ] **Step 4: Update `tools/cloudflare.rs`** — replace the `Err(CloudflareError::ClearanceTimeout) => Ok(Outcome::Timeout)` arm (lines ~126–129) with:
+
+```rust
+        Ok(ClearanceOutcome::TimedOut { .. }) => Ok(SolveOutput {
+            outcome: Outcome::Timeout,
+            token: None,
+        }),
+```
+The MCP wire `Outcome::Timeout` stays (snapshot unchanged). The old `Err(NoChallenge)` previously fell into the `Err(other) => real error` arm; now it never occurs (it's a `TimedOut` outcome), so no special handling needed.
+
+- [ ] **Step 5: Fix cloudflare unit tests** referencing `NoChallenge` / `ClearanceTimeout` — search `crates/zendriver-cloudflare/src/bypass.rs` tests and update any expecting those `Err`s to expect `Ok(ClearanceOutcome::TimedOut { .. })`.
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test -p zendriver-cloudflare && cargo test -p zendriver-mcp --features cloudflare cloudflare`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/zendriver-cloudflare crates/zendriver-mcp/src/tools/cloudflare.rs
+git commit -m "refactor(cloudflare): TimedOut is an Outcome, not an Error (unify result model)"
+```
+
+---
+
+## Phase 8 — MCP `browser_solve_datadome` tool
+
+### Task 8.1: tool module + server registration + ledger + schema snapshot
+
+**Files:**
+- Create: `crates/zendriver-mcp/src/tools/datadome.rs`
+- Modify: `crates/zendriver-mcp/src/tools/mod.rs`, `crates/zendriver-mcp/src/server.rs`, `crates/zendriver-mcp/Cargo.toml`, `crates/zendriver-mcp/mcp-coverage-ledger.toml`
+
+- [ ] **Step 1: `Cargo.toml`** — add to `[features]`:
+```toml
+datadome = ["zendriver/datadome"]
+```
+and add `"datadome"` to the `default` feature list (next to `"imperva"`).
+
+- [ ] **Step 2: Write `tools/datadome.rs`** (mirror `tools/imperva.rs`; output carries `datadome` cookie instead of `reese84`, plus `blocked` outcome):
+
+```rust
+//! DataDome bypass tool — `browser_solve_datadome`. Gated behind the
+//! `datadome` feature. Mirrors `tools/imperva.rs`: all flow-terminals
+//! (cleared / challenge_gone / already_clear / blocked / timed_out) are
+//! success-channel outcomes; only genuine faults (captcha-without-solver, CDP,
+//! JS) are MCP errors. The `on_captcha` solver hook is intentionally not wired
+//! over MCP (documented non-goal, same as imperva): a captcha surface without
+//! a solver surfaces as a `CaptchaRequired` error the agent handles
+//! out-of-band.
+
+#![cfg(feature = "datadome")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rmcp::ErrorData;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use zendriver::{DataDomeClearanceOutcome, DataDomeError, ZendriverError};
+
+use crate::errors::{McpServerError, map_error};
+use crate::state::SessionState;
+use crate::tools::common::current_tab;
+
+/// Input for `browser_solve_datadome`.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SolveDataDomeInput {
+    /// Maximum total wait for a terminal outcome, in milliseconds. Default
+    /// 30_000 (30s).
+    #[serde(default = "default_timeout")]
+    pub timeout_ms: u64,
+    /// Override the bypass driver's internal poll cadence, in milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub poll_interval_ms: Option<u64>,
+    /// Enable the Fetch-domain interception fast-path. Default `false`.
+    #[serde(default)]
+    pub with_interception: bool,
+}
+
+fn default_timeout() -> u64 {
+    30_000
+}
+
+/// Terminal outcome of a DataDome bypass attempt.
+#[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Outcome {
+    /// datadome cookie acquired (value in [`SolveDataDomeOutput::datadome`]).
+    Cleared,
+    /// Body markers cleared without a datadome cookie.
+    ChallengeGone,
+    /// No DataDome surface present at call time (fast path).
+    AlreadyClear,
+    /// `window.dd.t == 'bv'` — IP banned. Caller must change IP.
+    Blocked,
+    /// `timeout_ms` elapsed without a terminal state. Not a hard error.
+    Timeout,
+}
+
+/// Output of `browser_solve_datadome`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct SolveDataDomeOutput {
+    pub outcome: Outcome,
+    /// datadome cookie value. Populated only when `outcome == cleared`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub datadome: Option<String>,
+}
+
+/// Drive the DataDome clearance flow on the current tab.
+pub async fn solve_datadome(
+    state: Arc<Mutex<SessionState>>,
+    input: SolveDataDomeInput,
+) -> Result<SolveDataDomeOutput, ErrorData> {
+    let s = state.lock().await;
+    let tab = current_tab(&s).await?;
+    let mut bypass = tab.datadome().timeout(Duration::from_millis(input.timeout_ms));
+    if let Some(p) = input.poll_interval_ms {
+        bypass = bypass.poll_interval(Duration::from_millis(p));
+    }
+    if input.with_interception {
+        bypass = bypass.with_interception();
+    }
+    match bypass.wait_for_clearance().await {
+        Ok(DataDomeClearanceOutcome::Cleared { datadome }) => Ok(SolveDataDomeOutput {
+            outcome: Outcome::Cleared,
+            datadome: Some(datadome),
+        }),
+        Ok(DataDomeClearanceOutcome::ChallengeGone) => Ok(SolveDataDomeOutput {
+            outcome: Outcome::ChallengeGone,
+            datadome: None,
+        }),
+        Ok(DataDomeClearanceOutcome::AlreadyClear) => Ok(SolveDataDomeOutput {
+            outcome: Outcome::AlreadyClear,
+            datadome: None,
+        }),
+        Ok(DataDomeClearanceOutcome::Blocked) => Ok(SolveDataDomeOutput {
+            outcome: Outcome::Blocked,
+            datadome: None,
+        }),
+        Ok(DataDomeClearanceOutcome::TimedOut { .. }) => Ok(SolveDataDomeOutput {
+            outcome: Outcome::Timeout,
+            datadome: None,
+        }),
+        Err(other) => Err(map_error(McpServerError::from(ZendriverError::from(other)))),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn solve_datadome_with_no_browser_errors() {
+        let state = Arc::new(Mutex::new(SessionState::new()));
+        let err = solve_datadome(
+            state,
+            SolveDataDomeInput { timeout_ms: 100, poll_interval_ms: None, with_interception: false },
+        )
+        .await
+        .expect_err("expected BrowserNotOpen");
+        assert!(err.message.contains("Browser not open"));
+    }
+}
+```
+
+- [ ] **Step 3: `tools/mod.rs`** — add (next to the imperva entry):
+```rust
+#[cfg(feature = "datadome")]
+pub mod datadome;
+```
+
+- [ ] **Step 4: `server.rs`** — add the `use` (next to imperva, ~line 41):
+```rust
+#[cfg(feature = "datadome")]
+use crate::tools::datadome;
+```
+add a feature-gated `#[tool_router]` block (mirror the `imperva_tool_router` block @ ~978):
+```rust
+#[cfg(feature = "datadome")]
+#[tool_router(router = datadome_tool_router, vis = "pub")]
+impl ZendriverServer {
+    #[tool(
+        name = "browser_solve_datadome",
+        description = "Detect the active DataDome surface and poll until the datadome clearance cookie lands. Returns outcome: cleared/challenge_gone/already_clear/blocked/timeout. A captcha surface without a registered solver errors (handle out-of-band)."
+    )]
+    pub async fn browser_solve_datadome(
+        &self,
+        params: rmcp::handler::server::tool::Parameters<datadome::SolveDataDomeInput>,
+    ) -> Result<Json<datadome::SolveDataDomeOutput>, ErrorData> {
+        datadome::solve_datadome(self.state.clone(), params.0).await.map(Json)
+    }
+}
+```
+> Match the exact `#[tool]` method signature style of `browser_solve_imperva` at server.rs:982–991 (Parameters wrapper, `Json` return, `.map(Json)` or the existing pattern — copy it verbatim, swapping types/names).
+
+and in `combined_tool_router()` (~line 1094, after the `+ Self::imperva_tool_router();` line @ ~1103):
+```rust
+        #[cfg(feature = "datadome")]
+        let router = router + Self::datadome_tool_router();
+```
+
+- [ ] **Step 5: Ledger entries** — append to `crates/zendriver-mcp/mcp-coverage-ledger.toml`:
+```toml
+# ── Group D: DataDome bypass crate + WebGPU surface ─────────────────────────
+[[entry]]
+api = "zendriver::Tab::datadome"
+covered = "browser_solve_datadome"
+
+[[entry]]
+api = "zendriver::DataDomeBypass"
+covered = "browser_solve_datadome"
+
+[[entry]]
+api = "zendriver::DataDomeClearanceOutcome"
+covered = "browser_solve_datadome"
+
+[[entry]]
+api = "zendriver::DataDomeSurface"
+excluded = "diagnostic enum surfaced via browser_solve_datadome.outcome; the standalone datadome_detect_surface fn is a Rust convenience"
+
+[[entry]]
+api = "zendriver::DataDomeError"
+excluded = "error type surfaced through browser_solve_datadome MCP errors"
+
+[[entry]]
+api = "zendriver::DataDomeChallenge"
+excluded = "captcha-solver callback type; the on_captcha hook is a documented MCP non-goal (same as imperva CaptchaChallenge)"
+
+[[entry]]
+api = "zendriver::DataDomeSolution"
+excluded = "captcha-solver callback type; on_captcha hook is a documented MCP non-goal"
+
+[[entry]]
+api = "zendriver::datadome_detect_surface"
+excluded = "Rust convenience probe; surface is reported via browser_solve_datadome.outcome"
+```
+> Also add ledger entries (or confirm coverage) for any NEW imperva/cloudflare public items the retrofit added — `ImpervaClearanceOutcome::TimedOut` and `cloudflare ClearanceOutcome::TimedOut` are new enum variants. If `cargo public-api` flags them, add `covered = "browser_solve_imperva"` / `"browser_solve_turnstile"`. Run the public-api check (Step 7) to find out.
+
+- [ ] **Step 6: Regenerate schema snapshots**
+
+```bash
+cargo test -p zendriver-mcp --test schema_snapshots --all-features --locked
+cargo insta accept --all
+```
+Expected: a NEW `browser_solve_datadome` snapshot; imperva/cloudflare snapshots UNCHANGED (the wire `Outcome::Timeout` variants were preserved). If imperva/cloudflare snapshots changed, that's a regression in Phase 7 — investigate before accepting.
+
+- [ ] **Step 7: Public-API check + full gates**
+
+```bash
+cargo test -p zendriver-mcp --features public-api-check --test public_api
+cargo build -p zendriver-mcp --all-features
+cargo test -p zendriver-mcp --all-features datadome
+cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings
+```
+Expected: public-api check passes once ledger covers the new items; datadome tool test passes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/zendriver-mcp
+git commit -m "feat(mcp): browser_solve_datadome tool + ledger + schema snapshot"
+```
+
+---
+
+## Phase 9 — Integration tests (fixture + nightly)
+
+### Task 9.1: Synthetic-403 fixture integration test
+
+**Files:**
+- Create: `crates/zendriver/tests/datadome_v0.rs`
+
+Mirror `network_monitor_http.rs`'s wiremock harness. The fixture serves a DataDome-shaped 403 (a `var dd = {...}` body) at `/` first, then — after a "clearance" GET — serves a clean page AND sets the `datadome` cookie, so the poll loop observes the transition.
+
+- [ ] **Step 1: Write the test** (gated `integration-tests + datadome`, `#[ignore]`, `#[serial]`):
+
+```rust
+//! Integration tests for `tab.datadome()` against a synthetic DataDome fixture.
+//!
+//! Gated behind `integration-tests` + `datadome`, `#[ignore]` (needs a real
+//! Chrome). Run:
+//! ```bash
+//! cargo test -p zendriver --features datadome-tests --test datadome_v0 -- --ignored
+//! ```
+#![cfg(all(feature = "integration-tests", feature = "datadome"))]
+#![allow(clippy::panic, clippy::unwrap_used)]
+
+use std::time::Duration;
+
+use serial_test::serial;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+use zendriver::{Browser, DataDomeClearanceOutcome};
+
+/// A challenge page carrying a `var dd` config (device-check, t='fe').
+const CHALLENGE_HTML: &str = r#"<!doctype html><html><head>
+<script>var dd={'rt':'c','cid':'CID123','hsh':'HSH456','t':'fe','s':1,'host':'geo.captcha-delivery.com'};</script>
+</head><body>verifying…</body></html>"#;
+
+const CLEAN_HTML: &str = r#"<!doctype html><html><body>welcome</body></html>"#;
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn datadome_device_check_clears_when_cookie_set() {
+    let mock = MockServer::start().await;
+    // First the challenge page (no cookie); after a reload the server sets the
+    // datadome cookie + serves the clean page. wiremock has no built-in
+    // call-ordering, so use two paths: "/" = challenge, then the test sets the
+    // cookie via CDP through a captcha-less device-check is not possible — so
+    // this fixture exercises detection + AlreadyClear/TimedOut, and the
+    // cookie-set path is covered by the captcha integration variant below.
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(CHALLENGE_HTML.as_bytes().to_vec(), "text/html"))
+        .mount(&mock)
+        .await;
+
+    let browser = Browser::builder().build().await.unwrap();
+    let tab = browser.get(&mock.uri()).await.unwrap();
+    tab.wait_for_load(Duration::from_secs(5)).await.ok();
+
+    // No datadome cookie + device-check markers → times out (markers never clear).
+    let outcome = tab.datadome().timeout(Duration::from_millis(800)).poll_interval(Duration::from_millis(100)).wait_for_clearance().await.unwrap();
+    assert!(matches!(outcome, DataDomeClearanceOutcome::TimedOut { .. }));
+
+    browser.close().await.ok();
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn datadome_already_clear_on_plain_page() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(CLEAN_HTML.as_bytes().to_vec(), "text/html"))
+        .mount(&mock)
+        .await;
+    let browser = Browser::builder().build().await.unwrap();
+    let tab = browser.get(&mock.uri()).await.unwrap();
+    tab.wait_for_load(Duration::from_secs(5)).await.ok();
+    let outcome = tab.datadome().timeout(Duration::from_secs(2)).wait_for_clearance().await.unwrap();
+    assert!(matches!(outcome, DataDomeClearanceOutcome::AlreadyClear));
+    browser.close().await.ok();
+}
+```
+
+> The captcha-with-cookie-set happy path is hard to model in wiremock without an injected solver + cookie round-trip; the unit test `captcha_with_solver_applies_cookie_then_clears` (Task 3.2) already covers that flow deterministically. The fixture's job is to prove detection + AlreadyClear/TimedOut against a real Chrome.
+
+- [ ] **Step 2: Run (only if a Chrome binary is available)**
+
+Run: `cargo test -p zendriver --features datadome-tests --test datadome_v0 -- --ignored`
+Expected: both PASS against real Chrome. If no Chrome locally, verify it COMPILES: `cargo test -p zendriver --features datadome-tests --test datadome_v0 --no-run`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/zendriver/tests/datadome_v0.rs
+git commit -m "test(datadome): synthetic-403 fixture integration tests"
+```
+
+### Task 9.2: Nightly real-site probe + WebGPU coherence assertion
+
+**Files:**
+- Modify: `crates/zendriver/tests/datadome_v0.rs` (add a nightly real-site test, gated + `#[ignore]`)
+- Modify: the stealth nightly test file (find it: `rg -l 'sannysoft|areyouheadless' crates/zendriver*/tests crates/zendriver-stealth`) — add a WebGPU coherence assertion.
+
+- [ ] **Step 1: Add a real-site nightly test** to `datadome_v0.rs` (best-effort drift signal; never CI-blocking — it `#[ignore]`s and tolerates network failure):
+
+```rust
+/// Drift probe against a known DataDome-protected surface. Best-effort: skips
+/// (does not fail) on network errors. Run only in the nightly job.
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn datadome_real_site_drift_probe() {
+    let browser = match Browser::builder().stealth().build().await {
+        Ok(b) => b,
+        Err(_) => return,
+    };
+    // deviceandbrowserinfo.com/are_you_a_bot is the surface the #20 reporter used.
+    let Ok(tab) = browser.get("https://deviceandbrowserinfo.com/are_you_a_bot").await else { browser.close().await.ok(); return; };
+    tab.wait_for_load(Duration::from_secs(15)).await.ok();
+    // We don't assert pass/fail (sites change); we assert the bypass RUNS and
+    // returns a terminal without panicking.
+    let outcome = tab.datadome().timeout(Duration::from_secs(20)).wait_for_clearance().await;
+    eprintln!("datadome real-site outcome: {outcome:?}");
+    browser.close().await.ok();
+}
+```
+
+- [ ] **Step 2: Add a WebGPU coherence assertion** to the stealth nightly. After applying a `stealth()` persona on a real page, read `navigator.gpu.requestAdapter()` and assert the vendor matches the WebGL renderer. Add to the identified nightly file:
+
+```rust
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn webgpu_adapter_coheres_with_webgl_renderer() {
+    let browser = Browser::builder().stealth().build().await.unwrap();
+    let tab = browser.get("about:blank").await.unwrap();
+    let v: serde_json::Value = tab.evaluate_main(r#"(async () => {
+        const a = navigator.gpu && await navigator.gpu.requestAdapter();
+        const c = document.createElement('canvas').getContext('webgl');
+        const dbg = c && c.getExtension('WEBGL_debug_renderer_info');
+        return {
+          gpuVendor: a && a.info ? a.info.vendor : null,
+          webglRenderer: dbg ? c.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : null,
+        };
+    })()"#).await.unwrap();
+    // If WebGPU is available, its vendor must be a substring-consistent with
+    // the WebGL renderer (both nvidia / both intel / etc.). If gpuVendor is
+    // null (no GPU in this env), the test is a no-op pass.
+    if let Some(vendor) = v.get("gpuVendor").and_then(|x| x.as_str()) {
+        let renderer = v.get("webglRenderer").and_then(|x| x.as_str()).unwrap_or("").to_lowercase();
+        assert!(renderer.contains(vendor) || (vendor == "intel" && renderer.contains("intel")),
+            "webgpu vendor {vendor} must cohere with webgl renderer {renderer}");
+    }
+    browser.close().await.ok();
+}
+```
+> Adjust `evaluate_main` to the crate's actual main-world eval method name (check `tab.rs`). Use `about:blank` so the persona bootstrap script has applied.
+
+- [ ] **Step 3: Compile-check**
+
+Run: `cargo test -p zendriver --features datadome-tests --test datadome_v0 --no-run` and the stealth nightly's `--no-run`.
+Expected: compiles.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/zendriver/tests crates/zendriver-stealth
+git commit -m "test(datadome,stealth): nightly real-site drift probe + WebGPU coherence assertion"
+```
+
+---
+
+## Phase 10 — Docs + final gates
+
+### Task 10.1: mdBook chapter, README, CHANGELOG, full-workspace gates
+
+**Files:**
+- Create: `docs/book/src/datadome.md` (mirror `imperva.md`)
+- Modify: `docs/book/src/SUMMARY.md`, `README.md` (feature matrix + crate list), `CHANGELOG.md`
+
+- [ ] **Step 1: Write `docs/book/src/datadome.md`** — mirror the structure of `docs/book/src/imperva.md` (find it first). Cover: enabling the `datadome` feature, `tab.datadome()` builder, the three surfaces, the `on_captcha` solver recipe (2captcha-shaped, returning the `datadome` cookie), the `Blocked`/`TimedOut` outcomes, and the **WebGPU/#20 stealth note** (device-check needs `stealth()`; the `Surface::Webgpu` coherence patch ships with it).
+
+- [ ] **Step 2: Add to `SUMMARY.md`** — a `- [DataDome](datadome.md)` line next to the Imperva entry.
+
+- [ ] **Step 3: Update `README.md`** — add `zendriver-datadome` to the crate list / feature matrix (next to cloudflare + imperva), and note the new `Surface::Webgpu`.
+
+- [ ] **Step 4: Update `CHANGELOG.md`** — an entry under the unreleased section summarizing: new `zendriver-datadome` crate (#20), `Surface::Webgpu` coherence, and the imperva/cloudflare result-model unification (note the breaking lib-level change: `Timeout`/`NoChallenge`/`ClearanceTimeout` moved from `Error` to `Outcome`).
+
+- [ ] **Step 5: Full-workspace gates** (the complete CLAUDE.md pre-push set):
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings
+cargo test --workspace
+cargo test -p zendriver-mcp --all-features
+cargo test -p zendriver --no-default-features
+cargo test -p zendriver-mcp --test schema_snapshots --all-features --locked
+cargo doc --workspace --no-deps
+```
+Expected: all green; no doc warnings. (Background the long runs per the user's workflow.)
+
+- [ ] **Step 6: Commit + push**
+
+```bash
+git add docs README.md CHANGELOG.md
+git commit -m "docs(datadome): user guide chapter + README + CHANGELOG"
+git push -u origin claude/group-d-datadome
+```
+
+- [ ] **Step 7: Open the PR**, then run `/founders-review` on it (per the user's per-PR requirement) before merge. PR body must record the documented MCP non-goal (the `on_captcha` solver callback) and the breaking result-model unification.
+
+---
+
+## Self-review checklist (completed)
+
+**Spec coverage:** §3 crate layout → Tasks 0.1/1.x/2.x/3.x/4.1. §4 detection → 1.2. §5 result model → 2.1. §6 driver → 2.2. §7 captcha-delta → 3.1/3.2. §8 interception → 4.1. §9 feature wiring → 5.1. §10 WebGPU → 6.1/6.2/6.3. §11 retrofit → 7.1/7.2. §12 MCP → 8.1. §13 testing → unit (1.x–4.1), fixture (9.1), nightly + WebGPU (9.2). §14 sequencing → phase order. §15 non-goals → recorded in docs/PR (10.1).
+
+**Type consistency:** `ClearanceOutcome` variants identical across bypass.rs (2.1) ↔ MCP map (8.1) ↔ fixture asserts (9.1). `DataDomeSurface` four variants identical across detection.rs (1.2) ↔ bypass terminals (2.2) ↔ ledger (8.1). `DataDomeChallenge`/`DataDomeSolution` identical across captcha.rs (3.1) ↔ on_captcha (3.1) ↔ wire note (8.1). `CaptchaSolver`/`arc_solver` defined in 3.1, referenced by 2.1's field — dependency flagged in 2.1 Step 2 note. WebGPU tokens (`WEBGPU_VENDOR/ARCHITECTURE/DESCRIPTION/MODE`) consistent across webgpu.js (6.3 Step 1) ↔ push_webgpu (6.3 Step 3) ↔ no-unsubstituted-tokens test (6.3 Step 4).
+
+**Known risk flagged inline:** `cookie_domain` heuristic (no PSL); WebGPU patch decorates rather than fabricates an adapter; imperva/cloudflare snapshot-unchanged claim must be verified at 8.1 Step 6; the 2.1↔3.1 build-order dependency.

--- a/docs/superpowers/specs/2026-06-02-datadome-bypass-design.md
+++ b/docs/superpowers/specs/2026-06-02-datadome-bypass-design.md
@@ -1,0 +1,381 @@
+# Group D — `zendriver-datadome` bypass crate + WebGPU coherence
+
+**Status:** Approved (brainstorm, participate mode) — 2026-06-02
+**Upstream:** [cdpdriver/zendriver#20](https://github.com/cdpdriver/zendriver/issues/20) — "DataDome is able to detect zendriver"
+**PR2 group:** D (last remaining; A/B/C merged as #28/#29/#30)
+
+## 1. Context & motivation
+
+DataDome is an anti-bot vendor. zendriver's existing anti-bot crates
+(`zendriver-cloudflare`, `zendriver-imperva`) are the template: an optional,
+cargo-feature-gated crate with a thin `Tab::<name>()` entry point that
+detects the vendor's challenge surface, polls for clearance, and exposes an
+opt-in solver callback for the CAPTCHA step — **not** a bundled CAPTCHA solver.
+
+### What upstream #20 actually reports
+
+The #20 thread (~13 comments) is **entirely about fingerprint coherence, not
+CAPTCHA solving**. Reporters never reach a visible challenge — they are
+silently flagged by DataDome's *invisible device-check* because of GPU
+fingerprint leaks:
+
+- `webGLVendor` / `webGLRenderer` / `webGLCanvasHash` — containerized Chromium
+  leaks renderer strings (`ANGLE (AMD Radeon 760M ... radeonsi LLVM 19 ...)`)
+  that betray the container GPU.
+- `navigator.gpu.requestAdapter()` (WebGPU) — the issue title's vector; GPU
+  adapter info inconsistent with the WebGL renderer.
+
+Maintainer framing: (1) some sites block Linux outright (unfixable here), (2)
+container deployments lack GPU features (Vulkan/GLES) enabling detection.
+Their plan is to fix `zendriver-docker` + a Windows image — out of scope for
+this repo. The portion we *can* address in-library is fingerprint coherence.
+
+**Critical design constraint** (Camoufox, quoted in-thread): *"Do NOT randomly
+assign WebGL values. WAFs hash your fingerprint and compare against a dataset.
+Random → detection as unknown device."* All spoofed fingerprint values must be
+**coherent and dataset-sourced, never randomized**.
+
+### Why this is two complementary halves
+
+DataDome's dominant surface (the invisible device-check) has **no interactive
+element to drive** — passing it is ~95% fingerprint coherence, ~5% "wait for
+the `datadome` cookie." A pure imperva-style crate would therefore be hollow
+on the headline surface and repeat imperva's documented "cleared-but-still-403"
+trap. So Group D ships **both**:
+
+1. The **`zendriver-datadome` crate** — surface detection, observe-and-wait
+   clearance, opt-in CAPTCHA-solver callback, Block diagnosis.
+2. An **8th `Surface::Webgpu`** farble surface in `zendriver-stealth` — closes
+   the literal #20 leak so the device-check the crate waits on can actually
+   pass.
+
+PR #24 (fingerprint spoofing) already ships a `webgl` farble surface that
+Value-spoofs vendor/renderer; **WebGPU is 100% uncovered** today
+(`requestAdapter` / `navigator.gpu` / `GPUAdapter` appear nowhere in the
+workspace).
+
+### Guiding philosophy
+
+Least-opinionated, everything-overridable, coherent defaults; never lock a
+value (see memory `fingerprint-design-philosophy`). Pre-release: API churn is
+acceptable — prefer the technically-stronger design over backward-compat.
+
+## 2. Deliverables (one PR, 3 crates touched)
+
+1. **New `zendriver-datadome` crate** — sibling to cloudflare/imperva.
+2. **`Surface::Webgpu`** — 8th Persona farble surface in `zendriver-stealth`.
+3. **Retrofit** imperva + cloudflare to a unified single-channel result model
+   (folded into this PR, not deferred).
+
+## 3. Crate layout (mirror imperva file-for-file)
+
+```
+crates/zendriver-datadome/
+  Cargo.toml          # deps: zendriver-transport, zendriver-interception, tokio,
+                      #       serde, serde_json, thiserror, tracing
+  src/
+    lib.rs            # re-exports, crate docs, the "clearance ≠ acceptance —
+                      #   look upstream at WebGPU/stealth" limitations note
+    bypass.rs         # DataDomeBypass driver, wait_for_clearance, ClearanceOutcome
+    detection.rs      # detect.js + DataDomeSurface + detect_surface()
+    captcha.rs        # DataDomeChallenge / DataDomeSolution / solver type +
+                      #   cookie application
+    interception.rs   # opt-in Fetch fast-path (with_interception)
+    error.rs          # DataDomeError
+    detect.js
+```
+
+Crate version: `0.1.0`.
+
+## 4. Surface detection (`detection.rs` + `detect.js`)
+
+One `Runtime.evaluate` round-trip against the page main world (mirror imperva's
+bundled probe). `detect.js` reads, in one shot:
+
+- the `datadome` cookie (presence + value, via `document.cookie`),
+- the `window.dd` config object `{rt, cid, hsh, t, s, e, host}` — the challenge
+  descriptor DataDome injects into the 403 challenge page,
+- a `captcha-delivery.com` iframe (shadow-DOM-aware recursive walk, reuse
+  cloudflare's `findBbox` approach),
+- coarse body markers.
+
+```rust
+/// Which DataDome surface a tab is currently showing.
+pub enum DataDomeSurface {
+    /// window.dd.t == 'fe' device-check / interstitial — invisible JS
+    /// interrogation; also covers the auto-resolving "please wait" page.
+    DeviceCheck,
+    /// captcha-delivery.com iframe present (slider / puzzle / press-hold).
+    Captcha,
+    /// window.dd.t == 'bv' — IP banned; unsolvable in-browser.
+    Block,
+    /// No DataDome surface detected; the datadome cookie may already be valid.
+    None,
+}
+
+/// Surface-only convenience probe (mirror imperva's `detect_surface`).
+pub fn detect_surface(session: &SessionHandle)
+    -> Result<DataDomeSurface, DataDomeError>;
+```
+
+A `Captcha` surface is monolithic (no sub-kind) — unlike imperva's
+hCaptcha/reCAPTCHA/native split, DataDome's CAPTCHA is one solver task type;
+the crate just hands over the `captcha_url`.
+
+## 5. Result model (unified single channel)
+
+All flow-terminals are `Ok(Outcome)`; only genuine faults are `Err`.
+
+```rust
+pub enum ClearanceOutcome {
+    /// datadome cookie acquired AND challenge markers gone.
+    Cleared { datadome: String },
+    /// Markers cleared but no datadome cookie observed (rare / legacy path).
+    ChallengeGone,
+    /// No DataDome surface present at call time. Fast path; no waiting.
+    AlreadyClear,
+    /// window.dd.t == 'bv' — IP banned. Nothing in-browser can clear this;
+    /// the caller must change IP (e.g. residential proxy).
+    Blocked,
+    /// Deadline elapsed without reaching a terminal state.
+    TimedOut { last_surface: Option<DataDomeSurface> },
+}
+
+pub enum DataDomeError {           // faults ONLY
+    /// Captcha surface detected but no `on_captcha` solver registered.
+    CaptchaRequired,
+    /// Registered solver returned an error.
+    CaptchaSolver(Box<dyn std::error::Error + Send + Sync>),
+    /// with_interception hook failed at startup.
+    Interception(#[from] InterceptionError),
+    /// CDP transport / call error.
+    Call(#[from] CallError),
+    /// In-page evaluator raised or returned an unexpected shape.
+    JsError(String),
+}
+```
+
+`Block` is a successfully-*detected* terminal (we know exactly what's
+happening), so it is an `Outcome`, not an `Error` — the caller branches on it
+like `AlreadyClear`. `TimedOut` is likewise an outcome (a deadline in a
+bot-management flow is a normal signal, not a malfunction).
+
+## 6. Driver (`bypass.rs`)
+
+`DataDomeBypass<'tab>`, constructed via `Tab::datadome()`. Same struct shape as
+`ImpervaBypass` (`Arc<dyn solver>` + `interception_enabled: bool`, custom
+`Debug` that elides the closure). Builder methods:
+
+- `.timeout(Duration)` — overall deadline (default 30s).
+- `.poll_interval(Duration)` — poll cadence (default 250ms).
+- `.with_interception()` — enable the Fetch-domain fast-path (§8).
+- `.on_captcha(solver)` — register the CAPTCHA solver callback (§7).
+
+`wait_for_clearance(self) -> Result<ClearanceOutcome, DataDomeError>`:
+
+1. Pre-probe the surface, **raced against the deadline** (imperva's
+   `probe_with_deadline` — no probe, including the first, outlives the budget).
+2. `None` → `AlreadyClear` (no surface to clear; any existing datadome
+   cookie is left as-is).
+3. `Block` → `Blocked` (immediate terminal).
+4. `DeviceCheck` → poll loop: each tick re-detect; when the datadome cookie
+   lands AND markers are gone → `Cleared`. *(This is the surface WebGPU
+   coherence makes passable; without it the loop just `TimedOut`s.)*
+5. `Captcha` → no solver ⇒ `Err(CaptchaRequired)`; with solver ⇒ extract
+   `DataDomeChallenge` → call solver → apply `DataDomeSolution` → reload →
+   resume poll.
+6. Deadline reached ⇒ `TimedOut { last_surface }`.
+7. With `.with_interception()`: a background oneshot signal (first
+   `Set-Cookie: datadome=` or `captcha-delivery` 2xx) is raced against the
+   poll; first to fire wins (mirror imperva's `interception.rs` +
+   `InterceptionGuard` RAII cancel).
+
+## 7. CAPTCHA escalation (`captcha.rs`) — the DataDome delta vs imperva
+
+```rust
+/// CAPTCHA escalation handed to a caller-supplied solver.
+pub struct DataDomeChallenge {
+    /// Built from window.dd + the current datadome cookie, e.g.
+    /// https://geo.captcha-delivery.com/captcha/?initialCid=…&hash=…&cid=…&t=fe
+    pub captcha_url: String,
+    /// URL of the page presenting the CAPTCHA.
+    pub site_url: String,
+    /// Browser UA — MUST match the UA the page used (solver-service requirement).
+    pub user_agent: String,
+    pub cid: Option<String>,   // datadome cookie / dd.cid
+    pub hash: Option<String>,  // dd.hsh
+}
+
+/// Token returned by a caller-supplied solver. For DataDome this is the
+/// solved `datadome` COOKIE value — NOT a form-field token.
+pub struct DataDomeSolution {
+    pub datadome_cookie: String,
+}
+```
+
+Solver type: `Fn(DataDomeChallenge) -> Future<Result<DataDomeSolution,
+Box<dyn Error + Send + Sync>>>`, `Arc`-erased exactly like imperva's
+`CaptchaSolver` + `arc_solver`.
+
+**Applying the solution is the structural difference from imperva.** Imperva
+injects a token into a form field; DataDome's solution *is* the cookie — apply
+via `Network.setCookie { name: "datadome", value, domain, path: "/" }` then
+`Page.reload`, then resume the poll. `t == 'bv'` ⇒ never call the solver
+(a banned IP cannot be solved) ⇒ `Blocked`.
+
+The solver callback is opt-in; without it a CAPTCHA surface yields
+`Err(CaptchaRequired)`. We do **not** bundle a solver or attempt native slider
+geometry in v1 (the most cat-and-mouse surface — DataDome rotates the puzzle
+constantly). Native solving is a possible future feature behind its own flag.
+
+## 8. Opt-in interception fast-path (`interception.rs`)
+
+Mirror imperva: `spawn_signal(session)` subscribes (via
+`InterceptBuilder::pattern(...).at_response().subscribe()`) to Fetch responses
+matching `*captcha-delivery.com*` and any response carrying `Set-Cookie:
+datadome=`, releasing every pause (`continue_()`) so the page keeps loading and
+signalling a oneshot on the first clearance hit. An `InterceptionGuard`
+(CancellationToken + JoinHandle) cooperatively cancels on drop. The poll loop
+races this signal; first wins. Infallible setup (returns `-> _`, not
+`Result`, to dodge `clippy::result_large_err`).
+
+## 9. Feature wiring + `Tab` method
+
+- Workspace: add `crates/zendriver-datadome` to `members`; add
+  `zendriver-datadome = { path = "...", version = "0.1.0" }` to
+  `[workspace.dependencies]`.
+- `zendriver/Cargo.toml`:
+  - `datadome = ["interception", "dep:zendriver-datadome"]`
+  - `datadome-tests = ["datadome", "integration-tests"]`
+  - add `"datadome"` to the `integration-tests` feature list.
+  - `zendriver-datadome = { workspace = true, optional = true }`.
+- `zendriver/src/tab.rs`:
+  ```rust
+  #[cfg(feature = "datadome")]
+  impl Tab {
+      #[must_use]
+      pub fn datadome(&self) -> zendriver_datadome::DataDomeBypass<'_> {
+          zendriver_datadome::DataDomeBypass::new(self.session())
+      }
+  }
+  ```
+- Re-export `DataDomeBypass`, `ClearanceOutcome` (as `DataDomeClearanceOutcome`
+  at the zendriver-crate boundary, matching the `ImpervaClearanceOutcome`
+  convention), `DataDomeError`, `DataDomeSurface`, `DataDomeChallenge`,
+  `DataDomeSolution`, `detect_surface` through the zendriver crate behind the
+  feature, following the imperva re-export set.
+- `zendriver-mcp/Cargo.toml`: add `datadome = ["zendriver/datadome"]` to the
+  `default` feature list.
+
+`Tab::datadome()` also gives access to the standalone `detect_surface`
+passthrough (re-exported) for a "which surface am I on" check without driving a
+bypass.
+
+## 10. WebGPU surface (`zendriver-stealth`)
+
+- Add `Surface::Webgpu` to the `Surface` enum; classify as
+  `SurfaceKind::Value` (coherent value-spoof, like `Webgl`).
+- New `patches/webgpu.js`: override `navigator.gpu.requestAdapter()` to resolve
+  a `GPUAdapter` whose `info` (vendor / architecture / device / description),
+  `limits`, and `features` are **coherent with the already-spoofed WebGL
+  `UNMASKED_RENDERER`**. Both the `webgl` and `webgpu` patches read the same
+  persona-resolved renderer, so coherence is **by construction** (not
+  runtime-sniffed). Vendor/architecture derived from the renderer string
+  (NVIDIA / AMD / Intel / Apple) via a small dataset map; standard-tier
+  `limits`. **Never randomized.**
+- **Default strategy: coherent-mock** (B1). A real Chrome on the spoofed UA
+  *has* WebGPU; deleting `navigator.gpu` can itself be a tell. `Block` (delete
+  `navigator.gpu`) stays available per-persona via `.surface(Surface::Webgpu,
+  Strategy::Block)`.
+- Wire into the existing `bootstrap_script(persona, identity)` path; the
+  per-surface override machinery (`.surface(...)`, persona overlay) already
+  supports the new variant with no API change.
+- The renderer→adapter mapping table is a plan-time implementation detail;
+  v1 needs a small set covering the common vendors, defaulting to a plausible
+  coherent adapter when the renderer is unrecognized.
+
+## 11. Cross-crate retrofit (folded into this PR)
+
+Unify all three anti-bot crates on the single-channel model (flow-terminals =
+`Outcome`, faults = `Error`):
+
+- **imperva**: move `Timeout` from `ImpervaError` into
+  `ClearanceOutcome::TimedOut { last_surface }`. The MCP `solve_imperva` tool
+  drops its `Err(ImpervaError::Timeout) =>` collapse special-case for a direct
+  `Ok(TimedOut) =>` map. The MCP output enum already carries a `Timeout`
+  variant, so the wire schema (and `*.snap`) is unchanged — regenerate to
+  confirm.
+- **cloudflare**: move `NoChallenge` + `ClearanceTimeout` from `CloudflareError`
+  into `Outcome` variants; the MCP cloudflare tool drops its analogous collapse.
+- Net result: `Error` in every anti-bot crate means a genuine fault (CDP / JS /
+  solver error / captcha-without-solver) only.
+
+This deletes code (the MCP error-collapse hacks) and removes a 3-crate
+inconsistency. Pre-release, so the lib-level signature churn is acceptable;
+the work is internal + test updates.
+
+## 12. MCP tool (`browser_solve_datadome`)
+
+Mirror `browser_solve_imperva`:
+
+- Input: `{ timeout_ms (default 30_000), poll_interval_ms?, with_interception
+  (default false) }`.
+- Output: `{ outcome, datadome? }` where `outcome ∈ { cleared, challenge_gone,
+  already_clear, blocked, timed_out }` and `datadome` is populated only on
+  `cleared`.
+- The solver callback is **not** wired over MCP (documented non-goal, exactly
+  like imperva's `on_captcha`): a CAPTCHA surface without a registered solver
+  surfaces as a `CaptchaRequired` error the agent handles out-of-band.
+  `Blocked` is a distinct non-error outcome.
+
+MCP coverage rule (repo CLAUDE.md): add the tool + a ledger entry in
+`crates/zendriver-mcp/mcp-coverage-ledger.toml` for `Tab::datadome()` and the
+new `Surface::Webgpu` variant (the latter is reachable via the existing
+`browser_set_stealth_profile` / surface enum — regenerate schema snapshots).
+Run the schema-snapshot step and `cargo insta accept --all`; commit the `.snap`
+files.
+
+## 13. Testing
+
+- **Unit (MockConnection)** — deterministic, per-module, mirror the siblings:
+  detection classification (mocked `detect.js` payloads → each surface),
+  poll-loop terminals (mocked cookie/marker sequences → each `ClearanceOutcome`),
+  captcha extraction + cookie application (mocked evals + `Network.setCookie`),
+  interception signal.
+- **Fixture integration** — a synthetic DataDome 403 page (static HTML: a
+  `var dd = {...}` body + a fake `captcha-delivery` iframe + a clearance route
+  that sets the `datadome` cookie). Exercises detect → poll → cookie-apply in
+  normal CI with zero external dependency.
+- **Nightly** (`datadome-tests` feature, gated `#[ignore]`) — a real
+  DataDome-protected site + the deviceandbrowserinfo.com bot test, for drift
+  signal; best-effort, never CI-blocking (the repo already has flaky
+  network-timing tests; live anti-bot sites are worse).
+- **WebGPU coherence** — unit-test the `webgpu.js` patch shape; assert
+  `navigator.gpu.requestAdapter()` returns values coherent with the WebGL
+  renderer in the existing stealth nightly.
+
+## 14. Build sequencing
+
+1. This spec → committed.
+2. `writing-plans` → `docs/superpowers/plans/2026-06-02-datadome-bypass.md`.
+3. Build on this branch (`claude/group-d-datadome`, off main @ 704c4c4) via
+   subagent-driven TDD, per cohesive task.
+4. Gates: `cargo fmt --all --check`; `cargo clippy --workspace --all-targets
+   --locked -- -D warnings`; `cargo clippy -p zendriver-mcp --all-features
+   --all-targets -- -D warnings` (feature-gated code touched); schema snapshots;
+   unit + fixture tests.
+5. PR → `/founders-review` → merge → delete branch + worktree.
+
+## 15. Explicit non-goals (v1)
+
+- **Native slider / puzzle solving** (image-diff gap + Bézier drag) — the most
+  cat-and-mouse surface; deferred to a possible future flagged feature. v1
+  delegates to the opt-in solver callback.
+- **Forging the device-check payload directly** (generating the `tags.js` POST
+  out-of-browser to mint a cookie) — extremely brittle, rotates constantly;
+  contrary to "run a real browser." Non-goal.
+- **Fixing container GPU support** (Vulkan/GLES, Windows image) — belongs in
+  `zendriver-docker`, not this repo (the upstream maintainer tracks it
+  separately).
+- **MCP solver callback** — same class as imperva's; agents handle
+  `CaptchaRequired` out-of-band.


### PR DESCRIPTION
## Summary

Group D (final PR2 item) — adds DataDome anti-bot support to zendriver, closing upstream [cdpdriver/zendriver#20](https://github.com/cdpdriver/zendriver/issues/20). Three deliverables in one PR:

1. **New `zendriver-datadome` crate** — a feature-gated bypass crate (sibling to `zendriver-cloudflare` / `zendriver-imperva`). Detects the active DataDome surface (`device_check` / `captcha` / `block` / `none`), polls until the `datadome` clearance cookie lands, and escalates a CAPTCHA surface to a caller-supplied async solver whose returned **cookie** is applied via `Network.setCookie` + reload. Opt-in Fetch-domain fast-path (`with_interception`). Exposed via `Tab::datadome()` behind the `datadome` feature.
2. **`Surface::Webgpu`** — an 8th fingerprint-coherence farble in `zendriver-stealth`. #20 is literally a `navigator.gpu.requestAdapter()` leak: headless/container Chrome reports GPU adapter info inconsistent with the WebGL renderer. The patch overrides `GPUAdapter.prototype.info` (a prototype getter, matching real Chrome — no own-property tell) to return an adapter coherent with the already-spoofed WebGL `UNMASKED_RENDERER`. **Values validated empirically**: a live probe of native Chrome (Apple M4 Pro) confirmed the shape `{vendor, architecture, device:"", description:""}`; architecture tokens are taken from Dawn's `gpu_info.json` (normalized lowercase + spaces→hyphens) — `metal-3` (Apple), `lovelace`/`ampere`/`turing`/`pascal`/`blackwell` (NVIDIA), `rdna-1/2/3/4` (AMD), `gen-9`/`gen-12-lp` (Intel). Unrecognized models emit `""` (the safe, coherent default — Chrome itself returns `""` for unclassified GPUs).
3. **Cross-crate result-model unification** (**breaking, pre-release**) — `imperva` and `cloudflare` move their timeout / no-challenge terminals from `Error` into `ClearanceOutcome`: imperva `Timeout` → `ClearanceOutcome::TimedOut`; cloudflare `NoChallenge` + `ClearanceTimeout` → `ClearanceOutcome::TimedOut { saw_challenge }`. All three anti-bot crates now use one channel — flow-terminals are `Ok(Outcome)`, only genuine faults are `Err`. This deletes the MCP error-collapse special-cases. Wire schemas unchanged (the MCP `Outcome::Timeout` variant is preserved).

## MCP coverage

- New `browser_solve_datadome` tool (default `datadome` feature) mirroring `browser_solve_imperva`. Outcome enum: `cleared` / `challenge_gone` / `already_clear` / `blocked` / `timeout`.
- Ledger entries added for every new public item; `cargo public-api` baseline regenerated (purely additive).
- The `on_captcha` solver callback is a **documented MCP non-goal** (same class as imperva's) — a captcha surface without a solver surfaces as a `CaptchaRequired` error the agent handles out-of-band.

## Non-goals (v1)

- Native slider/puzzle solving (the most cat-and-mouse surface) — delegated to the opt-in solver callback.
- Forging the device-check payload out-of-browser.
- Container GPU support (Vulkan/GLES, Windows image) — belongs in `zendriver-docker`.
- Deep WebGPU tells (`instanceof GPUAdapterInfo`, `subgroupMin/MaxSize`) — documented limitations.

## Founder's-review findings fixed

In-loop probe now deadline-bounded (hang-safety); `setCookie success:false` now warns; `cookie_domain` + `build_challenge` + `webgpu_adapter` branches covered by unit tests; WebGPU tokens corrected from real-Chrome/Dawn data.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace` (94 test binaries green)
- [x] `cargo test -p zendriver-mcp --all-features` (incl. schema snapshots)
- [x] `cargo test -p zendriver --no-default-features`
- [x] `cargo doc --workspace --no-deps` (0 new warnings)
- [ ] Nightly `datadome-tests` + stealth WebGPU-coherence job (real Chrome) — gated `#[ignore]`, runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
