### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "async-trait",
  "base64",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.10", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.11", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.4" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.4.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.0" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.2.1" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.3" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.4.0" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.5.0" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.0" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.1" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.2" }

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.5.0] - 2026-06-03
+
+### Added
+
+- Opt-in stuck-request eviction for wait_for_idle (max_inflight_age)
+
+
 ## [0.4.0] - 2026-06-03
 
 ### Added

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,17 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.11] - 2026-06-03
+
+### Added
+
+- Opt-in stuck-request eviction for wait_for_idle (max_inflight_age)
+
+### Fixed
+
+- Start initial tab on about:blank to fix flaky wait_for_idle
+
+
 ## [0.2.10] - 2026-06-03
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.10"
+version = "0.2.11"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver`: 0.2.10 -> 0.2.11 (✓ API compatible changes)
* `zendriver-mcp`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `zendriver-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field IdleInput.max_inflight_age_ms in /tmp/.tmptTlyJC/zendriver-rs/crates/zendriver-mcp/src/tools/navigation.rs:288
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver`

<blockquote>

## [0.2.11] - 2026-06-03

### Added

- Opt-in stuck-request eviction for wait_for_idle (max_inflight_age)

### Fixed

- Start initial tab on about:blank to fix flaky wait_for_idle
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.5.0] - 2026-06-03

### Added

- Opt-in stuck-request eviction for wait_for_idle (max_inflight_age)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).