### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "async-trait",
  "base64",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.8", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.9", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.4" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.3.0" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.3.1" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.0" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.2.1" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.3" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.3.3" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.3.4" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.0" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.1" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.0" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.1" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.1] - 2026-06-03
+
+
 ## [0.2.0] - 2026-06-03
 
 ### Added

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.4] - 2026-06-03
+
+
 ## [0.3.3] - 2026-06-03
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.1] - 2026-06-03
+
+### Added
+
+- Accept_encoding_for(major) coherence rule
+- Warn when a pinned Chrome major leaks Accept-Encoding
+
+
 ## [0.3.0] - 2026-06-02
 
 ### Added

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-06-03
+
+### Added
+
+- Warn when a pinned Chrome major leaks Accept-Encoding
+
+
 ## [0.2.8] - 2026-06-03
 
 

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `zendriver`: 0.2.8 -> 0.2.9 (✓ API compatible changes)
* `zendriver-fingerprints`: 0.2.0 -> 0.2.1
* `zendriver-mcp`: 0.3.3 -> 0.3.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-stealth`

<blockquote>

## [0.3.1] - 2026-06-03

### Added

- Accept_encoding_for(major) coherence rule
- Warn when a pinned Chrome major leaks Accept-Encoding
</blockquote>

## `zendriver`

<blockquote>

## [0.2.9] - 2026-06-03

### Added

- Warn when a pinned Chrome major leaks Accept-Encoding
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).