### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "base64",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-cloudflare"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fetcher"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "dirs",
  "futures",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "futures",
  "serde",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",
@@ -3485,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-transport"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.6", default-features = false }
-zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.3" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.2.1" }
-zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.1.4" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.2.0" }
-zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.2" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.3.0" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.1.3" }
+zendriver               = { path = "crates/zendriver", version = "0.2.7", default-features = false }
+zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.4" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.3.0" }
+zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.0" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.2.1" }
+zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.3" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.3.1" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.0" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.0" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.1.2" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.1.3" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-cloudflare/CHANGELOG.md
+++ b/crates/zendriver-cloudflare/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-02
+
+### Changed
+
+- TimedOut is an Outcome, not an Error (unify result model)
+
+
 ## [0.1.4] - 2026-06-02
 
 

--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-cloudflare"
 description = "Cloudflare Turnstile bypass for zendriver"
-version = "0.1.4"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this crate documented here. Format: [Keep a
+Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
+
+## [0.1.0] - 2026-06-02
+
+### Added
+
+- Scaffold zendriver-datadome crate
+- DataDomeError (faults-only)
+- Surface detection (detect.js + DataDomeSurface)
+- Captcha challenge extraction + cookie application
+- ClearanceOutcome + DataDomeBypass driver + poll loop
+- Opt-in Fetch interception fast-path
+
+### Fixed
+
+- Deadline-race the pre-loop probe; warn on empty challenge url/ua
+- Deadline-bound the in-loop probe; warn on rejected setCookie; cover cookie_domain + build_challenge
+

--- a/crates/zendriver-fetcher/CHANGELOG.md
+++ b/crates/zendriver-fetcher/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.3] - 2026-06-02
+
+
 ## [0.1.2] - 2026-05-26
 
 

--- a/crates/zendriver-fetcher/Cargo.toml
+++ b/crates/zendriver-fetcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fetcher"
 description = "Chrome binary downloader for zendriver"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.3] - 2026-06-02
+
+
 ## [0.1.2] - 2026-06-02
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.0] - 2026-06-02
+
+### Changed
+
+- TimedOut is an Outcome, not an Error (unify result model)
+
+
 ## [0.1.3] - 2026-06-02
 
 

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.1.3"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.1] - 2026-06-02
+
+
 ## [0.2.0] - 2026-06-02
 
 ### Added

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.1] - 2026-06-02
+
+### Added
+
+- Browser_solve_datadome tool + ledger + schema snapshot
+
+### Changed
+
+- TimedOut is an Outcome, not an Error (unify result model)
+- TimedOut is an Outcome, not an Error (unify result model)
+
+
 ## [0.3.0] - 2026-06-02
 
 ### Added

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.0] - 2026-06-02
+
+### Added
+
+- Add Surface::Webgpu (Value kind) + Persona.webgpu plumbing
+- Renderer->GPUAdapter coherence map for WebGPU
+- WebGPU coherence patch (navigator.gpu adapter from WebGL renderer)
+- Validated WebGPU arch tokens from Dawn gpu_info.json (nvidia/amd/intel/apple model->uarch map)
+
+### Fixed
+
+- WebGPU patches GPUAdapter.prototype getter (no own-property/toString tell)
+- WebGPU adapter validated against real Chrome (Apple metal-3, mask device/description)
+
+
 ## [0.2.1] - 2026-06-02
 
 

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-transport/CHANGELOG.md
+++ b/crates/zendriver-transport/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-06-02
+
+
 ## [0.1.3] - 2026-06-02
 
 ### Added

--- a/crates/zendriver-transport/Cargo.toml
+++ b/crates/zendriver-transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-transport"
 description = "Internal: WebSocket + CDP routing actor for zendriver"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,18 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-06-02
+
+### Added
+
+- Wire Tab::datadome() + re-exports + error mapping behind the datadome feature
+
+### Changed
+
+- TimedOut is an Outcome, not an Error (unify result model)
+- TimedOut is an Outcome, not an Error (unify result model)
+
+
 ## [0.2.6] - 2026-06-02
 
 

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-transport`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `zendriver-cloudflare`: 0.1.4 -> 0.2.0 (⚠ API breaking changes)
* `zendriver-interception`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `zendriver-datadome`: 0.1.0
* `zendriver-fetcher`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `zendriver-imperva`: 0.1.3 -> 0.2.0 (⚠ API breaking changes)
* `zendriver-stealth`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)
* `zendriver`: 0.2.6 -> 0.2.7 (✓ API compatible changes)
* `zendriver-mcp`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `zendriver-fingerprints`: 0.1.2 -> 0.1.3

### ⚠ `zendriver-cloudflare` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant ClearanceOutcome:TimedOut in /tmp/.tmpnAWFR2/zendriver-rs/crates/zendriver-cloudflare/src/bypass.rs:55
  variant ClearanceOutcome:TimedOut in /tmp/.tmpnAWFR2/zendriver-rs/crates/zendriver-cloudflare/src/bypass.rs:55

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_missing.ron

Failed in:
  variant CloudflareError::NoChallenge, previously in file /tmp/.tmpUDtJm9/zendriver-cloudflare/src/error.rs:7
  variant CloudflareError::ClearanceTimeout, previously in file /tmp/.tmpUDtJm9/zendriver-cloudflare/src/error.rs:10
  variant CloudflareError::NoChallenge, previously in file /tmp/.tmpUDtJm9/zendriver-cloudflare/src/error.rs:7
  variant CloudflareError::ClearanceTimeout, previously in file /tmp/.tmpUDtJm9/zendriver-cloudflare/src/error.rs:10
```

### ⚠ `zendriver-imperva` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant ClearanceOutcome:TimedOut in /tmp/.tmpnAWFR2/zendriver-rs/crates/zendriver-imperva/src/bypass.rs:58
  variant ClearanceOutcome:TimedOut in /tmp/.tmpnAWFR2/zendriver-rs/crates/zendriver-imperva/src/bypass.rs:58

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ImpervaError::Timeout, previously in file /tmp/.tmpUDtJm9/zendriver-imperva/src/error.rs:18
  variant ImpervaError::Timeout, previously in file /tmp/.tmpUDtJm9/zendriver-imperva/src/error.rs:18
```

### ⚠ `zendriver-stealth` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Persona.webgpu in /tmp/.tmpnAWFR2/zendriver-rs/crates/zendriver-stealth/src/persona/mod.rs:29
  field Persona.webgpu in /tmp/.tmpnAWFR2/zendriver-rs/crates/zendriver-stealth/src/persona/mod.rs:29

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant Surface:Webgpu in /tmp/.tmpnAWFR2/zendriver-rs/crates/zendriver-stealth/src/persona/surface.rs:15
  variant Surface:Webgpu in /tmp/.tmpnAWFR2/zendriver-rs/crates/zendriver-stealth/src/persona/surface.rs:15
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `zendriver-cloudflare`

<blockquote>

## [0.2.0] - 2026-06-02

### Changed

- TimedOut is an Outcome, not an Error (unify result model)
</blockquote>


## `zendriver-datadome`

<blockquote>

## [0.1.0] - 2026-06-02

### Added

- Scaffold zendriver-datadome crate
- DataDomeError (faults-only)
- Surface detection (detect.js + DataDomeSurface)
- Captcha challenge extraction + cookie application
- ClearanceOutcome + DataDomeBypass driver + poll loop
- Opt-in Fetch interception fast-path

### Fixed

- Deadline-race the pre-loop probe; warn on empty challenge url/ua
- Deadline-bound the in-loop probe; warn on rejected setCookie; cover cookie_domain + build_challenge
</blockquote>


## `zendriver-imperva`

<blockquote>

## [0.2.0] - 2026-06-02

### Changed

- TimedOut is an Outcome, not an Error (unify result model)
</blockquote>

## `zendriver-stealth`

<blockquote>

## [0.3.0] - 2026-06-02

### Added

- Add Surface::Webgpu (Value kind) + Persona.webgpu plumbing
- Renderer->GPUAdapter coherence map for WebGPU
- WebGPU coherence patch (navigator.gpu adapter from WebGL renderer)
- Validated WebGPU arch tokens from Dawn gpu_info.json (nvidia/amd/intel/apple model->uarch map)

### Fixed

- WebGPU patches GPUAdapter.prototype getter (no own-property/toString tell)
- WebGPU adapter validated against real Chrome (Apple metal-3, mask device/description)
</blockquote>

## `zendriver`

<blockquote>

## [0.2.7] - 2026-06-02

### Added

- Wire Tab::datadome() + re-exports + error mapping behind the datadome feature

### Changed

- TimedOut is an Outcome, not an Error (unify result model)
- TimedOut is an Outcome, not an Error (unify result model)
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.3.1] - 2026-06-02

### Added

- Browser_solve_datadome tool + ledger + schema snapshot

### Changed

- TimedOut is an Outcome, not an Error (unify result model)
- TimedOut is an Outcome, not an Error (unify result model)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).