### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "async-trait",
  "base64",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "futures",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.7", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.8", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.4" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.3.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.0" }
@@ -30,7 +30,7 @@ zendriver-interception  = { path = "crates/zendriver-interception", version = "0
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.3" }
 zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.3.1" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.0" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.0" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.1" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.1.3" }
 
 # MCP server

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.1] - 2026-06-03
+
+
 ## [0.1.0] - 2026-06-02
 
 ### Added

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-06-03
+
+
 ## [0.2.7] - 2026-06-02
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-datadome`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `zendriver-mcp`: 0.3.0 -> 0.3.1
* `zendriver`: 0.2.7 -> 0.2.8

<details><summary><i><b>Changelog</b></i></summary><p>


## `zendriver-mcp`

<blockquote>

## [0.3.1] - 2026-06-02

### Added

- Browser_solve_datadome tool + ledger + schema snapshot

### Changed

- TimedOut is an Outcome, not an Error (unify result model)
- TimedOut is an Outcome, not an Error (unify result model)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).