### PR TITLE
feat(stealth): wire Persona.geolocation to Emulation.setGeolocationOverride

### DIFF
--- a/crates/zendriver-stealth/src/lib.rs
+++ b/crates/zendriver-stealth/src/lib.rs
@@ -59,4 +59,4 @@ pub use profile::{Platform, ProfileKind, StealthProfile};
 pub use persona::seed::Seed;
 pub use persona::specs::{FontSpec, HardwareSpec, SurfaceCfg, UaSpec, WebglSpec, WebrtcSpec};
 pub use persona::surface::{Strategy, Surface, SurfaceKind};
-pub use persona::{JsProbe, Persona, PersonaBuilder};
+pub use persona::{GeoPos, JsProbe, Persona, PersonaBuilder};

--- a/crates/zendriver-stealth/src/observer.rs
+++ b/crates/zendriver-stealth/src/observer.rs
@@ -12,6 +12,7 @@ use serde_json::json;
 use zendriver_transport::{ObserverError, PausedSession, TargetObserver};
 
 use crate::patches::bootstrap_script;
+use crate::persona::GeoPos;
 use crate::{Fingerprint, Persona, ProfileKind, StealthProfile};
 
 /// Observer that applies a [`StealthProfile`] + [`Fingerprint`] to every page
@@ -25,6 +26,11 @@ pub struct StealthObserver {
     /// `Page.addScriptToEvaluateOnNewDocument` in those modes, so there is no
     /// need to pay the patches-bundle cost for them.
     bootstrap: String,
+    /// Mock geolocation coordinates from the resolved [`Persona`], sent via
+    /// `Emulation.setGeolocationOverride`. Unlike `timezone`/`locale` (carried
+    /// on [`Fingerprint`]), geolocation has no `Fingerprint` counterpart, so
+    /// it's captured here straight off the persona at construction time.
+    geolocation: Option<GeoPos>,
 }
 
 impl StealthObserver {
@@ -54,10 +60,12 @@ impl StealthObserver {
         } else {
             String::new()
         };
+        let geolocation = persona.geolocation;
         Self {
             profile,
             fingerprint,
             bootstrap,
+            geolocation,
         }
     }
 }
@@ -137,6 +145,23 @@ impl TargetObserver for StealthObserver {
         if let Some(ref locale) = self.fingerprint.locale {
             session
                 .call("Emulation.setLocaleOverride", json!({ "locale": locale }))
+                .await?;
+        }
+        if let Some(ref geo) = self.geolocation {
+            // Sets the value the Geolocation API *would* return — it does
+            // NOT grant the `geolocation` permission. Chrome still gates the
+            // API behind a permission prompt/grant; auto-granting it here
+            // would be a separate (and itself suspicious) signal, so we
+            // deliberately leave permissioning to the caller.
+            let mut params = json!({
+                "latitude": geo.latitude,
+                "longitude": geo.longitude,
+            });
+            if let Some(accuracy) = geo.accuracy {
+                params["accuracy"] = json!(accuracy);
+            }
+            session
+                .call("Emulation.setGeolocationOverride", params)
                 .await?;
         }
 
@@ -246,6 +271,151 @@ mod tests {
                 assert!(
                     !al.contains(";q="),
                     "acceptLanguage must be a bare locale list (no q-weights); got: {al}"
+                );
+            }
+            mock.reply(id, json!({})).await;
+        }
+
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn spoofed_observer_emits_geolocation_override_when_persona_has_geo() {
+        let fp = Fingerprint {
+            platform: Platform::MacIntel,
+            chrome_major: 120,
+            chrome_full: "120.0.6099.234".into(),
+            cpu_count: 10,
+            memory_gb: 8,
+            ua_string: crate::ua::compose_ua_string(Platform::MacIntel, "120.0.6099.234"),
+            ua_metadata: crate::UserAgentMetadata::realistic(
+                Platform::MacIntel,
+                120,
+                "120.0.6099.234",
+            ),
+            timezone: None,
+            locale: None,
+            languages: None,
+        };
+        let persona = crate::Persona {
+            geolocation: Some(crate::persona::GeoPos {
+                latitude: 21.0285,
+                longitude: 105.8542,
+                accuracy: Some(50.0),
+            }),
+            ..crate::Persona::default()
+        };
+        let profile = StealthProfile::spoofed();
+        let observer = std::sync::Arc::new(StealthObserver::with_persona(profile, fp, persona));
+
+        let (mut mock, conn) = MockConnection::pair_with_observers(vec![observer.clone()]);
+
+        mock.emit_event(
+            "Target.attachedToTarget",
+            json!({
+                "sessionId": "S1",
+                "targetInfo": {
+                    "targetId": "T1",
+                    "type": "page",
+                    "url": "about:blank",
+                    "attached": true,
+                },
+                "waitingForDebugger": true,
+            }),
+        )
+        .await;
+
+        for expected in [
+            "Page.enable",
+            "Emulation.setUserAgentOverride",
+            "Emulation.setDeviceMetricsOverride",
+            "Emulation.setFocusEmulationEnabled",
+            "Emulation.setGeolocationOverride",
+            "Page.setBypassCSP",
+            "Page.addScriptToEvaluateOnNewDocument",
+            "Runtime.runIfWaitingForDebugger",
+        ] {
+            let id =
+                tokio::time::timeout(std::time::Duration::from_secs(2), mock.expect_cmd(expected))
+                    .await
+                    .unwrap_or_else(|_| panic!("did not see {expected} within 2s"));
+            if expected == "Emulation.setGeolocationOverride" {
+                let params = mock.last_sent()["params"].clone();
+                assert_eq!(params["latitude"].as_f64(), Some(21.0285));
+                assert_eq!(params["longitude"].as_f64(), Some(105.8542));
+                assert_eq!(params["accuracy"].as_f64(), Some(50.0));
+            }
+            mock.reply(id, json!({})).await;
+        }
+
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn geolocation_override_omits_accuracy_when_unset() {
+        let fp = Fingerprint {
+            platform: Platform::MacIntel,
+            chrome_major: 120,
+            chrome_full: "120.0.6099.234".into(),
+            cpu_count: 10,
+            memory_gb: 8,
+            ua_string: crate::ua::compose_ua_string(Platform::MacIntel, "120.0.6099.234"),
+            ua_metadata: crate::UserAgentMetadata::realistic(
+                Platform::MacIntel,
+                120,
+                "120.0.6099.234",
+            ),
+            timezone: None,
+            locale: None,
+            languages: None,
+        };
+        let persona = crate::Persona {
+            geolocation: Some(crate::persona::GeoPos {
+                latitude: 1.0,
+                longitude: 2.0,
+                accuracy: None,
+            }),
+            ..crate::Persona::default()
+        };
+        let profile = StealthProfile::native();
+        let observer = std::sync::Arc::new(StealthObserver::with_persona(profile, fp, persona));
+
+        let (mut mock, conn) = MockConnection::pair_with_observers(vec![observer.clone()]);
+
+        mock.emit_event(
+            "Target.attachedToTarget",
+            json!({
+                "sessionId": "S1",
+                "targetInfo": {
+                    "targetId": "T1",
+                    "type": "page",
+                    "url": "about:blank",
+                    "attached": true,
+                },
+                "waitingForDebugger": true,
+            }),
+        )
+        .await;
+
+        for expected in [
+            "Page.enable",
+            "Emulation.setUserAgentOverride",
+            "Emulation.setDeviceMetricsOverride",
+            "Emulation.setFocusEmulationEnabled",
+            "Emulation.setGeolocationOverride",
+            "Runtime.runIfWaitingForDebugger",
+        ] {
+            let id =
+                tokio::time::timeout(std::time::Duration::from_secs(2), mock.expect_cmd(expected))
+                    .await
+                    .unwrap_or_else(|_| panic!("did not see {expected} within 2s"));
+            if expected == "Emulation.setGeolocationOverride" {
+                let params = mock.last_sent()["params"].clone();
+                assert_eq!(params["latitude"].as_f64(), Some(1.0));
+                assert_eq!(params["longitude"].as_f64(), Some(2.0));
+                assert!(
+                    params.get("accuracy").is_none(),
+                    "accuracy must be omitted when unset, got: {params}"
                 );
             }
             mock.reply(id, json!({})).await;

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -16,6 +16,21 @@ use crate::Platform;
 
 static SYSTEM: OnceLock<Persona> = OnceLock::new();
 
+/// Mock geolocation coordinates, sent verbatim as
+/// `Emulation.setGeolocationOverride` params. Field names match the CDP
+/// params exactly (`latitude`, `longitude`, `accuracy`) so `GeoPos` can be
+/// deserialized straight out of `persona_overlay` JSON, e.g.
+/// `{"geolocation":{"latitude":21.0285,"longitude":105.8542}}`.
+///
+/// `accuracy` is optional — CDP accepts the override without it — and is
+/// omitted from the CDP call entirely (not sent as `null`) when unset.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct GeoPos {
+    pub latitude: f64,
+    pub longitude: f64,
+    pub accuracy: Option<f64>,
+}
+
 /// Unified fingerprint configuration. Every field optional → overlay semantics.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Persona {
@@ -29,6 +44,11 @@ pub struct Persona {
     /// `navigator.languages` and the q-weighted `Accept-Language`. When unset,
     /// derived from [`locale`](Self::locale).
     pub languages: Option<Vec<String>>,
+    /// Mock coordinates for the Geolocation API (`Emulation.setGeolocationOverride`).
+    /// Coherence axis alongside [`timezone`](Self::timezone) /
+    /// [`locale`](Self::locale) — keeps `navigator.geolocation` in step with
+    /// the exit IP's real location instead of leaking the host's.
+    pub geolocation: Option<GeoPos>,
     pub webgl: Option<WebglSpec>,
     pub webgpu: Option<SurfaceCfg>,
     pub canvas: Option<SurfaceCfg>,
@@ -106,6 +126,7 @@ impl Persona {
             timezone: over.timezone.or(self.timezone),
             locale: over.locale.or(self.locale),
             languages: over.languages.or(self.languages),
+            geolocation: over.geolocation.or(self.geolocation),
             webgl: over.webgl.or(self.webgl),
             webgpu: over.webgpu.or(self.webgpu),
             canvas: over.canvas.or(self.canvas),
@@ -475,5 +496,77 @@ mod persona_tests {
         assert_eq!(merged.timezone.as_deref(), Some("Asia/Tokyo")); // some wins
         assert_eq!(merged.device_memory_gb, Some(8)); // none inherits
         assert_eq!(merged.seed, Some(Seed::from_u64(1)));
+    }
+
+    #[test]
+    fn persona_round_trips_geolocation_json() {
+        let p = Persona {
+            geolocation: Some(GeoPos {
+                latitude: 21.0285,
+                longitude: 105.8542,
+                accuracy: Some(50.0),
+            }),
+            ..Persona::default()
+        };
+        let s = serde_json::to_string(&p).unwrap();
+        let back: Persona = serde_json::from_str(&s).unwrap();
+        assert_eq!(
+            back.geolocation,
+            Some(GeoPos {
+                latitude: 21.0285,
+                longitude: 105.8542,
+                accuracy: Some(50.0),
+            })
+        );
+    }
+
+    #[test]
+    fn geolocation_parses_without_accuracy() {
+        // `persona_overlay` accepts parsed JSON (BrowserBuilder doc example);
+        // accuracy is optional and must default to None when omitted.
+        let json = r#"{"geolocation":{"latitude":10.0,"longitude":20.0}}"#;
+        let p: Persona = json.parse().unwrap();
+        let geo = p.geolocation.expect("geolocation parsed");
+        assert_eq!(geo.latitude, 10.0);
+        assert_eq!(geo.longitude, 20.0);
+        assert_eq!(geo.accuracy, None);
+    }
+
+    #[test]
+    fn overlay_geolocation_some_wins_none_inherits() {
+        let base = Persona {
+            geolocation: Some(GeoPos {
+                latitude: 1.0,
+                longitude: 2.0,
+                accuracy: None,
+            }),
+            ..Persona::default()
+        };
+        let over = Persona {
+            geolocation: Some(GeoPos {
+                latitude: 9.0,
+                longitude: 8.0,
+                accuracy: Some(5.0),
+            }),
+            ..Persona::default()
+        };
+        let merged = base.clone().overlay(over);
+        assert_eq!(
+            merged.geolocation,
+            Some(GeoPos {
+                latitude: 9.0,
+                longitude: 8.0,
+                accuracy: Some(5.0),
+            })
+        ); // some wins
+        let merged2 = base.overlay(Persona::default());
+        assert_eq!(
+            merged2.geolocation,
+            Some(GeoPos {
+                latitude: 1.0,
+                longitude: 2.0,
+                accuracy: None,
+            })
+        ); // none inherits
     }
 }

--- a/crates/zendriver-stealth/tests/snapshots/persona_snapshot__persona_full_wire_shape.snap
+++ b/crates/zendriver-stealth/tests/snapshots/persona_snapshot__persona_full_wire_shape.snap
@@ -10,6 +10,7 @@ expression: p
   "timezone": "UTC",
   "locale": null,
   "languages": null,
+  "geolocation": null,
   "webgl": null,
   "webgpu": null,
   "canvas": null,


### PR DESCRIPTION
## What

Wires `Persona.geolocation` through to CDP `Emulation.setGeolocationOverride`, so a spoofed persona can present mock coordinates instead of the host's real position.

## Why

`Persona` already carries `timezone` and `locale` (on `Fingerprint`), so a persona can present a coherent locale + timezone — while `navigator.geolocation` still reports the **host's** real position. That's an internal contradiction: a persona claiming one region whose geolocation resolves to another. This closes the gap.

## Design notes

- Geolocation lives on `Persona`, **not** `Fingerprint` — unlike timezone/locale it has no `Fingerprint` counterpart, so it's carried on the persona and read directly by the observer.
- Emitted only for **Spoofed** profiles that actually set `geolocation`; a `None` persona field or a non-spoofed profile emits nothing (byte-identical to today).
- **Does not auto-grant the `geolocation` permission.** Chrome still gates the permission prompt; the override only takes effect once the page has permission. This is deliberate — silently granting a sensitive permission would itself be a tell.

## Testing

- New: `spoofed_observer_emits_geolocation_override_when_persona_has_geo`.
- `cargo test -p zendriver-stealth --features geo` → 123 pass (116 + 1 + 6), 0 fail.
- `cargo build -p zendriver --features geo` clean; `cargo fmt --all --check` clean.

Base is current `main` (one commit on top); merges clean.
