### PR TITLE
Resolve #38: warn on Accept-Encoding skew (header-network port N/A for real Chrome)

### DIFF
--- a/crates/zendriver-stealth/src/headers.rs
+++ b/crates/zendriver-stealth/src/headers.rs
@@ -7,6 +7,13 @@
 //! enabled-by-default in Chrome 123 (2024-03); `br` (brotli) since Chrome 50.
 //! Two branches therefore suffice — zendriver does not drive pre-`br` Chrome.
 //!
+//! Chrome's network service **owns** this header: `Network.setExtraHTTPHeaders`
+//! does *not* override it (verified against Chrome 148 — the override is
+//! silently dropped), and the `--disable-features=ZstdContentEncoding` launch
+//! flag is inert on current builds. The skew is therefore **observable but not
+//! correctable over CDP** — the stealth layer only *warns* about it (see
+//! [`accept_encoding_skew`]).
+//!
 //! See `docs/superpowers/specs/2026-06-02-header-coherence-design.md`.
 
 /// The `Accept-Encoding` a real Chrome of `major` sends for a top-level HTTPS
@@ -19,6 +26,19 @@ pub(crate) fn accept_encoding_for(major: u32) -> &'static str {
     }
 }
 
+/// The `Accept-Encoding` a `claimed_major` *should* advertise, returned only
+/// when it differs from what the launched `binary_major` actually sends — i.e.
+/// the two straddle the `zstd`/Chrome-123 boundary. `None` means the binary's
+/// native header already matches the claimed identity (no incoherence).
+///
+/// A `Some` result is a *warning signal*, not an override target: this header
+/// cannot be corrected over CDP (see the module docs). Callers warn the user
+/// that a pinned `chrome_version` will leak the binary's encodings.
+pub(crate) fn accept_encoding_skew(binary_major: u32, claimed_major: u32) -> Option<&'static str> {
+    let claimed = accept_encoding_for(claimed_major);
+    (claimed != accept_encoding_for(binary_major)).then_some(claimed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -28,5 +48,20 @@ mod tests {
         assert_eq!(accept_encoding_for(122), "gzip, deflate, br");
         assert_eq!(accept_encoding_for(123), "gzip, deflate, br, zstd");
         assert_eq!(accept_encoding_for(148), "gzip, deflate, br, zstd");
+    }
+
+    #[test]
+    fn accept_encoding_skew_flags_only_a_boundary_crossing() {
+        // Claimed pre-zstd on a zstd-capable binary -> skew (the leak case).
+        assert_eq!(accept_encoding_skew(148, 120), Some("gzip, deflate, br"));
+        // Claimed zstd-capable on a pre-zstd binary -> skew (other direction).
+        assert_eq!(
+            accept_encoding_skew(120, 148),
+            Some("gzip, deflate, br, zstd")
+        );
+        // Both sides of the boundary agree -> no skew.
+        assert_eq!(accept_encoding_skew(148, 140), None);
+        assert_eq!(accept_encoding_skew(120, 122), None);
+        assert_eq!(accept_encoding_skew(130, 130), None);
     }
 }

--- a/crates/zendriver-stealth/src/headers.rs
+++ b/crates/zendriver-stealth/src/headers.rs
@@ -1,0 +1,32 @@
+//! Coherent request-header values derived from the claimed stealth identity.
+//!
+//! A real Chrome over CDP already emits coherent request headers; the one value
+//! that can silently skew from the *claimed* identity is `Accept-Encoding`,
+//! because Chrome's network stack advertises the *real binary's* supported
+//! encodings regardless of the UA / UA-CH overrides we apply. `zstd` shipped
+//! enabled-by-default in Chrome 123 (2024-03); `br` (brotli) since Chrome 50.
+//! Two branches therefore suffice — zendriver does not drive pre-`br` Chrome.
+//!
+//! See `docs/superpowers/specs/2026-06-02-header-coherence-design.md`.
+
+/// The `Accept-Encoding` a real Chrome of `major` sends for a top-level HTTPS
+/// navigation.
+pub(crate) fn accept_encoding_for(major: u32) -> &'static str {
+    if major >= 123 {
+        "gzip, deflate, br, zstd"
+    } else {
+        "gzip, deflate, br"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accept_encoding_straddles_the_zstd_boundary() {
+        assert_eq!(accept_encoding_for(122), "gzip, deflate, br");
+        assert_eq!(accept_encoding_for(123), "gzip, deflate, br, zstd");
+        assert_eq!(accept_encoding_for(148), "gzip, deflate, br, zstd");
+    }
+}

--- a/crates/zendriver-stealth/src/lib.rs
+++ b/crates/zendriver-stealth/src/lib.rs
@@ -37,6 +37,7 @@
 pub mod error;
 pub mod fingerprint;
 pub mod flags;
+mod headers;
 pub mod input_profile;
 pub mod observer;
 pub mod patches;

--- a/crates/zendriver-stealth/src/profile.rs
+++ b/crates/zendriver-stealth/src/profile.rs
@@ -282,6 +282,9 @@ impl StealthProfile {
             Some(fp) => fp.clone(),
             None => Fingerprint::auto_detect(chrome_exe)?,
         };
+        // The Accept-Encoding the *real* binary advertises, captured before the
+        // claimed-major override below (used only to warn on an uncorrectable skew).
+        let binary_major = fp.chrome_major;
         if let Some(p) = self.per_field.platform {
             fp.platform = p;
         }
@@ -324,6 +327,24 @@ impl StealthProfile {
         }
         if let Some(ref locale) = self.per_field.locale {
             fp.locale = Some(locale.clone());
+        }
+        // Accept-Encoding coherence is observable but NOT correctable over CDP:
+        // Chrome's network service owns the header and ignores
+        // `Network.setExtraHTTPHeaders` for it (verified, Chrome 148). When a
+        // pinned `chrome_version` straddles the `zstd`/Chrome-123 boundary vs the
+        // launched binary, the request advertises the binary's encodings — an
+        // Accept-Encoding vs User-Agent mismatch we can only warn about.
+        if let Some(coherent) = crate::headers::accept_encoding_skew(binary_major, fp.chrome_major)
+        {
+            tracing::warn!(
+                claimed_major = fp.chrome_major,
+                binary_major,
+                coherent_accept_encoding = coherent,
+                "stealth: claimed Chrome major advertises a different Accept-Encoding \
+                 than the launched binary; Chrome controls this header and CDP cannot \
+                 override it, so requests will leak the binary's encodings — pin \
+                 chrome_version to the binary's major to stay coherent",
+            );
         }
         Ok(fp)
     }

--- a/crates/zendriver/tests/accept_encoding_coherence.rs
+++ b/crates/zendriver/tests/accept_encoding_coherence.rs
@@ -1,0 +1,95 @@
+//! Real-Chrome probe documenting that `Accept-Encoding` is **not** correctable
+//! over CDP: Chrome's network service owns the header. A stealth profile that
+//! pins a pre-`zstd` Chrome major (120) on a `zstd`-capable binary (>=123) still
+//! advertises `zstd` on the wire — the Accept-Encoding-vs-User-Agent mismatch
+//! that `zendriver_stealth` only *warns* about (it cannot fix it).
+//!
+//! Verified the negative result against Chrome 148:
+//!   - `Network.setExtraHTTPHeaders` for `Accept-Encoding` is silently dropped.
+//!   - `--disable-features=ZstdContentEncoding` is inert on current builds.
+//!
+//! See `docs/superpowers/specs/2026-06-02-header-coherence-design.md`.
+//!
+//! Gated by `#[cfg(feature = "integration-tests")]` + `#[ignore]` (same
+//! convention as `fingerprint_integration.rs`). Run on a machine with a real
+//! Chrome **>= 123**:
+//! ```sh
+//! cargo test -p zendriver --test accept_encoding_coherence \
+//!     --features integration-tests -- --ignored --nocapture
+//! ```
+#![cfg(feature = "integration-tests")]
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+
+use serial_test::serial;
+use zendriver::Browser;
+use zendriver::stealth::StealthProfile;
+
+/// With a forced claimed-major skew (claim Chrome 120 on a >=123 binary), the
+/// navigation request STILL advertises the binary's encodings (`zstd` present) —
+/// proving the header is binary-controlled and the stealth layer is right to
+/// only warn. Exactly one `Accept-Encoding` header (no duplication) is asserted
+/// to rule out any accidental append.
+#[tokio::test]
+#[serial]
+#[ignore] // requires a real Chrome binary >= 123; run with --ignored
+async fn pinned_chrome_major_leaks_binary_accept_encoding() {
+    // One-shot local HTTP/1.1 server that records the request headers it sees.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    let (tx, rx) = mpsc::channel::<Vec<String>>();
+    std::thread::spawn(move || {
+        if let Ok((stream, _)) = listener.accept() {
+            let mut reader = BufReader::new(&stream);
+            let mut headers = Vec::new();
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    break;
+                }
+                if line == "\r\n" {
+                    break;
+                }
+                headers.push(line.trim_end().to_string());
+            }
+            let mut w = &stream;
+            let _ =
+                w.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+            let _ = tx.send(headers);
+        }
+    });
+
+    // Claim Chrome 120 (pre-`zstd`). On a real >=123 binary this is a skew the
+    // stealth layer warns about but cannot correct.
+    let profile = StealthProfile::spoofed().chrome_version(120);
+    let browser = Browser::builder()
+        .stealth(profile)
+        .headless(true)
+        .launch()
+        .await
+        .expect("launch");
+    let tab = browser.main_tab();
+    let _ = tab.goto(format!("http://127.0.0.1:{port}/")).await;
+
+    let headers = rx
+        .recv_timeout(std::time::Duration::from_secs(20))
+        .expect("server saw a request");
+    let ae: Vec<&String> = headers
+        .iter()
+        .filter(|h| h.to_ascii_lowercase().starts_with("accept-encoding:"))
+        .collect();
+    // Exactly one Accept-Encoding header — the binary's, undisturbed.
+    assert_eq!(
+        ae.len(),
+        1,
+        "expected one Accept-Encoding header, got {ae:?}"
+    );
+    assert!(
+        ae[0].to_ascii_lowercase().contains("zstd"),
+        "expected the >=123 binary to leak `zstd` despite the claimed major; \
+         got {ae:?} (is this Chrome older than 123?)",
+    );
+    browser.close().await.ok();
+}

--- a/docs/superpowers/plans/2026-06-03-header-coherence-accept-encoding.md
+++ b/docs/superpowers/plans/2026-06-03-header-coherence-accept-encoding.md
@@ -1,0 +1,557 @@
+# Header coherence (Accept-Encoding) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep Chrome's `Accept-Encoding` request header coherent with the *claimed* stealth Chrome major, so a profile that pins an identity across the `zstd`/Chrome-123 boundary no longer leaks the real binary's encoding set.
+
+**Architecture:** A pure `accept_encoding_for(major)` rule in `zendriver-stealth`; `StealthProfile::resolve_fingerprint` detects a claimed-vs-binary skew and returns an `Option<String>` override; `StealthObserver` applies it via `Network.setExtraHTTPHeaders` (only on the skew path, so the default profile adds zero CDP traffic). No header network port, no download, no new carrier type, no new MCP tool. See spec: `docs/superpowers/specs/2026-06-02-header-coherence-design.md`.
+
+**Tech Stack:** Rust 2024, `serde_json`, `zendriver-transport` CDP actor + its `MockConnection` test harness, `tokio` tests.
+
+---
+
+## File Structure
+
+- **Create** `crates/zendriver-stealth/src/headers.rs` — the `accept_encoding_for` rule + unit tests. One responsibility: map a Chrome major to its coherent `Accept-Encoding`.
+- **Create** `crates/zendriver/tests/accept_encoding_coherence.rs` — `#[ignore]`d real-Chrome probe verifying `setExtraHTTPHeaders` *replaces* (not appends) `Accept-Encoding`.
+- **Modify** `crates/zendriver-stealth/src/lib.rs` — declare `mod headers;`.
+- **Modify** `crates/zendriver-stealth/src/observer.rs` — add an `accept_encoding: Option<String>` field, a `with_accept_encoding` setter, and the apply block; add a Some-path test.
+- **Modify** `crates/zendriver-stealth/src/profile.rs` — `resolve_fingerprint` returns `(Fingerprint, Option<String>)`; add skew unit tests; fix its existing test.
+- **Modify** `crates/zendriver/src/browser.rs:1796,2017` — destructure the tuple and wire the override into the observer.
+
+---
+
+## Task 0: Pre-flight — verify `setExtraHTTPHeaders` replaces `Accept-Encoding`
+
+**Why first:** the entire apply surface (Task 2) assumes `Network.setExtraHTTPHeaders` *replaces* `Accept-Encoding`. If Chrome *appends* instead, we'd ship a duplicated header (worse than nothing) and must pivot to the `Fetch` interception path. Settle this empirically before wiring.
+
+**Files:**
+- Create: `crates/zendriver/tests/accept_encoding_coherence.rs`
+
+- [ ] **Step 1: Write the `#[ignore]`d real-Chrome probe**
+
+```rust
+//! Real-Chrome probe (run with `--ignored`): confirms that
+//! `Network.setExtraHTTPHeaders` REPLACES `Accept-Encoding` rather than
+//! appending to it. This is the empirical gate behind the header-coherence
+//! design (`docs/superpowers/specs/2026-06-02-header-coherence-design.md`).
+//!
+//! Launches a stealth browser with a forced claimed-major skew, navigates to a
+//! local TCP listener that captures the raw request, and asserts the outbound
+//! `Accept-Encoding` is exactly our injected value — no `zstd`, no duplication.
+#![cfg(feature = "stealth")]
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+
+use zendriver::Browser;
+use zendriver_stealth::StealthProfile;
+
+#[tokio::test]
+#[ignore = "requires a real Chrome binary; run with --ignored"]
+async fn set_extra_http_headers_replaces_accept_encoding() {
+    // Local one-shot HTTP server that records the request headers it receives.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    let (tx, rx) = mpsc::channel::<Vec<String>>();
+    std::thread::spawn(move || {
+        if let Ok((stream, _)) = listener.accept() {
+            let mut reader = BufReader::new(&stream);
+            let mut headers = Vec::new();
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    break;
+                }
+                if line == "\r\n" {
+                    break;
+                }
+                headers.push(line.trim_end().to_string());
+            }
+            let mut w = &stream;
+            let _ = w.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok");
+            let _ = tx.send(headers);
+        }
+    });
+
+    // Force a skew: claim Chrome 120 (no zstd). If the real binary is >=123 the
+    // observer must inject `Accept-Encoding: gzip, deflate, br`.
+    let profile = StealthProfile::spoofed().chrome_version(120);
+    let browser = Browser::builder()
+        .stealth(profile)
+        .headless(true)
+        .launch()
+        .await
+        .expect("launch");
+    let tab = browser.new_tab().await.expect("tab");
+    let _ = tab
+        .goto(&format!("http://127.0.0.1:{port}/"))
+        .await;
+
+    let headers = rx
+        .recv_timeout(std::time::Duration::from_secs(20))
+        .expect("server saw a request");
+    let ae: Vec<&String> = headers
+        .iter()
+        .filter(|h| h.to_ascii_lowercase().starts_with("accept-encoding:"))
+        .collect();
+    // Exactly one Accept-Encoding header (no duplication = replace, not append).
+    assert_eq!(ae.len(), 1, "expected one Accept-Encoding header, got {ae:?}");
+    assert_eq!(
+        ae[0].to_ascii_lowercase(),
+        "accept-encoding: gzip, deflate, br",
+        "header was not replaced cleanly: {ae:?}",
+    );
+    browser.close().await.ok();
+}
+```
+
+> **API names (verified against current surface):** `Browser::builder()` → `BrowserBuilder` (`browser.rs:2257`), `.stealth(profile)` (`:819`), `.headless(bool)`, `.launch()` (`:1749`); `browser.new_tab()` (`:2490`); `tab.goto(url)` (`tab.rs:855`); `tab.close()` (`:1336`) and `browser.close()` (`:2771`) both consume `self`.
+
+- [ ] **Step 2: Run it (main thread, if a Chrome binary is available)**
+
+Run: `cargo test -p zendriver --test accept_encoding_coherence -- --ignored --nocapture`
+Expected: PASS — one `Accept-Encoding` header, value `gzip, deflate, br`.
+
+- [ ] **Step 3: Decision gate**
+
+- **PASS (clean replace):** proceed with Task 2 as written (`Network.setExtraHTTPHeaders`).
+- **FAIL (duplicated/append):** STOP. The lightweight path is unsafe. Re-spec to apply via the `Fetch` path (`zendriver-interception` `paused.rs:198` / `actor.rs:454`) gated behind the `interception` feature, then resume. Record the observed behavior in this test's doc comment.
+- **Chrome unavailable in this environment:** leave the test committed (`#[ignore]`), record in the task notes that the probe is pending, and proceed with `setExtraHTTPHeaders` on the documented high-confidence assumption that it replaces (the common stealth-tooling behavior). Flag for the user to run `--ignored` once.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/zendriver/tests/accept_encoding_coherence.rs
+git commit -m "test(zendriver): ignored real-Chrome probe for Accept-Encoding replacement"
+```
+
+---
+
+## Task 1: `accept_encoding_for` rule
+
+**Files:**
+- Create: `crates/zendriver-stealth/src/headers.rs`
+- Modify: `crates/zendriver-stealth/src/lib.rs` (add `mod headers;`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `crates/zendriver-stealth/src/headers.rs` with the test first:
+
+```rust
+//! Coherent request-header values derived from the claimed stealth identity.
+//!
+//! A real Chrome over CDP already emits coherent request headers; the one value
+//! that can silently skew from the *claimed* identity is `Accept-Encoding`,
+//! because Chrome's network stack advertises the *real binary's* supported
+//! encodings regardless of the UA / UA-CH overrides we apply. `zstd` shipped
+//! enabled-by-default in Chrome 123 (2024-03); `br` (brotli) since Chrome 50.
+//! Two branches therefore suffice — zendriver does not drive pre-`br` Chrome.
+//!
+//! See `docs/superpowers/specs/2026-06-02-header-coherence-design.md`.
+
+/// The `Accept-Encoding` a real Chrome of `major` sends for a top-level HTTPS
+/// navigation.
+pub(crate) fn accept_encoding_for(major: u32) -> &'static str {
+    if major >= 123 {
+        "gzip, deflate, br, zstd"
+    } else {
+        "gzip, deflate, br"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accept_encoding_straddles_the_zstd_boundary() {
+        assert_eq!(accept_encoding_for(122), "gzip, deflate, br");
+        assert_eq!(accept_encoding_for(123), "gzip, deflate, br, zstd");
+        assert_eq!(accept_encoding_for(148), "gzip, deflate, br, zstd");
+    }
+}
+```
+
+Add to `crates/zendriver-stealth/src/lib.rs` after `pub mod flags;` (keep the module list alphabetical — insert between `flags` and `input_profile`):
+
+```rust
+mod headers;
+```
+
+- [ ] **Step 2: Run test to verify it fails, then passes**
+
+Run: `cargo test -p zendriver-stealth headers::tests`
+Expected: compiles and PASSES (the rule is implemented alongside the test — there is no separate red phase for a 2-branch pure fn). If `mod headers;` is missing you'll get `unresolved module`; add it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/zendriver-stealth/src/headers.rs crates/zendriver-stealth/src/lib.rs
+git commit -m "feat(stealth): accept_encoding_for(major) coherence rule"
+```
+
+---
+
+## Task 2: Observer applies the `Accept-Encoding` override
+
+**Files:**
+- Modify: `crates/zendriver-stealth/src/observer.rs`
+
+- [ ] **Step 1: Add the field + setter**
+
+In the `StealthObserver` struct (after `bootstrap: String,`), add:
+
+```rust
+    /// Coherent `Accept-Encoding` override — `Some` only under a claimed-vs-binary
+    /// Chrome-major skew (see [`crate::headers`]). Applied via
+    /// `Network.setExtraHTTPHeaders` on the skew path only.
+    accept_encoding: Option<String>,
+```
+
+In `with_persona`, set it in the returned struct literal (it currently builds `Self { profile, fingerprint, bootstrap }`):
+
+```rust
+        Self {
+            profile,
+            fingerprint,
+            bootstrap,
+            accept_encoding: None,
+        }
+```
+
+Add the setter in the `impl StealthObserver` block (after `with_persona`):
+
+```rust
+    /// Set the coherent `Accept-Encoding` override applied to each page target
+    /// (see [`crate::headers`]). `None` (the default) sends no header.
+    #[must_use]
+    pub fn with_accept_encoding(mut self, accept_encoding: Option<String>) -> Self {
+        self.accept_encoding = accept_encoding;
+        self
+    }
+```
+
+- [ ] **Step 2: Write the failing test**
+
+In `observer.rs`'s `#[cfg(test)] mod tests`, add (alongside the existing sequence test):
+
+```rust
+    #[tokio::test]
+    async fn accept_encoding_override_injects_network_headers() {
+        let fp = Fingerprint {
+            platform: Platform::MacIntel,
+            chrome_major: 120,
+            chrome_full: "120.0.6099.234".into(),
+            cpu_count: 10,
+            memory_gb: 8,
+            ua_string: crate::ua::compose_ua_string(Platform::MacIntel, "120.0.6099.234"),
+            ua_metadata: crate::UserAgentMetadata::realistic(
+                Platform::MacIntel,
+                120,
+                "120.0.6099.234",
+            ),
+            timezone: None,
+            locale: None,
+        };
+        let observer = std::sync::Arc::new(
+            StealthObserver::new(StealthProfile::spoofed(), fp)
+                .with_accept_encoding(Some("gzip, deflate, br".into())),
+        );
+        let (mut mock, conn) = MockConnection::pair_with_observers(vec![observer]);
+
+        mock.emit_event(
+            "Target.attachedToTarget",
+            json!({
+                "sessionId": "S1",
+                "targetInfo": {
+                    "targetId": "T1",
+                    "type": "page",
+                    "url": "about:blank",
+                    "attached": true,
+                },
+                "waitingForDebugger": true,
+            }),
+        )
+        .await;
+
+        // Exact ordered sequence — the Accept-Encoding block sits between the
+        // Emulation overrides and the spoofed bootstrap block.
+        for expected in [
+            "Page.enable",
+            "Emulation.setUserAgentOverride",
+            "Emulation.setDeviceMetricsOverride",
+            "Emulation.setFocusEmulationEnabled",
+            "Network.enable",
+            "Network.setExtraHTTPHeaders",
+            "Page.setBypassCSP",
+            "Page.addScriptToEvaluateOnNewDocument",
+            "Runtime.runIfWaitingForDebugger",
+        ] {
+            let id =
+                tokio::time::timeout(std::time::Duration::from_secs(2), mock.expect_cmd(expected))
+                    .await
+                    .unwrap_or_else(|_| panic!("did not see {expected} within 2s"));
+            if expected == "Network.setExtraHTTPHeaders" {
+                assert_eq!(
+                    mock.last_sent()["params"]["headers"]["Accept-Encoding"],
+                    "gzip, deflate, br",
+                );
+            }
+            mock.reply(id, json!({})).await;
+        }
+        conn.shutdown();
+    }
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cargo test -p zendriver-stealth observer::tests::accept_encoding_override_injects_network_headers`
+Expected: FAIL/timeout — the observer does not yet emit `Network.enable`.
+
+- [ ] **Step 4: Add the apply block**
+
+In `on_target_attached`, immediately after the `setLocaleOverride` block (the `if let Some(ref locale) = self.fingerprint.locale { … }`) and **before** the `if self.profile.kind() == ProfileKind::Spoofed {` block:
+
+```rust
+        // Accept-Encoding coherence: when the claimed Chrome major straddles the
+        // `zstd` boundary vs the real binary, override the header so it matches
+        // the *claimed* identity (Chrome's network stack would otherwise leak the
+        // binary's encodings). `Network.enable` is idempotent + invisible to the
+        // page; both calls fire only on this skew path, so the default profile is
+        // unaffected.
+        if let Some(ref ae) = self.accept_encoding {
+            session.call("Network.enable", json!({})).await?;
+            session
+                .call(
+                    "Network.setExtraHTTPHeaders",
+                    json!({ "headers": { "Accept-Encoding": ae } }),
+                )
+                .await?;
+        }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p zendriver-stealth observer::tests`
+Expected: PASS — both the new Some-path test and the existing
+`spoofed_observer_sends_expected_sequence_for_page_target` (the latter proves the
+None path emits **no** `Network.*` commands: a wrongful injection would block the
+observer awaiting an unanswered reply and time the test out).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/zendriver-stealth/src/observer.rs
+git commit -m "feat(stealth): observer injects coherent Accept-Encoding on skew"
+```
+
+---
+
+## Task 3: Detect the skew in `resolve_fingerprint` + wire it through
+
+**Files:**
+- Modify: `crates/zendriver-stealth/src/profile.rs` (the `resolve_fingerprint` fn ~280 + its test ~463)
+- Modify: `crates/zendriver/src/browser.rs:1796,2017`
+
+- [ ] **Step 1: Write the failing skew tests**
+
+In `profile.rs`'s `#[cfg(test)] mod tests`, add:
+
+```rust
+    #[test]
+    fn resolve_returns_accept_encoding_only_on_zstd_skew() {
+        // Pin a fingerprint override so the "binary" baseline is deterministic
+        // (major 143 -> sends zstd), then claim a pre-zstd major.
+        let mut base = crate::Fingerprint::auto_detect(std::path::Path::new("/nonexistent"))
+            .expect("fallback fingerprint");
+        base.chrome_major = 143;
+        base.chrome_full = "143.0.0.0".into();
+        base.recompose();
+
+        // Claimed 120 (< 123) vs binary 143 (>= 123) -> skew -> Some.
+        let skewed = StealthProfile::spoofed()
+            .fingerprint(base.clone())
+            .chrome_version(120);
+        let (fp, ae) = skewed
+            .resolve_fingerprint(std::path::Path::new("/nonexistent"))
+            .expect("resolve");
+        assert_eq!(fp.chrome_major, 120);
+        assert_eq!(ae.as_deref(), Some("gzip, deflate, br"));
+
+        // Claimed 140 (>= 123) vs binary 143 (>= 123) -> same set -> None.
+        let no_skew = StealthProfile::spoofed()
+            .fingerprint(base.clone())
+            .chrome_version(140);
+        let (_fp, ae) = no_skew
+            .resolve_fingerprint(std::path::Path::new("/nonexistent"))
+            .expect("resolve");
+        assert_eq!(ae, None);
+
+        // No claimed-major override -> None (default path adds nothing).
+        let plain = StealthProfile::spoofed().fingerprint(base);
+        let (_fp, ae) = plain
+            .resolve_fingerprint(std::path::Path::new("/nonexistent"))
+            .expect("resolve");
+        assert_eq!(ae, None);
+    }
+```
+
+> Confirm the builder names against `profile.rs`: the per-field override is `.chrome_version(u32)` (verified at `profile.rs:202`); the full-fingerprint override builder is whatever sets `fingerprint_override` — check the method name (likely `.fingerprint(Fingerprint)`) and adjust the test if it differs.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p zendriver-stealth profile::tests::resolve_returns_accept_encoding_only_on_zstd_skew`
+Expected: FAIL to compile — `resolve_fingerprint` still returns `Fingerprint`, not a tuple.
+
+- [ ] **Step 3: Change `resolve_fingerprint` to detect the skew**
+
+Change the signature (`profile.rs:280`):
+
+```rust
+    pub fn resolve_fingerprint(
+        &self,
+        chrome_exe: &Path,
+    ) -> Result<(Fingerprint, Option<String>), StealthError> {
+```
+
+Capture the binary major right after `fp` is built, before any override — insert immediately after the `let mut fp = match … };` block (before the `if let Some(p) = self.per_field.platform`):
+
+```rust
+        // The encodings the *real* binary (or override-supplied fingerprint)
+        // advertises, captured before the claimed-major override below.
+        let binary_major = fp.chrome_major;
+```
+
+At the end, replace `Ok(fp)` with:
+
+```rust
+        // Accept-Encoding coherence: override only when the claimed major's
+        // encoding set differs from the binary's (straddles the zstd/Chrome-123
+        // boundary). Otherwise Chrome's native header is already coherent.
+        let claimed_major = fp.chrome_major;
+        let accept_encoding = (crate::headers::accept_encoding_for(claimed_major)
+            != crate::headers::accept_encoding_for(binary_major))
+        .then(|| crate::headers::accept_encoding_for(claimed_major).to_string());
+
+        Ok((fp, accept_encoding))
+```
+
+- [ ] **Step 4: Fix the existing `resolve_fingerprint` test**
+
+At `profile.rs:480`, the existing test binds `let fp = …resolve_fingerprint(…)`. Update it to destructure:
+
+```rust
+        let (fp, _ae) = profile
+            .resolve_fingerprint(std::path::Path::new("/nonexistent"))
+            .unwrap();
+```
+
+(Keep the rest of that test's assertions on `fp` unchanged.)
+
+- [ ] **Step 5: Wire both `browser.rs` call sites**
+
+At `browser.rs:1796`:
+
+```rust
+                let (fp, accept_encoding) = profile.resolve_fingerprint(&exe)?;
+                let stealth_obs: Arc<dyn TargetObserver> = Arc::new(
+                    StealthObserver::with_persona(profile.clone(), fp, self.resolved_persona())
+                        .with_accept_encoding(accept_encoding),
+                );
+```
+
+At `browser.rs:2017` (the connect path):
+
+```rust
+            let (fp, accept_encoding) = profile.resolve_fingerprint(Path::new(""))?;
+            let stealth_obs: Arc<dyn TargetObserver> = Arc::new(
+                StealthObserver::with_persona(profile.clone(), fp, self.resolved_persona())
+                    .with_accept_encoding(accept_encoding),
+            );
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test -p zendriver-stealth profile::tests` then `cargo build -p zendriver`
+Expected: PASS + clean build (both call sites destructure the tuple).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/zendriver-stealth/src/profile.rs crates/zendriver/src/browser.rs
+git commit -m "feat(stealth): resolve_fingerprint detects claimed-vs-binary Accept-Encoding skew"
+```
+
+---
+
+## Task 4: Full gates + final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Format + lint (auto-fix), exactly as CI runs them**
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --locked --fix --allow-dirty --allow-staged
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+```
+Expected: both `--check` and `-D warnings` gates clean. Re-stage any auto-fixes.
+
+- [ ] **Step 2: Feature-gated clippy (stealth touches no new feature, but mcp re-exposes stealth)**
+
+```bash
+cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings
+```
+Expected: clean.
+
+- [ ] **Step 3: Targeted test run**
+
+```bash
+cargo test -p zendriver-stealth
+cargo test -p zendriver --lib
+```
+Expected: PASS. (The `#[ignore]`d Task 0 probe is skipped by default.)
+
+- [ ] **Step 4: Public-API check (expected no diff)**
+
+`resolve_fingerprint` is `pub` in `zendriver-stealth` but is **not** surfaced in
+`zendriver`'s public baseline (only the `stealth()` builder + the `StealthProfile`
+re-export are), so the tuple-return change should not move the baseline.
+
+```bash
+cargo +nightly test -p zendriver-mcp --features public-api-check --test public_api --locked
+```
+Expected: PASS with no baseline diff. If it *does* report a new/changed item,
+regenerate per `CLAUDE.md`:
+`cargo +nightly public-api -p zendriver --all-features > crates/zendriver-mcp/public-api-baseline.txt`
+— then confirm the diff is only the intended internal change and commit it. No new
+MCP tool and no new capability ⇒ no `mcp-coverage-ledger.toml` entry.
+
+- [ ] **Step 5: Final commit (if Steps 1–4 produced fmt/lint/baseline changes)**
+
+```bash
+git add -A
+git commit -m "chore: fmt + lint + baseline for Accept-Encoding coherence"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (against `2026-06-02-header-coherence-design.md`):
+- §4.1 `accept_encoding_for` → Task 1. ✓
+- §4.2 skew detection in `resolve_fingerprint` → Task 3. ✓
+- §4.3 observer apply (`Network.enable` + `setExtraHTTPHeaders`, skew-only) → Task 2. ✓
+- §4.4 empirical replace-vs-append gate → Task 0. ✓
+- §5 files touched → all mapped (headers.rs, lib.rs, observer.rs, profile.rs, browser.rs, the probe test). ✓
+- §6 testing (boundary, skew detection, observer sequence, CDP probe) → Tasks 1/3/2/0. ✓
+- §7 gates (fmt, clippy, feature clippy, tests, public-api) → Task 4. ✓
+- §8 MCP coverage (no new tool/ledger) → Task 4 Step 4. ✓
+- §9 assumptions are design-level (no extra tasks needed); A8's empirical fork is Task 0's decision gate. ✓
+
+**Placeholder scan:** no TBD/TODO; every code step shows complete code. The two "confirm the API name" notes (Task 0 builder/tab names, Task 3 `.fingerprint()` builder) are verification prompts against real symbols, not missing content.
+
+**Type consistency:** `accept_encoding_for(u32) -> &'static str` (Task 1) used identically in Task 3. `with_accept_encoding(Option<String>)` defined in Task 2, called in Task 3. `resolve_fingerprint → Result<(Fingerprint, Option<String>), StealthError>` defined in Task 3, destructured at both call sites + the fixed test. Observer field `accept_encoding: Option<String>` consistent across struct, setter, and apply block.

--- a/docs/superpowers/plans/2026-06-03-header-coherence-accept-encoding.md
+++ b/docs/superpowers/plans/2026-06-03-header-coherence-accept-encoding.md
@@ -1,5 +1,13 @@
 # Header coherence (Accept-Encoding) Implementation Plan
 
+> 🔬 **Partly superseded during execution.** Task 0 (the empirical gate) proved
+> `Network.setExtraHTTPHeaders` cannot override `Accept-Encoding` — Chrome's
+> network service owns it (verified, Chrome 148). Tasks 1 (rule) shipped as-is;
+> the **apply mechanism (Tasks 2–3's `setExtraHTTPHeaders` override) was dropped**
+> in favor of a `tracing::warn!` on skew (Chrome can't be corrected, so we warn).
+> See the Empirical-outcome note in the spec. The Task 2/3 code below is retained
+> for the record but is NOT what shipped.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Keep Chrome's `Accept-Encoding` request header coherent with the *claimed* stealth Chrome major, so a profile that pins an identity across the `zstd`/Chrome-123 boundary no longer leaks the real binary's encoding set.

--- a/docs/superpowers/specs/2026-06-02-header-coherence-design.md
+++ b/docs/superpowers/specs/2026-06-02-header-coherence-design.md
@@ -1,0 +1,281 @@
+# Header coherence (#38): Accept-Encoding vs claimed Chrome major
+
+**Issue:** [#38](https://github.com/TurtIeSocks/zendriver-rs/issues/38) — "Generative
+fingerprints: header-network coherence (Accept / sec-ch-ua / header order)".
+Follow-up to [#25](https://github.com/TurtIeSocks/zendriver-rs/issues/25) (generative Bayesian fingerprint network).
+**Date:** 2026-06-02
+**Scope:** `zendriver-stealth` apply path (resolve + observer). **No** new crate,
+**no** network download, **no** `Persona`/`HeaderProfile` type, **no** new MCP tool.
+
+> ⚠️ **This spec reframes the issue.** #38 was filed assuming a faithful port of
+> browserforge's header Bayesian network (vendor the blobs, reuse #25's sampler,
+> add a carrier type, inject all headers + order via CDP). After grounding the
+> design in the actual data files and zendriver's apply path, that port is
+> **redundant and partly counter-productive for a real-Chrome-over-CDP tool**.
+> The genuinely valuable, non-harmful slice is a single deterministic override:
+> **`Accept-Encoding`, conditioned on the claimed Chrome major.** The reasoning
+> is in §3; the rejected work is in §9 (Assumptions) and §10 (Out of scope).
+> Assumption **A1** is the headline judgement call — the delegate-mode review
+> checkpoint.
+
+## 1. Goal
+
+Keep the request headers Chrome sends coherent with the **claimed** stealth
+identity. Concretely: when a spoofed profile pins a Chrome major (or platform)
+that differs from the real launched binary, ensure `Accept-Encoding` matches the
+*claimed* major rather than leaking the *binary's* value. Everything else the
+header network models is either already coherent or cannot be set safely/at all
+over CDP (§3).
+
+## 2. Why not the faithful header-network port — verified data
+
+Downloaded and inspected the three apify blobs the issue names
+(`packages/header-generator/src/data_files/`, Apache-2.0):
+
+- **`header-network-definition.zip`** — 43.5 KB → `network.json` 808 KB, **19
+  nodes**. Same Bayesian schema as #25 (`conditionalProbabilities`
+  `deeper`/`skip`, `*STRINGIFIED*`).
+  - 4 conditioning roots: `*BROWSER` (e.g. `chrome/147.0.0.0`, 126 values incl.
+    Safari/Firefox/Edge), `*OPERATING_SYSTEM` (`macos|windows|ios|android|linux`),
+    `*DEVICE` (`desktop|mobile`), `*HTTP_VERSION` (`_2.0_|_1.1_`).
+  - Header nodes come in **two casing variants** — lowercase (`accept`,
+    `user-agent`, `sec-ch-ua-mobile`, …) for HTTP/2, Title-Case (`Accept`,
+    `User-Agent`, …) for HTTP/1.1. **Header-name casing is itself the
+    fingerprint** the network models.
+  - `accept` / `accept-encoding` / `dnt` / `upgrade-insecure-requests` are
+    conditioned on the sampled **`user-agent` string** (the full UA is the CPT
+    key); `sec-ch-ua*` on the roots + `sec-ch-ua-mobile`.
+- **`input-network-definition.zip`** — 4.5 KB, **5 nodes** (`*DEVICE → *OS →
+  *BROWSER_HTTP → {*HTTP_VERSION, *BROWSER}`). Purpose: turn a user's *partial*
+  constraints into a coherent (device, os, browser, http) tuple. **zendriver
+  already knows all four** from the resolved `Fingerprint` (desktop, platform,
+  chrome/<major>, HTTP/2), so this network is unused for us.
+- **`headers-order.json`** — per-browser header order. The `chrome` list is
+  exactly the order **a real Chrome already emits** (`Host, Connection, …,
+  sec-ch-ua, sec-ch-ua-mobile, sec-ch-ua-platform, …, User-Agent, Accept,
+  Sec-Fetch-*, Referer, Accept-Encoding, Accept-Language, Cookie`, then the
+  HTTP/2 pseudo-headers).
+
+zendriver's apply path (verified in code):
+
+- `crates/zendriver-stealth/src/fingerprint.rs:113` — `probe_chrome_version(exe)`:
+  the default `chrome_major`/`chrome_full` is **read from the real binary**. So
+  **claimed major == binary major** unless the user calls `.chrome_version(n)`
+  (`profile.rs:202`) or supplies a full `Fingerprint` override.
+- `crates/zendriver-stealth/src/observer.rs:86` — `Emulation.setUserAgentOverride`
+  carries `userAgentMetadata`. Chrome **derives `sec-ch-ua`, `sec-ch-ua-mobile`,
+  `sec-ch-ua-platform`** (and the high-entropy UA-CH hints) from that metadata,
+  for the **claimed** major.
+
+## 3. The per-header verdict (the core of the design)
+
+For each header the network models, what a real Chrome over CDP already does, and
+whether we can/should override it:
+
+| Header | Chrome already sends | Override via CDP? | Verdict |
+|---|---|---|---|
+| `sec-ch-ua`, `-mobile`, `-platform` | **Yes, coherent** — derived from the UA-CH metadata the observer sets (claimed major) | Would *break* coherence (BN samples a different UA) | **Skip** |
+| `User-Agent` | Yes — we already override it coherently | n/a | **Skip** |
+| `Accept` | Yes — but it is **per-request-type** (document vs `image/*` vs `*/*` for fetch) | `setExtraHTTPHeaders` is **global** → forcing one value corrupts sub-resource requests | **Skip** (footgun) |
+| `Sec-Fetch-*` | Yes, per-request | global override would corrupt | **Skip** |
+| `Accept-Encoding` | Yes — the **binary's** value; **uniform across request types** | safe to set globally; skews with claimed-vs-binary major (`zstd` since Chrome 123) | **Override — the one valuable, safe header** |
+| `DNT` | No (only if user enabled it) | injecting `DNT:1` is *rarer*, not stealthier | **Skip** |
+| `upgrade-insecure-requests` | Yes (`1` on navigation) | redundant | **Skip** |
+| `Connection`, `te` | network-stack managed; unused on HTTP/2 | not injectable | **Skip** |
+| **header order / name casing** | Chrome's **real order**, HTTP/2-lowercased | `setExtraHTTPHeaders` cannot reorder; HTTP/2 forces lowercase | **Skip** (already correct; not controllable) |
+
+**Conclusion:** the lone header that is (a) uniform across request types,
+(b) able to skew from the claimed identity, and (c) safely settable globally over
+CDP is **`Accept-Encoding`**. Everything else is already coherent (Chrome is a
+real browser), per-request and unsafe to force globally, or non-injectable.
+Sampling headers from the BN would, at best, reproduce what Chrome already sends
+and, at worst, inject values inconsistent with the claimed major — the opposite
+of the issue's goal. A **deterministic, by-major** value is strictly *more*
+coherent than a BN sample.
+
+## 4. Design
+
+### 4.1 `accept_encoding_for(major)` — the coherence rule
+
+A tiny pure helper (new `crates/zendriver-stealth/src/headers.rs`):
+
+```rust
+/// The `Accept-Encoding` a real Chrome of `major` sends for a top-level
+/// navigation over HTTPS. `zstd` shipped enabled-by-default in Chrome 123
+/// (2024-03); `br` (brotli) since Chrome 50. Older majors zendriver will not
+/// realistically drive, so two branches suffice.
+pub(crate) fn accept_encoding_for(major: u32) -> &'static str {
+    if major >= 123 {
+        "gzip, deflate, br, zstd"
+    } else {
+        "gzip, deflate, br"
+    }
+}
+```
+
+### 4.2 Detect the skew in `resolve_fingerprint`
+
+`StealthProfile::resolve_fingerprint` (`profile.rs:280`) already holds both values
+it needs: on the `auto_detect` path, `fp.chrome_major` is the **binary** major
+*before* the `.chrome_version()` override is applied at line 288. Compute the
+override only when the claimed and binary majors land on **different sides of the
+`zstd` boundary** (i.e. the encodings actually differ):
+
+```rust
+// before applying per_field.chrome_major:
+let binary_major = fp.chrome_major;                 // probed (auto_detect path)
+// after applying overrides, with claimed = fp.chrome_major:
+let coherent_accept_encoding: Option<String> =
+    (accept_encoding_for(claimed) != accept_encoding_for(binary_major))
+        .then(|| accept_encoding_for(claimed).to_string());
+```
+
+- **Default path (no override):** claimed == binary → `None` → **zero added CDP
+  traffic, no `Network.enable`.** The common case pays nothing.
+- **`fingerprint_override` (full `Fingerprint`) / connect-without-exe path:** the
+  binary major is unknown; treat as `None` (no skew we can prove). Documented
+  limitation — these are explicit-identity paths where the user owns coherence.
+
+`resolve_fingerprint` returns the `Option<String>` alongside the `Fingerprint`
+(small struct or tuple — plan picks the seam; both are `pub(crate)`-reachable from
+`browser.rs`, **no public-API change**).
+
+### 4.3 Apply in the observer
+
+Thread the `Option<String>` into `StealthObserver` (constructor arg or builder
+setter, mirroring `with_persona`). In `on_target_attached`, for a `page` target in
+`Spoofed` mode **only when `Some`**:
+
+```rust
+session.call("Network.enable", json!({})).await?;
+session.call(
+    "Network.setExtraHTTPHeaders",
+    json!({ "headers": { "Accept-Encoding": ae } }),
+).await?;
+```
+
+`Network.enable` is idempotent (interception / monitor / network-idle already
+enable it where active) and is invisible to the page. It is sent **only** on the
+skew path, so the default profile is unaffected.
+
+### 4.4 Empirical CDP gate (resolved during implementation, not assumed)
+
+**Risk:** Chrome's network service may *append* rather than *replace*
+`Accept-Encoding` set via `setExtraHTTPHeaders`, yielding a duplicated/merged
+header — which is *more* detectable, not less. The plan's **first step** is a
+throwaway probe against a real Chrome (set the header, read the outbound request
+via a local echo server / `Network.requestWillBeSentExtraInfo`) to confirm
+clean replacement.
+
+- **If it replaces cleanly:** ship §4.3 as written (no new feature dependency).
+- **If it appends/duplicates:** escalate to the `Fetch` path — the
+  `zendriver-interception` crate already replaces request headers
+  (`paused.rs:198`, `actor.rs:454`). The coherence fix is then **gated behind the
+  `interception` feature** (off by default). This fork is decided by the probe,
+  not guessed.
+
+## 5. Files touched
+
+- `crates/zendriver-stealth/src/headers.rs` — **new**: `accept_encoding_for`,
+  unit tests, module doc explaining the `zstd`/`br` history.
+- `crates/zendriver-stealth/src/lib.rs` — `mod headers;`.
+- `crates/zendriver-stealth/src/profile.rs` — `resolve_fingerprint` also computes
+  + returns the `Option<String>` coherent `Accept-Encoding` (signature tweak;
+  update the 2 call sites in `browser.rs`).
+- `crates/zendriver-stealth/src/observer.rs` — carry the `Option<String>`; send
+  `Network.enable` + `Network.setExtraHTTPHeaders` on the skew path; extend the
+  existing command-sequence tests.
+- `crates/zendriver/src/browser.rs` (≈1796, ≈2017) — pass the new value from
+  `resolve_fingerprint` into `StealthObserver`.
+- **(conditional, only if §4.4 forks to Fetch):** `Cargo.toml` feature wiring +
+  interception-gated apply path.
+
+## 6. Testing
+
+- **`accept_encoding_for`**: `122 → "gzip, deflate, br"`, `123 → "…, zstd"`,
+  `140 → "…, zstd"` boundary table.
+- **Skew detection** (`resolve_fingerprint`): binary 143 + `.chrome_version(120)`
+  → `Some("gzip, deflate, br")`; binary 143 + `.chrome_version(140)` → `None`
+  (both ≥123); no override → `None`.
+- **Observer sequence** (extend `observer.rs` `MockConnection` tests): with a
+  `Some` override, the spoofed page target emits `Network.enable` +
+  `Network.setExtraHTTPHeaders` (assert the header value); with `None`, neither
+  command appears.
+- **CDP probe** (manual / `#[ignore]` real-Chrome): confirm clean replacement —
+  the empirical gate in §4.4. Documents the observed behavior in a test comment.
+
+## 7. Cargo / CI gates
+
+- `cargo fmt --all`; `cargo clippy --workspace --all-targets --locked -- -D warnings`.
+- `cargo test -p zendriver-stealth`.
+- If §4.4 forks to Fetch: `cargo clippy -p zendriver-mcp --all-features
+  --all-targets -- -D warnings` and the interception-feature build.
+- **Public-API:** the intended change is `pub(crate)`-internal (no `zendriver`
+  public surface delta) → no baseline regen expected. If the `resolve_fingerprint`
+  signature change turns out to be `pub`-visible, run the
+  `public-api` check (`CLAUDE.md`) and regenerate the baseline.
+
+## 8. MCP coverage
+
+No new public API and no new capability type → **no new tool, no ledger entry.**
+The behavior rides transitively on the existing stealth/launch tools: an MCP
+client that pins `chrome_version` already exercises the skew path. (If §4.4 forks
+to an interception-gated path, confirm the MCP interception feature still builds;
+still no new tool.)
+
+## 9. Assumptions (delegate-mode judgement calls — **review checkpoint**)
+
+1. **A1 — Reframe: do not port the header Bayesian network.** A real Chrome over
+   CDP already emits coherent `sec-ch-ua*`, `Accept`, order, and casing; the BN's
+   value is for *browser-less* HTTP clients, which zendriver is not. Porting 808 KB
+   of monthly-churning data to drive headers that are redundant (and, for `Accept`
+   / `sec-ch-ua`, *harmful* to force) is rejected in favor of the deterministic
+   `Accept-Encoding` fix. **This is the call most worth your veto** — if you want
+   the faithful port purely for browserforge parity, say so and I'll respec around
+   #25's `Generator` + a `HeaderProfile` carrier + an MCP tool.
+2. **A2 — `Accept-Encoding` is the only header we override.** Justified per-header
+   in §3 (uniformity, skew, safe-global-set).
+3. **A3 — Deterministic by-major, not BN-sampled.** A by-major constant is *more*
+   coherent than a random BN sample and needs no download. Two-branch rule on the
+   `zstd`/123 boundary.
+4. **A4 — Override only on proven skew** (claimed vs binary straddle the boundary),
+   so the default profile adds zero CDP traffic. Unknown-binary paths (full
+   `Fingerprint` override, connect-without-exe) → no injection.
+5. **A5 — `sec-ch-ua*` left untouched** — already coherent from the UA-CH metadata
+   the observer sets; injecting BN values would *introduce* mismatch.
+6. **A6 — Header order / casing not addressed** — Chrome's native order already
+   matches `headers-order.json`; `setExtraHTTPHeaders` cannot reorder and HTTP/2
+   forces lowercase. Not controllable via the lightweight path; no benefit for a
+   real Chrome.
+7. **A7 — `DNT` not injected** — default-absent is the common, less-suspicious case.
+8. **A8 — Application surface decided empirically (§4.4):** `setExtraHTTPHeaders`
+   first; fall back to the interception/`Fetch` path (feature-gated) only if the
+   probe shows it appends rather than replaces.
+9. **A9 — No new carrier type.** The issue's "extend `Persona` vs new
+   `HeaderProfile`" question is moot: a single derived string lives in the resolve
+   path, not a sampled profile object.
+
+## 10. Out of scope (recorded so #38's close is auditable)
+
+- Faithful header-network port + `HeaderProfile` carrier + generative-headers MCP
+  tool (rejected, A1). If revived, it is a separate spec.
+- Header **order** / name **casing** spoofing (A6).
+- `sec-ch-ua*`, `Accept`, `Sec-Fetch-*`, `DNT`, `te`, `Connection`,
+  `upgrade-insecure-requests` injection (§3).
+- A general user-facing "extra HTTP headers" builder API (`.extra_http_headers()`).
+  Reasonable future ergonomics, but speculative for #38 — YAGNI.
+- Geo-IP-derived `Accept-Language` (separate issue
+  [#39](https://github.com/TurtIeSocks/zendriver-rs/issues/39)).
+- Mobile / non-Chrome personas.
+
+## 11. Risks
+
+- **`setExtraHTTPHeaders` append-vs-replace** (§4.4) — the one real unknown;
+  retired by the probe before committing to the application surface.
+- **`Accept-Encoding` value drift** — if a future Chrome changes its default
+  encoding set, the two-branch rule needs a new boundary. Low frequency
+  (`zstd` was the first change since `br` in 2016); cheap to extend; covered by a
+  boundary test.
+- **Narrow benefit** — the fix only bites when a user pins an identity across the
+  `zstd` boundary. That is exactly the case that is otherwise silently
+  incoherent, and the cost on the default path is zero. Accepted.

--- a/docs/superpowers/specs/2026-06-02-header-coherence-design.md
+++ b/docs/superpowers/specs/2026-06-02-header-coherence-design.md
@@ -18,14 +18,37 @@ Follow-up to [#25](https://github.com/TurtIeSocks/zendriver-rs/issues/25) (gener
 > Assumption **A1** is the headline judgement call — the delegate-mode review
 > checkpoint.
 
+> 🔬 **Empirical outcome (2026-06-03) — supersedes the §4.3 apply mechanism.**
+> The §4.4 gate was run against real Chrome 148 and **failed**: `Accept-Encoding`
+> turns out to be **uncorrectable over CDP**. `Network.setExtraHTTPHeaders` for
+> `Accept-Encoding` is *silently dropped* (claimed Chrome 120 on a 148 binary →
+> the wire still showed `gzip, deflate, br, zstd`, a single unduplicated header —
+> i.e. the network service's own value, our override ignored). The
+> `--disable-features=ZstdContentEncoding` launch flag was also probed and is
+> **inert** on current builds (and version-fragile regardless). Chrome's network
+> service authoritatively owns this header.
+>
+> **Shipped design (chosen by the user):** keep the `accept_encoding_for` rule
+> and the skew detection, but **warn instead of override**. `resolve_fingerprint`
+> emits a `tracing::warn!` when a pinned `chrome_version` straddles the `zstd`
+> boundary vs the launched binary, telling the user their request will leak the
+> binary's encodings (pin to the binary's major to stay coherent). No
+> `Network.*` calls, no observer change, no per-request cost. The rejected
+> alternative — forcing the header via the heavyweight `Fetch`/interception path
+> — was judged not worth the per-request latency + feature coupling for so
+> narrow a gap. §3's per-header analysis below is unchanged and still correct;
+> only §4.3's *override* became a *warning*.
+
 ## 1. Goal
 
 Keep the request headers Chrome sends coherent with the **claimed** stealth
-identity. Concretely: when a spoofed profile pins a Chrome major (or platform)
-that differs from the real launched binary, ensure `Accept-Encoding` matches the
-*claimed* major rather than leaking the *binary's* value. Everything else the
-header network models is either already coherent or cannot be set safely/at all
-over CDP (§3).
+identity — or, where coherence is not achievable, make the incoherence visible.
+Concretely: when a spoofed profile pins a Chrome major (or platform) that differs
+from the real launched binary, `Accept-Encoding` will leak the *binary's* value.
+Since CDP cannot correct this (see the Empirical-outcome note above), the shipped
+behavior is to **warn** the user about the leak. Everything else the header
+network models is either already coherent or cannot be set safely/at all over CDP
+(§3).
 
 ## 2. Why not the faithful header-network port — verified data
 
@@ -140,7 +163,13 @@ let coherent_accept_encoding: Option<String> =
 (small struct or tuple — plan picks the seam; both are `pub(crate)`-reachable from
 `browser.rs`, **no public-API change**).
 
-### 4.3 Apply in the observer
+### 4.3 Apply in the observer — ❌ SUPERSEDED (the override is silently dropped)
+
+> The Empirical-outcome note at the top of this spec replaces this subsection:
+> Chrome ignores `Network.setExtraHTTPHeaders` for `Accept-Encoding`, so the
+> observer is **not** changed. The skew is surfaced via a `tracing::warn!` in
+> `resolve_fingerprint` instead. The original (non-working) plan is kept below
+> for the record.
 
 Thread the `Option<String>` into `StealthObserver` (constructor arg or builder
 setter, mirroring `with_persona`). In `on_target_attached`, for a `page` target in


### PR DESCRIPTION
Closes #38.

## TL;DR

#38 asked to port browserforge's header Bayesian network (Accept / sec-ch-ua / header order) and inject coherent request headers over CDP. Grounding the design in the actual apify data files + zendriver's apply path showed that port is **redundant and partly counter-productive for a real-Chrome-over-CDP tool**, and an empirical probe showed the one genuinely-applicable header (`Accept-Encoding`) **cannot be overridden over CDP at all**. So this ships the honest, useful slice: **detect the incoherence and warn**, rather than a silently-broken override.

## Why not the header-network port (per-header analysis)

A real Chrome driven over CDP already emits coherent request headers — it *is* a browser. The network's value is for *browser-less* HTTP clients (got-scraping et al.).

| Header | Reality for real Chrome | Verdict |
|---|---|---|
| `sec-ch-ua` / `-mobile` / `-platform` | Already coherent — derived from the UA-CH metadata the stealth observer sets (`Emulation.setUserAgentOverride`), for the claimed major | leave alone (injecting BN values would *break* it) |
| `User-Agent` | Already overridden coherently | leave alone |
| `Accept`, `Sec-Fetch-*` | **Per-request-type** (document vs `image/*` vs `*/*`); `setExtraHTTPHeaders` is global → forcing one value corrupts sub-resource requests | skip (footgun) |
| header **order** / name **casing** | Chrome's native order already matches `headers-order.json`; HTTP/2 forces lowercase; `setExtraHTTPHeaders` can't reorder | not controllable; already correct |
| `DNT` / `te` / `Connection` / `upgrade-insecure-requests` | default-absent is less suspicious / stack-managed | skip |
| **`Accept-Encoding`** | binary-controlled; uniform across request types; can skew from the claimed major (`zstd` since Chrome 123) | the only candidate worth pursuing |

zendriver probes the real binary version by default (`probe_chrome_version`), so claimed major == binary major unless the user calls `.chrome_version(n)`. The only residual gap is that explicit pin straddling the `zstd`/Chrome-123 boundary.

## Empirical finding (the key learning)

Probed against **Chrome 148**:
- `Network.setExtraHTTPHeaders` for `Accept-Encoding` is **silently dropped** — claimed Chrome 120 still sent `gzip, deflate, br, zstd` (a single, unduplicated header = the network service's own value). Chrome's network service authoritatively owns this header.
- `--disable-features=ZstdContentEncoding` is **inert** on current builds (and version-fragile regardless).

So the skew is **observable but not correctable over CDP**. The heavyweight `Fetch`/interception alternative was judged not worth the per-request latency + feature coupling for so narrow a gap.

## What shipped

- `zendriver-stealth/src/headers.rs` — `accept_encoding_for(major)` (the `zstd`/123 + `br`/50 rule) and `accept_encoding_skew(binary, claimed)`.
- `zendriver-stealth/src/profile.rs` — `resolve_fingerprint` emits a `tracing::warn!` when a pinned `chrome_version` will leak the binary's encodings, pointing the user to pin to their binary's major. **No `Network.*` calls, no observer change, zero per-request cost, signature unchanged.**
- `zendriver/tests/accept_encoding_coherence.rs` — an `#[ignore]`d real-Chrome probe (gated `integration-tests`, same convention as `fingerprint_integration.rs`) that **codifies the CDP limitation**.
- Design record updated: `docs/superpowers/specs/2026-06-02-header-coherence-design.md` (empirical-outcome note + reasoning), plan annotated as partly-superseded.

No public-API change, no new MCP tool, no `mcp-coverage-ledger.toml` entry, no `public-api-baseline.txt` churn.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings`
- [x] `cargo test -p zendriver-stealth` (95 pass) · `cargo test -p zendriver --lib` (276 pass)
- [x] Real-Chrome probe (`--features integration-tests -- --ignored`) confirms the documented behavior on Chrome 148

🤖 Generated with [Claude Code](https://claude.com/claude-code)