### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-trait",
  "base64",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "futures",
  "serde",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "futures",
  "serde",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,15 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.17", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.18", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.6" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.4.5" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.2" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.3" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.4" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.5" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.6.5" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.4" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.5" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.6.6" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.5" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.6" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.7" }
 
 # MCP server

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.6] - 2026-07-12
+
+
 ## [0.1.5] - 2026-07-10
 
 

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.5] - 2026-07-12
+
+
 ## [0.2.4] - 2026-07-10
 
 

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.4] - 2026-07-12
+
+### Fixed
+
+- Send a match-all pattern when handleAuthRequests is set
+
+
 ## [0.3.3] - 2026-07-10
 
 ### Fixed

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.6.6] - 2026-07-12
+
+
 ## [0.6.5] - 2026-07-10
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.6.5"
+version = "0.6.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.18] - 2026-07-12
+
+
 ## [0.2.17] - 2026-07-10
 
 

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.17"
+version = "0.2.18"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-interception`: 0.3.3 -> 0.3.4 (✓ API compatible changes)
* `zendriver-datadome`: 0.1.5 -> 0.1.6
* `zendriver-imperva`: 0.2.4 -> 0.2.5
* `zendriver`: 0.2.17 -> 0.2.18
* `zendriver-mcp`: 0.6.5 -> 0.6.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-interception`

<blockquote>

## [0.3.4] - 2026-07-12

### Fixed

- Send a match-all pattern when handleAuthRequests is set
</blockquote>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).