### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "async-trait",
  "base64",
@@ -3347,7 +3347,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-cloudflare"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "futures",
  "serde",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fetcher"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "dirs",
  "futures",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "futures",
  "serde",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-transport"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.14", default-features = false }
-zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.5" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.4.2" }
-zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.1" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.1" }
-zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.4" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.6.1" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.2" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.3" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.4" }
+zendriver               = { path = "crates/zendriver", version = "0.2.15", default-features = false }
+zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.6" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.4.3" }
+zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.2" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.2" }
+zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.5" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.6.2" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.3" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.4" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.5" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-cloudflare/CHANGELOG.md
+++ b/crates/zendriver-cloudflare/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-13
+
+
 ## [0.2.1] - 2026-06-03
 
 

--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-cloudflare"
 description = "Cloudflare Turnstile bypass for zendriver"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.4] - 2026-06-13
+
+
 ## [0.1.3] - 2026-06-03
 
 

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fetcher/CHANGELOG.md
+++ b/crates/zendriver-fetcher/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.5] - 2026-06-13
+
+
 ## [0.1.4] - 2026-06-03
 
 

--- a/crates/zendriver-fetcher/Cargo.toml
+++ b/crates/zendriver-fetcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fetcher"
 description = "Chrome binary downloader for zendriver"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.5] - 2026-06-13
+
+
 ## [0.2.4] - 2026-06-03
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.3] - 2026-06-13
+
+
 ## [0.2.2] - 2026-06-03
 
 

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.2] - 2026-06-13
+
+
 ## [0.3.1] - 2026-06-03
 
 

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.6.2] - 2026-06-13
+
+
 ## [0.6.1] - 2026-06-03
 
 ### Fixed

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.4.3] - 2026-06-13
+
+
 ## [0.4.2] - 2026-06-03
 
 

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-transport/CHANGELOG.md
+++ b/crates/zendriver-transport/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-06-13
+
+
 ## [0.1.5] - 2026-06-03
 
 

--- a/crates/zendriver-transport/Cargo.toml
+++ b/crates/zendriver-transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-transport"
 description = "Internal: WebSocket + CDP routing actor for zendriver"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.15] - 2026-06-13
+
+
 ## [0.2.14] - 2026-06-03
 
 

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.14"
+version = "0.2.15"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-transport`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `zendriver-cloudflare`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `zendriver-interception`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `zendriver-datadome`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `zendriver-fetcher`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `zendriver-imperva`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `zendriver-stealth`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `zendriver`: 0.2.14 -> 0.2.15 (✓ API compatible changes)
* `zendriver-mcp`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `zendriver-fingerprints`: 0.2.4 -> 0.2.5

<details><summary><i><b>Changelog</b></i></summary><p>












</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).