### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "async-trait",
  "base64",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-cloudflare"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "futures",
  "serde",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fetcher"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "dirs",
  "futures",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "futures",
  "serde",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "base64",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",
@@ -3604,7 +3604,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-transport"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.23", default-features = false }
-zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.9" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.5.2" }
-zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.5" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.7" }
-zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.7" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.7.0" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.8" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.9" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.11" }
+zendriver               = { path = "crates/zendriver", version = "0.2.24", default-features = false }
+zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.10" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.5.3" }
+zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.6" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.8" }
+zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.8" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.7.1" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.9" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.10" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.12" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-cloudflare/CHANGELOG.md
+++ b/crates/zendriver-cloudflare/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-07-17
+
+
 ## [0.2.5] - 2026-07-16
 
 

--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-cloudflare"
 description = "Cloudflare Turnstile bypass for zendriver"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.10] - 2026-07-17
+
+
 ## [0.1.9] - 2026-07-16
 
 

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.9"
+version = "0.1.10"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fetcher/CHANGELOG.md
+++ b/crates/zendriver-fetcher/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.8] - 2026-07-17
+
+
 ## [0.1.7] - 2026-07-16
 
 

--- a/crates/zendriver-fetcher/Cargo.toml
+++ b/crates/zendriver-fetcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fetcher"
 description = "Chrome binary downloader for zendriver"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.12] - 2026-07-17
+
+
 ## [0.2.11] - 2026-07-16
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.2.11"
+version = "0.2.12"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.9] - 2026-07-17
+
+
 ## [0.2.8] - 2026-07-16
 
 

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.8] - 2026-07-17
+
+
 ## [0.3.7] - 2026-07-16
 
 

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.3.7"
+version = "0.3.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.7.1] - 2026-07-17
+
+
 ## [0.7.0] - 2026-07-16
 
 ### Fixed

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.5.3] - 2026-07-17
+
+### Added
+
+- Derive representative timezone from country in geo::persona
+
+
 ## [0.5.2] - 2026-07-16
 
 

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-transport/CHANGELOG.md
+++ b/crates/zendriver-transport/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-07-17
+
+
 ## [0.1.9] - 2026-07-16
 
 

--- a/crates/zendriver-transport/Cargo.toml
+++ b/crates/zendriver-transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-transport"
 description = "Internal: WebSocket + CDP routing actor for zendriver"
-version = "0.1.9"
+version = "0.1.10"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.24] - 2026-07-17
+
+### Fixed
+
+- Explicit persona fields win over geo-derived (locale + timezone)
+
+
 ## [0.2.23] - 2026-07-16
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.23"
+version = "0.2.24"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-transport`: 0.1.9 -> 0.1.10 (✓ API compatible changes)
* `zendriver-cloudflare`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `zendriver-interception`: 0.3.7 -> 0.3.8 (✓ API compatible changes)
* `zendriver-datadome`: 0.1.9 -> 0.1.10 (✓ API compatible changes)
* `zendriver-fetcher`: 0.1.7 -> 0.1.8 (✓ API compatible changes)
* `zendriver-imperva`: 0.2.8 -> 0.2.9 (✓ API compatible changes)
* `zendriver-stealth`: 0.5.2 -> 0.5.3 (✓ API compatible changes)
* `zendriver`: 0.2.23 -> 0.2.24 (✓ API compatible changes)
* `zendriver-fingerprints`: 0.2.11 -> 0.2.12
* `zendriver-mcp`: 0.7.0 -> 0.7.1

<details><summary><i><b>Changelog</b></i></summary><p>







## `zendriver-stealth`

<blockquote>

## [0.5.3] - 2026-07-17

### Added

- Derive representative timezone from country in geo::persona
</blockquote>

## `zendriver`

<blockquote>

## [0.2.24] - 2026-07-17

### Fixed

- Explicit persona fields win over geo-derived (locale + timezone)
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).