### PR TITLE
docs: feature-sync README/book/CLAUDE.md + fix(mcp) dropped browser_snapshot error hint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ cargo clippy --workspace --all-targets --locked -- -D warnings
 - Re-stage / amend after the fixes so the pushed commit is already clean.
 
 CI clippy runs on **default features**; if you touched feature-gated code
-(`interception` / `expect` / `monitor` / `cloudflare` / `imperva` / `fetcher` /
-`fingerprints`), also run
+(`interception` / `expect` / `monitor` / `cloudflare` / `imperva` / `datadome` /
+`fetcher` / `geo` / `tracker-blocking` / `fingerprints`), also run
 `cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings`.
 
 ## Schema snapshots (zendriver-mcp)
@@ -78,6 +78,30 @@ If you intentionally changed the public API, regenerate the baseline:
 cargo +nightly public-api -p zendriver --all-features > crates/zendriver-mcp/public-api-baseline.txt
 ```
 
+## Documentation sync (REQUIRED before finishing a PR)
+
+Three doc surfaces must stay in sync with the public API. Any PR that adds or
+changes a user-facing capability MUST update **all three** (or consciously note
+why a surface doesn't apply) before it is finished:
+
+1. **READMEs** (`README.md` + `crates/zendriver-mcp/README.md`) — feature
+   matrix, install examples, the MCP tool count, and the "what agents get"
+   bullets. The tool count appears verbatim in several places — grep for the
+   old number and replace every hit.
+2. **Rustdocs** — doc comments on every new/changed public item (`BrowserBuilder`
+   option, `Tab`/`Frame`/`Element` method, new type, feature flag). These render
+   on docs.rs, so keep examples `no_run`-compilable.
+3. **The mdBook** (`docs/book/src/`) — add or extend the relevant chapter
+   (a new `BrowserBuilder` option → its feature's chapter; a new MCP tool →
+   `mcp.md`, including the tool count + category table). Confirm it still builds:
+   `mdbook build docs/book`.
+
+The published MCP tool count = tools compiled with the default features
+(`cargo install zendriver-mcp`); `--all-features` adds the opt-in
+`fingerprints` / `geo` tools. Treat a shipped behavior change with a stale
+README / rustdoc / book as an incomplete PR — same bar as the MCP coverage
+check above.
+
 ## Workspace layout
 
 9-crate workspace (`edition = 2024`, MSRV 1.85). Roles:
@@ -95,5 +119,6 @@ cargo +nightly public-api -p zendriver --all-features > crates/zendriver-mcp/pub
 | `zendriver-mcp` | MCP server exposing the `zendriver` surface as agent tools (see MCP coverage above). |
 
 Capability crates are wired into `zendriver` behind features (`interception` /
-`cloudflare` / `imperva` / `fetcher` / `expect` / `monitor`), which
-`zendriver-mcp` re-exposes behind matching MCP features.
+`cloudflare` / `imperva` / `datadome` / `fetcher` / `expect` / `monitor` /
+`geo` / `tracker-blocking`), which `zendriver-mcp` re-exposes behind matching
+MCP features (plus `fingerprints`).

--- a/README.md
+++ b/README.md
@@ -53,13 +53,16 @@ More working examples in [`crates/zendriver/examples/`](crates/zendriver/example
 | `cloudflare`   | no       | Solve Cloudflare Turnstile challenges                         | `zendriver-cloudflare`                |
 | `imperva`      | no       | Imperva WAF / Incapsula bypass (reese84 / legacy / CAPTCHA)   | `zendriver-imperva`                   |
 | `datadome`     | no       | DataDome bypass (device-check / CAPTCHA / block) + `Surface::Webgpu` coherence | `zendriver-datadome` |
+| `monitor`      | no       | Passive network monitor — buffered HTTP / WebSocket / SSE events via `tab.monitor()` | (in-tree, no extra crate)             |
+| `geo`          | no       | Country code → coherent `locale` + `languages` (Accept-Language) persona overlay | (via `zendriver-stealth`)             |
+| `tracker-blocking` | no   | Opt-in third-party tracker / fingerprinter host blocklist (curated bundled list + BYO file / URL) | `reqwest` + `dirs`         |
 | `fetcher`      | no       | Auto-download a pinned Chrome for Testing build               | `zendriver-fetcher` + `reqwest`/`zip` |
 
 Separate binary crate (not a feature on `zendriver`):
 
 | Crate           | Use case                                                                                                                         | Install                                                                                     |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `zendriver-mcp` | Drive a stealth Chrome from any LLM agent — [Model Context Protocol](https://modelcontextprotocol.io/) server, 49 tools, stdio + streamable HTTP | `cargo install zendriver-mcp` ([docs](https://turtiesocks.github.io/zendriver-rs/mcp.html)) |
+| `zendriver-mcp` | Drive a stealth Chrome from any LLM agent — [Model Context Protocol](https://modelcontextprotocol.io/) server, 70 tools, stdio + streamable HTTP | `cargo install zendriver-mcp` ([docs](https://turtiesocks.github.io/zendriver-rs/mcp.html)) |
 
 ## Install
 
@@ -84,14 +87,14 @@ Same as above — only spell out the feature if you want it visible in `Cargo.to
 **Everything:**
 
 ```bash
-cargo add zendriver --features "interception expect cloudflare imperva datadome fetcher"
+cargo add zendriver --features "interception expect cloudflare imperva datadome monitor geo tracker-blocking fetcher"
 ```
 
-Adds request interception, `expect()` matchers, Cloudflare Turnstile bypass, Imperva WAF / Incapsula bypass, DataDome bypass, and the Chrome for Testing fetcher.
+Adds request interception, `expect()` matchers, Cloudflare Turnstile bypass, Imperva WAF / Incapsula bypass, DataDome bypass, the passive network monitor, country→locale geo overlay, the opt-in tracker/fingerprinter blocklist, and the Chrome for Testing fetcher.
 
 ## Drive a stealth browser from your AI agent
 
-`zendriver-mcp` is a **first-class [Model Context Protocol](https://modelcontextprotocol.io/) server** that hands the entire zendriver-rs surface to any LLM client — Claude Desktop, Claude Code, Cursor, or your own agent loop. **49 tools**, two transports (stdio + streamable HTTP), and the same stealth-by-default fingerprinting baked into the lib. Unlike generic browser MCP servers, this one bypasses Cloudflare Turnstile, ships an isolated-world JS eval that survives anti-bot detection, and lets agents persist auth state across sessions.
+`zendriver-mcp` is a **first-class [Model Context Protocol](https://modelcontextprotocol.io/) server** that hands the entire zendriver-rs surface to any LLM client — Claude Desktop, Claude Code, Cursor, or your own agent loop. **70 tools**, two transports (stdio + streamable HTTP), and the same stealth-by-default fingerprinting baked into the lib. Unlike generic browser MCP servers, this one bypasses Cloudflare Turnstile, ships an isolated-world JS eval that survives anti-bot detection, and lets agents persist auth state across sessions.
 
 ```bash
 cargo install zendriver-mcp
@@ -114,9 +117,10 @@ cargo install zendriver-mcp
 - **Stealth navigation** — `browser_open`, `browser_goto`, `browser_back/forward/reload`, `browser_wait_for_idle`, plus a runtime-swappable `browser_set_stealth_profile` (auto / native / spoof_macos / spoof_linux / spoof_windows)
 - **Selector-based find + actions** — one `Selector` arg works across `browser_find`, `browser_click`, `browser_type`, `browser_press`, `browser_set_value`, `browser_upload`, etc., with CSS / XPath / visible-text / ARIA-role lookups and per-frame scoping
 - **Three ways to "see" the page** — `browser_html` (trimmed DOM), `browser_screenshot` (PNG / JPEG / WebP as inline image content), `browser_element_state` (visibility / geometry / attrs)
-- **Stateful primitives** agents need for real work — `browser_cookies_persist` for save/load auth, full `browser_storage_*`, multi-tab management, frame traversal
+- **Stateful primitives** agents need for real work — `browser_cookies_persist` for save/load auth, full `browser_storage_*`, multi-tab management, frame traversal; `browser_monitor_*` passive network monitor (HTTP / WS / SSE); `browser_request` for HTTP from the page's own session
 - **Anti-bot superpowers** (gated cargo features, on by default for the published binary):
   - `browser_solve_turnstile` — Cloudflare Turnstile bypass without a CAPTCHA-solving service
+  - `browser_open` `block_trackers` / `tracker_blocklist` — opt-in third-party tracker & fingerprinter host blocking (curated bundled list + bring-your-own file / URL)
   - `browser_solve_datadome` — DataDome device-check / CAPTCHA / block bypass (with `Surface::Webgpu` coherence)
   - `browser_intercept_*` — block/redirect/respond/modify requests via CDP `Fetch.*`
   - `browser_expect_register / _await` — Playwright-style "wait for response/dialog/download" matchers, split across MCP calls so the agent can act in between
@@ -133,7 +137,7 @@ Six development phases shipped into the v0.1.0 release. The [mdBook](https://tur
 2. **Stealth** — fingerprint patches + isolated worlds + stealth JS bundle. See [stealth](https://turtiesocks.github.io/zendriver-rs/stealth.html).
 3. **Element API completeness** — CSS/XPath/text/role selectors, actionability, input controller, screenshots. See [quickstart](https://turtiesocks.github.io/zendriver-rs/quickstart.html).
 4. **`Tab`/`Browser` completeness** — multi-tab, cookies, storage, frames, nav history, `wait_for_idle`. See [multi-tab](https://turtiesocks.github.io/zendriver-rs/multi-tab.html) + [frames](https://turtiesocks.github.io/zendriver-rs/frames.html).
-5. **Optional gated features** — request interception, `expect()` matchers, Cloudflare bypass, Chrome-for-Testing fetcher. See [interception](https://turtiesocks.github.io/zendriver-rs/interception.html), [expect](https://turtiesocks.github.io/zendriver-rs/expect.html), [cloudflare](https://turtiesocks.github.io/zendriver-rs/cloudflare.html), [fetcher](https://turtiesocks.github.io/zendriver-rs/fetcher.html).
+5. **Optional gated features** — request interception, `expect()` matchers, Cloudflare / Imperva / DataDome bypass, network monitor, geo locale overlay, tracker blocklist, Chrome-for-Testing fetcher. See [interception](https://turtiesocks.github.io/zendriver-rs/interception.html), [expect](https://turtiesocks.github.io/zendriver-rs/expect.html), [cloudflare](https://turtiesocks.github.io/zendriver-rs/cloudflare.html), [fetcher](https://turtiesocks.github.io/zendriver-rs/fetcher.html).
 6. **Polish + release** — trait extraction, rustdoc + mdBook, publish to crates.io.
 
 ## Comparison
@@ -145,7 +149,7 @@ Six development phases shipped into the v0.1.0 release. The [mdBook](https://tur
 | Multi-tab                | yes (first-class)       | yes               | yes             | yes             | yes             |
 | Interception             | yes (`Fetch.*` wrapper) | yes (raw)         | no (proxy-only) | partial         | no (proxy-only) |
 | Cloudflare bypass        | yes (`zendriver-cloudflare`) | no           | no              | no              | no              |
-| MCP server for AI agents | yes (`zendriver-mcp`, 49 tools) | no        | no              | no              | no              |
+| MCP server for AI agents | yes (`zendriver-mcp`, 70 tools) | no        | no              | no              | no              |
 | License                  | MIT OR Apache-2.0       | MIT OR Apache-2.0 | Apache-2.0      | MIT             | MIT             |
 | Async runtime            | tokio                   | tokio / async-std | tokio           | sync            | tokio           |
 

--- a/crates/zendriver-mcp/src/errors.rs
+++ b/crates/zendriver-mcp/src/errors.rs
@@ -68,21 +68,21 @@ fn map_zendriver(err: &ZendriverError) -> (String, Option<&'static str>) {
     match err {
         ZendriverError::ElementNotFound { selector } => (
             format!(
-                "No element matched `{selector}`. Try `browser_snapshot` or `browser_html` to inspect current page."
+                "No element matched `{selector}`. Try `browser_html` to inspect current page."
             ),
-            Some("browser_snapshot"),
+            Some("browser_html"),
         ),
         ZendriverError::Timeout(d) => (
             format!(
-                "Operation timed out after {d:?}. Retry with a larger `timeout_ms` or inspect with `browser_snapshot`."
+                "Operation timed out after {d:?}. Retry with a larger `timeout_ms` or inspect with `browser_html`."
             ),
-            Some("browser_snapshot"),
+            Some("browser_html"),
         ),
         ZendriverError::NotActionable(_, reason) => (
             format!(
-                "Element not actionable: {reason}. Inspect with `browser_snapshot` or wait for the page to settle."
+                "Element not actionable: {reason}. Inspect with `browser_html` or wait for the page to settle."
             ),
-            Some("browser_snapshot"),
+            Some("browser_html"),
         ),
         ZendriverError::TabNotFound(id) => (
             format!("Tab `{id}` not found. Use `browser_tab_list` to enumerate live tabs."),
@@ -130,14 +130,14 @@ mod tests {
     }
 
     #[test]
-    fn element_not_found_suggests_snapshot() {
+    fn element_not_found_suggests_html() {
         let inner = ZendriverError::ElementNotFound {
             selector: "css(button.primary)".into(),
         };
         let e = map_error(McpServerError::from(inner));
         assert!(e.message.contains("`css(button.primary)`"));
         let data = e.data.as_ref().expect("data populated");
-        assert_eq!(data["suggested_next"], "browser_snapshot");
+        assert_eq!(data["suggested_next"], "browser_html");
     }
 
     #[test]

--- a/crates/zendriver-mcp/src/tools/find.rs
+++ b/crates/zendriver-mcp/src/tools/find.rs
@@ -416,7 +416,7 @@ pub async fn find(
 
 /// `true` when the `ErrorData` was produced by mapping an
 /// [`zendriver::ZendriverError::ElementNotFound`]. We rely on the
-/// `_meta.suggested_next == "browser_snapshot"` marker that `map_error`
+/// `_meta.suggested_next == "browser_html"` marker that `map_error`
 /// attaches to that variant — checking the message would be brittle
 /// across translation tweaks.
 fn is_not_found(err: &ErrorData) -> bool {
@@ -424,7 +424,7 @@ fn is_not_found(err: &ErrorData) -> bool {
         .as_ref()
         .and_then(|v| v.get("suggested_next"))
         .and_then(|v| v.as_str())
-        == Some("browser_snapshot")
+        == Some("browser_html")
         && err.message.contains("No element matched")
 }
 

--- a/crates/zendriver-mcp/src/tools/reads.rs
+++ b/crates/zendriver-mcp/src/tools/reads.rs
@@ -312,7 +312,7 @@ fn is_not_found(err: &ErrorData) -> bool {
         .as_ref()
         .and_then(|v| v.get("suggested_next"))
         .and_then(|v| v.as_str())
-        == Some("browser_snapshot")
+        == Some("browser_html")
         && err.message.contains("No element matched")
 }
 

--- a/docs/book/src/faq.md
+++ b/docs/book/src/faq.md
@@ -224,6 +224,33 @@ the specific event you care about.
 
 [`ZendriverError::Navigation`]: https://docs.rs/zendriver/latest/zendriver/enum.ZendriverError.html#variant.Navigation
 
+## `wait_for_idle` never returns on a page with a long-poll, SSE, or analytics-beacon request
+
+By default `wait_for_idle` waits for *every* in-flight request to
+terminate, so a single never-completing request (a Server-Sent Events
+stream, a long-poll, a hung analytics beacon) keeps the tab non-idle
+until `timeout`. Use `Tab::wait_for_idle_opts` with an
+`IdleOptions::max_inflight_age` — any request older than that age is
+treated as background, letting idle resolve while it stays open:
+
+```rust,no_run
+# async fn ex() -> zendriver::Result<()> {
+# let browser = zendriver::Browser::builder().launch().await?;
+# let tab = browser.main_tab();
+use std::time::Duration;
+use zendriver::IdleOptions;
+
+tab.wait_for_idle_opts(IdleOptions {
+    max_inflight_age: Some(Duration::from_secs(5)),
+    ..Default::default()
+})
+.await?;
+# Ok(()) }
+```
+
+`max_inflight_age` defaults to `None` (the historical
+wait-for-everything behavior).
+
 ## Where do I find the full list of errors?
 
 [Error Reference](./error-reference.md) — every public variant of

--- a/docs/book/src/fingerprint.md
+++ b/docs/book/src/fingerprint.md
@@ -145,6 +145,30 @@ let browser = Browser::builder()
     .launch().await?;
 ```
 
+## Country → locale overlay (`geo_locale`)
+
+The optional `geo` feature adds [`BrowserBuilder::geo_locale`], which maps an
+ISO 3166-1 alpha-2 country code (e.g. `"US"`, `"de"`) to a coherent `locale` +
+`languages` (Accept-Language) set drawn from a bundled CLDR-derived table. It
+is layered as a **persona overlay**, so it composes with `.persona(..)` and is
+overridden by an explicit `.persona_overlay(..)` locale. An invalid / unknown
+country code is ignored (logged) — the value is never locked.
+
+```toml
+[dependencies]
+zendriver = { version = "0.1", features = ["geo"] }
+```
+
+```rust,no_run
+use zendriver::Browser;
+
+let browser = Browser::builder()
+    .geo_locale("DE")   // de-DE locale + matching Accept-Language
+    .launch().await?;
+```
+
+[`BrowserBuilder::geo_locale`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.geo_locale
+
 ## JSON persona (`try_from_json`)
 
 Any `Persona` can be expressed as a JSON object and round-trips cleanly.

--- a/docs/book/src/interception.md
+++ b/docs/book/src/interception.md
@@ -138,6 +138,43 @@ arrives. If your stream consumer panics mid-flow, the actor's `Drop`
 will dispatch `Fetch.disable` — every still-paused request fails with
 `net::ERR_BLOCKED_BY_CLIENT`, which is unpleasant but not silent.
 
+## Tracker / fingerprinter blocklist
+
+The `tracker-blocking` feature builds a ready-made host-blocking rule on top
+of interception, so you can block third-party trackers and fingerprinters
+without writing patterns. Enable it on the builder and it installs on the main
+tab and every new tab automatically.
+
+```toml
+[dependencies]
+zendriver = { version = "0.1", features = ["tracker-blocking"] }
+```
+
+```rust,no_run
+use zendriver::Browser;
+
+let browser = Browser::builder()
+    .block_trackers(true)                        // curated bundled list
+    .tracker_blocklist_add(["ads.example.com"])  // + your own hosts
+    .launch().await?;
+```
+
+| Method | Effect |
+|--------|--------|
+| [`block_trackers(true)`] | Enable blocking with the curated bundled list (`include_str!`-embedded — only adds binary size when the feature is on) |
+| [`tracker_blocklist_add`] | Add extra hosts (repeatable; implicitly enables blocking) |
+| [`tracker_blocklist_file`] | Add hosts from a local file (one host per line; `0.0.0.0 host` hosts-file lines tolerated) |
+| [`tracker_blocklist_url`] | Add hosts fetched from a URL at launch |
+
+Matching is host-based: a blocked host also blocks its subdomains. The bundle
+ships only our own clean list — point `tracker_blocklist_url` at a third-party
+list only if you accept that list's license.
+
+[`block_trackers(true)`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.block_trackers
+[`tracker_blocklist_add`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.tracker_blocklist_add
+[`tracker_blocklist_file`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.tracker_blocklist_file
+[`tracker_blocklist_url`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.tracker_blocklist_url
+
 ## Pattern + stage filters
 
 By default the builder pauses on every request at the `Request` stage.

--- a/docs/book/src/mcp.md
+++ b/docs/book/src/mcp.md
@@ -1,7 +1,8 @@
 # MCP server (`zendriver-mcp`)
 
 `zendriver-mcp` is a [Model Context Protocol](https://modelcontextprotocol.io/)
-server that exposes zendriver-rs through 65 MCP tools, so any
+server that exposes zendriver-rs through 70 MCP tools (71 with the
+optional `fingerprints` feature), so any
 MCP-compatible client (Claude Desktop, Claude Code, custom agents) can
 drive a real, stealth-by-default Chrome browser.
 
@@ -11,8 +12,10 @@ drive a real, stealth-by-default Chrome browser.
 cargo install zendriver-mcp
 ```
 
-The default build enables all gated features (`interception`, `expect`,
-`cloudflare`, `imperva`, `fetcher`). For a lean build:
+The default build enables `interception`, `expect`, `cloudflare`,
+`imperva`, `datadome`, `monitor`, `fetcher`, and `tracker-blocking`. The
+`fingerprints` and `geo` features are opt-in (add
+`--features fingerprints,geo`). For a lean build:
 
 ```bash
 cargo install zendriver-mcp --no-default-features
@@ -59,7 +62,8 @@ OPTIONS:
 
 ## Tool surface
 
-65 tools across these categories:
+70 tools across these categories (71 with the optional `fingerprints`
+feature):
 
 | Category               | Tools                                                                                                                       | Count |
 | ---------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----: |
@@ -72,6 +76,7 @@ OPTIONS:
 | Reads                  | `browser_element_state / _get_links / _search_resources`                                                                    |     3 |
 | Snapshots / Export     | `browser_html / _screenshot / _pdf / _save_mhtml`                                                                           |     4 |
 | Eval                   | `browser_evaluate / _evaluate_main`                                                                                         |     2 |
+| Network                | `browser_request`                                                                                                           |     1 |
 | Cookies                | `browser_cookies_get / _set / _delete / _clear / _persist`                                                                  |     5 |
 | Storage                | `browser_storage_get / _set / _delete / _clear`                                                                             |     4 |
 | Downloads              | `browser_download / _set_download_path`                                                                                     |     2 |
@@ -81,7 +86,10 @@ OPTIONS:
 | Expect (gated)         | `browser_expect_register / _await / _cancel`                                                                                |     3 |
 | Cloudflare (gated)     | `browser_solve_turnstile`                                                                                                   |     1 |
 | Imperva (gated)        | `browser_solve_imperva`                                                                                                     |     1 |
+| DataDome (gated)       | `browser_solve_datadome`                                                                                                   |     1 |
 | Fetcher (gated)        | `browser_install_chrome`                                                                                                    |     1 |
+| Monitor (gated)        | `browser_monitor_start / _read / _stop`                                                                                    |     3 |
+| Fingerprint (gated)    | `browser_fingerprint_generate`                                                                                             |     1 |
 
 All find / action tools share a `Selector` arg — one-of `css | xpath |
 text | text_exact | text_regex | role`, with modifiers `nth /
@@ -89,13 +97,27 @@ visible_only / timeout_ms / frame_id`. State-changing tools accept
 `return_snapshot: bool` for one-call action + observe. `browser_pdf` /
 `_save_mhtml` / `_download` return a binary-output shape (`{ byte_len,
 saved_path? , base64? }`): bytes go to `save_path` on the MCP host when
-given, else base64-inline (capped at 5 MiB). The default build adds
-`imperva` to the gated feature set alongside `interception` / `expect` /
-`cloudflare` / `fetcher`.
+given, else base64-inline (capped at 5 MiB). The default build enables
+`interception` / `expect` / `cloudflare` / `imperva` / `datadome` /
+`monitor` / `fetcher` / `tracker-blocking`; `fingerprints` and `geo` are
+opt-in.
 
 Full JSON Schema for every tool's input + output is captured in
 `crates/zendriver-mcp/tests/snapshots/` and changes there require an
 explicit `cargo insta accept` — the wire shape is reviewed.
+
+## `browser_open` options
+
+`browser_open` accepts opt-in third-party tracker / fingerprinter blocking:
+
+- `block_trackers: bool` — enable blocking with the curated bundled list.
+- `tracker_blocklist` — one of `{ "url": "..." }`, `{ "path": "..." }`, or
+  `{ "domains": ["..."] }` to add custom hosts (implicitly enables blocking).
+  Requires the default `tracker-blocking` feature.
+
+The stealth-profile override accepts `geo_country` (ISO 3166-1 alpha-2, e.g.
+`"DE"`) to derive a coherent `locale` + `Accept-Language`. The field is always
+present in the schema but only takes effect when the `geo` feature is enabled.
 
 ## Stealth
 


### PR DESCRIPTION
## Summary

Two related change-sets that came out of a documentation audit.

### docs: feature-sync (README, mdBook, CLAUDE.md)
- Corrected the MCP tool count everywhere (`49` / `65` → **70** default, **71** with the optional `fingerprints` feature).
- Added `monitor`, `geo`, and `tracker-blocking` to the README feature matrix + install examples, and to the mcp.md category table.
- New book sections: tracker / fingerprinter blocklist (interception), the `geo_locale` country→locale overlay (fingerprint), and `max_inflight_age` for `wait_for_idle` (faq).
- Documented `browser_open`'s `block_trackers` / `tracker_blocklist` args and the `geo_country` stealth override.
- CLAUDE.md: added a **REQUIRED doc-sync step** so future PRs keep README + rustdocs + book in sync; fixed two stale feature lists.

### fix(mcp): `browser_snapshot` → `browser_html` error hint
The `suggested_next` error-recovery hints (and their messages) pointed agents at `browser_snapshot`, an AX-snapshot tool that was **dropped** and is not registered — so a client following the hint hit a hard unknown-tool error. Repointed the `ElementNotFound` / `Timeout` / `NotActionable` hints at the existing `browser_html` tool, and updated the internal `is_not_found` marker in `find.rs` / `reads.rs` (which keys off the hint string) plus its test.

## Verification
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets --locked -- -D warnings` ✅
- `cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings` ✅
- `cargo test -p zendriver-mcp --all-features` → **142 passed, 0 failed** ✅
- `mdbook build docs/book` ✅

No public API change (only error strings, internal predicates, and docs), so no `public-api-baseline.txt` or schema-snapshot updates were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
