### PR TITLE
feat(stealth): native-function toString masking (full + cross-realm)

### DIFF
--- a/crates/zendriver-stealth/src/patches.rs
+++ b/crates/zendriver-stealth/src/patches.rs
@@ -14,6 +14,9 @@ use crate::persona::surface::{Strategy, Surface};
 use crate::persona::{FontSpec, HardwareSpec, SurfaceCfg, WebglSpec, WebrtcSpec};
 use crate::{Fingerprint, Persona, Seed, UserAgentMetadata};
 
+// --- Native-function masking prelude (runs first, wraps everything) ------
+const NATIVE: &str = include_str!("patches/_native.js");
+
 // --- Identity patches (run inside the fp IIFE) ---------------------------
 const WEBDRIVER: &str = include_str!("patches/webdriver.js");
 const PLUGINS: &str = include_str!("patches/plugins.js");
@@ -56,45 +59,51 @@ const WEBGPU: &str = include_str!("patches/webgpu.js");
 /// last), then the PRNG definition, then each persona surface.
 #[must_use]
 pub fn bootstrap_script(persona: &Persona, identity: &Fingerprint) -> String {
-    let mut out = identity_iife(persona, identity);
+    // Prelude first: installs the toString override + closure-local helpers
+    // that every patch below routes through.
+    let mut body = String::from(NATIVE);
+    body.push('\n');
+    body.push_str(&identity_iife(persona, identity));
 
     let seed = persona.seed.unwrap_or_else(Seed::random).value();
 
     // PRNG must be defined once, before any noise/font patch that references
     // `__zdRng`. Emit it unconditionally — cheap, and harmless if every
     // surface is Native (it just defines an unused function).
-    out.push('\n');
-    out.push_str(PRNG);
+    body.push('\n');
+    body.push_str(PRNG);
 
     push_noise(
-        &mut out,
+        &mut body,
         Surface::Canvas,
         persona.canvas.as_ref(),
         CANVAS,
         seed,
     );
     push_noise(
-        &mut out,
+        &mut body,
         Surface::Audio,
         persona.audio.as_ref(),
         AUDIO,
         seed,
     );
     push_noise(
-        &mut out,
+        &mut body,
         Surface::ClientRects,
         persona.client_rects.as_ref(),
         CLIENT_RECTS,
         seed,
     );
 
-    push_webgl(&mut out, persona.webgl.as_ref());
-    push_webgpu(&mut out, persona.webgpu.as_ref(), persona.webgl.as_ref());
-    push_fonts(&mut out, persona.fonts.as_ref(), seed);
-    push_hardware(&mut out, persona.hardware.as_ref());
-    push_webrtc(&mut out, persona.webrtc.as_ref());
+    push_webgl(&mut body, persona.webgl.as_ref());
+    push_webgpu(&mut body, persona.webgpu.as_ref(), persona.webgl.as_ref());
+    push_fonts(&mut body, persona.fonts.as_ref(), seed);
+    push_hardware(&mut body, persona.hardware.as_ref());
+    push_webrtc(&mut body, persona.webrtc.as_ref());
 
-    out
+    // Single outer IIFE: helpers stay closure-local (no globalThis leak); the
+    // Function.prototype.toString override inside still persists globally.
+    format!("(function(){{\n{body}\n}})();")
 }
 
 /// Emit the 9 identity patches wrapped in `(function(fp){ ... })(fpJson)`.
@@ -351,8 +360,31 @@ mod tests {
     #[test]
     fn bootstrap_is_an_iife_taking_fp() {
         let s = bootstrap_script(&Persona::default(), &mock_identity());
-        assert!(s.starts_with("(function(fp){"));
+        // The identity patches still run inside `(function(fp){…})({…})`, now
+        // nested within the outer masking IIFE.
+        assert!(s.contains("(function(fp){"));
         assert!(s.contains("})({"), "fp arg JSON should follow");
+    }
+
+    #[test]
+    fn bootstrap_installs_native_masking_prelude() {
+        let s = bootstrap_script(&Persona::default(), &mock_identity());
+        assert!(s.contains("__zdReplace"), "replace helper missing");
+        assert!(s.contains("__zdGetter"), "getter helper missing");
+        assert!(s.contains("__zdMark"), "mark helper missing");
+        assert!(
+            s.contains("Function.prototype, \"toString\""),
+            "toString override missing"
+        );
+    }
+
+    #[test]
+    fn bootstrap_wraps_everything_in_outer_masking_iife() {
+        let s = bootstrap_script(&Persona::default(), &mock_identity());
+        assert!(s.starts_with("(function(){"), "outer masking IIFE must be first");
+        // identity IIFE is now nested inside the outer one.
+        assert!(s.contains("(function(fp){"), "identity IIFE still present (nested)");
+        assert!(s.trim_end().ends_with("})();"), "outer IIFE is invoked");
     }
 
     #[test]

--- a/crates/zendriver-stealth/src/patches.rs
+++ b/crates/zendriver-stealth/src/patches.rs
@@ -764,6 +764,41 @@ mod tests {
     }
 
     #[test]
+    fn surface_patches_route_through_masking_helpers() {
+        let p = Persona {
+            webgl: Some(WebglSpec {
+                strategy: Some(Strategy::Value),
+                unmasked_vendor: Some("Google Inc. (NVIDIA)".into()),
+                unmasked_renderer: Some("ANGLE (NVIDIA GeForce RTX 4090)".into()),
+            }),
+            canvas: Some(SurfaceCfg {
+                strategy: Some(Strategy::Seeded),
+            }),
+            webgpu: Some(SurfaceCfg {
+                strategy: Some(Strategy::Value),
+            }),
+            seed: Some(Seed::from_u64(1)),
+            ..Persona::default()
+        };
+        let s = bootstrap_script(&p, &mock_identity());
+        assert!(
+            s.contains("__zdReplace(WebGLRenderingContext.prototype, 'getParameter'")
+                || s.contains("__zdReplace(proto, 'getParameter'"),
+            "webgl routed"
+        );
+        assert!(s.contains("__zdReplace"), "canvas/getImageData routed");
+        assert!(
+            s.contains("__zdGetter(GPUAdapter.prototype, 'info'"),
+            "webgpu info getter routed"
+        );
+        // tokens still substituted, not left raw:
+        assert!(
+            !s.contains("SEED") && !s.contains("WEBGL_VENDOR"),
+            "tokens substituted"
+        );
+    }
+
+    #[test]
     fn no_unsubstituted_tokens_remain() {
         // Exercise every surface so all token-bearing patches are emitted.
         let p = Persona {

--- a/crates/zendriver-stealth/src/patches.rs
+++ b/crates/zendriver-stealth/src/patches.rs
@@ -381,9 +381,15 @@ mod tests {
     #[test]
     fn bootstrap_wraps_everything_in_outer_masking_iife() {
         let s = bootstrap_script(&Persona::default(), &mock_identity());
-        assert!(s.starts_with("(function(){"), "outer masking IIFE must be first");
+        assert!(
+            s.starts_with("(function(){"),
+            "outer masking IIFE must be first"
+        );
         // identity IIFE is now nested inside the outer one.
-        assert!(s.contains("(function(fp){"), "identity IIFE still present (nested)");
+        assert!(
+            s.contains("(function(fp){"),
+            "identity IIFE still present (nested)"
+        );
         assert!(s.trim_end().ends_with("})();"), "outer IIFE is invoked");
     }
 
@@ -731,6 +737,29 @@ mod tests {
         assert!(
             !script.contains(r#"["fr-FR","en"]"#),
             "must not hardcode en"
+        );
+    }
+
+    #[test]
+    fn identity_patches_route_through_masking_helpers() {
+        let s = bootstrap_script(&Persona::default(), &mock_identity());
+        assert!(
+            s.contains("__zdGetter(Navigator.prototype, 'webdriver'"),
+            "webdriver"
+        );
+        assert!(
+            s.contains("__zdGetter(Navigator.prototype, 'plugins'"),
+            "plugins getter"
+        );
+        assert!(
+            s.contains("__zdReplace"),
+            "permissions/codecs methods routed"
+        );
+        assert!(s.contains("__zdMark"), "value-fn members marked");
+        // No raw defineProperty getter on Navigator.prototype.webdriver remains.
+        assert!(
+            !s.contains("Object.defineProperty(Navigator.prototype, 'webdriver'"),
+            "webdriver should go through __zdGetter, not raw defineProperty"
         );
     }
 

--- a/crates/zendriver-stealth/src/patches/_native.js
+++ b/crates/zendriver-stealth/src/patches/_native.js
@@ -1,0 +1,70 @@
+// Native-function masking prelude.
+//
+// Runs FIRST inside the bootstrap's single outer IIFE (see patches.rs
+// `bootstrap_script`). Declares __zdReplace / __zdGetter / __zdMark as
+// closure-locals — they are NOT placed on globalThis, so nothing leaks to the
+// page (Object.keys / getOwnPropertyNames(window) stay clean). The only global
+// side effect is overriding Function.prototype.toString, which MUST persist
+// beyond the IIFE so page scripts that inspect patched functions see native
+// code. Because the whole bootstrap is injected via
+// Page.addScriptToEvaluateOnNewDocument (every frame), the override is
+// re-installed per realm, so cross-realm probes
+// (iframe.contentWindow.Function.prototype.toString.call(fn)) also see native.
+const __zdFnToString = Function.prototype.toString;
+const __zdMarks = new WeakMap(); // fn -> native display string
+const __zdNativeStr = (name) => "function " + name + "() { [native code] }";
+
+const __zdFakeToString = function toString() {
+  const s = __zdMarks.get(this);
+  return s !== undefined ? s : __zdFnToString.call(this);
+};
+__zdMarks.set(__zdFakeToString, __zdNativeStr("toString"));
+__zdMarks.set(__zdFnToString, __zdNativeStr("toString"));
+Object.defineProperty(Function.prototype, "toString", {
+  value: __zdFakeToString,
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+// Match a native function's own name/length shape
+// (writable:false, enumerable:false, configurable:true).
+const __zdNameLen = (fn, name, length) => {
+  Object.defineProperty(fn, "name", { value: name, configurable: true });
+  Object.defineProperty(fn, "length", { value: length, configurable: true });
+};
+
+// Mark an arbitrary function native (value-function members, constructors).
+const __zdMark = (fn, name, length) => {
+  __zdNameLen(fn, name, length);
+  __zdMarks.set(fn, __zdNativeStr(name));
+  return fn;
+};
+
+// Replace obj[prop] (a method) with make(orig), copying the original's
+// name/length and marking the result native.
+const __zdReplace = (obj, prop, make) => {
+  const orig = obj[prop];
+  const fn = make(orig);
+  const name = orig && orig.name ? orig.name : prop;
+  const length =
+    orig && typeof orig.length === "number" ? orig.length : fn.length;
+  __zdMark(fn, name, length);
+  obj[prop] = fn;
+  return fn;
+};
+
+// Define an accessor whose getter (and optional setter) report the native
+// `function get NAME() { [native code] }` form.
+const __zdGetter = (obj, prop, getFn, opts) => {
+  opts = opts || {};
+  __zdNameLen(getFn, "get " + prop, 0);
+  __zdMarks.set(getFn, "function get " + prop + "() { [native code] }");
+  const desc = { get: getFn, enumerable: !!opts.enumerable, configurable: true };
+  if (opts.setFn) {
+    __zdNameLen(opts.setFn, "set " + prop, 1);
+    __zdMarks.set(opts.setFn, "function set " + prop + "() { [native code] }");
+    desc.set = opts.setFn;
+  }
+  Object.defineProperty(obj, prop, desc);
+};

--- a/crates/zendriver-stealth/src/patches/audio.js
+++ b/crates/zendriver-stealth/src/patches/audio.js
@@ -1,18 +1,16 @@
 (function (seed) {
   if (typeof AnalyserNode === 'undefined') return;
   const rng = __zdRng(seed);
-  const orig = AnalyserNode.prototype.getFloatFrequencyData;
-  AnalyserNode.prototype.getFloatFrequencyData = function (array) {
+  __zdReplace(AnalyserNode.prototype, 'getFloatFrequencyData', (orig) => function (array) {
     orig.call(this, array);
     for (let i = 0; i < array.length; i++) array[i] += (rng() - 0.5) * 1e-4;
-  };
-  const origTime = AnalyserNode.prototype.getByteTimeDomainData;
-  if (origTime) {
-    AnalyserNode.prototype.getByteTimeDomainData = function (array) {
-      origTime.call(this, array);
+  });
+  if (AnalyserNode.prototype.getByteTimeDomainData) {
+    __zdReplace(AnalyserNode.prototype, 'getByteTimeDomainData', (orig) => function (array) {
+      orig.call(this, array);
       for (let i = 0; i < array.length; i++) {
         array[i] = Math.max(0, Math.min(255, array[i] + (rng() < 0.5 ? -1 : 1)));
       }
-    };
+    });
   }
 })(SEED);

--- a/crates/zendriver-stealth/src/patches/broken_image.js
+++ b/crates/zendriver-stealth/src/patches/broken_image.js
@@ -4,20 +4,14 @@
 const origNaturalWidth  = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'naturalWidth')?.get;
 const origNaturalHeight = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'naturalHeight')?.get;
 if (origNaturalWidth && origNaturalHeight) {
-    Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', {
-        get: function() {
+    __zdGetter(HTMLImageElement.prototype, 'naturalWidth', function() {
             const v = origNaturalWidth.call(this);
             if (v === 0 && this.complete && !this.src) return 16;
             return v;
-        },
-        configurable: true, enumerable: true,
-    });
-    Object.defineProperty(HTMLImageElement.prototype, 'naturalHeight', {
-        get: function() {
+        }, { enumerable: true });
+    __zdGetter(HTMLImageElement.prototype, 'naturalHeight', function() {
             const v = origNaturalHeight.call(this);
             if (v === 0 && this.complete && !this.src) return 16;
             return v;
-        },
-        configurable: true, enumerable: true,
-    });
+        }, { enumerable: true });
 }

--- a/crates/zendriver-stealth/src/patches/canvas.js
+++ b/crates/zendriver-stealth/src/patches/canvas.js
@@ -10,23 +10,22 @@
     return data;
   }
   const origGetImageData = CanvasRenderingContext2D.prototype.getImageData;
-  CanvasRenderingContext2D.prototype.getImageData = function (...args) {
-    const img = origGetImageData.apply(this, args);
+  __zdReplace(CanvasRenderingContext2D.prototype, 'getImageData', (orig) => function (...args) {
+    const img = orig.apply(this, args);
     farble(img.data);
     return img;
-  };
-  const origToDataURL = HTMLCanvasElement.prototype.toDataURL;
-  HTMLCanvasElement.prototype.toDataURL = function (...args) {
+  });
+  __zdReplace(HTMLCanvasElement.prototype, 'toDataURL', (orig) => function (...args) {
     const ctx = this.getContext('2d');
     if (ctx && this.width > 0 && this.height > 0) {
-      const orig = origGetImageData.call(ctx, 0, 0, this.width, this.height);
-      const copy = new ImageData(new Uint8ClampedArray(orig.data), this.width, this.height);
+      const imgData = origGetImageData.call(ctx, 0, 0, this.width, this.height);
+      const copy = new ImageData(new Uint8ClampedArray(imgData.data), this.width, this.height);
       farble(copy.data);
       ctx.putImageData(copy, 0, 0);
-      const url = origToDataURL.apply(this, args);
-      ctx.putImageData(orig, 0, 0);
+      const url = orig.apply(this, args);
+      ctx.putImageData(imgData, 0, 0);
       return url;
     }
-    return origToDataURL.apply(this, args);
-  };
+    return orig.apply(this, args);
+  });
 })(SEED);

--- a/crates/zendriver-stealth/src/patches/client_rects.js
+++ b/crates/zendriver-stealth/src/patches/client_rects.js
@@ -1,19 +1,17 @@
 (function (seed) {
   const rng = __zdRng(seed);
   function noisy(v) { return v + (rng() - 0.5) * 1e-3; }
-  const origRect = Element.prototype.getBoundingClientRect;
-  Element.prototype.getBoundingClientRect = function () {
-    const r = origRect.call(this);
+  __zdReplace(Element.prototype, 'getBoundingClientRect', (orig) => function () {
+    const r = orig.call(this);
     return new DOMRect(noisy(r.x), noisy(r.y), noisy(r.width), noisy(r.height));
-  };
-  const origRects = Element.prototype.getClientRects;
-  Element.prototype.getClientRects = function () {
-    const list = origRects.call(this);
+  });
+  __zdReplace(Element.prototype, 'getClientRects', (orig) => function () {
+    const list = orig.call(this);
     const out = [];
     for (let i = 0; i < list.length; i++) {
       const r = list[i];
       out.push(new DOMRect(noisy(r.x), noisy(r.y), noisy(r.width), noisy(r.height)));
     }
     return out;
-  };
+  });
 })(SEED);

--- a/crates/zendriver-stealth/src/patches/codecs.js
+++ b/crates/zendriver-stealth/src/patches/codecs.js
@@ -1,12 +1,11 @@
 // Headless Chromium lacks proprietary codecs. Stub canPlayType so
 // media-feature detection sees 'probably' for common containers.
-const origCanPlay = HTMLMediaElement.prototype.canPlayType;
-HTMLMediaElement.prototype.canPlayType = function(type) {
+__zdReplace(HTMLMediaElement.prototype, 'canPlayType', (orig) => function(type) {
     if (typeof type === 'string') {
         const t = type.toLowerCase();
         if (t.includes('avc1') || t.includes('mp4a.40') || t.includes('video/mp4') || t.includes('audio/mp4')) {
             return 'probably';
         }
     }
-    return origCanPlay.call(this, type);
-};
+    return orig.call(this, type);
+});

--- a/crates/zendriver-stealth/src/patches/fonts.js
+++ b/crates/zendriver-stealth/src/patches/fonts.js
@@ -1,20 +1,18 @@
 (function (allow, seed) {
   const rng = __zdRng(seed);
-  const orig = CanvasRenderingContext2D.prototype.measureText;
-  CanvasRenderingContext2D.prototype.measureText = function (text) {
+  __zdReplace(CanvasRenderingContext2D.prototype, 'measureText', (orig) => function (text) {
     const m = orig.call(this, text);
     // Sub-pixel width noise, deterministic.
     try { Object.defineProperty(m, 'width', { value: m.width + (rng() - 0.5) * 1e-3 }); }
     catch (e) {}
     return m;
-  };
+  });
   // If an allow-list is provided, hide other fonts from FontFaceSet checks.
   if (Array.isArray(allow) && document.fonts && document.fonts.check) {
-    const origCheck = document.fonts.check.bind(document.fonts);
-    document.fonts.check = function (font, text) {
+    __zdReplace(document.fonts, 'check', (origCheck) => function (font, text) {
       const fam = (font || '').split(/\s+/).pop();
       if (fam && allow.indexOf(fam.replace(/["']/g, '')) === -1) return false;
-      return origCheck(font, text);
-    };
+      return origCheck.call(document.fonts, font, text);
+    });
   }
 })(FONT_ALLOW, SEED);

--- a/crates/zendriver-stealth/src/patches/hardware.js
+++ b/crates/zendriver-stealth/src/patches/hardware.js
@@ -1,27 +1,27 @@
 (function (battery, mediaDevices, voices) {
   if (typeof battery === 'number' && navigator.getBattery) {
-    navigator.getBattery = function () {
+    __zdReplace(navigator, 'getBattery', () => function () {
       return Promise.resolve({
         level: battery, charging: true, chargingTime: 0,
         dischargingTime: Infinity,
         addEventListener() {}, removeEventListener() {},
       });
-    };
+    });
   }
   if (typeof mediaDevices === 'number' && navigator.mediaDevices &&
       navigator.mediaDevices.enumerateDevices) {
-    navigator.mediaDevices.enumerateDevices = function () {
+    __zdReplace(navigator.mediaDevices, 'enumerateDevices', () => function () {
       const out = [];
       for (let i = 0; i < mediaDevices; i++) {
         out.push({ deviceId: 'dev' + i, kind: 'audioinput', label: '', groupId: 'g' + i });
       }
       return Promise.resolve(out);
-    };
+    });
   }
   if (Array.isArray(voices) && window.speechSynthesis) {
-    speechSynthesis.getVoices = function () {
+    __zdReplace(speechSynthesis, 'getVoices', () => function () {
       return voices.map((n) => ({ name: n, lang: 'en-US', default: false,
         localService: true, voiceURI: n }));
-    };
+    });
   }
 })(HW_BATTERY, HW_MEDIA_DEVICES, HW_VOICES);

--- a/crates/zendriver-stealth/src/patches/navigator_props.js
+++ b/crates/zendriver-stealth/src/patches/navigator_props.js
@@ -1,18 +1,6 @@
 // Patch platform, hardwareConcurrency, deviceMemory, languages on Navigator.prototype.
 // `fp` is the serialized Fingerprint object passed by the bundle factory.
-Object.defineProperty(Navigator.prototype, 'platform', {
-    get: () => fp.platformJs,
-    configurable: true, enumerable: true,
-});
-Object.defineProperty(Navigator.prototype, 'hardwareConcurrency', {
-    get: () => fp.cpuCount,
-    configurable: true, enumerable: true,
-});
-Object.defineProperty(Navigator.prototype, 'deviceMemory', {
-    get: () => fp.memoryGb,
-    configurable: true, enumerable: true,
-});
-Object.defineProperty(Navigator.prototype, 'languages', {
-    get: () => fp.languages,
-    configurable: true, enumerable: true,
-});
+__zdGetter(Navigator.prototype, 'platform', () => fp.platformJs, { enumerable: true });
+__zdGetter(Navigator.prototype, 'hardwareConcurrency', () => fp.cpuCount, { enumerable: true });
+__zdGetter(Navigator.prototype, 'deviceMemory', () => fp.memoryGb, { enumerable: true });
+__zdGetter(Navigator.prototype, 'languages', () => fp.languages, { enumerable: true });

--- a/crates/zendriver-stealth/src/patches/permissions.js
+++ b/crates/zendriver-stealth/src/patches/permissions.js
@@ -2,10 +2,9 @@
 // Real Chrome: Notification.permission === 'default' AND
 //   navigator.permissions.query({name:'notifications'}).state === 'prompt'
 // Headless: mismatch — Notification.permission is 'denied' but query says 'prompt'.
-const origQuery = navigator.permissions.query.bind(navigator.permissions);
-navigator.permissions.query = function(p) {
+__zdReplace(navigator.permissions, 'query', (orig) => function(p) {
     if (p && p.name === 'notifications') {
         return Promise.resolve({ state: Notification.permission, onchange: null });
     }
-    return origQuery(p);
-};
+    return orig.call(navigator.permissions, p);
+});

--- a/crates/zendriver-stealth/src/patches/plugins.js
+++ b/crates/zendriver-stealth/src/patches/plugins.js
@@ -1,7 +1,6 @@
 // Defeats: bot.sannysoft.com `Plugins Length (Old)` row.
 // Fakes 3 plugins matching Chrome's modern stub layout.
-Object.defineProperty(Navigator.prototype, 'plugins', {
-    get: function() {
+__zdGetter(Navigator.prototype, 'plugins', function() {
         const make = (name, filename, description) => {
             const p = Object.create(Plugin.prototype);
             Object.defineProperties(p, {
@@ -19,7 +18,4 @@ Object.defineProperty(Navigator.prototype, 'plugins', {
         ];
         Object.setPrototypeOf(arr, PluginArray.prototype);
         return arr;
-    },
-    configurable: true,
-    enumerable: true,
-});
+    }, { enumerable: true });

--- a/crates/zendriver-stealth/src/patches/user_agent_data.js
+++ b/crates/zendriver-stealth/src/patches/user_agent_data.js
@@ -1,11 +1,10 @@
 // navigator.userAgentData stub — many headless detectors check this.
 // Mirrors what Emulation.setUserAgentOverride sends, but JS-readable.
-Object.defineProperty(Navigator.prototype, 'userAgentData', {
-    get: () => ({
+__zdGetter(Navigator.prototype, 'userAgentData', () => ({
         brands: fp.brands,
         mobile: false,
         platform: fp.chPlatform,
-        getHighEntropyValues: function(hints) {
+        getHighEntropyValues: __zdMark(function getHighEntropyValues(hints) {
             return Promise.resolve({
                 architecture: fp.architecture,
                 bitness: fp.bitness,
@@ -17,10 +16,8 @@ Object.defineProperty(Navigator.prototype, 'userAgentData', {
                 platformVersion: fp.platformVersion,
                 wow64: false,
             });
-        },
-        toJSON: function() {
+        }, 'getHighEntropyValues', 1),
+        toJSON: __zdMark(function toJSON() {
             return { brands: fp.brands, mobile: false, platform: fp.chPlatform };
-        }
-    }),
-    configurable: true, enumerable: true,
-});
+        }, 'toJSON', 0),
+    }), { enumerable: true });

--- a/crates/zendriver-stealth/src/patches/webdriver.js
+++ b/crates/zendriver-stealth/src/patches/webdriver.js
@@ -1,8 +1,5 @@
 // Defeats: bot.sannysoft.com `WebDriver (New)` + `WebDriver Advanced` rows.
 // Patches Navigator.prototype (not navigator directly) so
-// Object.getOwnPropertyNames(navigator) doesn't reveal the hack.
-Object.defineProperty(Navigator.prototype, 'webdriver', {
-    get: () => false,
-    configurable: true,
-    enumerable: true,
-});
+// Object.getOwnPropertyNames(navigator) doesn't reveal the hack. Routed through
+// __zdGetter so the getter reports `function get webdriver() { [native code] }`.
+__zdGetter(Navigator.prototype, 'webdriver', () => false, { enumerable: true });

--- a/crates/zendriver-stealth/src/patches/webgl.js
+++ b/crates/zendriver-stealth/src/patches/webgl.js
@@ -1,27 +1,23 @@
 // Defeats: bot.sannysoft.com `WebGL Vendor` + `WebGL Renderer` rows.
-// Headless reports vendor="Brian Paul" / renderer="Mesa OffScreen" or SwiftShader.
-// Spoof to common Intel desktop values matching the fingerprint platform.
 const VENDOR = 'Google Inc. (Intel)';
 const RENDERER = 'ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)';
 [WebGLRenderingContext.prototype, WebGL2RenderingContext.prototype].forEach(proto => {
-    const orig = proto.getParameter;
-    proto.getParameter = function(param) {
+    __zdReplace(proto, 'getParameter', (orig) => function(param) {
         if (param === 37445) return VENDOR;    // UNMASKED_VENDOR_WEBGL
         if (param === 37446) return RENDERER;  // UNMASKED_RENDERER_WEBGL
         return orig.call(this, param);
-    };
+    });
 });
 
-// Persona-driven value substitution (B9 substitutes WEBGL_VENDOR / WEBGL_RENDERER tokens).
+// Persona-driven value substitution (WEBGL_VENDOR / WEBGL_RENDERER tokens).
 (function (vendor, renderer) {
   const VENDOR = 0x9245, RENDERER = 0x9246; // UNMASKED_VENDOR_WEBGL / RENDERER
   function patch(proto) {
-    const orig = proto.getParameter;
-    proto.getParameter = function (p) {
+    __zdReplace(proto, 'getParameter', (orig) => function (p) {
       if (vendor && p === VENDOR) return vendor;
       if (renderer && p === RENDERER) return renderer;
       return orig.call(this, p);
-    };
+    });
   }
   if (window.WebGLRenderingContext) patch(WebGLRenderingContext.prototype);
   if (window.WebGL2RenderingContext) patch(WebGL2RenderingContext.prototype);

--- a/crates/zendriver-stealth/src/patches/webgpu.js
+++ b/crates/zendriver-stealth/src/patches/webgpu.js
@@ -16,7 +16,7 @@
 (function (vendor, architecture, mode) {
   if (!('gpu' in navigator)) return;
   if (mode === 'block') {
-    try { Object.defineProperty(navigator, 'gpu', { get: function () { return undefined; }, configurable: true }); } catch (e) {}
+    try { __zdGetter(navigator, 'gpu', function () { return undefined; }, { enumerable: false }); } catch (e) {}
     return;
   }
   if (vendor === null) return;
@@ -25,11 +25,7 @@
   try {
     var d = Object.getOwnPropertyDescriptor(GPUAdapter.prototype, 'info');
     if (d && typeof d.get === 'function') {
-      Object.defineProperty(GPUAdapter.prototype, 'info', {
-        get: function () { return info; },
-        configurable: true,
-        enumerable: d.enumerable,
-      });
+      __zdGetter(GPUAdapter.prototype, 'info', function () { return info; }, { enumerable: d.enumerable });
     }
   } catch (e) {}
 })(WEBGPU_VENDOR, WEBGPU_ARCHITECTURE, WEBGPU_MODE);

--- a/crates/zendriver-stealth/src/patches/webrtc.js
+++ b/crates/zendriver-stealth/src/patches/webrtc.js
@@ -3,10 +3,10 @@
   if (policy === 'native') return;
   const RTC = window.RTCPeerConnection || window.webkitRTCPeerConnection;
   if (!RTC) return;
-  window.RTCPeerConnection = function (cfg, ...rest) {
+  window.RTCPeerConnection = __zdMark(function RTCPeerConnection(cfg, ...rest) {
     const pc = new RTC(cfg, ...rest);
     const origAdd = pc.addEventListener.bind(pc);
-    pc.addEventListener = function (type, cb, ...a) {
+    pc.addEventListener = __zdMark(function addEventListener(type, cb, ...a) {
       if (type === 'icecandidate') {
         const wrapped = function (e) {
           if (policy === 'block' && e && e.candidate) return; // drop local IPs
@@ -20,8 +20,8 @@
         return origAdd(type, wrapped, ...a);
       }
       return origAdd(type, cb, ...a);
-    };
+    }, 'addEventListener', 2);
     return pc;
-  };
+  }, 'RTCPeerConnection', 0);
   window.RTCPeerConnection.prototype = RTC.prototype;
 })(WEBRTC_POLICY, WEBRTC_FAKE_IP);

--- a/crates/zendriver/tests/stealth_native_masking.rs
+++ b/crates/zendriver/tests/stealth_native_masking.rs
@@ -1,0 +1,93 @@
+//! Headful integration: spoofed-profile patches must report as native code.
+//!
+//! Run with:
+//! ```sh
+//! cargo test -p zendriver --test stealth_native_masking \
+//!     --features integration-tests -- --ignored
+//! ```
+#![cfg(feature = "integration-tests")]
+
+use serial_test::serial;
+use zendriver::Browser;
+use zendriver::{Persona, Seed};
+
+// Probes the most-checked patched method + a getter + the toString override
+// itself, returning a JSON blob the Rust side asserts on.
+const PROBE_JS: &str = r#"(() => {
+    const gp = WebGLRenderingContext.prototype.getParameter;
+    const wd = Object.getOwnPropertyDescriptor(Navigator.prototype, 'webdriver').get;
+    return JSON.stringify({
+        gpStr: gp.toString(),
+        gpName: gp.name,
+        gpLen: gp.length,
+        wdStr: wd.toString(),
+        ftsStr: Function.prototype.toString.toString(),
+    });
+})()"#;
+
+// Cross-realm: a child frame's Function.prototype.toString must also mask the
+// parent's patched method (validates per-frame bootstrap injection).
+const CROSS_FRAME_JS: &str = r#"(() => {
+    const f = document.createElement('iframe');
+    document.body.appendChild(f);
+    const cwToString = f.contentWindow.Function.prototype.toString;
+    const out = cwToString.call(WebGLRenderingContext.prototype.getParameter);
+    f.remove();
+    return out;
+})()"#;
+
+#[tokio::test]
+#[serial]
+#[ignore] // run with: cargo test ... -- --ignored
+async fn patched_functions_report_native_code() {
+    let browser = Browser::builder()
+        .persona(Persona::builder().seed(Seed::from_u64(42)).build())
+        .launch()
+        .await
+        .unwrap();
+    let tab = browser.main_tab();
+    tab.goto("about:blank").await.unwrap();
+    tab.wait_for_load().await.unwrap();
+
+    let raw: String = tab.evaluate::<String>(PROBE_JS).await.unwrap();
+    let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+
+    assert!(
+        v["gpStr"].as_str().unwrap().contains("[native code]"),
+        "getParameter.toString() must read native: {raw}"
+    );
+    assert_eq!(v["gpName"], "getParameter", "name must match native");
+    assert_eq!(v["gpLen"], 1, "length must match native");
+    assert_eq!(
+        v["wdStr"], "function get webdriver() { [native code] }",
+        "webdriver getter must read native getter form"
+    );
+    assert!(
+        v["ftsStr"].as_str().unwrap().contains("[native code]"),
+        "Function.prototype.toString must mask itself"
+    );
+
+    browser.close().await.unwrap();
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn masking_holds_cross_realm() {
+    let browser = Browser::builder()
+        .persona(Persona::builder().seed(Seed::from_u64(7)).build())
+        .launch()
+        .await
+        .unwrap();
+    let tab = browser.main_tab();
+    tab.goto("about:blank").await.unwrap();
+    tab.wait_for_load().await.unwrap();
+
+    let cross: String = tab.evaluate::<String>(CROSS_FRAME_JS).await.unwrap();
+    assert!(
+        cross.contains("[native code]"),
+        "cross-realm toString must mask the parent's patched fn: {cross}"
+    );
+
+    browser.close().await.unwrap();
+}

--- a/docs/superpowers/deferred-backlog.md
+++ b/docs/superpowers/deferred-backlog.md
@@ -1,0 +1,98 @@
+# zendriver-rs — Deferred / Never-Got-Around-To Backlog
+
+> **Snapshot:** 2026-06-03. Point-in-time scan of `docs/superpowers/{specs,plans}/`, the mdBook (`docs/book/src/`), all crate code + tests, and `crates/zendriver-mcp/mcp-coverage-ledger.toml`. Statuses verified against shipped code/git as of this date — re-verify before acting on any item (a file/line/flag named here may have moved).
+>
+> **Method (to regenerate):** grep specs/plans for deferral language (`deferred`, `out of scope`, `later`, `follow-up`, `future`, `not yet`, `for now`, `Option B`, `post-1.0`, `TODO`, unchecked `- [ ]` that aren't TDD steps) + code for `TODO`/`FIXME`/`todo!()`/`#[ignore]`/`#[allow(dead_code)]`/prose deferrals + the MCP ledger `excluded` entries. Cross-check each against shipped code.
+>
+> **Already being handled (excluded from the tail below):**
+> - **#1 native-function `toString` masking** → PR [#49](https://github.com/TurtIeSocks/zendriver-rs/pull/49) (in review).
+> - **#2 tracker/fingerprinter blocklist** → handoff doc `docs/superpowers/plans/2026-06-03-tracker-blocklist-handoff.md`.
+>
+> **Big picture:** the 6-phase port + parity A–E + fingerprints PR2 + MCP all shipped; most "deferred to phase N" items were since built. The genuine remaining tail is small and concentrated in stealth depth + a few convenience/limitation tails.
+
+Legend: 🔧 actionable tail · 🎯 intentional non-goal (recorded decision — *not* a gap) · 🧹 cleanup / stale-doc / code-residue · ❓ status unverified
+
+---
+
+## §1 — 🔧 Genuine tail (actionable; "never got around to it")
+
+### Stealth / anti-detection
+- **DataDome native slider/puzzle solving** (image-diff gap + Bézier drag). v1 delegates to an opt-in solver callback. — `2026-06-02-datadome-bypass-design.md:371`
+- **DataDome `cookie_domain` public-suffix-list.** Multi-label TLDs (`co.uk`) fail; v1 accepts the limitation. — `crates/zendriver-datadome/src/captcha.rs:184`, `datadome plan:1000`
+- **WebGPU full-adapter fabrication when the host has no GPU.** v1 only decorates a real adapter's `.info`. — `datadome plan:1597`
+- **Sec-CH-UA for non-Chrome browsers** (Brave/Edge/Vivaldi); "post-1.0". — `2026-05-23-...-phase2-stealth-design.md:35`
+
+### Fingerprints
+- **`TODO(#25)` real pool release-asset URL** still a placeholder (pool sampling errors until the dataset is hosted). — `crates/zendriver-mcp/src/tools/fingerprints.rs:42`, `gen-bn plan:876`
+- **Mobile personas** (desktop-only today). — `fingerprint:51`, `gen-bn:180`
+- **Auto-refreshing pool on a schedule** + `force_refresh` / cache-TTL knob. — `fingerprint:52`, `gen-bn:103`
+- **Full attribute-coverage expansion** (screen metrics, navigator extras) + matching Persona/JS-patch growth. — `gen-bn:332`
+
+### Geo / locale
+- **timezone-from-geo derivation** (country → IANA tz, sharing the `geo` module). — `2026-06-03-geo-ip-locale-design.md:42`
+- **Auto IP-geo resolution / Option B exit-IP probe** (only the `GeoResolver` seam ships; `geo_locale` needs an explicit country). — `geo plan:1299`, `crates/zendriver-stealth/src/geo/mod.rs:54`
+
+### Network / cookies / tabs / frames
+- **Transparent handle-preserving reconnect** (session-id remap so live `Tab` handles survive) + feature re-arm. v1 invalidates handles; re-acquire via `main_tab()`/`tabs()`. — `parity-D:58`, `crates/zendriver/src/browser.rs:2715`
+- **`partition_key` as a structured object** (currently a flat `String` top-level-site). — `crates/zendriver/src/cookies/mod.rs:157`
+- **Streaming response bodies** (monitor + HTTP `request()`); needs a Fetch-interception path. — `network-monitor:200`
+- **OOPIF bootstrap placeholder Frame** — `crates/zendriver/src/browser.rs:3979,3988` (known limitation around out-of-process iframes).
+- **Frame-session follow-up:** `Runtime.evaluate` should run on the Frame's own session. — `crates/zendriver/src/query/mod.rs:1873`
+
+### Elements / input
+- **`visible_only` find filter is a NO-OP** pending `actionability::check_visible` (`TODO(T16)`; MCP passes the bool through). — `crates/zendriver/src/query/mod.rs:901,1276`
+- **Button-triggered file pickers** via `Page.fileChooserOpened`; today only direct `<input type=file>`. — `phase3:798`
+- **Case-insensitive matchers** (`[a="v" i]`, lowercased text compare). — `find-dom:152`
+- **Custom mouse pressure / pen / touch input.** — `phase3:38`
+- **Cross-tab drag-and-drop.** — `phase4:35`
+
+### Launch / context / fetcher
+- **Per-context proxy auth** (auth is browser-wide today). — `book/browser-context.md:73`
+- **Fetcher Beta/Dev/Canary channels not wired** (treated as Latest). — `crates/zendriver-fetcher/src/version.rs:13,26`
+
+### MCP surface
+- **Element-scoped find over MCP** (low demand). — `mcp-coverage-ledger.toml:159`
+- **Interception `Stream` escape-hatch over MCP** (needs server-side event buffering + backpressure). — `mcp-server:533`
+- **Per-action `version` accessor not exposed.** — `crates/zendriver-mcp/src/tools/lifecycle.rs:54`
+- **Intercept `method` / `post-data` reserved for follow-up.** — `crates/zendriver-mcp/src/tools/intercept.rs:30`
+- **Tab-scoped expectations/rules leak** until manual cancel/close (v0 limitation). — `crates/zendriver-mcp/src/tools/tabs.rs:244`, `crates/zendriver-mcp/src/server.rs:224`
+
+---
+
+## §2 — 🎯 Intentional non-goals (recorded decisions — do not mistake for gaps)
+
+- **bot.incolumitas behavioral-score / TCP-fingerprint / TLS-JA3 evasion** — needs proxy + TLS-stack control outside the workspace. — `phase2-stealth:30`
+- **Active reese84 token synthesis** — belongs in a separate out-of-workspace `imperva-sensor-rs`. — `imperva:27`
+- **Forging the DataDome device-check payload** (mint cookie out-of-browser) — extremely brittle. — `datadome:374`
+- **Container GPU support** (Vulkan/GLES, Windows image) — belongs in `zendriver-docker`. — `datadome:375`
+- **MCP `on_captcha` solver callback** — agents handle `CaptchaRequired` out-of-band. — `datadome:377`
+- **SOCKS5 proxy forwarder** — matches zendriver-py's own drop. — `parity-C:138`
+- **Real-device-data collection pipeline** — ship a curated asset, not a scraper. — `fingerprint:50`
+- **OCR helpers** (tesseract/easyocr) — pair with an external crate. — `migration:196`
+- **Widevine / DRM playback** — vanilla Chrome ships no CDM. — `migration:201`
+- **Trace viewer / video recording** — integrate externally. — `migration-playwright:177`
+- **Selenium-WebDriver drop-in API** — explicit non-goal since P1. — `phase5:31`
+- **`browser.get(url)` shorthand / `find(text, best_match=True)` fuzzy match** — deliberate API split; use `main_tab()`+`goto` / `text_regex`. — `migration docs`
+
+---
+
+## §3 — 🧹 Cleanup / stale-doc / code-residue
+
+- **Migration docs are stale.** "Known gaps in v0.1.0" still lists canvas/WebGL/font/audio fingerprint spoofing + browserforge integration as "not yet" — **all shipped**. Fix `docs/book/src/migration-zendriver-python.md:184+` and `migration-nodriver-python.md:233+`.
+- **~40 `#[allow(dead_code)]`** referencing tasks (T12/T15/T17/T23, etc.) that mostly shipped. Audit: stale allows to remove, or genuinely-unused code. Concentrated in `crates/zendriver/src/query/selectors.rs`, `query/actionability.rs`, `input/*`, `element/mod.rs`, `zendriver-fetcher/src/manifest.rs`.
+- **38 `#[ignore]` integration tests** (need real Chrome / `--ignored`). Confirm a CI job actually runs them on a Chrome runner; otherwise they're silently rotting. (The new `stealth_native_masking.rs` from PR #49 joins this set.)
+- **`TODO(P5)` re-enable per-tab dialog-routing override.** — `crates/zendriver/tests/integration_phase5.rs:215`
+- **Imperva demo-site list `TODO`** (no stable public demo). — `crates/zendriver/tests/imperva_v0.rs:7`
+- **Example placeholders:** `cloudflare_bypass.rs:13` ("not yet clicked; single raw left-click"), `imperva_bypass.rs:5` (placeholder URL — set `IMPERVA_TEST_URL`).
+
+---
+
+## §4 — ❓ Status unverified (couldn't confirm done/open quickly)
+
+- **`chromiumoxide_cdp` typed-Command migration** (P1 deferred raw-JSON → typed `Command`; many calls may still be raw). — `phase1 plan:4027`
+- **Nightly real-Chrome anti-detection CI** (sannysoft / areyouheadless) — does the job exist? — `phase2:12`
+- **Imperva fast-path interception integration test** (deferred to nightly). — `imperva plan:2197`
+
+---
+
+*Generated as a session artifact during the obscura-comparison / stealth-features work on 2026-06-03. Not a spec or plan — a tracking snapshot. Update or delete as items close.*

--- a/docs/superpowers/plans/2026-06-03-stealth-tostring-masking.md
+++ b/docs/superpowers/plans/2026-06-03-stealth-tostring-masking.md
@@ -1,0 +1,581 @@
+# Native-function `toString` masking — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every function/getter the spoofed stealth bootstrap installs report as native (`[native code]`, correct `.name`/`.length`, `function get NAME()` form for accessors) in every frame, defeating `Function.prototype.toString` / `.name` fingerprinting.
+
+**Architecture:** Add one JS prelude (`patches/_native.js`) that overrides `Function.prototype.toString` against a closure-private `WeakMap` and exposes three closure-local helpers (`__zdReplace`, `__zdGetter`, `__zdMark`). Wrap the whole bootstrap in a single outer IIFE so the helpers are in scope for every patch but never leak to `globalThis`. Route all 16 patch files' mutation sites through the helpers. Cross-realm coverage is free because the bootstrap is injected into every frame via `Page.addScriptToEvaluateOnNewDocument`.
+
+**Tech Stack:** Rust (`zendriver-stealth` bootstrap assembly + unit tests), JavaScript (injected patches), `zendriver` integration test against real Chrome (CDP).
+
+**Spec:** `docs/superpowers/specs/2026-06-03-stealth-tostring-masking-tracker-blocklist-design.md` §3.
+
+**Scope:** spoofed profile only. No public API or MCP surface added.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `crates/zendriver-stealth/src/patches/_native.js` | The masking prelude: toString override + `__zdReplace`/`__zdGetter`/`__zdMark` | **Create** |
+| `crates/zendriver-stealth/src/patches.rs` | Bootstrap assembly: add `NATIVE` const, wrap in outer IIFE, unit tests | Modify |
+| `crates/zendriver-stealth/src/patches/{webdriver,navigator_props,plugins,permissions,codecs,user_agent_data,broken_image}.js` | Identity patches | Modify (route through helpers) |
+| `crates/zendriver-stealth/src/patches/{webgl,canvas,audio,client_rects,fonts,hardware,webrtc,webgpu}.js` | Surface patches | Modify (route through helpers) |
+| `crates/zendriver/tests/stealth_native_masking.rs` | Real-Chrome assertions (`#[ignore]`) | **Create** |
+
+`chrome.js` and `_prng.js` have no function/getter mutation sites — leave them unchanged.
+
+## The mechanical transform (applies in Tasks 2–3)
+
+Three site kinds, three transforms. **Bodies are unchanged** — only the call wrapping each site changes:
+
+1. **METHOD** — `Proto.prototype.foo = function(args){ BODY }`
+   becomes
+   `__zdReplace(Proto.prototype, 'foo', (orig) => function(args){ BODY });`
+   (if the body calls the original, it already captured it as a local `const orig = ...`; reuse the `orig` parameter the factory provides and delete the now-redundant local capture).
+
+2. **GETTER** — `Object.defineProperty(Obj, 'p', { get: GETFN, enumerable: E, configurable: true })`
+   becomes
+   `__zdGetter(Obj, 'p', GETFN, { enumerable: E });`
+   (preserve each site's original `enumerable` value).
+
+3. **VALUE_FN / CTOR** — a function value or constructor reachable from the page (object-literal members, dynamically-created methods, a wrapper constructor)
+   becomes
+   `__zdMark(function NAME(args){ BODY }, 'NAME', LENGTH)` in place of the bare function expression
+   (`LENGTH` = the declared parameter count Chrome reports for that native; use the obvious arity).
+
+Helper reference (defined in `_native.js`):
+- `__zdReplace(obj, prop, make)` → installs `make(orig)`, copies `orig.name`/`orig.length`, marks native.
+- `__zdGetter(obj, prop, getFn, { enumerable, setFn })` → accessor whose getter/setter read `function get/set NAME() { [native code] }`.
+- `__zdMark(fn, name, length)` → marks an arbitrary fn native with the given name/length; returns `fn`.
+
+---
+
+## Task 1: Masking prelude + outer-IIFE assembly
+
+**Files:**
+- Create: `crates/zendriver-stealth/src/patches/_native.js`
+- Modify: `crates/zendriver-stealth/src/patches.rs` (add `NATIVE` const at the top with the other `include_str!`s; rewrite `bootstrap_script` to wrap in an outer IIFE; update the IIFE-shape test; add prelude tests)
+- Test: `crates/zendriver-stealth/src/patches.rs` (inline `#[cfg(test)]` module)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `tests` module in `patches.rs`:
+
+```rust
+#[test]
+fn bootstrap_installs_native_masking_prelude() {
+    let s = bootstrap_script(&Persona::default(), &mock_identity());
+    assert!(s.contains("__zdReplace"), "replace helper missing");
+    assert!(s.contains("__zdGetter"), "getter helper missing");
+    assert!(s.contains("__zdMark"), "mark helper missing");
+    assert!(
+        s.contains("Function.prototype, \"toString\""),
+        "toString override missing"
+    );
+}
+
+#[test]
+fn bootstrap_wraps_everything_in_outer_masking_iife() {
+    let s = bootstrap_script(&Persona::default(), &mock_identity());
+    assert!(s.starts_with("(function(){"), "outer masking IIFE must be first");
+    // identity IIFE is now nested inside the outer one.
+    assert!(s.contains("(function(fp){"), "identity IIFE still present (nested)");
+    assert!(s.trim_end().ends_with("})();"), "outer IIFE is invoked");
+}
+```
+
+Also **replace** the existing `bootstrap_is_an_iife_taking_fp` test body (it currently asserts `s.starts_with("(function(fp){")`, which the wrap breaks):
+
+```rust
+#[test]
+fn bootstrap_is_an_iife_taking_fp() {
+    let s = bootstrap_script(&Persona::default(), &mock_identity());
+    // The identity patches still run inside `(function(fp){…})({…})`, now
+    // nested within the outer masking IIFE.
+    assert!(s.contains("(function(fp){"));
+    assert!(s.contains("})({"), "fp arg JSON should follow");
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p zendriver-stealth patches:: --lib`
+Expected: FAIL — `bootstrap_installs_native_masking_prelude` / `bootstrap_wraps_everything_in_outer_masking_iife` fail (no prelude / wrong prefix).
+
+- [ ] **Step 3: Create the prelude `patches/_native.js`**
+
+```js
+// Native-function masking prelude.
+//
+// Runs FIRST inside the bootstrap's single outer IIFE (see patches.rs
+// `bootstrap_script`). Declares __zdReplace / __zdGetter / __zdMark as
+// closure-locals — they are NOT placed on globalThis, so nothing leaks to the
+// page (Object.keys / getOwnPropertyNames(window) stay clean). The only global
+// side effect is overriding Function.prototype.toString, which MUST persist
+// beyond the IIFE so page scripts that inspect patched functions see native
+// code. Because the whole bootstrap is injected via
+// Page.addScriptToEvaluateOnNewDocument (every frame), the override is
+// re-installed per realm, so cross-realm probes
+// (iframe.contentWindow.Function.prototype.toString.call(fn)) also see native.
+const __zdFnToString = Function.prototype.toString;
+const __zdMarks = new WeakMap(); // fn -> native display string
+const __zdNativeStr = (name) => "function " + name + "() { [native code] }";
+
+const __zdFakeToString = function toString() {
+  const s = __zdMarks.get(this);
+  return s !== undefined ? s : __zdFnToString.call(this);
+};
+__zdMarks.set(__zdFakeToString, __zdNativeStr("toString"));
+__zdMarks.set(__zdFnToString, __zdNativeStr("toString"));
+Object.defineProperty(Function.prototype, "toString", {
+  value: __zdFakeToString,
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+// Match a native function's own name/length shape
+// (writable:false, enumerable:false, configurable:true).
+const __zdNameLen = (fn, name, length) => {
+  Object.defineProperty(fn, "name", { value: name, configurable: true });
+  Object.defineProperty(fn, "length", { value: length, configurable: true });
+};
+
+// Mark an arbitrary function native (value-function members, constructors).
+const __zdMark = (fn, name, length) => {
+  __zdNameLen(fn, name, length);
+  __zdMarks.set(fn, __zdNativeStr(name));
+  return fn;
+};
+
+// Replace obj[prop] (a method) with make(orig), copying the original's
+// name/length and marking the result native.
+const __zdReplace = (obj, prop, make) => {
+  const orig = obj[prop];
+  const fn = make(orig);
+  const name = orig && orig.name ? orig.name : prop;
+  const length =
+    orig && typeof orig.length === "number" ? orig.length : fn.length;
+  __zdMark(fn, name, length);
+  obj[prop] = fn;
+  return fn;
+};
+
+// Define an accessor whose getter (and optional setter) report the native
+// `function get NAME() { [native code] }` form.
+const __zdGetter = (obj, prop, getFn, opts) => {
+  opts = opts || {};
+  __zdNameLen(getFn, "get " + prop, 0);
+  __zdMarks.set(getFn, "function get " + prop + "() { [native code] }");
+  const desc = { get: getFn, enumerable: !!opts.enumerable, configurable: true };
+  if (opts.setFn) {
+    __zdNameLen(opts.setFn, "set " + prop, 1);
+    __zdMarks.set(opts.setFn, "function set " + prop + "() { [native code] }");
+    desc.set = opts.setFn;
+  }
+  Object.defineProperty(obj, prop, desc);
+};
+```
+
+- [ ] **Step 4: Wire the prelude + outer IIFE in `patches.rs`**
+
+Add the const alongside the other identity `include_str!`s (after line 25):
+
+```rust
+// --- Native-function masking prelude (runs first, wraps everything) ------
+const NATIVE: &str = include_str!("patches/_native.js");
+```
+
+Rewrite `bootstrap_script` so the prelude is first and the whole script is one outer IIFE. Build into a `body` string, then wrap:
+
+```rust
+#[must_use]
+pub fn bootstrap_script(persona: &Persona, identity: &Fingerprint) -> String {
+    // Prelude first: installs the toString override + closure-local helpers
+    // that every patch below routes through.
+    let mut body = String::from(NATIVE);
+    body.push('\n');
+    body.push_str(&identity_iife(persona, identity));
+
+    let seed = persona.seed.unwrap_or_else(Seed::random).value();
+
+    body.push('\n');
+    body.push_str(PRNG);
+
+    push_noise(&mut body, Surface::Canvas, persona.canvas.as_ref(), CANVAS, seed);
+    push_noise(&mut body, Surface::Audio, persona.audio.as_ref(), AUDIO, seed);
+    push_noise(&mut body, Surface::ClientRects, persona.client_rects.as_ref(), CLIENT_RECTS, seed);
+
+    push_webgl(&mut body, persona.webgl.as_ref());
+    push_webgpu(&mut body, persona.webgpu.as_ref(), persona.webgl.as_ref());
+    push_fonts(&mut body, persona.fonts.as_ref(), seed);
+    push_hardware(&mut body, persona.hardware.as_ref());
+    push_webrtc(&mut body, persona.webrtc.as_ref());
+
+    // Single outer IIFE: helpers stay closure-local (no globalThis leak); the
+    // Function.prototype.toString override inside still persists globally.
+    format!("(function(){{\n{body}\n}})();")
+}
+```
+
+(The `push_*` helpers are unchanged — they already append to the `&mut String` they're given.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p zendriver-stealth patches:: --lib`
+Expected: PASS — all prelude/IIFE tests green, and the existing identity/surface/token tests still pass (wrapping is behavior-preserving; tokens untouched).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/zendriver-stealth/src/patches/_native.js crates/zendriver-stealth/src/patches.rs
+git commit -m "feat(stealth): native-function toString masking prelude + outer IIFE"
+```
+
+---
+
+## Task 2: Route identity patches through the helpers
+
+Apply the mechanical transform (top of plan) to each identity patch. **chrome.js has no sites — skip it.**
+
+**Files (modify):** `webdriver.js`, `navigator_props.js`, `plugins.js`, `permissions.js`, `codecs.js`, `user_agent_data.js`, `broken_image.js`
+**Test:** `crates/zendriver-stealth/src/patches.rs` (inline tests)
+
+Per-file sites:
+
+| File:line | Kind | Target | Helper |
+|-----------|------|--------|--------|
+| `webdriver.js:4` | GETTER | `Navigator.prototype.webdriver` (enumerable: true) | `__zdGetter` |
+| `navigator_props.js:3` | GETTER | `Navigator.prototype.platform` | `__zdGetter` |
+| `navigator_props.js:7` | GETTER | `Navigator.prototype.hardwareConcurrency` | `__zdGetter` |
+| `navigator_props.js:11` | GETTER | `Navigator.prototype.deviceMemory` | `__zdGetter` |
+| `navigator_props.js:15` | GETTER | `Navigator.prototype.languages` | `__zdGetter` |
+| `plugins.js:3` | GETTER | `Navigator.prototype.plugins` | `__zdGetter` |
+| `plugins.js:4,20` | VALUE_FN | Plugin members + `PluginArray` `item`/`namedItem`/`refresh` | `__zdMark` |
+| `permissions.js:6` | METHOD | `navigator.permissions.query` | `__zdReplace` |
+| `codecs.js:4` | METHOD | `HTMLMediaElement.prototype.canPlayType` | `__zdReplace` |
+| `user_agent_data.js:3` | GETTER | `Navigator.prototype.userAgentData` | `__zdGetter` |
+| `user_agent_data.js:8,21` | VALUE_FN | `getHighEntropyValues`, `toJSON` | `__zdMark` |
+| `broken_image.js:7,15` | GETTER | `HTMLImageElement.prototype.naturalWidth`/`naturalHeight` | `__zdGetter` |
+
+- [ ] **Step 1: Write the failing routing assertions**
+
+Add to the `patches.rs` tests module:
+
+```rust
+#[test]
+fn identity_patches_route_through_masking_helpers() {
+    let s = bootstrap_script(&Persona::default(), &mock_identity());
+    assert!(s.contains("__zdGetter(Navigator.prototype, 'webdriver'"), "webdriver");
+    assert!(s.contains("__zdGetter(Navigator.prototype, 'plugins'"), "plugins getter");
+    assert!(s.contains("__zdReplace"), "permissions/codecs methods routed");
+    assert!(s.contains("__zdMark"), "value-fn members marked");
+    // No raw defineProperty getter on Navigator.prototype.webdriver remains.
+    assert!(
+        !s.contains("Object.defineProperty(Navigator.prototype, 'webdriver'"),
+        "webdriver should go through __zdGetter, not raw defineProperty"
+    );
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p zendriver-stealth patches::tests::identity_patches_route_through_masking_helpers --lib`
+Expected: FAIL (patches still use raw `defineProperty`/assignment).
+
+- [ ] **Step 3: Edit each identity patch file**
+
+Worked example — **`webdriver.js`** in full:
+
+```js
+// Defeats: bot.sannysoft.com `WebDriver (New)` + `WebDriver Advanced` rows.
+// Patches Navigator.prototype (not navigator directly) so
+// Object.getOwnPropertyNames(navigator) doesn't reveal the hack. Routed through
+// __zdGetter so the getter reports `function get webdriver() { [native code] }`.
+__zdGetter(Navigator.prototype, 'webdriver', () => false, { enumerable: true });
+```
+
+Worked example — a **VALUE_FN** member (pattern for `user_agent_data.js` `getHighEntropyValues`, `plugins.js` array methods): wrap the function expression in `__zdMark(fn, 'name', length)`, e.g.
+
+```js
+// before:  getHighEntropyValues: function (hints) { /* BODY */ },
+// after:
+getHighEntropyValues: __zdMark(function getHighEntropyValues(hints) { /* BODY */ }, 'getHighEntropyValues', 1),
+```
+
+For the remaining files, read each and apply the transform from the table — **the function/getter bodies stay identical**; only the wrapping call changes (`Object.defineProperty(O,'p',{get,enumerable:E})` → `__zdGetter(O,'p',get,{enumerable:E})`; `O.p = function`→`__zdReplace`; bare value functions → `__zdMark`). Preserve each getter's original `enumerable` flag.
+
+- [ ] **Step 4: Run the routing + existing identity tests**
+
+Run: `cargo test -p zendriver-stealth patches:: --lib`
+Expected: PASS — routing assertion green; existing identity tests (`bootstrap_includes_all_nine_patches`, `persona_overrides_simple_identity_fields`, `navigator_languages_derives_base_lang_not_en`, etc.) still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/zendriver-stealth/src/patches/
+git commit -m "feat(stealth): route identity patches through native-masking helpers"
+```
+
+---
+
+## Task 3: Route surface patches through the helpers
+
+Same transform for the persona surfaces. **Preserve all `SEED` / `WEBGL_*` / `FONT_ALLOW` / `HW_*` / `WEBGPU_*` token placeholders verbatim** — `patches.rs` substitutes them.
+
+**Files (modify):** `webgl.js`, `canvas.js`, `audio.js`, `client_rects.js`, `fonts.js`, `hardware.js`, `webrtc.js`, `webgpu.js`
+
+| File:line | Kind | Target | Helper | Tokens |
+|-----------|------|--------|--------|--------|
+| `webgl.js:8,20` | METHOD | `WebGL{,2}RenderingContext.prototype.getParameter` (both blocks) | `__zdReplace` | WEBGL_VENDOR, WEBGL_RENDERER |
+| `canvas.js:13,19` | METHOD | `CanvasRenderingContext2D.prototype.getImageData`, `HTMLCanvasElement.prototype.toDataURL` | `__zdReplace` | SEED |
+| `audio.js:5,11` | METHOD | `AnalyserNode.prototype.getFloatFrequencyData`/`getByteTimeDomainData` | `__zdReplace` | SEED |
+| `client_rects.js:5,10` | METHOD | `Element.prototype.getBoundingClientRect`/`getClientRects` | `__zdReplace` | SEED |
+| `fonts.js:4,14` | METHOD | `CanvasRenderingContext2D.prototype.measureText`, `document.fonts.check` | `__zdReplace` | FONT_ALLOW, SEED |
+| `hardware.js:3,13,22` | METHOD | `navigator.getBattery`, `navigator.mediaDevices.enumerateDevices`, `speechSynthesis.getVoices` | `__zdReplace` | HW_BATTERY, HW_MEDIA_DEVICES, HW_VOICES |
+| `webrtc.js:6,9` | CTOR + METHOD | `window.RTCPeerConnection` (ctor), `pc.addEventListener` (instance) | `__zdMark` | WEBRTC_POLICY, WEBRTC_FAKE_IP |
+| `webgpu.js:19,28` | GETTER | `navigator.gpu` (block mode), `GPUAdapter.prototype.info` | `__zdGetter` | WEBGPU_VENDOR, WEBGPU_ARCHITECTURE, WEBGPU_MODE |
+
+- [ ] **Step 1: Write the failing routing assertion**
+
+```rust
+#[test]
+fn surface_patches_route_through_masking_helpers() {
+    let p = Persona {
+        webgl: Some(WebglSpec {
+            strategy: Some(Strategy::Value),
+            unmasked_vendor: Some("Google Inc. (NVIDIA)".into()),
+            unmasked_renderer: Some("ANGLE (NVIDIA GeForce RTX 4090)".into()),
+        }),
+        canvas: Some(SurfaceCfg { strategy: Some(Strategy::Seeded) }),
+        webgpu: Some(SurfaceCfg { strategy: Some(Strategy::Value) }),
+        seed: Some(Seed::from_u64(1)),
+        ..Persona::default()
+    };
+    let s = bootstrap_script(&p, &mock_identity());
+    assert!(s.contains("__zdReplace(WebGLRenderingContext.prototype, 'getParameter'") ||
+            s.contains("__zdReplace(proto, 'getParameter'"), "webgl routed");
+    assert!(s.contains("__zdReplace"), "canvas/getImageData routed");
+    assert!(s.contains("__zdGetter(GPUAdapter.prototype, 'info'"), "webgpu info getter routed");
+    // tokens still substituted, not left raw:
+    assert!(!s.contains("SEED") && !s.contains("WEBGL_VENDOR"), "tokens substituted");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p zendriver-stealth patches::tests::surface_patches_route_through_masking_helpers --lib`
+Expected: FAIL.
+
+- [ ] **Step 3: Edit each surface patch file**
+
+Worked example — **`webgl.js`** in full (both blocks, names/tokens preserved):
+
+```js
+// Defeats: bot.sannysoft.com `WebGL Vendor` + `WebGL Renderer` rows.
+const VENDOR = 'Google Inc. (Intel)';
+const RENDERER = 'ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)';
+[WebGLRenderingContext.prototype, WebGL2RenderingContext.prototype].forEach(proto => {
+    __zdReplace(proto, 'getParameter', (orig) => function(param) {
+        if (param === 37445) return VENDOR;    // UNMASKED_VENDOR_WEBGL
+        if (param === 37446) return RENDERER;  // UNMASKED_RENDERER_WEBGL
+        return orig.call(this, param);
+    });
+});
+
+// Persona-driven value substitution (WEBGL_VENDOR / WEBGL_RENDERER tokens).
+(function (vendor, renderer) {
+  const VENDOR = 0x9245, RENDERER = 0x9246; // UNMASKED_VENDOR_WEBGL / RENDERER
+  function patch(proto) {
+    __zdReplace(proto, 'getParameter', (orig) => function (p) {
+      if (vendor && p === VENDOR) return vendor;
+      if (renderer && p === RENDERER) return renderer;
+      return orig.call(this, p);
+    });
+  }
+  if (window.WebGLRenderingContext) patch(WebGLRenderingContext.prototype);
+  if (window.WebGL2RenderingContext) patch(WebGL2RenderingContext.prototype);
+})(WEBGL_VENDOR, WEBGL_RENDERER);
+```
+
+Worked example — **CTOR** (`webrtc.js`): wrap the wrapper constructor with `__zdMark`, e.g.
+
+```js
+// before:  window.RTCPeerConnection = function RTCPeerConnection(cfg) { /* BODY */ };
+// after:
+window.RTCPeerConnection = __zdMark(function RTCPeerConnection(cfg) { /* BODY */ }, 'RTCPeerConnection', 0);
+```
+
+For the remaining files, read each and apply the transform from the table — **bodies and tokens unchanged**, only the wrapping call changes. For files that currently capture `const orig = proto.x;` then reassign, fold that capture into the `(orig) => …` factory parameter.
+
+- [ ] **Step 4: Run the full stealth unit suite**
+
+Run: `cargo test -p zendriver-stealth --lib`
+Expected: PASS — routing assertion green; all existing surface/token tests (`webgl_value_substitutes_persona_renderer`, `no_unsubstituted_tokens_remain`, `webgpu_value_substitutes_coherent_adapter_from_renderer`, etc.) still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/zendriver-stealth/src/patches/
+git commit -m "feat(stealth): route surface patches through native-masking helpers"
+```
+
+---
+
+## Task 4: Real-Chrome integration test
+
+**Files:**
+- Create: `crates/zendriver/tests/stealth_native_masking.rs`
+
+This is `#[ignore]` + `#[cfg(feature = "integration-tests")]` (same gate as `fingerprint_integration.rs`); it needs a local Chrome and is not in the normal matrix.
+
+- [ ] **Step 1: Write the test**
+
+```rust
+//! Headful integration: spoofed-profile patches must report as native code.
+//!
+//! Run with:
+//! ```sh
+//! cargo test -p zendriver --test stealth_native_masking \
+//!     --features integration-tests -- --ignored
+//! ```
+#![cfg(feature = "integration-tests")]
+
+use serial_test::serial;
+use zendriver::Browser;
+use zendriver::{Persona, Seed};
+
+// Probes the most-checked patched method + a getter + the toString override
+// itself, returning a JSON blob the Rust side asserts on.
+const PROBE_JS: &str = r#"(() => {
+    const gp = WebGLRenderingContext.prototype.getParameter;
+    const wd = Object.getOwnPropertyDescriptor(Navigator.prototype, 'webdriver').get;
+    return JSON.stringify({
+        gpStr: gp.toString(),
+        gpName: gp.name,
+        gpLen: gp.length,
+        wdStr: wd.toString(),
+        ftsStr: Function.prototype.toString.toString(),
+    });
+})()"#;
+
+// Cross-realm: a child frame's Function.prototype.toString must also mask the
+// parent's patched method (validates per-frame bootstrap injection).
+const CROSS_FRAME_JS: &str = r#"(() => {
+    const f = document.createElement('iframe');
+    document.body.appendChild(f);
+    const cwToString = f.contentWindow.Function.prototype.toString;
+    const out = cwToString.call(WebGLRenderingContext.prototype.getParameter);
+    f.remove();
+    return out;
+})()"#;
+
+#[tokio::test]
+#[serial]
+#[ignore] // run with: cargo test ... -- --ignored
+async fn patched_functions_report_native_code() {
+    let browser = Browser::builder()
+        .persona(Persona::builder().seed(Seed::from_u64(42)).build())
+        .launch()
+        .await
+        .unwrap();
+    let tab = browser.main_tab();
+    tab.goto("about:blank").await.unwrap();
+    tab.wait_for_load().await.unwrap();
+
+    let raw: String = tab.evaluate::<String>(PROBE_JS).await.unwrap();
+    let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+
+    assert!(
+        v["gpStr"].as_str().unwrap().contains("[native code]"),
+        "getParameter.toString() must read native: {raw}"
+    );
+    assert_eq!(v["gpName"], "getParameter", "name must match native");
+    assert_eq!(v["gpLen"], 1, "length must match native");
+    assert_eq!(
+        v["wdStr"], "function get webdriver() { [native code] }",
+        "webdriver getter must read native getter form"
+    );
+    assert!(
+        v["ftsStr"].as_str().unwrap().contains("[native code]"),
+        "Function.prototype.toString must mask itself"
+    );
+
+    browser.close().await.unwrap();
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn masking_holds_cross_realm() {
+    let browser = Browser::builder()
+        .persona(Persona::builder().seed(Seed::from_u64(7)).build())
+        .launch()
+        .await
+        .unwrap();
+    let tab = browser.main_tab();
+    tab.goto("about:blank").await.unwrap();
+    tab.wait_for_load().await.unwrap();
+
+    let cross: String = tab.evaluate::<String>(CROSS_FRAME_JS).await.unwrap();
+    assert!(
+        cross.contains("[native code]"),
+        "cross-realm toString must mask the parent's patched fn: {cross}"
+    );
+
+    browser.close().await.unwrap();
+}
+```
+
+- [ ] **Step 2: Run the test (needs local Chrome)**
+
+Run: `cargo test -p zendriver --test stealth_native_masking --features integration-tests -- --ignored`
+Expected: PASS — both tests green. (If `masking_holds_cross_realm` fails because this Chrome doesn't inject into a synchronously-created `about:blank` child frame, that is the documented residual limit in spec §5.4 — note it and keep the primary test as the gate.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/zendriver/tests/stealth_native_masking.rs
+git commit -m "test(stealth): real-Chrome native-masking + cross-realm assertions"
+```
+
+---
+
+## Task 5: Pre-push gates
+
+- [ ] **Step 1: Format + lint + unit tests (parallel-safe; run all three)**
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo test -p zendriver-stealth --lib
+```
+Expected: fmt clean, clippy no warnings, stealth unit tests PASS. Fix anything flagged, re-stage.
+
+- [ ] **Step 2: Feature-gated clippy (CLAUDE.md — stealth is feature-gated)**
+
+```bash
+cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings
+```
+Expected: no warnings.
+
+- [ ] **Step 3: Confirm no public-API/MCP change**
+
+This feature adds no public items, so the MCP coverage ledger and schema snapshots are untouched. Sanity check that `git diff` shows only `zendriver-stealth/src/patches/*` and the new integration test.
+
+- [ ] **Step 4: Final commit (only if fmt/clippy changed anything)**
+
+```bash
+git add -A
+git commit -m "chore(stealth): fmt + clippy for native-masking"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage (§3):** prelude + helpers (Task 1) ✓; cross-realm via all-frames injection (Task 1 outer-IIFE + Task 4 cross-realm test) ✓; route all 16 files (Tasks 2–3, `chrome.js`/`_prng.js` correctly excluded — no sites) ✓; spoofed-only / no public API (Task 5 step 3) ✓; tests incl. `.name`/`.length`/getter-form/self-mask (Task 4) ✓; residual limit acknowledged (Task 4 step 2) ✓.
+- **Placeholders:** none — prelude shown in full; transform rule + per-file site tables are exact; integration test complete. Tasks 2–3 intentionally show the rule + worked examples rather than re-pasting 14 unread file bodies; the transform is uniform and each site is enumerated with file:line.
+- **Type/name consistency:** `__zdReplace` / `__zdGetter` / `__zdMark` / `__zdMarks` / `__zdNameLen` / `__zdFakeToString` / `__zdFnToString` used identically across the prelude, the routing assertions, and the transform examples; `NATIVE` const matches the `include_str!` path; `bootstrap_script` signature unchanged.

--- a/docs/superpowers/plans/2026-06-03-tracker-blocklist-handoff.md
+++ b/docs/superpowers/plans/2026-06-03-tracker-blocklist-handoff.md
@@ -1,0 +1,65 @@
+# Tracker/Fingerprinter Blocklist (#2) — Session Handoff
+
+> **Purpose:** Pick up feature #2 in a *fresh, short session*. This is a summarized handoff, not the full task-by-task plan. Full design: `docs/superpowers/specs/2026-06-03-stealth-tostring-masking-tracker-blocklist-design.md` §4. Style reference for the eventual plan: `docs/superpowers/plans/2026-06-03-stealth-tostring-masking.md`.
+>
+> **First action in the new session:** read spec §4, then either run `superpowers:writing-plans` to expand this into a task-by-task plan, or implement directly (it's small enough). Start with `HostMatcher` (pure, trivially testable), then the rule variant, then core wiring, then MCP.
+
+## What this is
+
+Opt-in blocking of third-party fingerprinter/tracker hosts, surfaced from the obscura comparison. zendriver-rs already has the network-interception mechanism (`zendriver-interception`, `Fetch.*`) but no list/policy. Independent of feature #1 (toString masking); #1 ships first.
+
+## Locked decisions (from brainstorm — do not relitigate)
+
+- **List:** bundle our *own* curated fingerprinter/3rd-party-tracker list (license-clean, ~50–150 hosts) **plus** runtime BYO (url / file / inline domains).
+- **Enable model:** opt-in via BrowserBuilder. Not auto-on with stealth (least-opinionated).
+- **Matching:** host-only (ignore path), suffix-on-dot (subdomains of a listed domain blocked), unconditional (no first-party exemption in v1).
+- **Block response:** reuse the existing `Fetch.failRequest { errorReason: "BlockedByClient" }` path — that's exactly what a real adblocker/Brave triggers (`net::ERR_BLOCKED_BY_CLIENT`), maximally plausible.
+- **Curation principle (load-bearing):** include third-party *passive* fingerprinters / cross-site trackers ONLY. **EXCLUDE active anti-bot challenge providers** (DataDome, Cloudflare, PerimeterX, Imperva) — you want to *pass* those; blocking breaks site access.
+- **License — why not vendor / compile-time:** `include_str!`, generate-and-commit, and `build.rs` fetch all embed the list into the shipped artifact = redistribution; the source license attaches identically. Peter Lowe's list (obscura's source) is use-restricted (no clean commercial redistribution) → must NOT be vendored. CLDR/apify are baked only because they permit it. The only model that moves the license boundary onto the user is a **runtime** fetch on the user's machine under their acceptance — which is also where real freshness lives (a library consumer pins a version + builds once). So: ship our own clean list; let users point `tracker_blocklist_url` at Peter Lowe's / uBlock / anything themselves.
+
+## Architecture & where code goes
+
+**`zendriver-interception` (pure mechanism — no data, no network):**
+- `HostMatcher`: `HashSet<String>` + parent-domain walk on dot boundaries. `is_blocked(host)` = exact, else strip leftmost label repeatedly (`a.b.evil.com → b.evil.com → evil.com`) to bare root.
+  - Suggested API: `HostMatcher::new(domains: impl IntoIterator<Item = String>) -> Self`; `fn is_blocked(&self, host: &str) -> bool`.
+- New enum variant `Rule::BlockHosts { matcher: std::sync::Arc<HostMatcher> }` in `crates/zendriver-interception/src/rule.rs:31`. The actor extracts the host from `Fetch.requestPaused.request.url` and, on a match, takes the **same** failRequest(BlockedByClient) branch the existing `Rule::Block` uses. Update `Rule::matches` + the actor's dispatch + the `Debug` impl.
+
+**`zendriver` core (opt-in API + list sourcing):**
+- Bundled curated list: `include_str!("trackers.txt")` (authored by us). Parser: ignore blank lines + `#` comments; collect hostnames.
+- BrowserBuilder methods (mirror existing `stealth`/`persona` builder style in `crates/zendriver/src/browser.rs:819-858`):
+  - `block_trackers(bool)` — toggle the bundled list.
+  - `tracker_blocklist_add(impl IntoIterator<Item = String>)` / `tracker_blocklist_file(PathBuf)` / `tracker_blocklist_url(String)` — accumulate custom sources; any source implicitly enables. Only-custom = source without `block_trackers(true)`; bundled+custom = both.
+- Runtime fetch + cache for `_url`: reuse the atomic-write download-on-first-use pattern in `crates/zendriver-fingerprints/src/pool/mod.rs:76` (`load_or_download`). Implement in core under the new feature (needs `reqwest`) so interception stays network-free.
+- Wiring: build one `Arc<HostMatcher>` on the browser; install a `Rule::BlockHosts` on each new tab's interception at tab creation (find the tab-creation seam in `browser.rs`).
+
+**Feature-gating:** new `tracker-blocking` feature in `zendriver` that implies `interception`; bundled list adds binary size only when enabled. `zendriver-mcp` gets a matching feature.
+
+## MCP coverage (REQUIRED — see CLAUDE.md)
+
+- Extend `browser_open` (`crates/zendriver-mcp/src/tools/`) with `block_trackers: bool` + optional `tracker_blocklist` input (url | file | inline domains).
+- Regenerate schema snapshots: `cargo test -p zendriver-mcp --test schema_snapshots --all-features --locked` then `cargo insta accept --all`; commit `crates/zendriver-mcp/tests/snapshots/*.snap`.
+- Regenerate public-API baseline (the builder methods are new public API): `cargo +nightly public-api -p zendriver --all-features > crates/zendriver-mcp/public-api-baseline.txt`.
+- Ledger-exclude the lower-level internals in `crates/zendriver-mcp/mcp-coverage-ledger.toml`: `HostMatcher` and `Rule::BlockHosts` (reached via the builder/tool, not directly).
+
+## Tests
+
+- `HostMatcher` unit: exact match, subdomain walk, miss, bare-root, comment/blank-line parsing.
+- `Rule::BlockHosts` actor test (mock transport): matching host → failRequest path.
+- Core: bundled `trackers.txt` parses; builder wires the matcher; `_url` fetch+cache against a mock server (or `#[ignore]`).
+- Integration (`#[ignore]`, `integration-tests` feature, real Chrome — pattern in `crates/zendriver/tests/fingerprint_integration.rs`): a listed host → `net::ERR_BLOCKED_BY_CLIENT`; an unlisted host loads.
+
+## Pre-push gates (CLAUDE.md)
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings   # feature-gated code touched
+cargo test -p zendriver-mcp --test schema_snapshots --all-features --locked   # + cargo insta accept --all
+cargo +nightly test -p zendriver-mcp --features public-api-check --test public_api --locked
+```
+
+## Open items (resolve during plan/implementation)
+
+1. **Curate `trackers.txt`** (~50–150 third-party passive fingerprinter/tracker hosts; apply the §4.4 exclusion principle — no active anti-bot vendors). This is the one piece requiring judgement/research.
+2. **Tab-creation seam** in `browser.rs` where the per-tab `Rule::BlockHosts` gets installed.
+3. Decide whether the core fetch+cache helper is duplicated from `pool/mod.rs` or lifted into a shared spot (duplication is acceptable for v1 — it's small).

--- a/docs/superpowers/specs/2026-06-03-stealth-tostring-masking-tracker-blocklist-design.md
+++ b/docs/superpowers/specs/2026-06-03-stealth-tostring-masking-tracker-blocklist-design.md
@@ -1,0 +1,223 @@
+# Stealth: native-function `toString` masking + tracker/fingerprinter blocklist
+
+- **Date:** 2026-06-03
+- **Status:** Approved design (pre-implementation)
+- **Crates touched:** `zendriver-stealth`, `zendriver-interception`, `zendriver`, `zendriver-mcp`
+- **Origin:** comparison with [obscura](https://github.com/h4ckf0r0day/obscura) (a synthetic DOM + V8 engine) surfaced two anti-detection techniques worth importing into zendriver-rs, which drives *real* Chrome.
+
+The two features are independent and may be implemented as separate task groups; they share this spec because they share the obscura-derived motivation and the stealth theme.
+
+## 1. Context & motivation
+
+1. **Native-function `toString` masking.** The spoofed profile patches ~16 prototype
+   methods/getters by reassignment (`proto.getParameter = function(p){…}`,
+   `crates/zendriver-stealth/src/patches/webgl.js:8`) and `Object.defineProperty(..,{get})`
+   (`patches/webdriver.js:4`). Those replacements report their JS source via
+   `Function.prototype.toString` and carry an empty `.name` — the canonical
+   FingerprintJS/CreepJS unmasking vector. The spoofed profile does not currently
+   mask this; it was deferred under the "detected-sites out of scope" tier
+   (`2026-05-23-zendriver-rs-phase2-stealth-design.md` §scope).
+2. **Tracker/fingerprinter blocklist.** obscura ships a domain blocklist that
+   short-circuits requests. zendriver-rs already has the mechanism
+   (`zendriver-interception`, `Fetch.*`) but no list or policy. Blocking
+   third-party fingerprinters shrinks the detection surface and speeds page loads.
+
+obscura's own `toString` masking is single-realm (it cannot defend cross-realm
+probes), and its blocklist is vendored from Peter Lowe's list with no attribution
+(a latent license problem). This design improves on both.
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- Spoofed-profile patched functions/getters are indistinguishable from native under
+  direct *and* cross-realm `toString` / `.name` / `.length` inspection, in every frame.
+- Opt-in blocking of third-party fingerprinter/tracker hosts, with a license-clean
+  bundled default and runtime-extensible custom lists.
+
+**Non-goals**
+
+- Masking in synthetic/detached realms that never receive a CDP document lifecycle
+  (best-effort only; see §5.4).
+- Blocking active anti-bot challenge providers (we want to *pass* those; see §4.4).
+- Build-time or vendored third-party blocklists (license + reproducibility; see §4.3).
+- Native-profile changes (it patches nothing, so it has no `toString` tell).
+
+## 3. Feature 1 — native-function `toString` masking
+
+### 3.1 Approach — centralized JS prelude + route all patches through helpers
+
+New `crates/zendriver-stealth/src/patches/_native.js`, prepended **first** in
+`bootstrap_script` (before the identity IIFE in `patches.rs:58`). Inside the
+bootstrap's scope it installs:
+
+- A `Function.prototype.toString` override backed by a closure-private `WeakSet` of
+  marked functions. If `this` is marked, return a synthesized native string —
+  `function NAME() { [native code] }`, or the `function get NAME() { [native code] }`
+  / `set` form for accessors. Otherwise delegate to the saved original `toString`.
+- The override marks itself and the saved original native (self-concealing), so
+  `Function.prototype.toString.toString()` also reports native.
+- `__zdReplace(obj, prop, make)`: capture `orig = obj[prop]`; `fn = make(orig)`; copy
+  `orig.name` and `orig.length` onto `fn` via `defineProperty`; add `fn` to the marked
+  set; assign `obj[prop] = fn`.
+- `__zdGetter(obj, prop, getFn, { enumerable, setFn })`: `defineProperty` an accessor;
+  mark `getFn` (and `setFn`) native, recording the `get `/`set ` name form.
+
+Each patch file is refactored to route its method replacement and `defineProperty`
+through these helpers instead of raw assignment/`defineProperty`.
+
+### 3.2 Cross-realm coverage
+
+The full bootstrap is injected via `Page.addScriptToEvaluateOnNewDocument`, which runs
+in every frame/document. The prelude therefore re-installs the override in each realm,
+so cross-realm probes (`iframe.contentWindow.Function.prototype.toString.call(patchedFn)`)
+hit the *child* realm's overridden `toString`. This closes the single-realm hole obscura
+cannot.
+
+### 3.3 Files touched
+
+- **New:** `patches/_native.js`.
+- `patches.rs`: prepend the prelude; tests asserting routing.
+- Patch files routed through helpers: `webdriver.js`, `navigator_props.js`, `plugins.js`,
+  `chrome.js`, `permissions.js`, `codecs.js`, `user_agent_data.js`, `broken_image.js`,
+  `webgl.js`, `canvas.js`, `audio.js`, `client_rects.js`, `fonts.js`, `hardware.js`,
+  `webrtc.js`, `webgpu.js`.
+
+### 3.4 Rejected alternatives
+
+- **Trap `Object.defineProperty` to auto-mark:** misses plain `proto.x = fn`
+  reassignment, the dominant pattern here.
+- **Post-pass snapshot diff:** requires a hand-maintained registry of patched targets;
+  brittle.
+
+### 3.5 Scope, API, tests
+
+- Spoofed profile only.
+- No public API or MCP surface added (internal bootstrap behavior).
+- **Unit:** bootstrap contains the prelude; patches route through `__zdReplace` /
+  `__zdGetter`.
+- **Integration (`#[ignore]`, real Chrome):** `WebGLRenderingContext.prototype.getParameter.toString()`
+  ends in `[native code]`, `.name === 'getParameter'`, `.length === 1`;
+  `Object.getOwnPropertyDescriptor(Navigator.prototype,'webdriver').get.toString()` is
+  the getter native form; a cross-frame iframe repeats the `getParameter` assertion.
+
+## 4. Feature 2 — tracker/fingerprinter blocklist
+
+### 4.1 Mechanism (`zendriver-interception`, pure matching — no data, no network)
+
+- `HostMatcher`: a `HashSet<String>` plus a parent-domain walk on dot boundaries.
+  `is_blocked(host)` checks the exact host, then strips the leftmost label repeatedly
+  (`a.b.evil.com → b.evil.com → evil.com`) until a match or the bare root.
+- `Rule::BlockHosts { matcher: Arc<HostMatcher> }` (extends the enum in
+  `rule.rs:31`): the actor extracts the host from `Fetch.requestPaused.request.url`; on a
+  match it reuses the existing `Block` path
+  (`Fetch.failRequest { errorReason: "BlockedByClient" }`). Composes in registration
+  order with other rules.
+
+### 4.2 Opt-in & sourcing (`zendriver` core)
+
+- **Bundled curated list:** `include_str!` of our own `trackers.txt` (~50–150 known
+  third-party fingerprinter/tracker hosts). Authored by us → no third-party license.
+- **BrowserBuilder methods:**
+  - `block_trackers(bool)` — toggle the bundled list.
+  - `tracker_blocklist_add(domains)` / `tracker_blocklist_file(path)` /
+    `tracker_blocklist_url(url)` — accumulate custom sources; the presence of any source
+    implicitly enables blocking. Only-custom = supply a source without
+    `block_trackers(true)`; bundled + custom = both.
+- **Runtime fetch + cache for `_url`:** reuse the atomic-write download-on-first-use
+  pattern from `zendriver-fingerprints` `pool::load_or_download` (`pool/mod.rs:76`).
+  Implemented in core (under the `tracker-blocking` feature, with `reqwest`) so
+  interception stays network-free.
+- **Wiring:** the browser builds one `Arc<HostMatcher>` and installs a `Rule::BlockHosts`
+  on each new tab's interception at creation.
+
+### 4.3 Why not vendored / compile-time
+
+The shipped artifact embeds whatever the build sees, so `include_str!`,
+generate-and-commit, and `build.rs` fetch are **all redistribution** — the list's
+license attaches identically. CLDR (Unicode license) and the apify fingerprint network
+(Apache-2.0) are baked precisely because they *permit* redistribution; Peter Lowe's list
+does not (use-restricted, redistribution discouraged, commercial use gated). The only
+model that moves the license boundary onto the end user is a runtime fetch on the user's
+machine under their acceptance — which is also where actual freshness lives (a library
+consumer pins a version and builds once, so a compile-time list is stale by runtime).
+Hence: bundle our own clean list; offer runtime BYO for everything else (a user who
+accepts Peter Lowe's terms points `tracker_blocklist_url` at it themselves).
+
+### 4.4 Curation principle (load-bearing)
+
+The curated list contains third-party *passive* fingerprinters and cross-site trackers
+only. It **deliberately excludes active anti-bot challenge providers** (DataDome,
+Cloudflare, PerimeterX, Imperva): blocking those breaks access to the very sites we are
+trying to reach.
+
+### 4.5 Matching semantics
+
+Host-only (path ignored), suffix-on-dot (subdomains of a listed domain are blocked),
+unconditional (no first-party exemption in v1; possible later refinement).
+
+### 4.6 Feature-gating
+
+New `tracker-blocking` feature in core that implies `interception`; the bundled list
+adds binary size only when enabled. `zendriver-mcp` exposes a matching feature.
+
+### 4.7 MCP coverage
+
+Extend `browser_open` with `block_trackers: bool` and an optional `tracker_blocklist`
+input (url | file | inline domains). Regenerate the `insta` schema snapshots and
+`public-api-baseline.txt`. Ledger-exclude the lower-level `HostMatcher` and
+`Rule::BlockHosts` as internal (reached via the builder/tool).
+
+### 4.8 Rejected alternatives
+
+- **Separate pre-filter layer before the rule list:** a parallel concept; the rule
+  variant composes and reuses the handle/teardown.
+- **A dedicated Fetch handler in core:** duplicates the interception actor.
+- **List as N `Rule::Block` glob patterns:** O(n) glob per request over thousands of
+  entries; `HostMatcher` is the reason for a set-membership variant.
+
+### 4.9 Tests
+
+- `HostMatcher` unit: exact match, subdomain walk, miss, bare-root.
+- `Rule::BlockHosts` actor (mock transport): match → fail path.
+- Core: bundled list parses; builder wires the matcher; fetch+cache against a mock
+  server (or `#[ignore]`).
+- Integration (`#[ignore]`, real Chrome): a listed host yields
+  `net::ERR_BLOCKED_BY_CLIENT`; an unlisted host loads.
+
+## 5. Cross-cutting
+
+### 5.1 Crate layering
+
+Interception holds the pure matching mechanism (no data, no network). Core owns the
+bundled data, the opt-in builder API, and the runtime fetch/cache. Stealth owns the
+`toString` prelude. No new cross-crate dependencies beyond core → interception (already
+present behind the `interception` feature).
+
+### 5.2 MCP & schema discipline
+
+Per project rules, any public API change is validated against `zendriver-mcp`. Feature 1
+adds none. Feature 2 adds builder options surfaced through `browser_open`; regenerate
+schema snapshots and the public-API baseline, and record ledger exclusions for the
+internal types.
+
+### 5.3 Pre-push gates
+
+`cargo fmt --all`; `clippy --all-targets -D warnings` (default features, and — since
+feature-gated code is touched — `-p zendriver-mcp --all-features`); schema snapshots;
+the public-api check.
+
+### 5.4 Residual limitations
+
+- **toString masking:** synthetic/detached realms with no CDP document lifecycle
+  (`document.implementation.createHTMLDocument`, a detached-never-inserted iframe) keep a
+  pristine `Function.prototype.toString` and can unmask. Niche; obscura cannot do real
+  cross-frame at all.
+- **Blocklist:** an unconditional host match may block a listed host used first-party;
+  acceptable for a curated third-party list, revisitable via a first-party exemption.
+
+## 6. Open items (plan-time)
+
+- Exact contents of the curated `trackers.txt` (authored during implementation; reviewed
+  against the §4.4 exclusion principle).
+- Precise seam in core where per-tab interception is installed at tab creation.


### PR DESCRIPTION
## Summary
- Adds a masking prelude (`crates/zendriver-stealth/src/patches/_native.js`) that overrides `Function.prototype.toString` against a closure-private `WeakMap` and exposes `__zdReplace` / `__zdGetter` / `__zdMark`. The whole spoofed-profile bootstrap is now wrapped in a single outer IIFE so the helpers stay closure-local (no `globalThis`/`window` leak); the `toString` override is the one intentional global side effect.
- Routes all 16 stealth patch files through the helpers so every spoofed function/getter reports `[native code]` with the correct `.name`/`.length` and `function get NAME() { [native code] }` form — defeating FingerprintJS/CreepJS `toString`/`.name` probes. Cross-realm coverage is free because the bootstrap is injected into every frame (`Page.addScriptToEvaluateOnNewDocument`), so `iframe.contentWindow.Function.prototype.toString.call(patchedFn)` also sees native.
- Adds `#[ignore]` real-Chrome integration tests: direct `toString`/`.name`/`.length`, the `webdriver` getter form, `Function.prototype.toString` self-mask, and a cross-realm iframe check.

Spoofed profile only (the native profile patches nothing, so has no `toString` tell). No public API / MCP surface change — internal bootstrap behavior only.

Design: `docs/superpowers/specs/2026-06-03-stealth-tostring-masking-tracker-blocklist-design.md` §3 · Plan: `docs/superpowers/plans/2026-06-03-stealth-tostring-masking.md`. (Feature #2, the tracker blocklist from the same spec, is handed off separately in `docs/superpowers/plans/2026-06-03-tracker-blocklist-handoff.md`.)

## Test plan
- [x] `cargo test -p zendriver-stealth` — 106 unit + 6 doctests pass
- [x] `cargo test --workspace` (default features) green
- [x] `cargo fmt --all --check`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings` — all clean
- [ ] Real-Chrome assertions (needs a Chrome runner): `cargo test -p zendriver --test stealth_native_masking --features integration-tests -- --ignored`

🤖 Generated with [Claude Code](https://claude.com/claude-code)