### PR TITLE
fix flaky wait_for_idle: about:blank start page + opt-in stuck-request eviction

### DIFF
--- a/crates/zendriver-mcp/public-api-baseline.txt
+++ b/crates/zendriver-mcp/public-api-baseline.txt
@@ -3751,6 +3751,54 @@ impl<T> typenum::type_operators::Same for zendriver::tab::FrameResourceMatch
 pub type zendriver::tab::FrameResourceMatch::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for zendriver::tab::FrameResourceMatch where V: ppv_lite86::types::MultiLane<T>
 pub fn zendriver::tab::FrameResourceMatch::vzip(self) -> V
+pub struct zendriver::tab::IdleOptions
+pub zendriver::tab::IdleOptions::max_inflight_age: core::option::Option<core::time::Duration>
+pub zendriver::tab::IdleOptions::quiet_window: core::time::Duration
+pub zendriver::tab::IdleOptions::timeout: core::time::Duration
+impl core::clone::Clone for zendriver::tab::IdleOptions
+pub fn zendriver::tab::IdleOptions::clone(&self) -> zendriver::tab::IdleOptions
+impl core::default::Default for zendriver::tab::IdleOptions
+pub fn zendriver::tab::IdleOptions::default() -> Self
+impl core::fmt::Debug for zendriver::tab::IdleOptions
+pub fn zendriver::tab::IdleOptions::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for zendriver::tab::IdleOptions
+impl core::marker::Send for zendriver::tab::IdleOptions
+impl core::marker::Sync for zendriver::tab::IdleOptions
+impl core::marker::Unpin for zendriver::tab::IdleOptions
+impl core::marker::UnsafeUnpin for zendriver::tab::IdleOptions
+impl core::panic::unwind_safe::RefUnwindSafe for zendriver::tab::IdleOptions
+impl core::panic::unwind_safe::UnwindSafe for zendriver::tab::IdleOptions
+impl<T, U> core::convert::Into<U> for zendriver::tab::IdleOptions where U: core::convert::From<T>
+pub fn zendriver::tab::IdleOptions::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for zendriver::tab::IdleOptions where U: core::convert::Into<T>
+pub type zendriver::tab::IdleOptions::Error = core::convert::Infallible
+pub fn zendriver::tab::IdleOptions::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for zendriver::tab::IdleOptions where U: core::convert::TryFrom<T>
+pub type zendriver::tab::IdleOptions::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn zendriver::tab::IdleOptions::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for zendriver::tab::IdleOptions where T: core::clone::Clone
+pub type zendriver::tab::IdleOptions::Owned = T
+pub fn zendriver::tab::IdleOptions::clone_into(&self, &mut T)
+pub fn zendriver::tab::IdleOptions::to_owned(&self) -> T
+impl<T> core::any::Any for zendriver::tab::IdleOptions where T: 'static + ?core::marker::Sized
+pub fn zendriver::tab::IdleOptions::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for zendriver::tab::IdleOptions where T: ?core::marker::Sized
+pub fn zendriver::tab::IdleOptions::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for zendriver::tab::IdleOptions where T: ?core::marker::Sized
+pub fn zendriver::tab::IdleOptions::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for zendriver::tab::IdleOptions where T: core::clone::Clone
+pub unsafe fn zendriver::tab::IdleOptions::clone_to_uninit(&self, *mut u8)
+impl<T> core::convert::From<T> for zendriver::tab::IdleOptions
+pub fn zendriver::tab::IdleOptions::from(T) -> T
+impl<T> tower_http::follow_redirect::policy::PolicyExt for zendriver::tab::IdleOptions where T: ?core::marker::Sized
+pub fn zendriver::tab::IdleOptions::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn zendriver::tab::IdleOptions::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for zendriver::tab::IdleOptions
+impl<T> tracing::instrument::WithSubscriber for zendriver::tab::IdleOptions
+impl<T> typenum::type_operators::Same for zendriver::tab::IdleOptions
+pub type zendriver::tab::IdleOptions::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for zendriver::tab::IdleOptions where V: ppv_lite86::types::MultiLane<T>
+pub fn zendriver::tab::IdleOptions::vzip(self) -> V
 pub struct zendriver::tab::ReloadOptions
 pub zendriver::tab::ReloadOptions::ignore_cache: bool
 pub zendriver::tab::ReloadOptions::script_to_evaluate_on_load: core::option::Option<alloc::string::String>
@@ -3890,6 +3938,7 @@ pub fn zendriver::tab::Tab::target_id(&self) -> &str
 pub async fn zendriver::tab::Tab::title(&self) -> zendriver::error::Result<alloc::string::String>
 pub async fn zendriver::tab::Tab::url(&self) -> zendriver::error::Result<url::Url>
 pub async fn zendriver::tab::Tab::wait_for_idle(&self) -> zendriver::error::Result<()>
+pub async fn zendriver::tab::Tab::wait_for_idle_opts(&self, zendriver::tab::IdleOptions) -> zendriver::error::Result<()>
 pub async fn zendriver::tab::Tab::wait_for_idle_with(&self, core::time::Duration, core::time::Duration) -> zendriver::error::Result<()>
 pub async fn zendriver::tab::Tab::wait_for_load(&self) -> zendriver::error::Result<()>
 pub async fn zendriver::tab::Tab::wait_for_ready_state(&self, zendriver::tab::ReadyState) -> zendriver::error::Result<()>
@@ -6226,6 +6275,54 @@ impl<T> typenum::type_operators::Same for zendriver::tab::FrameResourceMatch
 pub type zendriver::tab::FrameResourceMatch::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for zendriver::tab::FrameResourceMatch where V: ppv_lite86::types::MultiLane<T>
 pub fn zendriver::tab::FrameResourceMatch::vzip(self) -> V
+pub struct zendriver::IdleOptions
+pub zendriver::IdleOptions::max_inflight_age: core::option::Option<core::time::Duration>
+pub zendriver::IdleOptions::quiet_window: core::time::Duration
+pub zendriver::IdleOptions::timeout: core::time::Duration
+impl core::clone::Clone for zendriver::tab::IdleOptions
+pub fn zendriver::tab::IdleOptions::clone(&self) -> zendriver::tab::IdleOptions
+impl core::default::Default for zendriver::tab::IdleOptions
+pub fn zendriver::tab::IdleOptions::default() -> Self
+impl core::fmt::Debug for zendriver::tab::IdleOptions
+pub fn zendriver::tab::IdleOptions::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for zendriver::tab::IdleOptions
+impl core::marker::Send for zendriver::tab::IdleOptions
+impl core::marker::Sync for zendriver::tab::IdleOptions
+impl core::marker::Unpin for zendriver::tab::IdleOptions
+impl core::marker::UnsafeUnpin for zendriver::tab::IdleOptions
+impl core::panic::unwind_safe::RefUnwindSafe for zendriver::tab::IdleOptions
+impl core::panic::unwind_safe::UnwindSafe for zendriver::tab::IdleOptions
+impl<T, U> core::convert::Into<U> for zendriver::tab::IdleOptions where U: core::convert::From<T>
+pub fn zendriver::tab::IdleOptions::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for zendriver::tab::IdleOptions where U: core::convert::Into<T>
+pub type zendriver::tab::IdleOptions::Error = core::convert::Infallible
+pub fn zendriver::tab::IdleOptions::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for zendriver::tab::IdleOptions where U: core::convert::TryFrom<T>
+pub type zendriver::tab::IdleOptions::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn zendriver::tab::IdleOptions::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for zendriver::tab::IdleOptions where T: core::clone::Clone
+pub type zendriver::tab::IdleOptions::Owned = T
+pub fn zendriver::tab::IdleOptions::clone_into(&self, &mut T)
+pub fn zendriver::tab::IdleOptions::to_owned(&self) -> T
+impl<T> core::any::Any for zendriver::tab::IdleOptions where T: 'static + ?core::marker::Sized
+pub fn zendriver::tab::IdleOptions::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for zendriver::tab::IdleOptions where T: ?core::marker::Sized
+pub fn zendriver::tab::IdleOptions::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for zendriver::tab::IdleOptions where T: ?core::marker::Sized
+pub fn zendriver::tab::IdleOptions::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for zendriver::tab::IdleOptions where T: core::clone::Clone
+pub unsafe fn zendriver::tab::IdleOptions::clone_to_uninit(&self, *mut u8)
+impl<T> core::convert::From<T> for zendriver::tab::IdleOptions
+pub fn zendriver::tab::IdleOptions::from(T) -> T
+impl<T> tower_http::follow_redirect::policy::PolicyExt for zendriver::tab::IdleOptions where T: ?core::marker::Sized
+pub fn zendriver::tab::IdleOptions::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn zendriver::tab::IdleOptions::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for zendriver::tab::IdleOptions
+impl<T> tracing::instrument::WithSubscriber for zendriver::tab::IdleOptions
+impl<T> typenum::type_operators::Same for zendriver::tab::IdleOptions
+pub type zendriver::tab::IdleOptions::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for zendriver::tab::IdleOptions where V: ppv_lite86::types::MultiLane<T>
+pub fn zendriver::tab::IdleOptions::vzip(self) -> V
 pub struct zendriver::KeyModifiers(_)
 impl zendriver::input::keyboard::KeyModifiers
 pub const zendriver::input::keyboard::KeyModifiers::ALT: Self
@@ -7360,6 +7457,7 @@ pub fn zendriver::tab::Tab::target_id(&self) -> &str
 pub async fn zendriver::tab::Tab::title(&self) -> zendriver::error::Result<alloc::string::String>
 pub async fn zendriver::tab::Tab::url(&self) -> zendriver::error::Result<url::Url>
 pub async fn zendriver::tab::Tab::wait_for_idle(&self) -> zendriver::error::Result<()>
+pub async fn zendriver::tab::Tab::wait_for_idle_opts(&self, zendriver::tab::IdleOptions) -> zendriver::error::Result<()>
 pub async fn zendriver::tab::Tab::wait_for_idle_with(&self, core::time::Duration, core::time::Duration) -> zendriver::error::Result<()>
 pub async fn zendriver::tab::Tab::wait_for_load(&self) -> zendriver::error::Result<()>
 pub async fn zendriver::tab::Tab::wait_for_ready_state(&self, zendriver::tab::ReadyState) -> zendriver::error::Result<()>

--- a/crates/zendriver-mcp/src/tools/navigation.rs
+++ b/crates/zendriver-mcp/src/tools/navigation.rs
@@ -13,7 +13,7 @@ use rmcp::ErrorData;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
-use zendriver::{ReadyState, ReloadOptions};
+use zendriver::{IdleOptions, ReadyState, ReloadOptions};
 
 use crate::errors::{McpServerError, map_error};
 use crate::snapshot::html_trim;
@@ -280,6 +280,12 @@ pub struct IdleInput {
     /// Outer timeout in milliseconds (default: 5000).
     #[serde(default = "default_idle_timeout")]
     pub timeout_ms: u64,
+    /// Ignore requests in flight longer than this many milliseconds when
+    /// judging idle — treat them as stuck/background (a hung beacon, long-poll,
+    /// SSE stream, …) so idle can resolve even while one is still open. Omit to
+    /// wait for every request to complete (the default).
+    #[serde(default)]
+    pub max_inflight_age_ms: Option<u64>,
 }
 
 const fn default_idle_timeout() -> u64 {
@@ -290,6 +296,7 @@ impl Default for IdleInput {
     fn default() -> Self {
         Self {
             timeout_ms: default_idle_timeout(),
+            max_inflight_age_ms: None,
         }
     }
 }
@@ -304,16 +311,19 @@ pub struct IdleOutput {
 /// Wait until the current tab's network has been idle for ~500ms.
 ///
 /// Quiet window is fixed at 500ms; `timeout_ms` is the outer bound.
+/// `max_inflight_age_ms`, when set, lets idle resolve even while a stuck /
+/// background request is still open.
 pub async fn wait_for_idle(
     state: Arc<Mutex<SessionState>>,
     input: IdleInput,
 ) -> Result<IdleOutput, ErrorData> {
     let s = state.lock().await;
     let tab = current_tab(&s).await?;
-    tab.wait_for_idle_with(
-        Duration::from_millis(input.timeout_ms),
-        Duration::from_millis(500),
-    )
+    tab.wait_for_idle_opts(IdleOptions {
+        timeout: Duration::from_millis(input.timeout_ms),
+        quiet_window: Duration::from_millis(500),
+        max_inflight_age: input.max_inflight_age_ms.map(Duration::from_millis),
+    })
     .await
     .map_err(|e| map_error(McpServerError::from(e)))?;
     Ok(IdleOutput { idle: true })

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__navigation_idle_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__navigation_idle_in.snap
@@ -7,6 +7,14 @@ title: IdleInput
 description: "Arg block for `browser_wait_for_idle`."
 type: object
 properties:
+  max_inflight_age_ms:
+    description: "Ignore requests in flight longer than this many milliseconds when\njudging idle — treat them as stuck/background (a hung beacon, long-poll,\nSSE stream, …) so idle can resolve even while one is still open. Omit to\nwait for every request to complete (the default)."
+    type:
+      - integer
+      - "null"
+    format: uint64
+    default: ~
+    minimum: 0
   timeout_ms:
     description: "Outer timeout in milliseconds (default: 5000)."
     type: integer

--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -1040,6 +1040,25 @@ impl BrowserBuilder {
             v.push("--no-sandbox".to_string());
         }
         v.extend(self.extra_args.iter().cloned());
+        // Start the initial tab on `about:blank` instead of Chrome's default
+        // New Tab Page. The NTP (`chrome://new-tab-page`) issues its own
+        // network requests — realbox icons plus, on a fresh user-data-dir,
+        // external Google fetches (logo/doodle, OneGoogle, suggest, background
+        // collections). Those land on the *main tab's* CDP session, so they
+        // pollute the in-flight set that [`Tab::wait_for_idle`] watches; on a
+        // network-restricted host (e.g. CI with no outbound egress) they never
+        // complete, and the first `wait_for_idle` after launch hangs until its
+        // timeout. A blank start page issues zero requests, so idle detection
+        // sees only the caller's own navigation traffic. Every mainstream
+        // driver (Puppeteer, Playwright, nodriver) starts on `about:blank` for
+        // the same reason.
+        //
+        // Emitted as the final positional argument (a bare URL, not a flag),
+        // and skipped when the caller already supplied their own positional
+        // start URL via `.arg`/`.args` — an explicit start page still wins.
+        if !self.extra_args.iter().any(|a| !a.starts_with('-')) {
+            v.push("about:blank".to_string());
+        }
         v
     }
 }
@@ -3142,6 +3161,42 @@ mod tests {
             .unwrap();
         let lang = flags.iter().position(|f| f == "--lang=en-US").unwrap();
         assert!(proxy < lang);
+    }
+
+    #[test]
+    fn build_flags_appends_about_blank_start_page() {
+        // Default launch must open the initial tab on about:blank (the final
+        // positional argument), not Chrome's New Tab Page — the NTP's own
+        // requests would otherwise pollute `wait_for_idle`'s in-flight set.
+        let flags = BrowserBuilder::new().build_flags(Path::new("/tmp/x"));
+        assert_eq!(
+            flags.last().map(String::as_str),
+            Some("about:blank"),
+            "about:blank must be the final positional arg in {flags:?}"
+        );
+        assert_eq!(
+            flags.iter().filter(|f| f.as_str() == "about:blank").count(),
+            1,
+            "exactly one start page expected in {flags:?}"
+        );
+    }
+
+    #[test]
+    fn build_flags_user_positional_url_suppresses_about_blank() {
+        // A caller-supplied positional start URL wins; we must not also append
+        // about:blank (which would open a second, blank tab).
+        let flags = BrowserBuilder::new()
+            .arg("https://example.com")
+            .build_flags(Path::new("/tmp/x"));
+        assert!(
+            !flags.contains(&"about:blank".to_string()),
+            "explicit positional URL should suppress about:blank in {flags:?}"
+        );
+        assert_eq!(
+            flags.last().map(String::as_str),
+            Some("https://example.com"),
+            "explicit start URL should remain the final arg in {flags:?}"
+        );
     }
 
     // ----- C4: lang / user_agent / sandbox / channel ---------------------

--- a/crates/zendriver/src/lib.rs
+++ b/crates/zendriver/src/lib.rs
@@ -109,7 +109,8 @@ pub use request::{RequestBuilder, Response};
 pub use screenshot::{Format, ScreenshotBuilder};
 pub use storage::Storage;
 pub use tab::{
-    FrameResourceMatch, ReadyState, ReloadOptions, ScrollOptions, Tab, UserAgentOverride,
+    FrameResourceMatch, IdleOptions, ReadyState, ReloadOptions, ScrollOptions, Tab,
+    UserAgentOverride,
 };
 pub use traits::{Evaluable, Queryable};
 pub use window::{WindowBounds, WindowState};

--- a/crates/zendriver/src/network_idle.rs
+++ b/crates/zendriver/src/network_idle.rs
@@ -28,7 +28,7 @@
 //! finishes. Tracking continuously lets us answer "has the count been 0 for
 //! N ms?" without losing events that fired before the call.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use futures::StreamExt;
@@ -45,10 +45,13 @@ use zendriver_transport::SessionHandle;
 /// the current count and wait on `notifier` for change events.
 #[derive(Debug)]
 pub(crate) struct InFlightTracker {
-    /// Currently-pending request IDs. Inserted on `Network.requestWillBeSent`,
-    /// removed on terminal events (`responseReceived` / `loadingFailed` /
-    /// `loadingFinished`).
-    pub(crate) in_flight: Mutex<HashSet<String>>,
+    /// Currently-pending requests, mapping `requestId` to the instant it was
+    /// inserted (on `Network.requestWillBeSent`). Entries are removed on
+    /// terminal events (`responseReceived` / `loadingFailed` /
+    /// `loadingFinished`). The insertion instant lets `wait_for_idle_opts`
+    /// ignore requests that have been in flight longer than
+    /// [`crate::IdleOptions::max_inflight_age`] (stuck / background requests).
+    pub(crate) in_flight: Mutex<HashMap<String, tokio::time::Instant>>,
     /// Notified on every membership change. `wait_for_idle` selects on this
     /// alongside a 50ms tick to wake immediately when the count moves.
     pub(crate) notifier: Notify,
@@ -69,7 +72,7 @@ impl InFlightTracker {
     /// task without an extra wrapper layer.
     pub(crate) fn new() -> Arc<Self> {
         Arc::new(Self {
-            in_flight: Mutex::new(HashSet::new()),
+            in_flight: Mutex::new(HashMap::new()),
             notifier: Notify::new(),
         })
     }
@@ -145,7 +148,7 @@ impl InFlightTracker {
                         "Network.requestWillBeSent" => {
                             let Ok(parsed) = serde_json::from_value::<RequestEvent>(ev.params) else { continue };
                             let mut set = self.in_flight.lock().await;
-                            set.insert(parsed.request_id);
+                            set.insert(parsed.request_id, tokio::time::Instant::now());
                             true
                         }
                         "Network.responseReceived"
@@ -217,7 +220,7 @@ mod tests {
         {
             let set = tracker.in_flight.lock().await;
             assert_eq!(set.len(), 1, "expected exactly one in-flight request");
-            assert!(set.contains("R1"));
+            assert!(set.contains_key("R1"));
         }
 
         // Remove via responseReceived.

--- a/crates/zendriver/src/snapshots/zendriver__browser__tests__default_launch_flags.snap
+++ b/crates/zendriver/src/snapshots/zendriver__browser__tests__default_launch_flags.snap
@@ -11,3 +11,4 @@ expression: flags
 - "--disable-features=PasswordManagerOnboarding,AutofillServerCommunication"
 - "--headless=new"
 - "--disable-gpu"
+- "about:blank"

--- a/crates/zendriver/src/snapshots/zendriver__browser__tests__non_headless_launch_flags.snap
+++ b/crates/zendriver/src/snapshots/zendriver__browser__tests__non_headless_launch_flags.snap
@@ -9,3 +9,4 @@ expression: flags
 - "--password-store=basic"
 - "--disable-save-password-bubble"
 - "--disable-features=PasswordManagerOnboarding,AutofillServerCommunication"
+- "about:blank"

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -370,6 +370,48 @@ impl Drop for TabInner {
     }
 }
 
+/// Tunables for [`Tab::wait_for_idle_opts`].
+///
+/// Construct from [`IdleOptions::default`] and override the fields you care
+/// about:
+///
+/// ```no_run
+/// # use std::time::Duration;
+/// # use zendriver::IdleOptions;
+/// let opts = IdleOptions {
+///     max_inflight_age: Some(Duration::from_secs(5)),
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct IdleOptions {
+    /// Outer bound on the whole wait. [`Tab::wait_for_idle_opts`] returns
+    /// [`ZendriverError::Timeout`] once it elapses. Default: 30 s.
+    pub timeout: Duration,
+    /// The in-flight set must stay empty for this long to count as idle.
+    /// Default: 500 ms.
+    pub quiet_window: Duration,
+    /// Requests that have been in flight *longer than* this are ignored when
+    /// judging idleness — they are treated as stuck/background (a hung beacon,
+    /// long-poll, SSE stream, …) rather than active page loading. This lets
+    /// idle resolve even while such a request is still technically open.
+    ///
+    /// `None` (the default) waits for **every** request to terminate, which is
+    /// the historical behavior: a single never-completing request keeps the
+    /// tab non-idle until `timeout`.
+    pub max_inflight_age: Option<Duration>,
+}
+
+impl Default for IdleOptions {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(30),
+            quiet_window: Duration::from_millis(500),
+            max_inflight_age: None,
+        }
+    }
+}
+
 impl Tab {
     pub(crate) fn new(
         session: SessionHandle,
@@ -1671,23 +1713,13 @@ impl Tab {
     /// # Ok(()) }
     /// ```
     pub async fn wait_for_idle(&self) -> Result<()> {
-        self.wait_for_idle_with(Duration::from_secs(30), Duration::from_millis(500))
-            .await
+        self.wait_for_idle_opts(IdleOptions::default()).await
     }
 
     /// Wait until the tab's network has been idle for `quiet_window`,
-    /// bounded by `timeout`.
-    ///
-    /// Algorithm: poll the in-flight set with a `Notify`-driven wake (or a
-    /// 50ms fallback tick). Track `quiet_start = Some(now)` on the first
-    /// observation of an empty set; reset to `None` on any observation
-    /// where the set is non-empty. Return once `now - quiet_start
-    /// >= quiet_window`.
-    ///
-    /// The 50ms tick is a safety net for the case where the tracker is
-    /// already at 0 in-flight requests and no further events fire to wake
-    /// the notifier. Worst-case latency to detect "stayed idle long enough"
-    /// is `quiet_window + 50ms`.
+    /// bounded by `timeout`. Convenience wrapper over
+    /// [`Tab::wait_for_idle_opts`] with no stuck-request eviction
+    /// (`max_inflight_age: None`).
     ///
     /// # Errors
     ///
@@ -1713,6 +1745,59 @@ impl Tab {
         timeout: Duration,
         quiet_window: Duration,
     ) -> Result<()> {
+        self.wait_for_idle_opts(IdleOptions {
+            timeout,
+            quiet_window,
+            max_inflight_age: None,
+        })
+        .await
+    }
+
+    /// Wait for network idle with full control over the policy via
+    /// [`IdleOptions`].
+    ///
+    /// Algorithm: poll the in-flight set with a `Notify`-driven wake (or a
+    /// 50ms fallback tick). Each iteration computes the number of *active*
+    /// requests — every in-flight request when
+    /// [`IdleOptions::max_inflight_age`] is `None`, otherwise only those in
+    /// flight for less than that age (older ones are treated as stuck /
+    /// background and ignored). Track `quiet_start = Some(now)` on the first
+    /// observation of zero active requests; reset to `None` whenever the active
+    /// count is non-zero or a membership change fires. Return once
+    /// `now - quiet_start >= quiet_window`.
+    ///
+    /// The 50ms tick bounds latency both for the already-idle case (no further
+    /// events fire) and for an age-out crossing (which emits no CDP event), so
+    /// worst-case latency to detect "stayed idle long enough" is
+    /// `quiet_window + 50ms`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZendriverError::Timeout`] (carrying [`IdleOptions::timeout`])
+    /// once the outer deadline elapses.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use std::time::Duration;
+    /// # use zendriver::IdleOptions;
+    /// # async fn ex() -> zendriver::Result<()> {
+    /// # let browser = zendriver::Browser::builder().launch().await?;
+    /// # let tab = browser.main_tab();
+    /// tab.goto("https://example.com").await?;
+    /// // Resolve even if a beacon / long-poll stays open past 5s.
+    /// tab.wait_for_idle_opts(IdleOptions {
+    ///     max_inflight_age: Some(Duration::from_secs(5)),
+    ///     ..Default::default()
+    /// }).await?;
+    /// # Ok(()) }
+    /// ```
+    pub async fn wait_for_idle_opts(&self, opts: IdleOptions) -> Result<()> {
+        let IdleOptions {
+            timeout,
+            quiet_window,
+            max_inflight_age,
+        } = opts;
         let tracker = self.inner.network_tracker.clone();
         let deadline = tokio::time::Instant::now() + timeout;
         let mut quiet_start: Option<tokio::time::Instant> = None;
@@ -1728,8 +1813,23 @@ impl Tab {
             tokio::pin!(notif);
             notif.as_mut().enable();
 
-            let in_flight_count = tracker.in_flight.lock().await.len();
-            if in_flight_count == 0 {
+            // "Active" = requests that still count toward busy-ness. With
+            // `max_inflight_age` set, a request in flight longer than that age
+            // is treated as stuck/background and excluded, so a never-
+            // terminating request can no longer pin the tab non-idle forever.
+            let active_count = {
+                let set = tracker.in_flight.lock().await;
+                match max_inflight_age {
+                    None => set.len(),
+                    Some(age) => {
+                        let now = tokio::time::Instant::now();
+                        set.values()
+                            .filter(|inserted| now.duration_since(**inserted) < age)
+                            .count()
+                    }
+                }
+            };
+            if active_count == 0 {
                 let now = tokio::time::Instant::now();
                 match quiet_start {
                     None => quiet_start = Some(now),
@@ -3864,7 +3964,7 @@ mod tests {
                 .in_flight
                 .lock()
                 .await
-                .contains("R2")
+                .contains_key("R2")
             {
                 break;
             }
@@ -3876,7 +3976,7 @@ mod tests {
                 .in_flight
                 .lock()
                 .await
-                .contains("R2"),
+                .contains_key("R2"),
             "R2 did not register inside quiet window",
         );
 
@@ -3984,6 +4084,76 @@ mod tests {
             elapsed >= Duration::from_millis(355),
             "wait_for_idle resolved too early ({elapsed:?}); 0→1→0 burst inside \
              quiet window must reset quiet_start",
+        );
+
+        conn.shutdown();
+    }
+
+    /// A request that never receives a terminal CDP event (a hung beacon /
+    /// long-poll / stuck XHR) must not pin `wait_for_idle` forever when the
+    /// caller sets [`IdleOptions::max_inflight_age`]: once it has been in
+    /// flight longer than that age it stops counting toward "active network",
+    /// so the quiet window can elapse and the call resolves.
+    #[tokio::test]
+    async fn wait_for_idle_opts_evicts_stuck_request_past_max_inflight_age() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+
+        let id_enable =
+            tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Network.enable"))
+                .await
+                .expect("tracker did not send Network.enable within 2s");
+        mock.reply(id_enable, json!({})).await;
+
+        // Insert a request and NEVER emit a terminal event for it.
+        mock.emit_event_for_session(
+            "Network.requestWillBeSent",
+            json!({ "requestId": "STUCK" }),
+            "S1",
+        )
+        .await;
+        for _ in 0..50 {
+            if tab.inner.network_tracker.in_flight.lock().await.len() == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            tab.inner.network_tracker.in_flight.lock().await.len(),
+            1,
+            "stuck request did not register before wait_for_idle starts",
+        );
+
+        // age 300ms + 200ms window ⇒ resolves ~500ms even though the request
+        // never completes. The 5s inner timeout is never reached on success;
+        // the 3s outer timeout below fails the test if eviction is missing
+        // (the stub hangs to the inner timeout instead of resolving).
+        let start = tokio::time::Instant::now();
+        let res = tokio::time::timeout(
+            Duration::from_secs(3),
+            tab.wait_for_idle_opts(IdleOptions {
+                timeout: Duration::from_secs(5),
+                quiet_window: Duration::from_millis(200),
+                max_inflight_age: Some(Duration::from_millis(300)),
+            }),
+        )
+        .await
+        .expect("wait_for_idle_opts did not resolve despite max_inflight_age eviction");
+        res.unwrap();
+        let elapsed = start.elapsed();
+
+        // Must clear the eviction age (300ms) + quiet window (200ms).
+        assert!(
+            elapsed >= Duration::from_millis(450),
+            "resolved too early ({elapsed:?}); eviction age + quiet window not enforced",
+        );
+        // Eviction is a counting filter, not a removal: the never-terminated id
+        // still lingers in the map (so a `None` waiter would still block on it).
+        assert_eq!(
+            tab.inner.network_tracker.in_flight.lock().await.len(),
+            1,
+            "stuck id should remain in the map (age filter, not prune)",
         );
 
         conn.shutdown();

--- a/crates/zendriver/tests/integration_phase4.rs
+++ b/crates/zendriver/tests/integration_phase4.rs
@@ -308,32 +308,49 @@ async fn reload_dispatches_page_reload() {
 #[tokio::test]
 #[serial]
 async fn wait_for_idle_on_spa_with_delayed_xhr() {
-    // Fixture fires an XHR ~300ms after the inline script runs.
-    // `wait_for_idle` should observe the request, wait for it to complete,
-    // then require its quiet window before resolving. The request is timed to
-    // fire well inside the (widened) quiet window so the catch is not a race;
-    // see the `wait_for_idle_with` call below for the timing rationale.
+    // Regression coverage: `wait_for_idle` must block on a request that is
+    // still in flight when it is called, and only resolve once that request
+    // completes and the quiet window elapses.
     //
-    // Use a single mock server for both the page and the data endpoint so
-    // the fetch is same-origin — a cross-origin fetch from a separate
-    // wiremock instance would be CORS-blocked and `window.x` would never
-    // be set, failing the read-back assertion below for an unrelated
-    // reason.
+    // Design that makes this deterministic (no dependence on host load):
+    //   * The page fires `fetch("/data")` immediately on parse.
+    //   * The server holds that response open for `DATA_DELAY` before replying.
+    //   * A `fetch` is NOT a document subresource, so the `load` event — and
+    //     therefore `wait_for_load` — fires while the request is still pending.
+    // So at the instant `wait_for_idle` starts, the `/data` request is
+    // guaranteed in flight; idle detection MUST observe it and wait. (The
+    // earlier version delayed the XHR with a client-side `setTimeout`, whose
+    // firing time relative to the measurement start drifted under CI load, and
+    // — separately — relied on the browser reaching a *global* network-idle
+    // state that Chrome's New Tab Page startup requests could prevent. The
+    // initial tab now launches on `about:blank`, so the only traffic is this
+    // fixture's own.)
+    //
+    // Page and data endpoint share one origin so the fetch is same-origin (a
+    // cross-origin fetch would be CORS-blocked and never set `window.x`).
+    const DATA_DELAY: Duration = Duration::from_millis(1500);
+    const QUIET_WINDOW: Duration = Duration::from_millis(500);
+
     let mock = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/data"))
-        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("ok")
+                .set_delay(DATA_DELAY),
+        )
         .mount(&mock)
         .await;
     Mock::given(method("GET"))
         .and(path("/"))
         .respond_with(
             ResponseTemplate::new(200).set_body_raw(
-                r#"<!doctype html><html><body>
+                // `<link rel="icon" href="data:,">` suppresses the implicit
+                // /favicon.ico request, leaving the document + the XHR as the
+                // only network traffic the tab generates.
+                r#"<!doctype html><html><head><link rel="icon" href="data:,"></head><body>
           <script>
-            setTimeout(() => {
-              fetch("/data").then(r => r.text()).then(t => { window.x = t; });
-            }, 300);
+            fetch("/data").then(r => r.text()).then(t => { window.x = t; });
           </script>
         </body></html>"#
                     .as_bytes()
@@ -343,43 +360,37 @@ async fn wait_for_idle_on_spa_with_delayed_xhr() {
         )
         .mount(&mock)
         .await;
-    let mock_page = mock;
 
     let browser = Browser::builder().headless(true).launch().await.unwrap();
     let tab = browser.main_tab();
-    tab.goto(&mock_page.uri()).await.unwrap();
+    tab.goto(&mock.uri()).await.unwrap();
     tab.wait_for_load().await.unwrap();
 
     let start = std::time::Instant::now();
-    // Use an explicit 800ms quiet window (vs the 500ms default). The fixture
-    // delays its XHR ~300ms, so the request fires roughly in the *middle* of
-    // the window — leaving ~500ms of slack before the window would otherwise
-    // close. With the old 500ms-delay / 500ms-window pairing the request
-    // landed within ~30ms of the window closing, so any CDP event lag or
-    // timer jitter (common under CI load) let `wait_for_idle` close the
-    // window before the request registered and it returned ~500ms early.
-    tab.wait_for_idle_with(Duration::from_secs(30), Duration::from_millis(800))
+    // Outer timeout is a generous multiple of the ~2s happy path (DATA_DELAY +
+    // QUIET_WINDOW) so a genuinely-stuck request fails fast instead of hanging
+    // the suite for 30s, while normal CI jitter never trips it.
+    tab.wait_for_idle_with(Duration::from_secs(10), QUIET_WINDOW)
         .await
         .unwrap();
     let elapsed = start.elapsed();
 
+    // Primary, *causal* assertion: `window.x` is only set when the delayed
+    // `/data` response arrives at +DATA_DELAY. Had `wait_for_idle` ignored the
+    // in-flight request, it would have resolved at the first quiet window
+    // (~QUIET_WINDOW) with `window.x` still empty. Independent of wall-clock
+    // timing, so it cannot flake.
     let x: String = tab.evaluate_main("window.x || ''").await.unwrap();
-    // Primary, *causal* assertion: the XHR result is only set after the
-    // delayed request completes. Reading it after `wait_for_idle` returns
-    // proves idle detection observed the request and waited for it to finish
-    // — had it returned at the first quiet window (before the XHR fired),
-    // `window.x` would still be unset. This check does not depend on timing,
-    // so it does not flake.
-    assert_eq!(x, "ok", "XHR result should be present once idle resolves");
+    assert_eq!(x, "ok", "XHR result must be present once idle resolves");
 
-    // Sanity floor: confirm a quiet window was actually enforced *after* the
-    // request (i.e. idle didn't resolve the instant the XHR finished). Kept
-    // well below the ~1.13s expected elapsed (~300ms delay + 800ms window) so
-    // scheduler jitter never trips it; the assertion above is what proves the
-    // delayed request was awaited.
+    // Secondary: idle cannot resolve until the response is delivered, so the
+    // elapsed time must clear the server delay. The floor sits far above the
+    // ~QUIET_WINDOW an oblivious wait would take and well below the ~2s
+    // expected, so scheduler jitter never trips it either way.
     assert!(
-        elapsed >= Duration::from_millis(600),
-        "wait_for_idle returned too early ({elapsed:?}); expected delayed XHR + quiet window"
+        elapsed >= Duration::from_millis(1200),
+        "wait_for_idle returned too early ({elapsed:?}); the in-flight XHR \
+         (held {DATA_DELAY:?} server-side) should have kept the tab non-idle"
     );
 
     browser.close().await.unwrap();

--- a/crates/zendriver/tests/integration_phase4.rs
+++ b/crates/zendriver/tests/integration_phase4.rs
@@ -398,6 +398,76 @@ async fn wait_for_idle_on_spa_with_delayed_xhr() {
 
 #[tokio::test]
 #[serial]
+async fn wait_for_idle_opts_resolves_despite_stuck_request() {
+    // A request that never completes within the test (server holds it open far
+    // longer than the wait) must NOT pin `wait_for_idle_opts` to its outer
+    // timeout when `max_inflight_age` is set: once the request has been in
+    // flight past that age it is ignored, so idle resolves on the quiet window.
+    //
+    // Single origin + suppressed favicon so the held `/hang` fetch is the only
+    // thing keeping the tab busy.
+    const HANG_DELAY: Duration = Duration::from_secs(5); // ≫ the ~0.6s we wait
+    const MAX_AGE: Duration = Duration::from_millis(400);
+    const QUIET_WINDOW: Duration = Duration::from_millis(200);
+
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/hang"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("late")
+                .set_delay(HANG_DELAY),
+        )
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(
+                r#"<!doctype html><html><head><link rel="icon" href="data:,"></head><body>
+          <script>fetch("/hang");</script>
+        </body></html>"#
+                    .as_bytes()
+                    .to_vec(),
+                "text/html",
+            ),
+        )
+        .mount(&mock)
+        .await;
+
+    let browser = Browser::builder().headless(true).launch().await.unwrap();
+    let tab = browser.main_tab();
+    tab.goto(&mock.uri()).await.unwrap();
+    tab.wait_for_load().await.unwrap();
+
+    let start = std::time::Instant::now();
+    tab.wait_for_idle_opts(zendriver::IdleOptions {
+        timeout: Duration::from_secs(10),
+        quiet_window: QUIET_WINDOW,
+        max_inflight_age: Some(MAX_AGE),
+    })
+    .await
+    .unwrap();
+    let elapsed = start.elapsed();
+
+    // Resolved by eviction, not by the request finishing (it can't — held 5s)
+    // and not by the 10s outer timeout. So elapsed clears MAX_AGE + window but
+    // stays far below HANG_DELAY.
+    assert!(
+        elapsed >= Duration::from_millis(500),
+        "resolved too early ({elapsed:?}); eviction age + quiet window not enforced"
+    );
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "resolved too late ({elapsed:?}); the stuck /hang request should have been \
+         evicted at {MAX_AGE:?}, not awaited"
+    );
+
+    browser.close().await.unwrap();
+}
+
+#[tokio::test]
+#[serial]
 async fn frame_find_inside_iframe() {
     // Fixture page hosts an iframe with `srcdoc` content. After load the
     // tab's frame registry should contain the main frame + the iframe;

--- a/docs/superpowers/specs/2026-06-03-wait-for-idle-stuck-request-design.md
+++ b/docs/superpowers/specs/2026-06-03-wait-for-idle-stuck-request-design.md
@@ -1,0 +1,122 @@
+# `wait_for_idle` stuck-request hardening — design
+
+Date: 2026-06-03
+Status: approved
+
+## Problem
+
+`Tab::wait_for_idle` (and `wait_for_idle_with`) resolves only when the per-tab
+in-flight request count stays at 0 for the whole `quiet_window`. A single
+request that never reaches a terminal CDP event — a hung beacon, a long-poll,
+Server-Sent-Events, a websocket-style upgrade, or just a stuck XHR — keeps the
+count at ≥ 1 forever, so the call hangs until its outer `timeout` and returns
+`Err(Timeout)`. This is the well-known fragility of Playwright's `networkidle`.
+
+The preceding fix (launching the initial tab on `about:blank`) removed the
+*trigger* that surfaced this in CI (Chrome New Tab Page requests hanging on a
+network-restricted runner), but the underlying limitation remains for real
+pages.
+
+## Decision: opt-in age eviction, default unchanged
+
+Add a `max_inflight_age: Option<Duration>`. A request that has been in flight
+*longer than* this threshold is excluded from the idle calculation — treated as
+background/stuck rather than active loading.
+
+- `None` (default) → **identical to today's behavior**: no eviction; a stuck
+  request hangs to the outer timeout. Existing callers are unaffected.
+- `Some(age)` → the caller opts in with a threshold *they* choose.
+
+Rationale: no age threshold can distinguish "a legitimate 5 s request, 4 s in"
+from "an infinite request, 4 s in". The right value is a per-call tradeoff, not
+a default the library should impose — consistent with the project's
+"least-opinionated, everything-overridable, never lock a value" stance.
+
+## API
+
+```rust
+/// Tunables for `Tab::wait_for_idle_opts`.
+#[derive(Debug, Clone)]
+pub struct IdleOptions {
+    /// Outer bound; `Err(Timeout)` once it elapses. Default 30 s.
+    pub timeout: Duration,
+    /// The set must stay empty this long to count as idle. Default 500 ms.
+    pub quiet_window: Duration,
+    /// Requests in flight longer than this are ignored when judging idle.
+    /// `None` (default) waits for every request to terminate.
+    pub max_inflight_age: Option<Duration>,
+}
+
+impl Default for IdleOptions {
+    // 30 s, 500 ms, None
+}
+```
+
+Methods:
+
+```rust
+// unchanged signatures, now thin delegates over wait_for_idle_opts:
+pub async fn wait_for_idle(&self) -> Result<()>;
+pub async fn wait_for_idle_with(&self, timeout: Duration, quiet_window: Duration) -> Result<()>;
+
+// new — full control:
+pub async fn wait_for_idle_opts(&self, opts: IdleOptions) -> Result<()>;
+```
+
+Usage:
+
+```rust
+tab.wait_for_idle_opts(IdleOptions {
+    max_inflight_age: Some(Duration::from_secs(5)),
+    ..Default::default()
+}).await?;
+```
+
+## Mechanism
+
+- **Tracker** (`network_idle.rs`): `in_flight: Mutex<HashSet<String>>` becomes
+  `Mutex<HashMap<String, tokio::time::Instant>>`. `Network.requestWillBeSent`
+  inserts `(request_id, Instant::now())`; the three terminal events remove by
+  id. The tracker uses the same `tokio::time` clock the wait loop reads, so ages
+  are consistent.
+- **Wait loop** (`tab.rs::wait_for_idle_opts`): compute an *active count* each
+  iteration — `None` ⇒ `map.len()`; `Some(age)` ⇒ number of entries whose
+  `now - inserted < age`. Idle accounting is otherwise unchanged (quiet-window
+  accumulation, notifier + 50 ms fallback tick, outer-deadline check). A request
+  crossing the age threshold fires no CDP event, so the 50 ms tick is what
+  notices the age-out — already the loop's worst-case latency.
+- Map membership is purely event-driven; it is **never** age-pruned. A `None`
+  waiter therefore still waits forever as contracted even if a concurrent
+  `Some` waiter is filtering the same map. A genuinely-stuck id lingers in the
+  map until the tab is dropped — a negligible, documented memory cost.
+
+## MCP exposure
+
+`browser_wait_for_idle` (`crates/zendriver-mcp/src/tools/navigation.rs`) gains an
+optional `max_inflight_age_ms: Option<u64>` on `IdleInput`, threaded into
+`wait_for_idle_opts`. Regenerate and accept the `insta` schema snapshots.
+
+## Testing
+
+- **Unit** (`tab.rs` tests, `Tab::new_for_test` + `MockConnection`): emit
+  `Network.requestWillBeSent` and **never** a terminal event. With
+  `max_inflight_age: Some(300ms)` + 200 ms window the call resolves (~500 ms);
+  with `None` + a 1 s outer timeout it returns `Err(Timeout)`. Short real
+  durations, matching the existing idle tests.
+- **Integration** (`integration_phase4.rs`): a fixture endpoint held open with
+  `set_delay` far beyond the test, fetched on load; `wait_for_idle_opts` with a
+  short `max_inflight_age` resolves well under the outer timeout — assert
+  elapsed ≈ age + window, not the timeout.
+
+## Out of scope
+
+- Changing any default (stays `None`).
+- The broadcast-`Lagged` dropped-event leak (separate latent issue; bus capacity
+  1024, unrelated trigger).
+- Age-pruning the map (would break `None`-waiter semantics).
+
+## Public-API impact
+
+New `pub struct IdleOptions` + `wait_for_idle_opts` method ⇒ regenerate
+`crates/zendriver-mcp/public-api-baseline.txt`. No MCP coverage-ledger entry
+needed (the capability stays reachable via `browser_wait_for_idle`).


### PR DESCRIPTION
## Why

`wait_for_idle_on_spa_with_delayed_xhr` flaked on CI — failing with a **30s timeout across all three retries**, not an assertion failure ([latest red run](https://github.com/TurtIeSocks/zendriver-rs/actions)).

Instrumenting the in-flight tracker showed the real cause: the initial tab opens on Chrome's **New Tab Page** (`chrome://new-tab-page`), which issues its own requests on the main tab's CDP session — realbox `chrome://` resources plus, on a fresh `user-data-dir`, **external Google fetches** (logo/doodle, OneGoogle, suggest, background collections). On a network-restricted CI runner those external requests hang, so the in-flight set never drains and the first `wait_for_idle` after launch times out. (`12 × chrome://new-tab-page + 4 × chrome://resources` on the page session — all gone once the start page is `about:blank`.)

That's also a latent correctness bug for every user, and it exposed a second, deeper limitation: a single never-terminating request pins `wait_for_idle` until its timeout regardless (the well-known `networkidle` fragility).

## What

**Commit 1 — `fix(browser)`: start initial tab on `about:blank`.** Eliminates the NTP request storm at the source (what Puppeteer/Playwright/nodriver all do). Skipped if the caller passed their own positional URL. The flaky integration test is also redesigned to hold its `/data` response open server-side (`set_delay`) so the request is *deterministically in flight* when `wait_for_idle` is called — removing client-timer drift and making the `window.x == "ok"` assertion genuinely causal (the old assertions passed even when the tracker observed nothing).

**Commit 2 — `feat(tab)`: opt-in stuck-request eviction.** New `IdleOptions { timeout, quiet_window, max_inflight_age }` + `Tab::wait_for_idle_opts`. A request in flight longer than `max_inflight_age` is excluded from the idle judgement, so idle resolves even while a hung beacon / long-poll / SSE stream is open.

```rust
tab.wait_for_idle_opts(IdleOptions {
    max_inflight_age: Some(Duration::from_secs(5)),
    ..Default::default()
}).await?;
```

- **Default `None` = exactly the old behavior.** `wait_for_idle` / `wait_for_idle_with` keep their signatures and delegate — zero caller churn.
- Tracker's in-flight set becomes `HashMap<String, Instant>` (insertion time); membership stays event-driven, so a `None` waiter still blocks forever — the age filter only changes the active *count*, never removes entries.
- Exposed on the `browser_wait_for_idle` MCP tool as `max_inflight_age_ms`.

Design spec: `docs/superpowers/specs/2026-06-03-wait-for-idle-stuck-request-design.md`.

## Verification

- TDD: the eviction test failed correctly first (stub ignored the age → stuck request hung → outer timeout), then passed once implemented.
- `wait_for_idle_on_spa_with_delayed_xhr` run 6× locally — deterministic 3.13–3.26s.
- lib idle + tracker **9/9** · doctests **260/260** · **public-api check passes** (baseline regen: +98 lines, all `IdleOptions`/`wait_for_idle_opts`, 0 removed) · MCP schema snapshot regenerated (only `max_inflight_age_ms` added) · `integration_phase4` **11/11**.
- `cargo fmt --all --check` clean; `clippy -D warnings` clean (default + `zendriver-mcp --all-features` + `zendriver --features integration-tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
