### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.3.0"
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.0" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.2.1" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.3" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.3.1" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.3.2" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.0" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.1" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.1.3" }

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.2] - 2026-06-03
+
+
 ## [0.3.1] - 2026-06-02
 
 ### Added

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-datadome`: 0.1.0 -> 0.1.1
* `zendriver`: 0.2.7 -> 0.2.8
* `zendriver-mcp`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).