### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "async-trait",
  "base64",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-cloudflare"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "futures",
  "serde",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "futures",
  "serde",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -3551,7 +3551,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "async-trait",
  "axum",
@@ -3583,7 +3583,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",
@@ -3603,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-transport"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.18", default-features = false }
-zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.6" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.4.5" }
-zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.2" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.4" }
+zendriver               = { path = "crates/zendriver", version = "0.2.19", default-features = false }
+zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.7" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.4.6" }
+zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.3" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.5" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.5" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.6.6" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.5" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.6" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.7" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.6.7" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.6" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.7" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.8" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-cloudflare/CHANGELOG.md
+++ b/crates/zendriver-cloudflare/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-07-15
+
+
 ## [0.2.2] - 2026-06-13
 
 

--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-cloudflare"
 description = "Cloudflare Turnstile bypass for zendriver"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.7] - 2026-07-15
+
+
 ## [0.1.6] - 2026-07-12
 
 

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.8] - 2026-07-15
+
+
 ## [0.2.7] - 2026-07-10
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.6] - 2026-07-15
+
+
 ## [0.2.5] - 2026-07-12
 
 

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.5] - 2026-07-15
+
+
 ## [0.3.4] - 2026-07-12
 
 ### Fixed

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.6.7] - 2026-07-15
+
+### Fixed
+
+- Bound every CDP call, not just the launch handshake
+
+
 ## [0.6.6] - 2026-07-12
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.6.6"
+version = "0.6.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.4.6] - 2026-07-15
+
+### Fixed
+
+- Stop exec'ing `chrome --version` on Windows, where it never exits
+
+
 ## [0.4.5] - 2026-07-10
 
 ### Fixed

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.4.5"
+version = "0.4.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-transport/CHANGELOG.md
+++ b/crates/zendriver-transport/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-07-15
+
+### Fixed
+
+- Bound every CDP call, not just the launch handshake
+
+
 ## [0.1.6] - 2026-06-13
 
 

--- a/crates/zendriver-transport/Cargo.toml
+++ b/crates/zendriver-transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-transport"
 description = "Internal: WebSocket + CDP routing actor for zendriver"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,25 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.19] - 2026-07-15
+
+### Added
+
+- Resolve the WS endpoint from DevToolsActivePort as a fallback
+- Discover per-user %LOCALAPPDATA% chrome installs on windows
+
+### Fixed
+
+- Bound the CDP handshake and kill the child on timeout
+- Send CDP Browser.close before falling back to signals
+- Sweep stray page targets instead of silently discarding them
+- Kill chrome's whole process tree via a windows job object
+- Gate the owning-browser test helper to unix like its callers
+- Bound every CDP call, not just the launch handshake
+- Stop exec'ing `chrome --version` on Windows, where it never exits
+- Stop crying wolf on the initial target attach
+
+
 ## [0.2.18] - 2026-07-12
 
 

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.18"
+version = "0.2.19"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-transport`: 0.1.6 -> 0.1.7 (✓ API compatible changes)
* `zendriver-stealth`: 0.4.5 -> 0.4.6 (✓ API compatible changes)
* `zendriver`: 0.2.18 -> 0.2.19 (✓ API compatible changes)
* `zendriver-mcp`: 0.6.6 -> 0.6.7 (✓ API compatible changes)
* `zendriver-cloudflare`: 0.2.2 -> 0.2.3
* `zendriver-interception`: 0.3.4 -> 0.3.5
* `zendriver-datadome`: 0.1.6 -> 0.1.7
* `zendriver-imperva`: 0.2.5 -> 0.2.6
* `zendriver-fingerprints`: 0.2.7 -> 0.2.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-transport`

<blockquote>

## [0.1.7] - 2026-07-15

### Fixed

- Bound every CDP call, not just the launch handshake
</blockquote>

## `zendriver-stealth`

<blockquote>

## [0.4.6] - 2026-07-15

### Fixed

- Stop exec'ing `chrome --version` on Windows, where it never exits
</blockquote>

## `zendriver`

<blockquote>

## [0.2.19] - 2026-07-15

### Added

- Resolve the WS endpoint from DevToolsActivePort as a fallback
- Discover per-user %LOCALAPPDATA% chrome installs on windows

### Fixed

- Bound the CDP handshake and kill the child on timeout
- Send CDP Browser.close before falling back to signals
- Sweep stray page targets instead of silently discarding them
- Kill chrome's whole process tree via a windows job object
- Gate the owning-browser test helper to unix like its callers
- Bound every CDP call, not just the launch handshake
- Stop exec'ing `chrome --version` on Windows, where it never exits
- Stop crying wolf on the initial target attach
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.6.7] - 2026-07-15

### Fixed

- Bound every CDP call, not just the launch handshake
</blockquote>







</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).