### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "async-trait",
  "base64",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.21", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.22", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.8" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.5.1" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.4" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.6" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.6" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.6.9" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.6.10" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.7" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.8" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.10" }

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.6.10] - 2026-07-16
+
+
 ## [0.6.9] - 2026-07-16
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.6.9"
+version = "0.6.10"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,14 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.22] - 2026-07-16
+
+### Fixed
+
+- Honor visible_only by filtering finds through check_visible
+- Honor visible_only across include_frames() fan-out paths
+
+
 ## [0.2.21] - 2026-07-16
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.21"
+version = "0.2.22"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver`: 0.2.21 -> 0.2.22 (✓ API compatible changes)
* `zendriver-mcp`: 0.6.9 -> 0.6.10

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver`

<blockquote>

## [0.2.22] - 2026-07-16

### Fixed

- Honor visible_only by filtering finds through check_visible
- Honor visible_only across include_frames() fan-out paths
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).