### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "async-trait",
  "base64",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.9", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.10", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.4" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.3.1" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.4.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.0" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.2.1" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.3" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.3.4" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.4.0" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.0" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.1" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.1" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.2" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.2] - 2026-06-03
+
+### Added
+
+- Generator::generate_geo locale overlay
+
+
 ## [0.2.1] - 2026-06-03
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.4.0] - 2026-06-03
+
+### Added
+
+- Geo_country stealth override + schema snapshots
+
+### Fixed
+
+- Make geo_country field unconditional for feature-stable schema
+
+
 ## [0.3.4] - 2026-06-03
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.3.4"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.4.0] - 2026-06-03
+
+
 ## [0.3.1] - 2026-06-03
 
 ### Added

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.10] - 2026-06-03
+
+### Added
+
+- BrowserBuilder::geo_locale (geo feature)
+
+
 ## [0.2.9] - 2026-06-03
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.9"
+version = "0.2.10"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)
* `zendriver`: 0.2.9 -> 0.2.10 (✓ API compatible changes)
* `zendriver-fingerprints`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `zendriver-mcp`: 0.3.4 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `zendriver-stealth` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Fingerprint.languages in /tmp/.tmpy508cW/zendriver-rs/crates/zendriver-stealth/src/fingerprint.rs:104
  field Fingerprint.languages in /tmp/.tmpy508cW/zendriver-rs/crates/zendriver-stealth/src/fingerprint.rs:104
  field Persona.languages in /tmp/.tmpy508cW/zendriver-rs/crates/zendriver-stealth/src/persona/mod.rs:31
  field Persona.languages in /tmp/.tmpy508cW/zendriver-rs/crates/zendriver-stealth/src/persona/mod.rs:31
```

### ⚠ `zendriver-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field StealthOverrides.geo_country in /tmp/.tmpy508cW/zendriver-rs/crates/zendriver-mcp/src/state.rs:113
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `zendriver`

<blockquote>

## [0.2.10] - 2026-06-03

### Added

- BrowserBuilder::geo_locale (geo feature)
</blockquote>

## `zendriver-fingerprints`

<blockquote>

## [0.2.2] - 2026-06-03

### Added

- Generator::generate_geo locale overlay
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.4.0] - 2026-06-03

### Added

- Geo_country stealth override + schema snapshots

### Fixed

- Make geo_country field unconditional for feature-stable schema
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).