### PR TITLE
fix(stealth): stop doubling the q-weight in Accept-Language

### DIFF
--- a/crates/zendriver-stealth/src/observer.rs
+++ b/crates/zendriver-stealth/src/observer.rs
@@ -85,7 +85,13 @@ impl TargetObserver for StealthObserver {
         // separately.
         let accept_language = {
             let langs = crate::lang::resolve_languages(&Persona::default(), &self.fingerprint);
-            crate::lang::accept_language(&langs)
+            // `Emulation.setUserAgentOverride.acceptLanguage` wants a PLAIN
+            // comma-separated locale list (e.g. `en-US,en`) — Chrome appends the
+            // `;q=` weights itself. Passing an already-weighted string (the
+            // `accept_language()` header form) makes Chrome double them, yielding
+            // a malformed `Accept-Language: en-US,en;q=0.9;q=0.9`. Send the bare
+            // list so the emitted header is a clean `en-US,en;q=0.9`.
+            langs.join(",")
         };
         session
             .call(
@@ -228,6 +234,20 @@ mod tests {
                 tokio::time::timeout(std::time::Duration::from_secs(2), mock.expect_cmd(expected))
                     .await
                     .unwrap_or_else(|_| panic!("did not see {expected} within 2s"));
+            // `acceptLanguage` must be a PLAIN locale list — Chrome adds the
+            // `;q=` weights. A weighted value here makes Chrome double them into
+            // a malformed `en-US,en;q=0.9;q=0.9` header.
+            if expected == "Emulation.setUserAgentOverride" {
+                let al = mock.last_sent()["params"]["acceptLanguage"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string();
+                assert!(!al.is_empty(), "acceptLanguage must be set");
+                assert!(
+                    !al.contains(";q="),
+                    "acceptLanguage must be a bare locale list (no q-weights); got: {al}"
+                );
+            }
             mock.reply(id, json!({})).await;
         }
 


### PR DESCRIPTION
## Problem

The stealth observer passed the **q-weighted** `accept_language()` output (e.g. `en-US,en;q=0.9`) into `Emulation.setUserAgentOverride.acceptLanguage`. That CDP field expects a **bare** comma-separated locale list — Chrome appends the `;q=` weights itself. Feeding it a pre-weighted string makes Chrome double them, so every request went out with a malformed header:

```
Accept-Language: en-US,en;q=0.9;q=0.9
```

Observed live against `join.pokemon.com` under `StealthProfile::native()`.

## Fix

Pass `langs.join(",")` (`en-US,en`) instead. Chrome now emits a clean `Accept-Language: en-US,en;q=0.9`.

`accept_language()` stays public API for callers that set the header directly (e.g. via `Network.setExtraHTTPHeaders`); it was just the wrong input for `setUserAgentOverride`.

## Verification

- **Live:** navigated `httpbin.org/headers` under the native profile — both the CDP-reported request headers and the header httpbin actually received are now `en-US,en;q=0.9` (single weight).
- **Test:** the existing observer mock test now asserts the emitted `acceptLanguage` carries no `;q=` weights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)