### PR TITLE
feat(geo): auto IP-geo resolution (GeoResolver exit-IP probe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ More working examples in [`crates/zendriver/examples/`](crates/zendriver/example
 | `imperva`      | no       | Imperva WAF / Incapsula bypass (reese84 / legacy / CAPTCHA)   | `zendriver-imperva`                   |
 | `datadome`     | no       | DataDome bypass (device-check / CAPTCHA / block) + `Surface::Webgpu` coherence | `zendriver-datadome` |
 | `monitor`      | no       | Passive network monitor — buffered HTTP / WebSocket / SSE events via `tab.monitor()` | (in-tree, no extra crate)             |
-| `geo`          | no       | Country code → coherent `locale` + `languages` (Accept-Language) persona overlay | (via `zendriver-stealth`)             |
+| `geo`          | no       | Country code → coherent `locale` + `languages` (Accept-Language) persona overlay, plus opt-in `geo_auto()` exit-IP auto-resolution | `reqwest` (via `zendriver-stealth`) |
 | `tracker-blocking` | no   | Opt-in third-party tracker / fingerprinter host blocklist (curated bundled list + BYO file / URL) | `reqwest` + `dirs`         |
 | `fetcher`      | no       | Auto-download a pinned Chrome for Testing build               | `zendriver-fetcher` + `reqwest`/`zip` |
 
@@ -90,7 +90,7 @@ Same as above — only spell out the feature if you want it visible in `Cargo.to
 cargo add zendriver --features "interception expect cloudflare imperva datadome monitor geo tracker-blocking fetcher"
 ```
 
-Adds request interception, `expect()` matchers, Cloudflare Turnstile bypass, Imperva WAF / Incapsula bypass, DataDome bypass, the passive network monitor, country→locale geo overlay, the opt-in tracker/fingerprinter blocklist, and the Chrome for Testing fetcher.
+Adds request interception, `expect()` matchers, Cloudflare Turnstile bypass, Imperva WAF / Incapsula bypass, DataDome bypass, the passive network monitor, country→locale geo overlay (explicit `geo_locale()` or auto-resolved via `geo_auto()`), the opt-in tracker/fingerprinter blocklist, and the Chrome for Testing fetcher.
 
 ## Drive a stealth browser from your AI agent
 

--- a/crates/zendriver-mcp/mcp-coverage-ledger.toml
+++ b/crates/zendriver-mcp/mcp-coverage-ledger.toml
@@ -435,3 +435,20 @@ excluded = "builder for BrowserContext (proxy / proxy_bypass / proxy_auth / buil
 [[entry]]
 api = "zendriver::BrowserContextBuilder"
 excluded = "crate-root re-export of the above builder; same non-goal"
+
+# ── Auto IP-geo resolution (geo_auto / structured proxy) ────────────────────
+[[entry]]
+api = "zendriver::browser::BrowserBuilder::proxy"
+covered = "browser_open.proxy"
+
+[[entry]]
+api = "zendriver::browser::BrowserBuilder::geo_auto"
+covered = "browser_open.geo_auto / browser_open.geo_endpoint"
+
+[[entry]]
+api = "zendriver::browser::BrowserBuilder::geo_resolver"
+excluded = "accepts `impl GeoResolver + 'static` — a custom Rust trait implementation has no request/response wire form; browser_open.geo_auto covers the bundled IpApiResolver path (with an optional geo_endpoint override) instead"
+
+[[entry]]
+api = "zendriver::IpApiResolver"
+covered = "browser_open.geo_auto / browser_open.geo_endpoint"

--- a/crates/zendriver-mcp/public-api-baseline.txt
+++ b/crates/zendriver-mcp/public-api-baseline.txt
@@ -270,7 +270,9 @@ pub fn zendriver::browser::BrowserBuilder::executable(self, impl core::convert::
 pub fn zendriver::browser::BrowserBuilder::expert(self, bool) -> Self
 pub fn zendriver::browser::BrowserBuilder::extensions(self, impl core::iter::traits::collect::IntoIterator<Item = std::path::PathBuf>) -> Self
 pub fn zendriver::browser::BrowserBuilder::force_open_shadow_roots(self, bool) -> Self
+pub fn zendriver::browser::BrowserBuilder::geo_auto(self) -> Self
 pub fn zendriver::browser::BrowserBuilder::geo_locale(self, impl core::convert::TryInto<zendriver_stealth::geo::Country>) -> Self
+pub fn zendriver::browser::BrowserBuilder::geo_resolver(self, impl zendriver_stealth::geo::GeoResolver + 'static) -> Self
 pub fn zendriver::browser::BrowserBuilder::headless(self, bool) -> Self
 pub fn zendriver::browser::BrowserBuilder::lang(self, impl core::convert::Into<alloc::string::String>) -> Self
 pub fn zendriver::browser::BrowserBuilder::new() -> Self
@@ -278,6 +280,7 @@ pub fn zendriver::browser::BrowserBuilder::observer(self, alloc::sync::Arc<dyn z
 pub fn zendriver::browser::BrowserBuilder::persona(self, zendriver_stealth::persona::Persona) -> Self
 pub fn zendriver::browser::BrowserBuilder::persona_overlay(self, zendriver_stealth::persona::Persona) -> Self
 pub fn zendriver::browser::BrowserBuilder::preference(self, impl core::convert::Into<alloc::string::String>, serde_json::value::Value) -> Self
+pub fn zendriver::browser::BrowserBuilder::proxy(self, impl core::convert::Into<alloc::string::String>) -> Self
 pub fn zendriver::browser::BrowserBuilder::proxy_auth(self, impl core::convert::Into<alloc::string::String>, impl core::convert::Into<alloc::string::String>) -> Self
 pub fn zendriver::browser::BrowserBuilder::resolved_persona(&self) -> zendriver_stealth::persona::Persona
 pub fn zendriver::browser::BrowserBuilder::sandbox(self, bool) -> Self
@@ -5625,7 +5628,9 @@ pub fn zendriver::browser::BrowserBuilder::executable(self, impl core::convert::
 pub fn zendriver::browser::BrowserBuilder::expert(self, bool) -> Self
 pub fn zendriver::browser::BrowserBuilder::extensions(self, impl core::iter::traits::collect::IntoIterator<Item = std::path::PathBuf>) -> Self
 pub fn zendriver::browser::BrowserBuilder::force_open_shadow_roots(self, bool) -> Self
+pub fn zendriver::browser::BrowserBuilder::geo_auto(self) -> Self
 pub fn zendriver::browser::BrowserBuilder::geo_locale(self, impl core::convert::TryInto<zendriver_stealth::geo::Country>) -> Self
+pub fn zendriver::browser::BrowserBuilder::geo_resolver(self, impl zendriver_stealth::geo::GeoResolver + 'static) -> Self
 pub fn zendriver::browser::BrowserBuilder::headless(self, bool) -> Self
 pub fn zendriver::browser::BrowserBuilder::lang(self, impl core::convert::Into<alloc::string::String>) -> Self
 pub fn zendriver::browser::BrowserBuilder::new() -> Self
@@ -5633,6 +5638,7 @@ pub fn zendriver::browser::BrowserBuilder::observer(self, alloc::sync::Arc<dyn z
 pub fn zendriver::browser::BrowserBuilder::persona(self, zendriver_stealth::persona::Persona) -> Self
 pub fn zendriver::browser::BrowserBuilder::persona_overlay(self, zendriver_stealth::persona::Persona) -> Self
 pub fn zendriver::browser::BrowserBuilder::preference(self, impl core::convert::Into<alloc::string::String>, serde_json::value::Value) -> Self
+pub fn zendriver::browser::BrowserBuilder::proxy(self, impl core::convert::Into<alloc::string::String>) -> Self
 pub fn zendriver::browser::BrowserBuilder::proxy_auth(self, impl core::convert::Into<alloc::string::String>, impl core::convert::Into<alloc::string::String>) -> Self
 pub fn zendriver::browser::BrowserBuilder::resolved_persona(&self) -> zendriver_stealth::persona::Persona
 pub fn zendriver::browser::BrowserBuilder::sandbox(self, bool) -> Self
@@ -6418,6 +6424,47 @@ impl<T> typenum::type_operators::Same for zendriver::tab::IdleOptions
 pub type zendriver::tab::IdleOptions::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for zendriver::tab::IdleOptions where V: ppv_lite86::types::MultiLane<T>
 pub fn zendriver::tab::IdleOptions::vzip(self) -> V
+pub struct zendriver::IpApiResolver
+impl zendriver::IpApiResolver
+pub fn zendriver::IpApiResolver::endpoint(self, impl core::convert::Into<alloc::string::String>) -> Self
+pub fn zendriver::IpApiResolver::new() -> Self
+pub fn zendriver::IpApiResolver::timeout(self, core::time::Duration) -> Self
+impl core::default::Default for zendriver::IpApiResolver
+pub fn zendriver::IpApiResolver::default() -> Self
+impl zendriver_stealth::geo::GeoResolver for zendriver::IpApiResolver
+pub fn zendriver::IpApiResolver::country<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::option::Option<zendriver_stealth::geo::Country>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+impl core::marker::Freeze for zendriver::IpApiResolver
+impl core::marker::Send for zendriver::IpApiResolver
+impl core::marker::Sync for zendriver::IpApiResolver
+impl core::marker::Unpin for zendriver::IpApiResolver
+impl core::marker::UnsafeUnpin for zendriver::IpApiResolver
+impl core::panic::unwind_safe::RefUnwindSafe for zendriver::IpApiResolver
+impl core::panic::unwind_safe::UnwindSafe for zendriver::IpApiResolver
+impl<T, U> core::convert::Into<U> for zendriver::IpApiResolver where U: core::convert::From<T>
+pub fn zendriver::IpApiResolver::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for zendriver::IpApiResolver where U: core::convert::Into<T>
+pub type zendriver::IpApiResolver::Error = core::convert::Infallible
+pub fn zendriver::IpApiResolver::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for zendriver::IpApiResolver where U: core::convert::TryFrom<T>
+pub type zendriver::IpApiResolver::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn zendriver::IpApiResolver::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for zendriver::IpApiResolver where T: 'static + ?core::marker::Sized
+pub fn zendriver::IpApiResolver::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for zendriver::IpApiResolver where T: ?core::marker::Sized
+pub fn zendriver::IpApiResolver::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for zendriver::IpApiResolver where T: ?core::marker::Sized
+pub fn zendriver::IpApiResolver::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for zendriver::IpApiResolver
+pub fn zendriver::IpApiResolver::from(T) -> T
+impl<T> tower_http::follow_redirect::policy::PolicyExt for zendriver::IpApiResolver where T: ?core::marker::Sized
+pub fn zendriver::IpApiResolver::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn zendriver::IpApiResolver::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: core::marker::Sized + tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for zendriver::IpApiResolver
+impl<T> tracing::instrument::WithSubscriber for zendriver::IpApiResolver
+impl<T> typenum::type_operators::Same for zendriver::IpApiResolver
+pub type zendriver::IpApiResolver::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for zendriver::IpApiResolver where V: ppv_lite86::types::MultiLane<T>
+pub fn zendriver::IpApiResolver::vzip(self) -> V
 pub struct zendriver::KeyModifiers(_)
 impl zendriver::input::keyboard::KeyModifiers
 pub const zendriver::input::keyboard::KeyModifiers::ALT: Self

--- a/crates/zendriver-mcp/src/tools/lifecycle.rs
+++ b/crates/zendriver-mcp/src/tools/lifecycle.rs
@@ -145,6 +145,11 @@ pub async fn open(
         if input.geo_auto {
             builder = match &input.geo_endpoint {
                 Some(endpoint) => {
+                    if input.proxy.is_some() {
+                        tracing::warn!(
+                            "geo_endpoint overrides the default ip-api.com probe but is NOT proxy-mirrored (unlike geo_auto's bundled default) — the probe will hit this endpoint directly from the host, not through `proxy`, so its exit IP may not match the browser's"
+                        );
+                    }
                     builder.geo_resolver(zendriver::IpApiResolver::new().endpoint(endpoint.clone()))
                 }
                 None => builder.geo_auto(),

--- a/crates/zendriver-mcp/src/tools/lifecycle.rs
+++ b/crates/zendriver-mcp/src/tools/lifecycle.rs
@@ -51,6 +51,33 @@ pub struct OpenInput {
     /// to also include the bundled list.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tracker_blocklist: Option<TrackerBlocklist>,
+    /// Route the browser through an upstream proxy
+    /// (`scheme://[user:pass@]host:port`). Userinfo is auto-split into proxy
+    /// auth credentials and answered via the `Fetch.authRequired` handshake
+    /// (requires the `interception` feature — without it the credentials are
+    /// simply not auto-wired). See `BrowserBuilder::proxy`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proxy: Option<String>,
+    /// Auto-derive `locale`/`languages` from the exit IP's country via a
+    /// proxied probe to an IP-geolocation service (default `ip-api.com`).
+    /// Opt-in; makes at most ONE outbound HTTP request, at launch, and only
+    /// when this is `true`. Mirrors `proxy` above when both are set, so the
+    /// probe reports the same exit IP Chrome will actually use. Overridden by
+    /// an explicit `persona`/locale, which also skips the probe. Always
+    /// present in the schema so the wire shape is feature-stable; only takes
+    /// effect when the server is built with the `geo` feature (otherwise
+    /// ignored — a warning is logged).
+    #[serde(default)]
+    pub geo_auto: bool,
+    /// Override the geo-probe endpoint (default `http://ip-api.com/json`).
+    /// Only meaningful together with `geo_auto: true`; ignored otherwise.
+    /// Same feature gating as `geo_auto`. Note: this bypasses proxy
+    /// mirroring — the probe against a custom endpoint is NOT routed through
+    /// `proxy` above (the underlying `IpApiResolver::with_proxy` wiring is
+    /// crate-private to `zendriver`); only the bundled default endpoint gets
+    /// proxy mirroring.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub geo_endpoint: Option<String>,
 }
 
 /// A custom tracker-blocklist source for `browser_open`.
@@ -109,6 +136,26 @@ pub async fn open(
         let persona = zendriver::Persona::try_from_json(&p.to_string())
             .map_err(|e| ErrorData::invalid_params(format!("invalid persona JSON: {e}"), None))?;
         builder = builder.persona(persona);
+    }
+    if let Some(proxy) = &input.proxy {
+        builder = builder.proxy(proxy.clone());
+    }
+    #[cfg(feature = "geo")]
+    {
+        if input.geo_auto {
+            builder = match &input.geo_endpoint {
+                Some(endpoint) => {
+                    builder.geo_resolver(zendriver::IpApiResolver::new().endpoint(endpoint.clone()))
+                }
+                None => builder.geo_auto(),
+            };
+        }
+    }
+    #[cfg(not(feature = "geo"))]
+    if input.geo_auto || input.geo_endpoint.is_some() {
+        tracing::warn!(
+            "geo_auto/geo_endpoint requested but this server was built without the `geo` feature; ignoring"
+        );
     }
     #[cfg(feature = "tracker-blocking")]
     {

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__lifecycle_open_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__lifecycle_open_in.snap
@@ -12,6 +12,15 @@ properties:
     type:
       - boolean
       - "null"
+  geo_auto:
+    description: "Auto-derive `locale`/`languages` from the exit IP's country via a\nproxied probe to an IP-geolocation service (default `ip-api.com`).\nOpt-in; makes at most ONE outbound HTTP request, at launch, and only\nwhen this is `true`. Mirrors `proxy` above when both are set, so the\nprobe reports the same exit IP Chrome will actually use. Overridden by\nan explicit `persona`/locale, which also skips the probe. Always\npresent in the schema so the wire shape is feature-stable; only takes\neffect when the server is built with the `geo` feature (otherwise\nignored — a warning is logged)."
+    type: boolean
+    default: false
+  geo_endpoint:
+    description: "Override the geo-probe endpoint (default `http://ip-api.com/json`).\nOnly meaningful together with `geo_auto: true`; ignored otherwise.\nSame feature gating as `geo_auto`. Note: this bypasses proxy\nmirroring — the probe against a custom endpoint is NOT routed through\n`proxy` above (the underlying `IpApiResolver::with_proxy` wiring is\ncrate-private to `zendriver`); only the bundled default endpoint gets\nproxy mirroring."
+    type:
+      - string
+      - "null"
   headless:
     description: "Run Chrome with `--headless=new` (default: `true`)."
     type: boolean
@@ -24,6 +33,11 @@ properties:
       - object
       - "null"
     additionalProperties: true
+  proxy:
+    description: "Route the browser through an upstream proxy\n(`scheme://[user:pass@]host:port`). Userinfo is auto-split into proxy\nauth credentials and answered via the `Fetch.authRequired` handshake\n(requires the `interception` feature — without it the credentials are\nsimply not auto-wired). See `BrowserBuilder::proxy`."
+    type:
+      - string
+      - "null"
   stealth_profile:
     description: "Override the session's default stealth profile for this launch.\nWhen `None`, the session-wide default (set via CLI / construct time)\nis used."
     anyOf:

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -47,7 +47,7 @@ datadome = ["interception", "dep:zendriver-datadome"]
 # Network-touching DataDome nightly tests (real protected sites).
 datadome-tests = ["datadome", "integration-tests"]
 # Country -> coherent locale/languages (BrowserBuilder::geo_locale).
-geo = ["zendriver-stealth/geo"]
+geo = ["zendriver-stealth/geo", "dep:reqwest"]
 # Chrome for Testing binary downloader.
 fetcher = ["dep:zendriver-fetcher"]
 # Network-touching fetcher tests (CfT manifest, real downloads).
@@ -90,7 +90,7 @@ zip.workspace                 = true
 # from `[features]`).
 wiremock    = { workspace = true, optional = true }
 serial_test = { workspace = true, optional = true }
-reqwest     = { workspace = true, optional = true }
+reqwest     = { workspace = true, optional = true, features = ["json"] }
 dirs        = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
@@ -108,6 +108,11 @@ tracing-subscriber.workspace  = true
 # confined that regression lock to Unix).
 sysinfo.workspace             = true
 zendriver-transport = { workspace = true, features = ["testing"] }
+# Unconditional (unlike the `dep:wiremock` optional entry above, which only
+# gates the real-Chrome `integration-tests` binaries): the `geo_resolver`
+# unit tests mock an HTTP server and must run under a plain
+# `--features geo` build, without pulling in all of `integration-tests`.
+wiremock.workspace = true
 
 [[test]]
 name = "datadome_v0"

--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -442,6 +442,10 @@ pub struct BrowserBuilder {
     /// profile's `Default/Preferences` at launch. User entries override the
     /// default suppression set. See [`BrowserBuilder::preference`].
     pub(crate) preferences: Vec<(String, serde_json::Value)>,
+    /// Structured browser-wide proxy (userinfo-stripped server + optional
+    /// credentials), set via [`BrowserBuilder::proxy`]. Emitted as
+    /// `--proxy-server=` at launch and mirrored by `geo_auto`'s probe.
+    pub(crate) proxy: Option<crate::proxy::ParsedProxy>,
     /// Optional `(username, password)` for proxy / HTTP basic-auth handling.
     /// Only honored when the `interception` feature is enabled; when present
     /// at launch, an interception actor is spawned on the main tab session
@@ -488,7 +492,21 @@ impl std::fmt::Debug for BrowserBuilder {
                 "extra_observers",
                 &format_args!("<{} observers>", self.extra_observers.len()),
             )
-            .field("preferences", &self.preferences);
+            .field("preferences", &self.preferences)
+            .field(
+                "proxy",
+                &self.proxy.as_ref().map(|p| {
+                    format!(
+                        "ParsedProxy {{ server: {:?}, credentials: {} }}",
+                        p.server,
+                        if p.credentials.is_some() {
+                            "Some(<redacted>)"
+                        } else {
+                            "None"
+                        }
+                    )
+                }),
+            );
         #[cfg(feature = "interception")]
         s.field(
             "proxy_auth",
@@ -607,6 +625,39 @@ impl BrowserBuilder {
     #[must_use]
     pub fn proxy_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
         self.proxy_auth = Some((user.into(), pass.into()));
+        self
+    }
+
+    /// Route the browser through `proxy` (`scheme://[user:pass@]host:port`).
+    /// Emits `--proxy-server=<host:port>` (Chrome ignores userinfo there) and,
+    /// when the URL carries credentials and `proxy_auth` is unset, auto-wires
+    /// them. The structured form lets `geo_auto()` probe the exit IP through
+    /// the same proxy.
+    ///
+    /// # Errors
+    /// Silently ignores an unparseable URL (logs a warning) to keep the
+    /// builder chainable; the bad value simply isn't applied.
+    #[must_use]
+    pub fn proxy(mut self, proxy: impl Into<String>) -> Self {
+        let raw = proxy.into();
+        match crate::proxy::split_proxy_url(&raw) {
+            Ok(parsed) => {
+                // Auto-wiring `proxy_auth` from the URL's userinfo only makes
+                // sense when that field exists at all, which requires the
+                // `interception` feature (it drives the `Fetch.authRequired`
+                // auto-reply actor at launch).
+                #[cfg(feature = "interception")]
+                {
+                    if self.proxy_auth.is_none() {
+                        if let Some((u, p)) = parsed.credentials.clone() {
+                            self.proxy_auth = Some((u, p));
+                        }
+                    }
+                }
+                self.proxy = Some(parsed);
+            }
+            Err(e) => tracing::warn!(error = %e, "proxy: ignoring invalid proxy URL"),
+        }
         self
     }
 
@@ -1180,6 +1231,19 @@ impl BrowserBuilder {
         // root should opt in explicitly with `.sandbox(false)`.
         if self.sandbox == Some(false) {
             v.push("--no-sandbox".to_string());
+        }
+        // Structured browser-wide proxy set via `BrowserBuilder::proxy`.
+        // Emits the userinfo-stripped `--proxy-server=` flag unless the
+        // caller already supplied their own via `.arg`/`.args` — an explicit
+        // flag wins over the structured form.
+        if let Some(parsed) = self.proxy.as_ref() {
+            let explicit = self
+                .extra_args
+                .iter()
+                .any(|a| a.starts_with("--proxy-server="));
+            if !explicit {
+                v.push(format!("--proxy-server={}", parsed.server));
+            }
         }
         v.extend(self.extra_args.iter().cloned());
         // Start the initial tab on `about:blank` instead of Chrome's default
@@ -4060,6 +4124,22 @@ mod tests {
             .unwrap();
         let lang = flags.iter().position(|f| f == "--lang=en-US").unwrap();
         assert!(proxy < lang);
+    }
+
+    #[test]
+    fn proxy_stores_parsed_and_strips_userinfo_arg() {
+        let b = Browser::builder().proxy("http://bob:pw@host:3128");
+        let p = b.proxy.as_ref().unwrap();
+        assert_eq!(p.server, "http://host:3128");
+        assert_eq!(p.credentials, Some(("bob".into(), "pw".into())));
+        // proxy_auth auto-wired from userinfo (field only exists under the
+        // `interception` feature, which drives the auth-reply actor).
+        #[cfg(feature = "interception")]
+        assert_eq!(b.proxy_auth, Some(("bob".into(), "pw".into())));
+
+        // At launch, the userinfo-stripped `--proxy-server=` flag is emitted.
+        let flags = b.build_flags(Path::new("/tmp/x"));
+        assert!(flags.contains(&"--proxy-server=http://host:3128".to_string()));
     }
 
     #[test]

--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -452,6 +452,14 @@ pub struct BrowserBuilder {
     /// that auto-replies to `Fetch.authRequired`. See cdpdriver/zendriver#208.
     #[cfg(feature = "interception")]
     pub(crate) proxy_auth: Option<(String, String)>,
+    /// Custom or auto-derived exit-IP -> country resolver. Set via
+    /// [`BrowserBuilder::geo_auto`] (wraps [`crate::IpApiResolver`], mirroring
+    /// `self.proxy`) or [`BrowserBuilder::geo_resolver`] (bring your own).
+    /// Probed once, asynchronously, by `apply_geo_overlay` in `launch()` /
+    /// `connect()` — before an explicit `persona_overlay`/`geo_locale` locale,
+    /// which wins and skips the probe entirely.
+    #[cfg(feature = "geo")]
+    pub(crate) geo_resolver: Option<Arc<dyn zendriver_stealth::geo::GeoResolver>>,
     /// Enable the bundled curated tracker/fingerprinter blocklist.
     #[cfg(feature = "tracker-blocking")]
     pub(crate) block_trackers: bool,
@@ -515,6 +523,15 @@ impl std::fmt::Debug for BrowserBuilder {
                 .as_ref()
                 .map(|(u, _)| format!("Some({u:?}, <redacted>)"))
                 .unwrap_or_else(|| "None".into()),
+        );
+        #[cfg(feature = "geo")]
+        s.field(
+            "geo_resolver",
+            &if self.geo_resolver.is_some() {
+                "Some(<dyn GeoResolver>)"
+            } else {
+                "None"
+            },
         );
         #[cfg(feature = "tracker-blocking")]
         s.field("block_trackers", &self.block_trackers)
@@ -1072,6 +1089,64 @@ impl BrowserBuilder {
             Err(_) => tracing::warn!("geo_locale: invalid country code; ignoring"),
         }
         self
+    }
+
+    /// Auto-derive locale/languages from the exit IP's country via a proxied
+    /// probe to `ip-api.com`. Opt-in; makes ONE outbound request at launch
+    /// only when set. Overridden by an explicit `geo_locale`/`persona_overlay`
+    /// locale (which also skips the probe). Mirrors the proxy set via
+    /// [`Self::proxy`].
+    #[cfg(feature = "geo")]
+    #[must_use]
+    pub fn geo_auto(mut self) -> Self {
+        let proxy = self.proxy.as_ref().map(|p| p.server.clone());
+        self.geo_resolver = Some(Arc::new(crate::IpApiResolver::new().with_proxy(proxy)));
+        self
+    }
+
+    /// Supply a custom [`zendriver_stealth::geo::GeoResolver`] (your own
+    /// service / offline DB) in place of the bundled `ip-api.com` probe.
+    #[cfg(feature = "geo")]
+    #[must_use]
+    pub fn geo_resolver(
+        mut self,
+        resolver: impl zendriver_stealth::geo::GeoResolver + 'static,
+    ) -> Self {
+        self.geo_resolver = Some(Arc::new(resolver));
+        self
+    }
+
+    /// Resolve the geo-derived locale (if a resolver is set) and merge it
+    /// into `persona_overlay`, honoring the same precedence
+    /// [`Self::geo_locale`] uses: an explicit overlay locale wins and skips
+    /// the probe entirely. Extracted out of `launch`/`connect` so it's
+    /// unit-testable without a live Chrome.
+    #[cfg(feature = "geo")]
+    async fn apply_geo_overlay(&mut self) {
+        let Some(resolver) = self.geo_resolver.clone() else {
+            return;
+        };
+        // An explicit locale (via `.persona_overlay(..)` or `.geo_locale(..)`)
+        // already set → skip the probe entirely; the auto-derived overlay
+        // must never outrank it.
+        if self
+            .persona_overlay
+            .as_ref()
+            .is_some_and(|p| p.locale.is_some())
+        {
+            return;
+        }
+        if let Some(country) = resolver.country().await {
+            let derived = zendriver_stealth::geo::persona(country);
+            self.persona_overlay = Some(match self.persona_overlay.take() {
+                // Same direction as `geo_locale` above: `existing.overlay(derived)`
+                // (derived's `Some` fields win where existing didn't already
+                // set them — the early return above guarantees `existing.locale`
+                // is `None` here, so precedence matches `geo_locale` exactly).
+                Some(existing) => existing.overlay(derived),
+                None => derived,
+            });
+        }
     }
 
     /// Override a single fingerprint [`Surface`]'s render [`Strategy`].
@@ -2590,6 +2665,13 @@ impl BrowserBuilder {
         // we can `set_browser` after construction.
         let registrar = Arc::new(TabRegistrar::new(input_profile.clone()));
 
+        // 3b. Resolve the geo-derived locale overlay (if `.geo_auto()` /
+        // `.geo_resolver(..)` is set), before `resolved_persona()` below reads
+        // `persona_overlay`. Fail-soft and a no-op when unset or when an
+        // explicit locale already wins.
+        #[cfg(feature = "geo")]
+        self.apply_geo_overlay().await;
+
         // 4. Resolve fingerprint + build observer chain + profile flags.
         // Observer order: stealth (patches each new target) → tab registrar
         // (records the resulting Tab handle) → user-supplied observers →
@@ -2880,7 +2962,10 @@ impl BrowserBuilder {
     /// browser.close().await?;
     /// # Ok(()) }
     /// ```
-    pub async fn connect(self, endpoint: impl Into<String>) -> Result<Browser, ZendriverError> {
+    // `mut` is only exercised by `apply_geo_overlay` under the `geo` feature;
+    // without it, `self` is never mutated in this body.
+    #[cfg_attr(not(feature = "geo"), allow(unused_mut))]
+    pub async fn connect(mut self, endpoint: impl Into<String>) -> Result<Browser, ZendriverError> {
         let endpoint = endpoint.into();
 
         // Resolve the browser WebSocket URL from the endpoint scheme.
@@ -2891,6 +2976,11 @@ impl BrowserBuilder {
         } else {
             return Err(BrowserError::DevtoolsParse.into());
         };
+
+        // Resolve the geo-derived locale overlay (same as `launch`) before
+        // `resolved_persona()` below reads `persona_overlay`.
+        #[cfg(feature = "geo")]
+        self.apply_geo_overlay().await;
 
         // Resolve the per-tab InputProfile + build the observer chain exactly
         // like `launch` does (stealth observer → tab registrar → user
@@ -4025,6 +4115,63 @@ mod tests {
         let builder = Browser::builder().geo_locale("US");
         let p = builder.resolved_persona();
         assert_eq!(p.locale.as_deref(), Some("en-US"));
+    }
+
+    /// A [`zendriver_stealth::geo::GeoResolver`] stub that always resolves to
+    /// a fixed country and counts how many times it was probed, so tests can
+    /// assert the probe fired (or, for the explicit-locale-wins case, did
+    /// NOT fire).
+    #[cfg(feature = "geo")]
+    struct StubCountryResolver {
+        cc: &'static str,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[cfg(feature = "geo")]
+    #[async_trait::async_trait]
+    impl zendriver_stealth::geo::GeoResolver for StubCountryResolver {
+        async fn country(&self) -> Option<zendriver_stealth::geo::Country> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            zendriver_stealth::geo::Country::try_from(self.cc).ok()
+        }
+    }
+
+    #[cfg(feature = "geo")]
+    #[tokio::test]
+    async fn geo_resolver_augments_persona_at_launch() {
+        // Drives `apply_geo_overlay` directly (no Chrome launched) — a stub
+        // resolver reporting "DE" must land as the `de-DE` locale overlay.
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut builder = Browser::builder().geo_resolver(StubCountryResolver {
+            cc: "DE",
+            calls: calls.clone(),
+        });
+        builder.apply_geo_overlay().await;
+        let p = builder.resolved_persona();
+        assert_eq!(p.locale.as_deref(), Some("de-DE"));
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[cfg(feature = "geo")]
+    #[tokio::test]
+    async fn explicit_geo_locale_wins_and_skips_probe() {
+        // An explicit `.geo_locale("US")` must win over a `.geo_resolver(..)`
+        // reporting a different country, AND the probe must never fire.
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut builder = Browser::builder()
+            .geo_locale("US")
+            .geo_resolver(StubCountryResolver {
+                cc: "DE",
+                calls: calls.clone(),
+            });
+        builder.apply_geo_overlay().await;
+        let p = builder.resolved_persona();
+        assert_eq!(p.locale.as_deref(), Some("en-US"));
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "explicit locale must skip the geo probe entirely"
+        );
     }
 
     #[test]

--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -454,10 +454,11 @@ pub struct BrowserBuilder {
     pub(crate) proxy_auth: Option<(String, String)>,
     /// Custom or auto-derived exit-IP -> country resolver. Set via
     /// [`BrowserBuilder::geo_auto`] (wraps [`crate::IpApiResolver`], mirroring
-    /// `self.proxy`) or [`BrowserBuilder::geo_resolver`] (bring your own).
-    /// Probed once, asynchronously, by `apply_geo_overlay` in `launch()` /
-    /// `connect()` — before an explicit `persona_overlay`/`geo_locale` locale,
-    /// which wins and skips the probe entirely.
+    /// `self.proxy` including its credentials) or [`BrowserBuilder::geo_resolver`]
+    /// (bring your own). Probed once, asynchronously, by `apply_geo_overlay`
+    /// in `launch()` / `connect()` — before an explicit base `.persona(..)`
+    /// locale or `persona_overlay`/`geo_locale` locale, either of which wins
+    /// and skips the probe entirely.
     #[cfg(feature = "geo")]
     pub(crate) geo_resolver: Option<Arc<dyn zendriver_stealth::geo::GeoResolver>>,
     /// Enable the bundled curated tracker/fingerprinter blocklist.
@@ -1093,14 +1094,18 @@ impl BrowserBuilder {
 
     /// Auto-derive locale/languages from the exit IP's country via a proxied
     /// probe to `ip-api.com`. Opt-in; makes ONE outbound request at launch
-    /// only when set. Overridden by an explicit `geo_locale`/`persona_overlay`
-    /// locale (which also skips the probe). Mirrors the proxy set via
-    /// [`Self::proxy`].
+    /// only when set. Overridden by an explicit `geo_locale`/`persona`/
+    /// `persona_overlay` locale (which also skips the probe). Mirrors the
+    /// proxy set via [`Self::proxy`], including its credentials — the probe
+    /// authenticates the same way the browser itself will.
     #[cfg(feature = "geo")]
     #[must_use]
     pub fn geo_auto(mut self) -> Self {
-        let proxy = self.proxy.as_ref().map(|p| p.server.clone());
-        self.geo_resolver = Some(Arc::new(crate::IpApiResolver::new().with_proxy(proxy)));
+        let server = self.proxy.as_ref().map(|p| p.server.clone());
+        let auth = self.proxy.as_ref().and_then(|p| p.credentials.clone());
+        self.geo_resolver = Some(Arc::new(
+            crate::IpApiResolver::new().with_proxy(server, auth),
+        ));
         self
     }
 
@@ -1126,14 +1131,17 @@ impl BrowserBuilder {
         let Some(resolver) = self.geo_resolver.clone() else {
             return;
         };
-        // An explicit locale (via `.persona_overlay(..)` or `.geo_locale(..)`)
-        // already set → skip the probe entirely; the auto-derived overlay
-        // must never outrank it.
-        if self
+        // An explicit locale already set — via `.persona_overlay(..)` /
+        // `.geo_locale(..)` (both land in `persona_overlay`) or via the base
+        // `.persona(..)` (how the MCP layer sets a caller-supplied persona)
+        // — skips the probe entirely; the auto-derived overlay must never
+        // outrank it.
+        let explicit_locale = self
             .persona_overlay
             .as_ref()
             .is_some_and(|p| p.locale.is_some())
-        {
+            || self.persona.as_ref().is_some_and(|p| p.locale.is_some());
+        if explicit_locale {
             return;
         }
         if let Some(country) = resolver.country().await {
@@ -4171,6 +4179,110 @@ mod tests {
             calls.load(std::sync::atomic::Ordering::SeqCst),
             0,
             "explicit locale must skip the geo probe entirely"
+        );
+    }
+
+    #[cfg(feature = "geo")]
+    #[tokio::test]
+    async fn base_persona_locale_wins_and_skips_probe() {
+        // I2: the MCP layer sets the base `.persona(..)`, not the overlay.
+        // A locale-bearing base persona must skip the geo probe exactly like
+        // an explicit `.persona_overlay(..)`/`.geo_locale(..)` locale does —
+        // otherwise geo_auto both fires an unwanted request AND clobbers the
+        // caller's chosen locale.
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut builder = Browser::builder()
+            .persona(Persona::builder().locale("ja-JP").build())
+            .geo_resolver(StubCountryResolver {
+                cc: "DE",
+                calls: calls.clone(),
+            });
+        builder.apply_geo_overlay().await;
+        let p = builder.resolved_persona();
+        assert_eq!(p.locale.as_deref(), Some("ja-JP"));
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "a locale-bearing base persona must skip the geo probe entirely"
+        );
+    }
+
+    #[cfg(feature = "geo")]
+    #[tokio::test]
+    async fn failed_probe_leaves_existing_overlay_untouched() {
+        // M4(a): a resolver reporting `None` (network down, bad proxy,
+        // unrecognized country, ...) must fail soft — an already-set overlay
+        // is left exactly as the caller wrote it.
+        struct NoneResolver;
+        #[async_trait::async_trait]
+        impl zendriver_stealth::geo::GeoResolver for NoneResolver {
+            async fn country(&self) -> Option<zendriver_stealth::geo::Country> {
+                None
+            }
+        }
+        let overlay = Persona::builder().timezone("UTC").build();
+        let mut builder = Browser::builder()
+            .persona_overlay(overlay)
+            .geo_resolver(NoneResolver);
+        builder.apply_geo_overlay().await;
+        let p = builder.resolved_persona();
+        assert_eq!(p.timezone.as_deref(), Some("UTC"));
+        assert_eq!(p.locale, None);
+    }
+
+    #[cfg(feature = "geo")]
+    #[tokio::test]
+    async fn geo_overlay_merges_with_existing_overlay_fields() {
+        // M4(b): a `.persona_overlay(..)` with no locale set (e.g. just
+        // `device_memory_gb`) must be preserved AND have the geo-derived
+        // locale/languages folded in — the two must compose, not clobber.
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let overlay = Persona::builder().device_memory_gb(16).build();
+        let mut builder =
+            Browser::builder()
+                .persona_overlay(overlay)
+                .geo_resolver(StubCountryResolver {
+                    cc: "DE",
+                    calls: calls.clone(),
+                });
+        builder.apply_geo_overlay().await;
+        let p = builder.resolved_persona();
+        assert_eq!(p.device_memory_gb, Some(16));
+        assert_eq!(p.locale.as_deref(), Some("de-DE"));
+        assert!(p.languages.is_some());
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[cfg(feature = "geo")]
+    #[tokio::test]
+    async fn geo_auto_mirrors_proxy_and_credentials_into_resolver() {
+        // M4(c) / C1: `geo_auto()` must thread BOTH the userinfo-stripped
+        // server AND its credentials into the `IpApiResolver` it builds, end
+        // to end — a wiremock server standing in for the upstream proxy
+        // only responds when it sees a `Proxy-Authorization` header. Before
+        // the C1 fix, `geo_auto()` only mirrored `p.server` and dropped
+        // `p.credentials`, so this probe would have gone out unauthenticated
+        // and (against a real auth-requiring proxy) failed with a silent
+        // 407.
+        let proxy = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::header_exists("Proxy-Authorization"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_string(r#"{"countryCode":"DE"}"#),
+            )
+            .mount(&proxy)
+            .await;
+
+        let builder = Browser::builder()
+            .proxy(format!("http://bob:s3cret@{}", proxy.address()))
+            .geo_auto();
+        let resolver = builder
+            .geo_resolver
+            .clone()
+            .expect("geo_auto sets a resolver");
+        assert_eq!(
+            resolver.country().await,
+            Some(zendriver_stealth::geo::Country::try_from("DE").unwrap())
         );
     }
 

--- a/crates/zendriver/src/geo_resolver.rs
+++ b/crates/zendriver/src/geo_resolver.rs
@@ -53,10 +53,8 @@ impl IpApiResolver {
     /// Route the probe through `proxy` (mirrors the browser's own proxy so
     /// the resolved country matches the exit IP Chrome will actually use).
     ///
-    /// Not yet called anywhere in-tree — `BrowserBuilder::geo_auto` (a
-    /// follow-up task) is the only planned caller, wiring `self.proxy` from
+    /// Called by `BrowserBuilder::geo_auto`, wiring `self.proxy` from
     /// [`crate::browser::BrowserBuilder::proxy`] through here.
-    #[allow(dead_code)]
     #[must_use]
     pub(crate) fn with_proxy(mut self, proxy: Option<String>) -> Self {
         self.proxy = proxy;

--- a/crates/zendriver/src/geo_resolver.rs
+++ b/crates/zendriver/src/geo_resolver.rs
@@ -1,0 +1,129 @@
+//! `IpApiResolver`: derive the exit-IP country via a proxied HTTP probe.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use zendriver_stealth::geo::{Country, GeoResolver};
+
+/// Resolves the apparent country by querying an IP-geolocation service
+/// (default `ip-api.com`) through the browser's proxy. Opt-in via
+/// `BrowserBuilder::geo_auto`; endpoint overridable; swap the whole thing out
+/// with a custom [`GeoResolver`].
+pub struct IpApiResolver {
+    endpoint: String,
+    proxy: Option<String>,
+    timeout: Duration,
+}
+
+impl Default for IpApiResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IpApiResolver {
+    /// A resolver hitting `http://ip-api.com/json` directly (no proxy), with
+    /// a 5-second timeout. Chain [`Self::endpoint`] / [`Self::timeout`] to
+    /// customize; `BrowserBuilder::geo_auto` wires the proxy via the
+    /// crate-private [`Self::with_proxy`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            endpoint: "http://ip-api.com/json".into(),
+            proxy: None,
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    /// Override the probe endpoint (default `http://ip-api.com/json`).
+    /// Must return a JSON body with a top-level `countryCode` string field.
+    #[must_use]
+    pub fn endpoint(mut self, url: impl Into<String>) -> Self {
+        self.endpoint = url.into();
+        self
+    }
+
+    /// Override the request timeout (default 5s).
+    #[must_use]
+    pub fn timeout(mut self, d: Duration) -> Self {
+        self.timeout = d;
+        self
+    }
+
+    /// Route the probe through `proxy` (mirrors the browser's own proxy so
+    /// the resolved country matches the exit IP Chrome will actually use).
+    ///
+    /// Not yet called anywhere in-tree — `BrowserBuilder::geo_auto` (a
+    /// follow-up task) is the only planned caller, wiring `self.proxy` from
+    /// [`crate::browser::BrowserBuilder::proxy`] through here.
+    #[allow(dead_code)]
+    #[must_use]
+    pub(crate) fn with_proxy(mut self, proxy: Option<String>) -> Self {
+        self.proxy = proxy;
+        self
+    }
+}
+
+#[async_trait]
+impl GeoResolver for IpApiResolver {
+    async fn country(&self) -> Option<Country> {
+        let mut builder = reqwest::Client::builder().timeout(self.timeout);
+        if let Some(p) = &self.proxy {
+            match reqwest::Proxy::all(p) {
+                Ok(px) => builder = builder.proxy(px),
+                Err(e) => {
+                    tracing::warn!(error = %e, "geo probe: bad proxy; skipping");
+                    return None;
+                }
+            }
+        }
+        let client = builder.build().ok()?;
+        let resp = match client.get(&self.endpoint).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "geo probe request failed");
+                return None;
+            }
+        };
+        let body: serde_json::Value = resp.json().await.ok()?;
+        let cc = body.get("countryCode").and_then(|v| v.as_str())?;
+        match Country::try_from(cc) {
+            Ok(c) => Some(c),
+            Err(_) => {
+                tracing::warn!(country = %cc, "geo probe: unrecognized country code");
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn resolves_country_from_ipapi_json() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_string(r#"{"countryCode":"DE"}"#),
+            )
+            .mount(&server)
+            .await;
+        let r = IpApiResolver::new().endpoint(server.uri());
+        assert_eq!(r.country().await, Some(Country::try_from("DE").unwrap()));
+    }
+
+    #[tokio::test]
+    async fn bad_body_yields_none() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_string("nope"))
+            .mount(&server)
+            .await;
+        assert_eq!(
+            IpApiResolver::new().endpoint(server.uri()).country().await,
+            None
+        );
+    }
+}

--- a/crates/zendriver/src/geo_resolver.rs
+++ b/crates/zendriver/src/geo_resolver.rs
@@ -6,12 +6,16 @@ use async_trait::async_trait;
 use zendriver_stealth::geo::{Country, GeoResolver};
 
 /// Resolves the apparent country by querying an IP-geolocation service
-/// (default `ip-api.com`) through the browser's proxy. Opt-in via
-/// `BrowserBuilder::geo_auto`; endpoint overridable; swap the whole thing out
-/// with a custom [`GeoResolver`].
+/// (default `http://ip-api.com/json` — **plaintext**; the proxy operator can
+/// tamper with the response in transit, so override [`Self::endpoint`] to an
+/// HTTPS service if response integrity matters for your threat model)
+/// through the browser's proxy. Opt-in via `BrowserBuilder::geo_auto`;
+/// endpoint overridable; swap the whole thing out with a custom
+/// [`GeoResolver`].
 pub struct IpApiResolver {
     endpoint: String,
     proxy: Option<String>,
+    proxy_auth: Option<(String, String)>,
     timeout: Duration,
 }
 
@@ -24,18 +28,22 @@ impl Default for IpApiResolver {
 impl IpApiResolver {
     /// A resolver hitting `http://ip-api.com/json` directly (no proxy), with
     /// a 5-second timeout. Chain [`Self::endpoint`] / [`Self::timeout`] to
-    /// customize; `BrowserBuilder::geo_auto` wires the proxy via the
-    /// crate-private [`Self::with_proxy`].
+    /// customize; `BrowserBuilder::geo_auto` wires the proxy (and its
+    /// credentials, if any) via the crate-private [`Self::with_proxy`].
     #[must_use]
     pub fn new() -> Self {
         Self {
             endpoint: "http://ip-api.com/json".into(),
             proxy: None,
+            proxy_auth: None,
             timeout: Duration::from_secs(5),
         }
     }
 
-    /// Override the probe endpoint (default `http://ip-api.com/json`).
+    /// Override the probe endpoint (default `http://ip-api.com/json`, which
+    /// is plaintext HTTP — a malicious or compromised proxy operator can
+    /// observe or tamper with the response since it's routed through
+    /// `with_proxy`; override to an HTTPS endpoint if you need integrity).
     /// Must return a JSON body with a top-level `countryCode` string field.
     #[must_use]
     pub fn endpoint(mut self, url: impl Into<String>) -> Self {
@@ -50,14 +58,23 @@ impl IpApiResolver {
         self
     }
 
-    /// Route the probe through `proxy` (mirrors the browser's own proxy so
-    /// the resolved country matches the exit IP Chrome will actually use).
+    /// Route the probe through `server` (mirrors the browser's own proxy so
+    /// the resolved country matches the exit IP Chrome will actually use),
+    /// authenticating with `auth` (`user`, `pass`) when the proxy requires
+    /// it — passed to reqwest via [`reqwest::Proxy::basic_auth`], never
+    /// embedded in the proxy URL string, so it can't leak into an error
+    /// `Display`.
     ///
     /// Called by `BrowserBuilder::geo_auto`, wiring `self.proxy` from
     /// [`crate::browser::BrowserBuilder::proxy`] through here.
     #[must_use]
-    pub(crate) fn with_proxy(mut self, proxy: Option<String>) -> Self {
-        self.proxy = proxy;
+    pub(crate) fn with_proxy(
+        mut self,
+        server: Option<String>,
+        auth: Option<(String, String)>,
+    ) -> Self {
+        self.proxy = server;
+        self.proxy_auth = auth;
         self
     }
 }
@@ -68,8 +85,17 @@ impl GeoResolver for IpApiResolver {
         let mut builder = reqwest::Client::builder().timeout(self.timeout);
         if let Some(p) = &self.proxy {
             match reqwest::Proxy::all(p) {
-                Ok(px) => builder = builder.proxy(px),
+                Ok(mut px) => {
+                    if let Some((user, pass)) = &self.proxy_auth {
+                        px = px.basic_auth(user, pass);
+                    }
+                    builder = builder.proxy(px);
+                }
                 Err(e) => {
+                    // `reqwest::Error`'s `Display` only ever includes the
+                    // failed proxy/target URL text, never proxy credentials
+                    // (those are sent via `basic_auth`, not embedded in the
+                    // URL) — safe to log as-is.
                     tracing::warn!(error = %e, "geo probe: bad proxy; skipping");
                     return None;
                 }
@@ -123,5 +149,57 @@ mod tests {
             IpApiResolver::new().endpoint(server.uri()).country().await,
             None
         );
+    }
+
+    /// C1: `with_proxy`'s `auth` must actually reach the underlying
+    /// `reqwest::Proxy` (via `basic_auth`), not just be stored and ignored.
+    /// A real authenticated-proxy wiremock (mocking the CONNECT/tunnel
+    /// handshake a real forward proxy performs) is impractical with
+    /// `wiremock` (it's an HTTP server, not a proxy), so this instead stands
+    /// a plain wiremock server in for the proxy and drives a plain-HTTP
+    /// target through it — reqwest relays plain-HTTP-through-HTTP-proxy
+    /// requests as absolute-form requests directly to the proxy's socket
+    /// with a `Proxy-Authorization` header when `basic_auth` was set, so the
+    /// mock server IS the thing that receives (and can assert on) that
+    /// header. If `with_proxy`'s `auth` were dropped (the C1 bug), the mock
+    /// (which requires the header) would never match and `country()` would
+    /// return `None`.
+    #[tokio::test]
+    async fn threads_proxy_credentials_into_reqwest_proxy() {
+        let proxy = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::header_exists("Proxy-Authorization"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_string(r#"{"countryCode":"DE"}"#),
+            )
+            .mount(&proxy)
+            .await;
+
+        let r = IpApiResolver::new()
+            .endpoint("http://geo-probe.invalid/json")
+            .with_proxy(Some(proxy.uri()), Some(("bob".into(), "s3cret".into())));
+        assert_eq!(r.country().await, Some(Country::try_from("DE").unwrap()));
+    }
+
+    /// Without credentials, the mock (which requires `Proxy-Authorization`)
+    /// must NOT match — a control proving the above test isn't a false
+    /// positive from some other matcher laxity.
+    #[tokio::test]
+    async fn no_credentials_means_no_proxy_auth_header() {
+        let proxy = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::header_exists("Proxy-Authorization"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_string(r#"{"countryCode":"DE"}"#),
+            )
+            .mount(&proxy)
+            .await;
+
+        let r = IpApiResolver::new()
+            .endpoint("http://geo-probe.invalid/json")
+            .with_proxy(Some(proxy.uri()), None);
+        // No `Proxy-Authorization` header sent -> mock doesn't match -> 404
+        // from wiremock -> `.json()` fails -> `country()` yields `None`.
+        assert_eq!(r.country().await, None);
     }
 }

--- a/crates/zendriver/src/lib.rs
+++ b/crates/zendriver/src/lib.rs
@@ -79,6 +79,8 @@ pub mod error;
 pub mod expect;
 pub(crate) mod expert;
 pub mod frame;
+#[cfg(feature = "geo")]
+mod geo_resolver;
 pub mod input;
 pub(crate) mod isolated_world;
 #[cfg(feature = "monitor")]
@@ -225,6 +227,15 @@ pub use zendriver_fetcher::{
     Channel as FetcherChannel, Fetcher, FetcherError, FetcherPhase, FetcherProgress, Platform,
     VersionSpec,
 };
+
+/// Proxied exit-IP -> country resolver, derived from the browser's proxy.
+///
+/// Gated by the `geo` cargo feature (pulls in `reqwest`). Implements
+/// [`zendriver_stealth::geo::GeoResolver`] via a GET against an IP-geolocation
+/// service (default `ip-api.com`); swap in your own resolver if that doesn't
+/// fit.
+#[cfg(feature = "geo")]
+pub use geo_resolver::IpApiResolver;
 
 /// Stealth profile + fingerprint configuration re-exported from `zendriver-stealth`.
 pub mod stealth {

--- a/docs/book/src/fingerprint.md
+++ b/docs/book/src/fingerprint.md
@@ -185,15 +185,23 @@ use zendriver::Browser;
 
 let browser = Browser::builder()
     .proxy("http://user:pass@residential-proxy.example:8000")
-    .geo_auto()   // probes the exit IP through the proxy above
+    .geo_auto()   // probes the exit IP through the proxy above, credentials included
     .launch().await?;
 ```
+
+`geo_auto()` mirrors the proxy's credentials into the probe too (via
+`reqwest::Proxy::basic_auth`, never embedded in a URL string), so an
+authenticated proxy like the one above is probed authenticated — the probe
+would otherwise 407 silently and fail soft with no overlay.
 
 **Privacy:** the bundled `ip-api.com` probe fires ONLY when `.geo_auto()` (or
 `.geo_resolver()`) is called — it is fully opt-in, never implicit. Failure
 (no network, proxy down, unrecognized country) is fail-soft: a
 `tracing::warn!` is logged and `launch()` proceeds with no overlay; it never
-blocks or fails the launch.
+blocks or fails the launch. The default endpoint (`http://ip-api.com/json`)
+is **plaintext HTTP** — a proxy operator can observe or tamper with the
+response in transit; override [`IpApiResolver::endpoint`] to an HTTPS service
+if response integrity matters for your threat model.
 
 ### Structured `proxy(..)`
 
@@ -239,6 +247,7 @@ called wins — both set the same underlying resolver slot).
 [`BrowserBuilder::geo_resolver`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.geo_resolver
 [`BrowserBuilder::proxy`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.proxy
 [`IpApiResolver`]: https://docs.rs/zendriver/latest/zendriver/struct.IpApiResolver.html
+[`IpApiResolver::endpoint`]: https://docs.rs/zendriver/latest/zendriver/struct.IpApiResolver.html#method.endpoint
 [`zendriver_stealth::geo::GeoResolver`]: https://docs.rs/zendriver-stealth/latest/zendriver_stealth/geo/trait.GeoResolver.html
 
 ## JSON persona (`try_from_json`)

--- a/docs/book/src/fingerprint.md
+++ b/docs/book/src/fingerprint.md
@@ -169,6 +169,78 @@ let browser = Browser::builder()
 
 [`BrowserBuilder::geo_locale`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.geo_locale
 
+## Auto IP-geo resolution (`geo_auto`)
+
+`geo_locale` requires knowing the country up front. When you don't — e.g. the
+browser is routed through a rotating or third-party proxy pool and you want
+the locale to match wherever that proxy happens to exit — use
+[`BrowserBuilder::geo_auto`] instead. It probes the exit IP through a bundled
+[`IpApiResolver`] (a proxied GET against `ip-api.com`) and folds the resulting
+country's locale/languages into the persona overlay, with the exact same
+precedence as `geo_locale`: an explicit `.persona(..)`/`.persona_overlay(..)`
+locale always wins and skips the probe entirely.
+
+```rust,no_run
+use zendriver::Browser;
+
+let browser = Browser::builder()
+    .proxy("http://user:pass@residential-proxy.example:8000")
+    .geo_auto()   // probes the exit IP through the proxy above
+    .launch().await?;
+```
+
+**Privacy:** the bundled `ip-api.com` probe fires ONLY when `.geo_auto()` (or
+`.geo_resolver()`) is called — it is fully opt-in, never implicit. Failure
+(no network, proxy down, unrecognized country) is fail-soft: a
+`tracing::warn!` is logged and `launch()` proceeds with no overlay; it never
+blocks or fails the launch.
+
+### Structured `proxy(..)`
+
+[`BrowserBuilder::proxy`] parses a `scheme://[user:pass@]host:port` URL,
+strips the userinfo before emitting `--proxy-server=` (Chrome ignores
+credentials there), and auto-wires `proxy_auth` from the userinfo when set
+(requires the `interception` feature to actually answer the
+`Fetch.authRequired` challenge). It also makes `geo_auto()`'s probe traffic
+mirror the same upstream proxy the browser itself will use, so the resolved
+country matches the exit IP Chrome actually sees.
+
+### Custom resolver (`geo_resolver`)
+
+Swap the bundled `ip-api.com` probe for your own service, an offline
+MaxMind-style DB, or a test double by implementing
+[`zendriver_stealth::geo::GeoResolver`] and passing it to
+[`BrowserBuilder::geo_resolver`]:
+
+```rust,no_run
+use async_trait::async_trait;
+use zendriver::Browser;
+use zendriver_stealth::geo::{Country, GeoResolver};
+
+struct MyResolver;
+
+#[async_trait]
+impl GeoResolver for MyResolver {
+    async fn country(&self) -> Option<Country> {
+        // Query your own service / offline DB instead of ip-api.com.
+        Country::try_from("DE").ok()
+    }
+}
+
+let browser = Browser::builder()
+    .geo_resolver(MyResolver)
+    .launch().await?;
+```
+
+Only ONE of `geo_auto()` / `geo_resolver(..)` takes effect (the last one
+called wins — both set the same underlying resolver slot).
+
+[`BrowserBuilder::geo_auto`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.geo_auto
+[`BrowserBuilder::geo_resolver`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.geo_resolver
+[`BrowserBuilder::proxy`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.proxy
+[`IpApiResolver`]: https://docs.rs/zendriver/latest/zendriver/struct.IpApiResolver.html
+[`zendriver_stealth::geo::GeoResolver`]: https://docs.rs/zendriver-stealth/latest/zendriver_stealth/geo/trait.GeoResolver.html
+
 ## JSON persona (`try_from_json`)
 
 Any `Persona` can be expressed as a JSON object and round-trips cleanly.

--- a/docs/book/src/mcp.md
+++ b/docs/book/src/mcp.md
@@ -123,6 +123,23 @@ The stealth-profile override accepts `geo_country` (ISO 3166-1 alpha-2, e.g.
 `"DE"`) to derive a coherent `locale` + `Accept-Language`. The field is always
 present in the schema but only takes effect when the `geo` feature is enabled.
 
+`browser_open` also accepts:
+
+- `proxy: string` — route the browser through an upstream proxy
+  (`scheme://[user:pass@]host:port`); userinfo is auto-split into proxy-auth
+  credentials (requires the default `interception` feature to actually answer
+  the `Fetch.authRequired` challenge). Always present in the schema.
+- `geo_auto: bool` — auto-derive `locale`/`languages` from the exit IP's
+  country via a proxied probe to `ip-api.com` (mirrors `proxy` above), instead
+  of naming a country explicitly via `geo_country`. Makes at most one outbound
+  request, only at launch, only when `true`. An explicit `persona` locale wins
+  and skips the probe. Requires the opt-in `geo` feature; always present in
+  the schema (ignored with a logged warning on a non-`geo` build).
+- `geo_endpoint: string` — override the probe endpoint (default
+  `http://ip-api.com/json`); only meaningful with `geo_auto: true`. Note this
+  bypasses proxy mirroring — only the bundled default endpoint routes through
+  `proxy`.
+
 ## Stealth
 
 Stealth is on by default (matching the `zendriver` library). Configure

--- a/docs/superpowers/deferred-backlog.md
+++ b/docs/superpowers/deferred-backlog.md
@@ -55,6 +55,7 @@ Legend: 🐞 shipped-but-broken · 🔧 actionable tail · 🎯 intentional non-
 - **Per-action `version` accessor not exposed.** `chrome_version` hardcoded `String::new()`; core lib has no version getter. — `crates/zendriver-mcp/src/tools/lifecycle.rs:146` (doc `:78-80`)
 - **Intercept `method` / `post-data` reserved for follow-up.** `ModifyRequest` exposes only `headers`. — `crates/zendriver-mcp/src/tools/intercept.rs:29-30,87-95`
 - **Tab-scoped expectations/rules leak** until manual cancel or full `browser_close`. `browser_tab_close` never drains `s.expectations`/`s.rules`; handles carry no `tab_id`. — `crates/zendriver-mcp/src/tools/tabs.rs:244,264-311`, `state.rs:150,166`
+- **MCP `geo_endpoint` override is not proxy-mirrored** (`IpApiResolver`'s proxy setter is `pub(crate)` to `zendriver`, so `zendriver-mcp` can't thread `input.proxy` into a custom-endpoint resolver the way `geo_auto()`'s bundled default gets mirrored). Currently only a `tracing::warn!` when both are set. Proper fix: expose the setter (or a builder arg) and wire `input.proxy` through in `lifecycle.rs::open`. — `crates/zendriver-mcp/src/tools/lifecycle.rs:143-159`, `crates/zendriver/src/geo_resolver.rs` (`with_proxy`)
 
 ---
 

--- a/docs/superpowers/deferred-backlog.md
+++ b/docs/superpowers/deferred-backlog.md
@@ -34,8 +34,7 @@ Legend: 🐞 shipped-but-broken · 🔧 actionable tail · 🎯 intentional non-
 - **Full attribute-coverage expansion** (screen metrics, navigator extras) + matching Persona/JS-patch growth. `persona_from_assignment` maps only platform/deviceMemory/hardwareConcurrency/videoCard/fonts; `Persona` has no screen-metric/navigator-extra fields. (Commit `402a427c` added *static* screen.js/mouse.js patches — coherent surface — but did **not** grow the BN or Persona.) — `crates/zendriver-fingerprints/src/generative/mapping.rs:41-83`, `crates/zendriver-stealth/src/persona/mod.rs:36-61`
 
 ### Geo / locale
-- **timezone-from-geo derivation** (country → IANA tz, sharing the `geo` module). `geo::persona()` derives locale+languages only, leaves timezone `None`. — `crates/zendriver-stealth/src/geo/mod.rs:34-50`
-- **Auto IP-geo resolution / Option B exit-IP probe.** Only the empty `GeoResolver` seam ships; zero `impl`; `geo_locale` still needs an explicit country. — `crates/zendriver-stealth/src/geo/mod.rs:52-62`, `browser.rs:1012`
+- **timezone-from-geo derivation** (country → IANA tz, sharing the `geo` module). `geo::persona()` derives locale+languages only, leaves timezone `None`. Still open — `geo_auto`/`IpApiResolver` (below) only close the country→locale/languages half. — `crates/zendriver-stealth/src/geo/mod.rs:34-50`
 
 ### Network / cookies / tabs / frames
 - **Transparent handle-preserving reconnect** (session-id remap so live `Tab` handles survive) + feature re-arm. `reconnect` clears the tab map (new sessionIds → invalidated handles). — `crates/zendriver/src/browser.rs:3479` (doc `:3436-3438`)
@@ -98,6 +97,7 @@ Legend: 🐞 shipped-but-broken · 🔧 actionable tail · 🎯 intentional non-
 - **Nightly real-Chrome anti-detection CI** → **exists**. `nightly-stealth-tests` (cron `0 6 * * *`, real Chrome) runs `--test stealth_phase2`, which hits `bot.sannysoft.com` and `arh.antoinevastel.com/bots/areyouheadless`. — `.github/workflows/ci.yml:200-224`
 - **OOPIF bootstrap "placeholder Frame"** → **was already done**; the backlog mis-cited test-fixture setup. Real impl: `crates/zendriver/src/frame/oopif.rs:49` `register_oopif_frame`, wired at `browser.rs:1497` for `kind=="iframe"` (commit `b13fdbd3`).
 - **Per-context proxy auth — first-class API** → **shipped** via `Browser::browser_context()` → `BrowserContextBuilder` (`.proxy()`/`.proxy_bypass()`/`.proxy_auth()`/`.build()`), auto-installing per-tab `Fetch.authRequired` chained into the one per-session interception actor (2026-07-16 plan).
+- **Auto IP-geo resolution / Option B exit-IP probe** → **shipped** via `BrowserBuilder::geo_auto()` (bundled `IpApiResolver`, a proxied `ip-api.com` GET, opt-in) + `BrowserBuilder::geo_resolver()` for a custom `GeoResolver` impl, plus a structured `BrowserBuilder::proxy(url)` (reusing `crate::proxy::split_proxy_url`) so the probe mirrors the browser's own proxy. Exposed over MCP as `browser_open.geo_auto` / `.geo_endpoint` / `.proxy`. Explicit `geo_locale`/persona locale still wins and skips the probe; fail-soft on probe failure. (2026-07-16 `geo-auto-resolver` plan.) Note: **timezone-from-geo derivation remains open** (see §1 Geo/locale above) — this closes only the country→locale/languages half.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-16-geo-auto-resolver.md
+++ b/docs/superpowers/plans/2026-07-16-geo-auto-resolver.md
@@ -1,0 +1,285 @@
+# Auto IP-Geo Resolution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** An opt-in `BrowserBuilder::geo_auto()` that probes the exit IP through the browser's proxy, maps the country to a coherent locale/languages persona overlay, and applies it at launch — plus `geo_resolver()` for custom resolvers.
+
+**Architecture:** A structured `BrowserBuilder::proxy(url)` (reusing `crate::proxy::split_proxy_url` from the per-context work) makes the proxy mirrorable. `IpApiResolver` (in `zendriver`, behind `geo`+`reqwest`) implements the existing `zendriver_stealth::geo::GeoResolver` trait via a proxied `reqwest` GET. `launch()`/`connect()` run the resolver async before `StealthObserver::with_persona`, folding `geo::persona(country)` into `persona_overlay`.
+
+**Tech stack:** Rust 2024, Tokio, `reqwest` (optional dep, already present), `async-trait`, `wiremock` (dev-dep under `integration-tests`), `MockConnection`.
+
+## Global Constraints
+- **MSRV 1.85, edition 2024.**
+- **`geo` is opt-in; the whole feature is `#[cfg(feature = "geo")]`.** Default-feature build must be unaffected.
+- **Reuse, don't duplicate:** `crate::proxy::split_proxy_url` / `ParsedProxy` already exist (per-context proxy work) — reuse for `BrowserBuilder::proxy`.
+- **Precedence:** an explicit `geo_locale()`/`persona_overlay()` locale always beats the auto-derived one. Match the exact overlay-merge pattern `geo_locale` already uses (`browser.rs` ~1015-1019) so precedence is correct by construction; if both `geo_auto` and an explicit locale are set, skip the probe.
+- **Fail-soft:** probe failure / no network / unknown country → `tracing::warn!` + no overlay; NEVER block or fail `launch()`.
+- **Privacy:** the bundled `ip-api.com` probe fires only on `.geo_auto()`; endpoint overridable; `GeoResolver` trait swappable.
+- **Before commit:** `cargo fmt --all`; `cargo clippy --workspace --all-targets --locked -- -D warnings`; and since this is feature-gated, `cargo clippy -p zendriver --all-targets --features geo -- -D warnings`. Schema-snapshot + public-api steps per CLAUDE.md when MCP/public API changes (Task 4).
+
+---
+
+### Task 1: `BrowserBuilder::proxy(url)` — structured browser-wide proxy
+
+**Files:** Modify `crates/zendriver/src/browser.rs` (builder field + method + arg emission at launch); Test: same file `#[cfg(test)]`.
+
+**Interfaces:**
+- Consumes: `crate::proxy::{split_proxy_url, ParsedProxy}`.
+- Produces: `pub fn proxy(self, impl Into<String>) -> Self`; a `pub(crate) proxy: Option<crate::proxy::ParsedProxy>` field on `BrowserBuilder` (read by Task 3's `geo_auto`).
+
+- [ ] **Step 1: Failing test** — assert `Browser::builder().proxy("http://user:pass@host:3128")` (a) stores a `ParsedProxy { server: "http://host:3128", credentials: Some(("user","pass")) }`, and (b) at launch emits `--proxy-server=http://host:3128` (userinfo-stripped) into the Chrome args, and (c) auto-populates `proxy_auth` from the userinfo when not already set. Model arg-inspection on the existing `--proxy-server` test (`browser.rs:4054`) and the per-context builder tests.
+
+```rust
+#[test]
+fn proxy_stores_parsed_and_strips_userinfo_arg() {
+    let b = Browser::builder().proxy("http://bob:pw@host:3128");
+    let p = b.proxy.as_ref().unwrap();
+    assert_eq!(p.server, "http://host:3128");
+    assert_eq!(p.credentials, Some(("bob".into(), "pw".into())));
+    // proxy_auth auto-wired from userinfo
+    assert_eq!(b.proxy_auth, Some(("bob".into(), "pw".into())));
+}
+```
+(Add a launch-arg assertion following the `--proxy-server` arg-inspection pattern already in the file.)
+
+- [ ] **Step 2: Run — fails** (`no field proxy` / `no method proxy`). `cargo test -p zendriver --lib proxy_stores_parsed --features geo`
+
+- [ ] **Step 3: Implement.** Add field near `proxy_auth`:
+```rust
+    /// Structured browser-wide proxy (userinfo-stripped server + optional
+    /// credentials), set via [`BrowserBuilder::proxy`]. Emitted as
+    /// `--proxy-server=` at launch and mirrored by `geo_auto`'s probe.
+    pub(crate) proxy: Option<crate::proxy::ParsedProxy>,
+```
+Initialize `proxy: None` at every `BrowserBuilder` constructor (grep the builder's `Default`/`new`; there is typically one). Add the method:
+```rust
+    /// Route the browser through `proxy` (`scheme://[user:pass@]host:port`).
+    /// Emits `--proxy-server=<host:port>` (Chrome ignores userinfo there) and,
+    /// when the URL carries credentials and `proxy_auth` is unset, auto-wires
+    /// them. The structured form lets `geo_auto()` probe the exit IP through
+    /// the same proxy.
+    ///
+    /// # Errors
+    /// Silently ignores an unparseable URL (logs a warning) to keep the
+    /// builder chainable; the bad value simply isn't applied.
+    #[must_use]
+    pub fn proxy(mut self, proxy: impl Into<String>) -> Self {
+        let raw = proxy.into();
+        match crate::proxy::split_proxy_url(&raw) {
+            Ok(parsed) => {
+                if self.proxy_auth.is_none() {
+                    if let Some((u, p)) = parsed.credentials.clone() {
+                        self.proxy_auth = Some((u, p));
+                    }
+                }
+                self.proxy = Some(parsed);
+            }
+            Err(e) => tracing::warn!(error = %e, "proxy: ignoring invalid proxy URL"),
+        }
+        self
+    }
+```
+At launch arg assembly, when `self.proxy` is set and no explicit `--proxy-server` arg is present, push `format!("--proxy-server={}", parsed.server)`. (Find where args are finalized before spawn; follow the existing pattern for injected flags.)
+
+- [ ] **Step 4: Run — passes** (both feature sets: default build unaffected because the field/method are un-gated but harmless; `--features geo` for the resolver later). `cargo test -p zendriver --lib proxy_stores_parsed`
+
+- [ ] **Step 5: Commit** — `feat(browser): structured BrowserBuilder::proxy reusing split_proxy_url`
+
+---
+
+### Task 2: `IpApiResolver` — proxied exit-IP → country probe
+
+**Files:** Create `crates/zendriver/src/geo_resolver.rs`; Modify `crates/zendriver/src/lib.rs` (`#[cfg(feature="geo")] mod geo_resolver;` + re-export), `crates/zendriver/Cargo.toml` (`geo` pulls `reqwest`); Test: inline `#[cfg(test)]` using `wiremock`.
+
+**Interfaces:**
+- Consumes: `zendriver_stealth::geo::{GeoResolver, Country}`, `reqwest`.
+- Produces: `pub struct IpApiResolver` with `new()`, `endpoint(self, impl Into<String>)`, `timeout(self, Duration)`, `pub(crate) fn with_proxy(self, Option<String>)`; `impl GeoResolver for IpApiResolver`.
+
+- [ ] **Step 1: Cargo** — change `crates/zendriver/Cargo.toml`: `geo = ["zendriver-stealth/geo", "dep:reqwest"]`. Run `cargo build -p zendriver --features geo` to confirm reqwest resolves.
+
+- [ ] **Step 2: Failing test** (wiremock canned body):
+```rust
+#[tokio::test]
+async fn resolves_country_from_ipapi_json() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(wiremock::ResponseTemplate::new(200)
+            .set_body_string(r#"{"countryCode":"DE"}"#))
+        .mount(&server).await;
+    let r = IpApiResolver::new().endpoint(server.uri());
+    assert_eq!(r.country().await, Some(Country::try_from("DE").unwrap()));
+}
+
+#[tokio::test]
+async fn bad_body_yields_none() {
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string("nope"))
+        .mount(&server).await;
+    assert_eq!(IpApiResolver::new().endpoint(server.uri()).country().await, None);
+}
+```
+(`wiremock` is a dev-dep under `integration-tests`; gate the test module `#[cfg(all(test, feature = "geo", feature = "integration-tests"))]` OR confirm wiremock is available to the `geo` test build — if not, add `wiremock` to dev-deps unconditionally and gate the test on `feature="geo"`.)
+
+- [ ] **Step 3: Run — fails.**
+
+- [ ] **Step 4: Implement** `crates/zendriver/src/geo_resolver.rs`:
+```rust
+//! `IpApiResolver`: derive the exit-IP country via a proxied HTTP probe.
+use std::time::Duration;
+use async_trait::async_trait;
+use zendriver_stealth::geo::{Country, GeoResolver};
+
+/// Resolves the apparent country by querying an IP-geolocation service
+/// (default `ip-api.com`) through the browser's proxy. Opt-in via
+/// [`crate::BrowserBuilder::geo_auto`]; endpoint overridable; swap the whole
+/// thing out with a custom [`GeoResolver`].
+pub struct IpApiResolver {
+    endpoint: String,
+    proxy: Option<String>,
+    timeout: Duration,
+}
+impl Default for IpApiResolver { fn default() -> Self { Self::new() } }
+impl IpApiResolver {
+    #[must_use] pub fn new() -> Self {
+        Self { endpoint: "http://ip-api.com/json".into(), proxy: None, timeout: Duration::from_secs(5) }
+    }
+    #[must_use] pub fn endpoint(mut self, url: impl Into<String>) -> Self { self.endpoint = url.into(); self }
+    #[must_use] pub fn timeout(mut self, d: Duration) -> Self { self.timeout = d; self }
+    #[must_use] pub(crate) fn with_proxy(mut self, proxy: Option<String>) -> Self { self.proxy = proxy; self }
+}
+#[async_trait]
+impl GeoResolver for IpApiResolver {
+    async fn country(&self) -> Option<Country> {
+        let mut b = reqwest::Client::builder().timeout(self.timeout);
+        if let Some(p) = &self.proxy {
+            match reqwest::Proxy::all(p) {
+                Ok(px) => b = b.proxy(px),
+                Err(e) => { tracing::warn!(error=%e, "geo probe: bad proxy; skipping"); return None; }
+            }
+        }
+        let client = b.build().ok()?;
+        let resp = match client.get(&self.endpoint).send().await {
+            Ok(r) => r, Err(e) => { tracing::warn!(error=%e, "geo probe request failed"); return None; }
+        };
+        let body: serde_json::Value = resp.json().await.ok()?;
+        let cc = body.get("countryCode").and_then(|v| v.as_str())?;
+        match Country::try_from(cc) {
+            Ok(c) => Some(c),
+            Err(_) => { tracing::warn!(country=%cc, "geo probe: unrecognized country code"); None }
+        }
+    }
+}
+```
+Wire `mod geo_resolver;` (gated) + `pub use geo_resolver::IpApiResolver;` in `lib.rs`. Confirm `Country: TryFrom<&str>` exists (it does — `geo_locale` uses `TryInto`); if the concrete `TryFrom<&str>` isn't public, use the same conversion `geo_locale` uses.
+
+- [ ] **Step 5: Run — passes.** `cargo test -p zendriver --lib --features geo geo_resolver::`
+
+- [ ] **Step 6: Commit** — `feat(geo): add IpApiResolver (proxied exit-IP country probe)`
+
+---
+
+### Task 3: `geo_auto()` / `geo_resolver()` + launch integration
+
+**Files:** Modify `crates/zendriver/src/browser.rs` (builder fields/methods + launch/connect wiring); Test: same file `#[cfg(test)]`.
+
+**Interfaces:**
+- Consumes: `IpApiResolver` (Task 2), `self.proxy` (Task 1), `zendriver_stealth::geo::{GeoResolver, persona}`, `self.persona_overlay`, `resolved_persona()`.
+- Produces: `pub fn geo_auto(self) -> Self`, `pub fn geo_resolver(self, impl GeoResolver + 'static) -> Self`; `pub(crate) geo_resolver: Option<std::sync::Arc<dyn GeoResolver>>` field.
+
+- [ ] **Step 1: Failing test** — with a stub resolver, launch resolves the persona locale:
+```rust
+#[cfg(feature = "geo")]
+#[tokio::test]
+async fn geo_resolver_augments_persona_at_launch() {
+    struct StubDe;
+    #[async_trait::async_trait]
+    impl zendriver_stealth::geo::GeoResolver for StubDe {
+        async fn country(&self) -> Option<zendriver_stealth::geo::Country> {
+            Some(zendriver_stealth::geo::Country::try_from("DE").unwrap())
+        }
+    }
+    // Build a BrowserBuilder with .geo_resolver(StubDe), then drive the
+    // same overlay-resolution path launch() uses (extract it into a testable
+    // async helper `apply_geo_overlay(&mut self)` so the test needs no Chrome),
+    // and assert resolved_persona().locale == Some("de-DE").
+}
+```
+Design note for the implementer: extract the async overlay-merge into a `#[cfg(feature="geo")] async fn apply_geo_overlay(&mut self)` so it's unit-testable without launching Chrome; `launch()`/`connect()` call it before `StealthObserver::with_persona`. Also add: an explicit `geo_locale("US")` + `geo_resolver(StubDe)` → locale stays `en-US` (explicit wins, probe skipped).
+
+- [ ] **Step 2: Run — fails.**
+
+- [ ] **Step 3: Implement.** Fields + methods:
+```rust
+    #[cfg(feature = "geo")]
+    pub(crate) geo_resolver: Option<std::sync::Arc<dyn zendriver_stealth::geo::GeoResolver>>,
+```
+(init `None` at the builder constructor(s), gated.)
+```rust
+    /// Auto-derive locale/languages from the exit IP's country via a proxied
+    /// probe to `ip-api.com`. Opt-in; makes ONE outbound request at launch
+    /// only when set. Overridden by an explicit `geo_locale`/`persona_overlay`
+    /// locale (which also skips the probe). Mirrors the proxy set via
+    /// [`Self::proxy`].
+    #[cfg(feature = "geo")]
+    #[must_use]
+    pub fn geo_auto(mut self) -> Self {
+        let proxy = self.proxy.as_ref().map(|p| p.server.clone());
+        self.geo_resolver = Some(std::sync::Arc::new(
+            crate::IpApiResolver::new().with_proxy(proxy),
+        ));
+        self
+    }
+
+    /// Supply a custom [`GeoResolver`] (your own service / offline DB).
+    #[cfg(feature = "geo")]
+    #[must_use]
+    pub fn geo_resolver(mut self, resolver: impl zendriver_stealth::geo::GeoResolver + 'static) -> Self {
+        self.geo_resolver = Some(std::sync::Arc::new(resolver));
+        self
+    }
+```
+The overlay helper (match `geo_locale`'s existing merge direction so explicit wins):
+```rust
+    #[cfg(feature = "geo")]
+    async fn apply_geo_overlay(&mut self) {
+        let Some(resolver) = self.geo_resolver.clone() else { return };
+        // explicit locale already set → skip the probe entirely
+        if self.persona_overlay.as_ref().is_some_and(|p| p.locale.is_some()) { return; }
+        if let Some(country) = resolver.country().await {
+            let derived = zendriver_stealth::geo::persona(country);
+            self.persona_overlay = Some(match self.persona_overlay.take() {
+                Some(existing) => existing.overlay(derived), // SAME direction as geo_locale
+                None => derived,
+            });
+        }
+    }
+```
+Call `self.apply_geo_overlay().await;` in both `launch()` (before browser.rs:2536) and `connect()` (before ~2846). **Verify the overlay direction against `geo_locale` (browser.rs ~1015): use whichever of `existing.overlay(derived)` / `derived.overlay(existing)` `geo_locale` uses — they must match so precedence is identical.**
+
+- [ ] **Step 4: Run — passes** (`--features geo`).
+
+- [ ] **Step 5: Commit** — `feat(geo): geo_auto/geo_resolver builder + launch-time exit-IP resolution`
+
+---
+
+### Task 4: MCP coverage + docs + backlog
+
+**Files:** `crates/zendriver-mcp/src/tools/*` (browser_open geo fields), `mcp-coverage-ledger.toml`, `public-api-baseline.txt`, snapshots; `docs/book/src/*geo*`, `README.md`, `docs/superpowers/deferred-backlog.md`.
+
+- [ ] **Step 1: MCP.** Add `geo_auto: bool` (and optional `geo_endpoint: Option<String>`) to `browser_open` under the `geo` MCP feature, mirroring how `geo_country` was wired in PR #45 (grep `geo_country` in `crates/zendriver-mcp/`). Ledger the `geo_resolver(impl GeoResolver)` method as `excluded` (a trait object has no wire form); `geo_auto`/`proxy` get `covered` entries.
+- [ ] **Step 2: Regenerate + accept snapshots + public-api baseline** per CLAUDE.md (`cargo test -p zendriver-mcp --test schema_snapshots --all-features --locked` + `cargo insta accept --all`; `cargo +nightly public-api …` if flagged).
+- [ ] **Step 3: Docs.** Rustdoc already inline (Tasks 1-3). mdBook geo chapter: auto-resolution section + the privacy note + a custom-`GeoResolver` example + `.proxy()` mention. README geo bullet. `mdbook build docs/book`.
+- [ ] **Step 4: Backlog.** Move the §1 "Auto IP-geo resolution / Option B exit-IP probe" item to the `✅ closed` section (shipped via `geo_auto`/`IpApiResolver`); note timezone-from-geo remains open.
+- [ ] **Step 5: Final gates + commit** — `fmt`; `clippy --workspace` + `-p zendriver --features geo` + `-p zendriver-mcp --all-features`; `cargo test -p zendriver --features geo`. Commit `docs(geo): expose geo_auto over MCP + sync docs and backlog`.
+
+---
+
+## Self-Review
+- **Structured proxy** (Task 1) → prerequisite for proxy-mirrored probe. ✓ reuses split_proxy_url.
+- **IpApiResolver** (Task 2) → the probe; wiremock-tested, fail-soft. ✓
+- **geo_auto/geo_resolver + launch wiring** (Task 3) → async resolve, explicit-wins precedence, testable helper. ✓
+- **MCP + docs + backlog** (Task 4). ✓
+- **Precedence correctness** hinges on matching `geo_locale`'s overlay direction — Task 3 Step 3 explicitly instructs verifying it against `browser.rs:~1015`. Flagged.
+- **Types:** `ParsedProxy`/`split_proxy_url` (Task 1), `IpApiResolver`/`GeoResolver`/`Country` (Task 2), `geo_resolver` field + `apply_geo_overlay` (Task 3) consistent across tasks.
+- **Open risk:** `wiremock` availability under the `geo` (non-`integration-tests`) test build — Task 2 Step 2 tells the implementer to reconcile (add to dev-deps or gate the test).

--- a/docs/superpowers/specs/2026-07-16-geo-auto-resolver-design.md
+++ b/docs/superpowers/specs/2026-07-16-geo-auto-resolver-design.md
@@ -1,0 +1,120 @@
+# Design: auto IP-geo resolution (the `GeoResolver` "option B" exit-IP probe)
+
+**Date:** 2026-07-16
+**Status:** delegate-mode design; assumptions flagged for veto at review
+**Crates:** `zendriver` (builder + `IpApiResolver` + launch wiring), `zendriver-stealth` (the `GeoResolver` trait already ships here)
+**Feature:** `geo` (extended to pull `reqwest` for the HTTP probe)
+**Backlog item:** §1 geo — "Auto IP-geo resolution / Option B exit-IP probe" (deferred in PR #45, which shipped only the `GeoResolver` seam).
+
+## Problem
+
+PR #45 shipped the caller-supplies-country path (`BrowserBuilder::geo_locale("US")`) and an **empty `GeoResolver` seam** (`zendriver-stealth/src/geo/mod.rs`: `#[async_trait] pub trait GeoResolver { async fn country(&self) -> Option<Country>; }`), explicitly deferring the auto-resolving implementation ("`IpApiResolver` + structured proxy URL + outbound probe") to a follow-up. This is that follow-up: derive a coherent `locale`/`languages` automatically from the **exit IP's** country — critically, the *proxy's* exit IP, not the host's.
+
+Today `geo_locale` layers a geo persona overlay at builder time (sync). Auto-resolution is inherently async (a network probe), so it must run during `launch()`/`connect()`.
+
+## Goals / non-goals
+
+- **Goal:** an opt-in `BrowserBuilder::geo_auto()` that probes the exit IP through the browser's proxy, maps the country to a persona overlay via the existing `geo::persona(country)`, and applies it before the first navigation. Plus `geo_resolver(...)` for a fully custom resolver.
+- **Non-goal (v1):** per-context geo (each `BrowserContext` its own exit IP). Browser-wide only; per-context is a later extension (post-launch tab probe).
+- **Non-goal:** bundling an offline GeoIP database. Users who want offline resolution implement `GeoResolver` themselves.
+
+## The exit-IP subtlety (why a structured proxy is a prerequisite)
+
+To learn the *proxy's* exit country, the probe must egress **through the same proxy** as the browser. Today the browser-wide proxy is a raw `.arg("--proxy-server=…")` — unstructured, so nothing can mirror it. So v1 adds:
+
+### `BrowserBuilder::proxy(impl Into<String>)`  (prerequisite)
+A structured browser-wide proxy. Parses via the existing `crate::proxy::split_proxy_url` (built for per-context proxy auth), then:
+- emits `--proxy-server=<server>` (userinfo-stripped) into the launch args,
+- if the URL carried userinfo and no explicit `proxy_auth` is set, auto-wires `proxy_auth(user, pass)` (mirrors the per-context builder's ergonomic),
+- stores the parsed proxy on the builder so the `IpApiResolver` can mirror it.
+
+`proxy(...)` and a manual `.arg("--proxy-server=…")` are both honored; if both are set, `proxy(...)` wins for the resolver-mirroring purpose (document it). Precedence and coexistence with `proxy_auth` mirror the per-context design.
+
+## The resolver
+
+### `GeoResolver` trait — unchanged
+Stays in `zendriver-stealth` (pure, no network dep): `async fn country(&self) -> Option<Country>`.
+
+### `IpApiResolver` — new, in `zendriver` core (behind `geo`)
+Lives in `zendriver` (which has `reqwest`), not `zendriver-stealth` (which must stay network-free). Implements `GeoResolver`.
+
+```rust
+pub struct IpApiResolver {
+    endpoint: String,          // default "http://ip-api.com/json"
+    proxy: Option<String>,     // mirror the browser proxy (set by geo_auto from BrowserBuilder::proxy)
+    timeout: Duration,         // default 5s
+}
+impl IpApiResolver {
+    pub fn new() -> Self { /* defaults */ }
+    pub fn endpoint(self, url: impl Into<String>) -> Self { … }   // override the service
+    pub fn timeout(self, d: Duration) -> Self { … }
+}
+```
+`country()`:
+1. Build a `reqwest::Client` with `.proxy(reqwest::Proxy::all(proxy)?)` when `proxy` is set, and the timeout.
+2. GET the endpoint; parse the JSON `countryCode` field (ip-api.com returns e.g. `{"countryCode":"US",...}`).
+3. `Country::try_from(country_code).ok()` — on any error (network, parse, invalid code) return `None` + `tracing::warn!`. Never panics, never blocks beyond the timeout.
+
+**Privacy:** this makes an outbound call to a third-party service (`ip-api.com`). It fires ONLY when the user calls `.geo_auto()`. The endpoint is overridable, and the `GeoResolver` trait lets users swap in their own service or an offline DB. Per the stealth-hardening philosophy (volatile/external → expose config, never hardcode).
+
+## Builder API
+
+- `BrowserBuilder::geo_auto()` — use the default `IpApiResolver`, mirroring the browser proxy set via `BrowserBuilder::proxy(...)` (if any). Sugar over `geo_resolver(IpApiResolver::new()...)`.
+- `BrowserBuilder::geo_resolver(impl GeoResolver + 'static)` — supply any resolver (stored as `Option<Arc<dyn GeoResolver>>`).
+- Both gated `#[cfg(feature = "geo")]`.
+- **Precedence:** the auto-derived overlay is applied with *lower* precedence than an explicit `geo_locale(...)` / `persona_overlay(...)` locale — explicit always wins. If both `geo_auto` and `geo_locale` are set, `geo_locale` wins (and the probe is skipped, to avoid a pointless network call — document it).
+
+## Launch integration
+
+In `launch()` and `connect()`, immediately before the `StealthObserver::with_persona(…, self.resolved_persona(), …)` calls (browser.rs:2536 / 2846):
+
+```rust
+#[cfg(feature = "geo")]
+if let Some(resolver) = self.geo_resolver.take() {
+    // skip if an explicit geo/locale overlay already set the locale
+    if !self.persona_overlay.as_ref().is_some_and(|p| p.locale.is_some()) {
+        if let Some(country) = resolver.country().await {
+            let derived = zendriver_stealth::geo::persona(country);
+            self.persona_overlay = Some(match self.persona_overlay.take() {
+                Some(existing) => derived.overlay(existing), // existing wins over derived
+                None => derived,
+            });
+        }
+    }
+}
+```
+Then `resolved_persona()` picks up the augmented overlay exactly as today. Fail-soft: a `None` country leaves the overlay untouched and launch proceeds.
+
+**Latency/robustness:** launch now waits up to the probe timeout (default 5s) when `geo_auto` is set. Bounded, opt-in. A failed probe never blocks launch.
+
+## Feature gating
+
+`geo` gains `reqwest`: `geo = ["zendriver-stealth/geo", "dep:reqwest"]` in `crates/zendriver/Cargo.toml`. `reqwest` is already an optional dep (used by `tracker-blocking`), so this only compiles it in when `geo` is on. The `GeoResolver` trait and `Country` stay in stealth (no network dep). (Alternative considered: a separate `geo-auto` sub-feature to keep `geo` network-free — rejected for v1 as feature-sprawl; revisit if the reqwest pull on `geo` bothers downstreams.)
+
+## Errors
+
+Reuse `tracing::warn!` + `Option` returns throughout (mirrors `geo::persona`'s unknown-country handling). `IpApiResolver::country` never returns an error type — it logs and yields `None`. `BrowserBuilder::proxy` reuses `ZendriverError::Navigation` for an unparseable URL (same as the per-context builder).
+
+## Testing
+
+- **Unit (no network):** `IpApiResolver` country parsing from a canned JSON body (inject the body / use a `wiremock` server already a dev-dep under `integration-tests`); proxy-mirroring config assembled correctly; precedence logic (geo_locale set → probe skipped); overlay merge keeps explicit locale winning.
+- **`BrowserBuilder::proxy`:** emits the stripped `--proxy-server=` arg + auto-wires proxy_auth from userinfo + stores the parsed proxy (MockConnection / arg inspection, mirroring the per-context proxy tests).
+- **Launch integration (MockConnection):** a stub `GeoResolver` returning `Some("DE")` → the resolved persona carries `de-DE`; returning `None` → persona untouched.
+- **Integration (`#[ignore]`, real network):** `geo_auto()` against a live `ip-api.com` (behind a known proxy if available) resolves a plausible country. Joins the nightly `#[ignore]` set.
+
+## MCP coverage
+
+Add `geo_auto` + a `geo_resolver`/`geo_proxy` shape to `browser_open` under the existing `geo` MCP feature (mirrors how `geo_country` was added in PR #45), OR ledger the `GeoResolver`-trait-taking method as `excluded` (a trait object doesn't fit a wire tool) while exposing `geo_auto` (a bool) + an optional endpoint override on `browser_open`. Regenerate schema snapshots + public-api baseline per CLAUDE.md.
+
+## Docs
+
+Rustdoc (no_run) on `proxy`, `geo_auto`, `geo_resolver`, `IpApiResolver`. mdBook: extend the geo chapter (auto-resolution + the privacy note + custom-resolver example). README geo bullet. Flip the backlog §1 "Auto IP-geo" item to closed on ship.
+
+## Assumptions (delegate-mode calls — flag any to veto at review)
+
+1. **Bundled opt-in `ip-api.com` default** for `geo_auto()`, endpoint-overridable + trait-swappable. (The one fork surfaced to the user; absent a redirect, this ships. Alternative: trait-only, no bundled service.)
+2. **New `BrowserBuilder::proxy(url)`** structured field as a prerequisite, reusing `split_proxy_url` + auto-wiring `proxy_auth` from userinfo.
+3. **Browser-wide, pre-launch proxied `reqwest` probe** (not a post-launch browser-tab probe); per-context geo deferred.
+4. **`geo` feature pulls `reqwest`** (no separate sub-feature for v1).
+5. **Explicit `geo_locale`/`persona_overlay` locale beats auto**, and setting both skips the probe.
+6. **5s default probe timeout**, fail-soft (never blocks launch).


### PR DESCRIPTION
## Summary

Implements the `GeoResolver` "option B" exit-IP probe deferred in PR #45 (which shipped only the empty seam). Auto-derives a coherent `locale`/`languages` from the **proxy's exit-IP country** — third of the ①→③→② backlog cleanup.

```rust
let browser = Browser::builder()
    .proxy("http://user:pass@residential.example:8000")  // structured, reusable
    .geo_auto()                                            // probe exit IP → locale
    .launch().await?;
```

## What changed

- **`BrowserBuilder::proxy(impl Into<String>)`** — a structured browser-wide proxy (prerequisite). Reuses `crate::proxy::split_proxy_url` from the per-context proxy work: emits userinfo-stripped `--proxy-server=`, auto-wires `proxy_auth` from embedded userinfo (under `interception`), and stores the parsed proxy so the geo probe can mirror it. Credentials are redacted in `Debug`.
- **`IpApiResolver`** (behind `geo`) — implements the existing `zendriver_stealth::geo::GeoResolver` trait via a proxied `reqwest` GET (default `http://ip-api.com/json`, `.endpoint()`/`.timeout()` overridable). **Authenticates through the proxy via `reqwest::Proxy::basic_auth`** (creds never in the URL string, so they can't leak into error Displays). Fail-soft: any error → `warn!` + `None`, bounded by a 5s timeout.
- **`BrowserBuilder::geo_auto()`** (bundled `IpApiResolver`, mirroring `.proxy()` incl. credentials) + **`geo_resolver(impl GeoResolver)`** (custom / offline DB). Resolved async during `launch()`/`connect()` — folded into `persona_overlay` right before the stealth observer reads the persona.
- **Precedence:** an explicit `geo_locale()` / `persona_overlay()` locale **or a locale-bearing base `persona`** wins and **skips the probe entirely** (no wasted network call). The auto-derived overlay only ever fills a gap.

## Privacy

The bundled probe makes one outbound call to a third-party service (`ip-api.com`), **only** when `.geo_auto()` is set. The endpoint is overridable and the `GeoResolver` trait is swappable (your own service or an offline GeoIP DB). Per the project's stealth-hardening philosophy (volatile/external → expose config, never hardcode).

## Tests

Unit (no Chrome): `IpApiResolver` country parse + fail-soft (wiremock); `BrowserBuilder::proxy` arg/credential handling; `apply_geo_overlay` — geo applied when unset, **explicit `geo_locale`/`persona_overlay`/base-persona locale wins + skips probe**, fail-soft leaves overlays untouched, device_memory preserved while geo fills locale, and `geo_auto` mirrors proxy **+ credentials** into the resolver. Full workspace suite + `--features geo` (320 lib + 261 doctests) green; clippy (default / `geo` / `zendriver-mcp --all-features`), schema snapshots, public-api baseline, and mdBook all pass.

## MCP / docs

`browser_open` gains `proxy`, `geo_auto`, `geo_endpoint` (under the `geo` MCP feature); `geo_resolver(impl GeoResolver)` ledgered `excluded` (trait object, no wire form). Rustdoc + mdBook geo chapter (auto-resolution + privacy note + custom-resolver example) + README updated; backlog §1 "Auto IP-geo" flipped to closed (timezone-from-geo remains open).

## Review

Whole-branch review (opus) found 1 Critical (probe dropped proxy credentials → dead against authenticated proxies) + 1 Important (MCP base-persona locale wasn't honored by the skip guard) — **both fixed** in `a87b6a25` with regression tests. Minors: plaintext-endpoint doc caveat added; the MCP `geo_endpoint`-override-not-proxied limitation is filed as a follow-up in the backlog (§1 MCP surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)