### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "async-trait",
  "base64",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3551,7 +3551,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "async-trait",
  "axum",
@@ -3583,7 +3583,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.19", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.20", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.7" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.4.6" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.5.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.3" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.5" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.5" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.6.7" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.6.8" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.6" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.7" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.8" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.9" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.9] - 2026-07-16
+
+
 ## [0.2.8] - 2026-07-15
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.6.8] - 2026-07-16
+
+
 ## [0.6.7] - 2026-07-15
 
 ### Fixed

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.6.7"
+version = "0.6.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.5.0] - 2026-07-16
+
+### Added
+
+- Wire Persona.geolocation to Emulation.setGeolocationOverride
+
+
 ## [0.4.6] - 2026-07-15
 
 ### Fixed

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.4.6"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.20] - 2026-07-16
+
+
 ## [0.2.19] - 2026-07-15
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.19"
+version = "0.2.20"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.4.6 -> 0.5.0 (⚠ API breaking changes)
* `zendriver`: 0.2.19 -> 0.2.20
* `zendriver-fingerprints`: 0.2.8 -> 0.2.9
* `zendriver-mcp`: 0.6.7 -> 0.6.8

### ⚠ `zendriver-stealth` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Persona.geolocation in /tmp/.tmpJfPXe6/zendriver-rs/crates/zendriver-stealth/src/persona/mod.rs:51
  field Persona.geolocation in /tmp/.tmpJfPXe6/zendriver-rs/crates/zendriver-stealth/src/persona/mod.rs:51
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-stealth`

<blockquote>

## [0.5.0] - 2026-07-16

### Added

- Wire Persona.geolocation to Emulation.setGeolocationOverride
</blockquote>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).