### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "async-trait",
  "base64",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "futures",
  "serde",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "futures",
  "serde",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,15 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.12", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.13", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.4" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.4.1" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.0" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.2.1" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.0" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.3" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.5.1" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.0" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.1" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.6.0" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.1" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.2" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.3" }
 
 # MCP server

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.2] - 2026-06-03
+
+
 ## [0.1.1] - 2026-06-03
 
 

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.1] - 2026-06-03
+
+
 ## [0.2.0] - 2026-06-02
 
 ### Changed

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.0] - 2026-06-03
+
+### Added
+
+- Opt-in tracker/fingerprinter blocklist ([#51](https://github.com/TurtIeSocks/zendriver-rs/pull/51))
+
+
 ## [0.2.1] - 2026-06-02
 
 

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.6.0] - 2026-06-03
+
+### Added
+
+- Opt-in tracker/fingerprinter blocklist ([#51](https://github.com/TurtIeSocks/zendriver-rs/pull/51))
+
+
 ## [0.5.1] - 2026-06-03
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.5.1"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.13] - 2026-06-03
+
+### Added
+
+- Opt-in tracker/fingerprinter blocklist ([#51](https://github.com/TurtIeSocks/zendriver-rs/pull/51))
+
+
 ## [0.2.12] - 2026-06-03
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.12"
+version = "0.2.13"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-interception`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)
* `zendriver`: 0.2.12 -> 0.2.13 (✓ API compatible changes)
* `zendriver-mcp`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `zendriver-datadome`: 0.1.1 -> 0.1.2
* `zendriver-imperva`: 0.2.0 -> 0.2.1

### ⚠ `zendriver-interception` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant Rule:BlockHosts in /tmp/.tmp4exjOJ/zendriver-rs/crates/zendriver-interception/src/rule.rs:97
  variant Rule:BlockHosts in /tmp/.tmp4exjOJ/zendriver-rs/crates/zendriver-interception/src/rule.rs:97
```

### ⚠ `zendriver-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field OpenInput.block_trackers in /tmp/.tmp4exjOJ/zendriver-rs/crates/zendriver-mcp/src/tools/lifecycle.rs:48
  field OpenInput.tracker_blocklist in /tmp/.tmp4exjOJ/zendriver-rs/crates/zendriver-mcp/src/tools/lifecycle.rs:53
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-interception`

<blockquote>

## [0.3.0] - 2026-06-03

### Added

- Opt-in tracker/fingerprinter blocklist ([#51](https://github.com/TurtIeSocks/zendriver-rs/pull/51))
</blockquote>

## `zendriver`

<blockquote>

## [0.2.13] - 2026-06-03

### Added

- Opt-in tracker/fingerprinter blocklist ([#51](https://github.com/TurtIeSocks/zendriver-rs/pull/51))
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.6.0] - 2026-06-03

### Added

- Opt-in tracker/fingerprinter blocklist ([#51](https://github.com/TurtIeSocks/zendriver-rs/pull/51))
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).