### PR TITLE
feat(stealth): Persona custom UA-CH metadata + ScreenSpec

### DIFF
--- a/crates/zendriver-stealth/src/fingerprint.rs
+++ b/crates/zendriver-stealth/src/fingerprint.rs
@@ -1,10 +1,10 @@
 //! Fingerprint: composed UA + Sec-CH-UA metadata + system facts.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::Platform;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Brand {
     pub brand: String,
     pub version: String,
@@ -12,7 +12,7 @@ pub struct Brand {
 
 /// Sent to CDP as `Emulation.setUserAgentOverride.userAgentMetadata`.
 /// Mirrors the [W3C UA-CH spec](https://wicg.github.io/ua-client-hints/).
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct UserAgentMetadata {
     pub brands: Vec<Brand>,
     #[serde(rename = "fullVersionList")]
@@ -103,6 +103,11 @@ pub struct Fingerprint {
     pub timezone: Option<String>,
     pub locale: Option<String>,
     pub languages: Option<Vec<String>>,
+    /// Screen / device-metrics override resolved from
+    /// [`StealthProfile::screen`](crate::StealthProfile::screen). `None` by
+    /// default (`auto_detect` never probes a screen size) — the observer's
+    /// fixed 1920x1080 default is untouched until this is explicitly set.
+    pub screen: Option<crate::persona::specs::ScreenSpec>,
 }
 
 impl Fingerprint {
@@ -132,6 +137,7 @@ impl Fingerprint {
             timezone: None,
             locale: None,
             languages: None,
+            screen: None,
         })
     }
 
@@ -603,6 +609,7 @@ mod fingerprint_tests {
             timezone: None,
             locale: None,
             languages: None,
+            screen: None,
         };
         fp.recompose();
         assert!(fp.ua_string.contains("Windows NT 10.0"));

--- a/crates/zendriver-stealth/src/lang.rs
+++ b/crates/zendriver-stealth/src/lang.rs
@@ -75,6 +75,7 @@ mod tests {
             timezone: None,
             locale: None,
             languages: None,
+            screen: None,
         }
     }
 

--- a/crates/zendriver-stealth/src/lib.rs
+++ b/crates/zendriver-stealth/src/lib.rs
@@ -57,6 +57,8 @@ pub use observer::StealthObserver;
 pub use profile::{Platform, ProfileKind, StealthProfile};
 
 pub use persona::seed::Seed;
-pub use persona::specs::{FontSpec, HardwareSpec, SurfaceCfg, UaSpec, WebglSpec, WebrtcSpec};
+pub use persona::specs::{
+    FontSpec, HardwareSpec, ScreenSpec, SurfaceCfg, UaMetadata, UaSpec, WebglSpec, WebrtcSpec,
+};
 pub use persona::surface::{Strategy, Surface, SurfaceKind};
 pub use persona::{GeoPos, JsProbe, Persona, PersonaBuilder};

--- a/crates/zendriver-stealth/src/observer.rs
+++ b/crates/zendriver-stealth/src/observer.rs
@@ -13,6 +13,7 @@ use zendriver_transport::{ObserverError, PausedSession, TargetObserver};
 
 use crate::patches::bootstrap_script;
 use crate::persona::GeoPos;
+use crate::persona::specs::{ScreenSpec, UaMetadata};
 use crate::{Fingerprint, Persona, ProfileKind, StealthProfile};
 
 /// Observer that applies a [`StealthProfile`] + [`Fingerprint`] to every page
@@ -31,6 +32,16 @@ pub struct StealthObserver {
     /// on [`Fingerprint`]), geolocation has no `Fingerprint` counterpart, so
     /// it's captured here straight off the persona at construction time.
     geolocation: Option<GeoPos>,
+    /// Custom UA-CH from the resolved [`Persona`]'s `ua.ua_metadata`. When
+    /// set, [`UaMetadata::resolve`] fills any unset sub-field from
+    /// `fingerprint.ua_metadata` and the result drives
+    /// `Emulation.setUserAgentOverride.userAgentMetadata` in place of the
+    /// fingerprint-derived value outright.
+    ua_metadata: Option<UaMetadata>,
+    /// Custom screen / device-metrics from the resolved [`Persona`]. When
+    /// set, drives `Emulation.setDeviceMetricsOverride` in place of the
+    /// fixed 1920x1080 default.
+    screen: Option<ScreenSpec>,
 }
 
 impl StealthObserver {
@@ -61,11 +72,15 @@ impl StealthObserver {
             String::new()
         };
         let geolocation = persona.geolocation;
+        let ua_metadata = persona.ua.as_ref().and_then(|u| u.ua_metadata.clone());
+        let screen = persona.screen;
         Self {
             profile,
             fingerprint,
             bootstrap,
             geolocation,
+            ua_metadata,
+            screen,
         }
     }
 }
@@ -101,6 +116,14 @@ impl TargetObserver for StealthObserver {
             // list so the emitted header is a clean `en-US,en;q=0.9`.
             langs.join(",")
         };
+        // Persona UA-CH wins when supplied — field-wise, falling back to the
+        // fingerprint-derived value for any sub-field the persona left
+        // unset. Absent persona UA-CH → today's behavior (fingerprint's
+        // UAM verbatim).
+        let user_agent_metadata = match &self.ua_metadata {
+            Some(custom) => custom.resolve(&self.fingerprint.ua_metadata),
+            None => self.fingerprint.ua_metadata.clone(),
+        };
         session
             .call(
                 "Emulation.setUserAgentOverride",
@@ -108,24 +131,29 @@ impl TargetObserver for StealthObserver {
                     "userAgent": &self.fingerprint.ua_string,
                     "acceptLanguage": accept_language,
                     "platform": self.fingerprint.platform.ch_platform(),
-                    "userAgentMetadata": &self.fingerprint.ua_metadata,
+                    "userAgentMetadata": &user_agent_metadata,
                 }),
             )
             .await?;
 
         // Screen-size override + focus emulation: keeps headless from leaking
         // an oddly-shaped viewport and from reporting `document.hasFocus()`
-        // false for the (always-backgrounded) headless tab.
+        // false for the (always-backgrounded) headless tab. Persona screen
+        // wins when supplied; absent → today's fixed 1920x1080 default.
+        let (screen_width, screen_height, device_scale_factor) = match self.screen {
+            Some(s) => (s.width, s.height, s.device_pixel_ratio),
+            None => (1920, 1080, 1.0),
+        };
         session
             .call(
                 "Emulation.setDeviceMetricsOverride",
                 json!({
-                    "width": 1920,
-                    "height": 1080,
-                    "deviceScaleFactor": 1.0,
+                    "width": screen_width,
+                    "height": screen_height,
+                    "deviceScaleFactor": device_scale_factor,
                     "mobile": false,
-                    "screenWidth": 1920,
-                    "screenHeight": 1080,
+                    "screenWidth": screen_width,
+                    "screenHeight": screen_height,
                 }),
             )
             .await?;
@@ -346,6 +374,172 @@ mod tests {
                 assert_eq!(params["latitude"].as_f64(), Some(21.0285));
                 assert_eq!(params["longitude"].as_f64(), Some(105.8542));
                 assert_eq!(params["accuracy"].as_f64(), Some(50.0));
+            }
+            mock.reply(id, json!({})).await;
+        }
+
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn spoofed_observer_emits_persona_ua_metadata_and_screen_when_present() {
+        let fp = Fingerprint {
+            platform: Platform::MacIntel,
+            chrome_major: 120,
+            chrome_full: "120.0.6099.234".into(),
+            cpu_count: 10,
+            memory_gb: 8,
+            ua_string: crate::ua::compose_ua_string(Platform::MacIntel, "120.0.6099.234"),
+            ua_metadata: crate::UserAgentMetadata::realistic(
+                Platform::MacIntel,
+                120,
+                "120.0.6099.234",
+            ),
+            timezone: None,
+            locale: None,
+            languages: None,
+            screen: None,
+        };
+        let persona = crate::Persona {
+            ua: Some(crate::UaSpec {
+                ua_metadata: Some(crate::persona::specs::UaMetadata {
+                    platform_version: Some("15.0.0".into()),
+                    architecture: Some("arm".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            screen: Some(crate::persona::specs::ScreenSpec {
+                width: 1536,
+                height: 864,
+                device_pixel_ratio: 1.25,
+            }),
+            ..crate::Persona::default()
+        };
+        let profile = StealthProfile::spoofed();
+        let observer = std::sync::Arc::new(StealthObserver::with_persona(profile, fp, persona));
+
+        let (mut mock, conn) = MockConnection::pair_with_observers(vec![observer.clone()]);
+
+        mock.emit_event(
+            "Target.attachedToTarget",
+            json!({
+                "sessionId": "S1",
+                "targetInfo": {
+                    "targetId": "T1",
+                    "type": "page",
+                    "url": "about:blank",
+                    "attached": true,
+                },
+                "waitingForDebugger": true,
+            }),
+        )
+        .await;
+
+        for expected in [
+            "Page.enable",
+            "Emulation.setUserAgentOverride",
+            "Emulation.setDeviceMetricsOverride",
+            "Emulation.setFocusEmulationEnabled",
+            "Page.setBypassCSP",
+            "Page.addScriptToEvaluateOnNewDocument",
+            "Runtime.runIfWaitingForDebugger",
+        ] {
+            let id =
+                tokio::time::timeout(std::time::Duration::from_secs(2), mock.expect_cmd(expected))
+                    .await
+                    .unwrap_or_else(|_| panic!("did not see {expected} within 2s"));
+            if expected == "Emulation.setUserAgentOverride" {
+                let uam = mock.last_sent()["params"]["userAgentMetadata"].clone();
+                // Persona-set sub-fields win.
+                assert_eq!(uam["platformVersion"].as_str(), Some("15.0.0"));
+                assert_eq!(uam["architecture"].as_str(), Some("arm"));
+                // Unset sub-fields fall back to the fingerprint-derived UAM.
+                assert_eq!(uam["platform"].as_str(), Some("macOS"));
+                assert!(uam["brands"].is_array());
+            }
+            if expected == "Emulation.setDeviceMetricsOverride" {
+                let params = mock.last_sent()["params"].clone();
+                assert_eq!(params["width"].as_u64(), Some(1536));
+                assert_eq!(params["height"].as_u64(), Some(864));
+                assert_eq!(params["deviceScaleFactor"].as_f64(), Some(1.25));
+                assert_eq!(params["screenWidth"].as_u64(), Some(1536));
+                assert_eq!(params["screenHeight"].as_u64(), Some(864));
+            }
+            mock.reply(id, json!({})).await;
+        }
+
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn spoofed_observer_uses_fingerprint_uam_and_fixed_screen_when_persona_absent() {
+        let fp = Fingerprint {
+            platform: Platform::MacIntel,
+            chrome_major: 120,
+            chrome_full: "120.0.6099.234".into(),
+            cpu_count: 10,
+            memory_gb: 8,
+            ua_string: crate::ua::compose_ua_string(Platform::MacIntel, "120.0.6099.234"),
+            ua_metadata: crate::UserAgentMetadata::realistic(
+                Platform::MacIntel,
+                120,
+                "120.0.6099.234",
+            ),
+            timezone: None,
+            locale: None,
+            languages: None,
+            screen: None,
+        };
+        let expected_uam = fp.ua_metadata.clone();
+        let profile = StealthProfile::spoofed();
+        // `Persona::default()` — no ua_metadata, no screen.
+        let observer = std::sync::Arc::new(StealthObserver::new(profile, fp));
+
+        let (mut mock, conn) = MockConnection::pair_with_observers(vec![observer.clone()]);
+
+        mock.emit_event(
+            "Target.attachedToTarget",
+            json!({
+                "sessionId": "S1",
+                "targetInfo": {
+                    "targetId": "T1",
+                    "type": "page",
+                    "url": "about:blank",
+                    "attached": true,
+                },
+                "waitingForDebugger": true,
+            }),
+        )
+        .await;
+
+        for expected in [
+            "Page.enable",
+            "Emulation.setUserAgentOverride",
+            "Emulation.setDeviceMetricsOverride",
+            "Emulation.setFocusEmulationEnabled",
+            "Page.setBypassCSP",
+            "Page.addScriptToEvaluateOnNewDocument",
+            "Runtime.runIfWaitingForDebugger",
+        ] {
+            let id =
+                tokio::time::timeout(std::time::Duration::from_secs(2), mock.expect_cmd(expected))
+                    .await
+                    .unwrap_or_else(|_| panic!("did not see {expected} within 2s"));
+            if expected == "Emulation.setUserAgentOverride" {
+                let uam = mock.last_sent()["params"]["userAgentMetadata"].clone();
+                let expected_json = serde_json::to_value(&expected_uam).unwrap();
+                assert_eq!(
+                    uam, expected_json,
+                    "absent persona UAM → fingerprint's verbatim"
+                );
+            }
+            if expected == "Emulation.setDeviceMetricsOverride" {
+                let params = mock.last_sent()["params"].clone();
+                // Today's fixed default, unchanged.
+                assert_eq!(params["width"].as_u64(), Some(1920));
+                assert_eq!(params["height"].as_u64(), Some(1080));
+                assert_eq!(params["deviceScaleFactor"].as_f64(), Some(1.0));
             }
             mock.reply(id, json!({})).await;
         }

--- a/crates/zendriver-stealth/src/observer.rs
+++ b/crates/zendriver-stealth/src/observer.rs
@@ -221,6 +221,7 @@ mod tests {
             timezone: None,
             locale: None,
             languages: None,
+            screen: None,
         };
         let profile = StealthProfile::spoofed();
         let observer = std::sync::Arc::new(StealthObserver::new(profile, fp));
@@ -296,6 +297,7 @@ mod tests {
             timezone: None,
             locale: None,
             languages: None,
+            screen: None,
         };
         let persona = crate::Persona {
             geolocation: Some(crate::persona::GeoPos {
@@ -368,6 +370,7 @@ mod tests {
             timezone: None,
             locale: None,
             languages: None,
+            screen: None,
         };
         let persona = crate::Persona {
             geolocation: Some(crate::persona::GeoPos {
@@ -441,6 +444,7 @@ mod tests {
             timezone: None,
             locale: None,
             languages: None,
+            screen: None,
         };
         let observer = std::sync::Arc::new(StealthObserver::new(StealthProfile::off(), fp));
         let (mut mock, conn) = MockConnection::pair_with_observers(vec![observer]);

--- a/crates/zendriver-stealth/src/patches.rs
+++ b/crates/zendriver-stealth/src/patches.rs
@@ -345,6 +345,7 @@ mod tests {
             timezone: None,
             locale: Some("en-US".into()),
             languages: None,
+            screen: None,
         }
     }
 

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -6,7 +6,9 @@ pub mod surface;
 pub(crate) mod webgpu_adapter;
 
 pub use seed::Seed;
-pub use specs::{FontSpec, HardwareSpec, SurfaceCfg, UaSpec, WebglSpec, WebrtcSpec};
+pub use specs::{
+    FontSpec, HardwareSpec, ScreenSpec, SurfaceCfg, UaMetadata, UaSpec, WebglSpec, WebrtcSpec,
+};
 
 use std::sync::OnceLock;
 
@@ -49,6 +51,9 @@ pub struct Persona {
     /// [`locale`](Self::locale) — keeps `navigator.geolocation` in step with
     /// the exit IP's real location instead of leaking the host's.
     pub geolocation: Option<GeoPos>,
+    /// Screen / device-metrics override (`Emulation.setDeviceMetricsOverride`).
+    /// `None` → the observer's fixed 1920x1080 default (today's behavior).
+    pub screen: Option<ScreenSpec>,
     pub webgl: Option<WebglSpec>,
     pub webgpu: Option<SurfaceCfg>,
     pub canvas: Option<SurfaceCfg>,
@@ -120,13 +125,21 @@ impl Persona {
     pub fn overlay(self, over: Persona) -> Persona {
         Persona {
             platform: over.platform.or(self.platform),
-            ua: over.ua.or(self.ua),
+            // UA-CH composes field-wise (via `UaSpec::overlay`) rather than
+            // one side wholesale-replacing the other, so layering two
+            // personas can patch e.g. just `platform_version` without
+            // clobbering a base persona's `brands`.
+            ua: match (self.ua, over.ua) {
+                (Some(base), Some(add)) => Some(base.overlay(add)),
+                (base, add) => add.or(base),
+            },
             hardware_concurrency: over.hardware_concurrency.or(self.hardware_concurrency),
             device_memory_gb: over.device_memory_gb.or(self.device_memory_gb),
             timezone: over.timezone.or(self.timezone),
             locale: over.locale.or(self.locale),
             languages: over.languages.or(self.languages),
             geolocation: over.geolocation.or(self.geolocation),
+            screen: over.screen.or(self.screen),
             webgl: over.webgl.or(self.webgl),
             webgpu: over.webgpu.or(self.webgpu),
             canvas: over.canvas.or(self.canvas),
@@ -530,6 +543,109 @@ mod persona_tests {
         assert_eq!(geo.latitude, 10.0);
         assert_eq!(geo.longitude, 20.0);
         assert_eq!(geo.accuracy, None);
+    }
+
+    #[test]
+    fn persona_round_trips_ua_metadata_and_screen_json() {
+        let p = Persona {
+            ua: Some(UaSpec {
+                ua_string: Some("Mozilla/5.0 (Windows NT 10.0; Win64; x64)".into()),
+                ua_metadata: Some(UaMetadata {
+                    platform_version: Some("15.0.0".into()),
+                    architecture: Some("arm".into()),
+                    bitness: Some("64".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            screen: Some(ScreenSpec {
+                width: 1536,
+                height: 864,
+                device_pixel_ratio: 1.25,
+            }),
+            ..Persona::default()
+        };
+        let s = serde_json::to_string(&p).unwrap();
+        let back: Persona = serde_json::from_str(&s).unwrap();
+        assert_eq!(
+            back.ua
+                .as_ref()
+                .and_then(|u| u.ua_metadata.as_ref())
+                .and_then(|m| m.architecture.clone())
+                .as_deref(),
+            Some("arm")
+        );
+        assert_eq!(
+            back.screen,
+            Some(ScreenSpec {
+                width: 1536,
+                height: 864,
+                device_pixel_ratio: 1.25
+            })
+        );
+    }
+
+    #[test]
+    fn overlay_screen_some_wins_none_inherits() {
+        let base = Persona {
+            screen: Some(ScreenSpec {
+                width: 1920,
+                height: 1080,
+                device_pixel_ratio: 1.0,
+            }),
+            ..Persona::default()
+        };
+        let over = Persona {
+            screen: Some(ScreenSpec {
+                width: 1536,
+                height: 864,
+                device_pixel_ratio: 1.25,
+            }),
+            ..Persona::default()
+        };
+        let merged = base.clone().overlay(over);
+        assert_eq!(
+            merged.screen,
+            Some(ScreenSpec {
+                width: 1536,
+                height: 864,
+                device_pixel_ratio: 1.25
+            })
+        ); // some wins
+        let merged2 = base.overlay(Persona::default());
+        assert_eq!(
+            merged2.screen,
+            Some(ScreenSpec {
+                width: 1920,
+                height: 1080,
+                device_pixel_ratio: 1.0
+            })
+        ); // none inherits
+    }
+
+    #[test]
+    fn overlay_ua_composes_field_wise_not_whole_swap() {
+        // A base persona's `platform` override must survive an overlay that
+        // only sets `ua_string` — whole-swap semantics would have silently
+        // dropped it.
+        let base = Persona {
+            ua: Some(UaSpec {
+                platform: Some("Windows".into()),
+                ..Default::default()
+            }),
+            ..Persona::default()
+        };
+        let over = Persona {
+            ua: Some(UaSpec {
+                ua_string: Some("custom-ua".into()),
+                ..Default::default()
+            }),
+            ..Persona::default()
+        };
+        let merged = base.overlay(over);
+        let ua = merged.ua.expect("ua merged");
+        assert_eq!(ua.platform.as_deref(), Some("Windows")); // inherited
+        assert_eq!(ua.ua_string.as_deref(), Some("custom-ua")); // over wins
     }
 
     #[test]

--- a/crates/zendriver-stealth/src/persona/specs.rs
+++ b/crates/zendriver-stealth/src/persona/specs.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::surface::Strategy;
+use crate::fingerprint::{Brand, UserAgentMetadata};
 
 /// Noise-surface config (canvas, audio, clientRects).
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
@@ -17,6 +18,109 @@ pub struct UaSpec {
     pub ua_string: Option<String>,
     /// Free-form UA-CH overrides; merged onto realistic() output at resolve.
     pub platform: Option<String>,
+    /// Full UA-CH (`Emulation.setUserAgentOverride.userAgentMetadata`)
+    /// override, field-wise. Any sub-field left `None` falls back to the
+    /// fingerprint-derived value at resolve (see [`UaMetadata::resolve`]).
+    /// JSON key is `userAgentMetadata` to match the wire shape callers
+    /// harvest it from (e.g. `navigator.userAgentData.getHighEntropyValues`).
+    #[serde(rename = "userAgentMetadata")]
+    pub ua_metadata: Option<UaMetadata>,
+}
+
+impl UaSpec {
+    /// Field-wise merge: `Some` in `over` wins, `None` inherits from `self`.
+    /// `ua_metadata` recurses into [`UaMetadata::overlay`] when both sides
+    /// carry one, so layering two personas composes UA-CH sub-fields instead
+    /// of one side wholesale-replacing the other.
+    #[must_use]
+    pub fn overlay(self, over: UaSpec) -> UaSpec {
+        UaSpec {
+            ua_string: over.ua_string.or(self.ua_string),
+            platform: over.platform.or(self.platform),
+            ua_metadata: match (self.ua_metadata, over.ua_metadata) {
+                (Some(base), Some(add)) => Some(base.overlay(add)),
+                (base, add) => add.or(base),
+            },
+        }
+    }
+}
+
+/// Field-wise `userAgentMetadata` (UA-CH) override. Mirrors
+/// [`UserAgentMetadata`] but every field is optional: unset fields fall back
+/// to the fingerprint-derived value at resolve (see [`Self::resolve`]).
+/// `wow64` is intentionally absent — it has no independent override surface
+/// here and always comes from the derived base.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct UaMetadata {
+    pub brands: Option<Vec<Brand>>,
+    #[serde(rename = "fullVersionList")]
+    pub full_version_list: Option<Vec<Brand>>,
+    pub platform: Option<String>,
+    #[serde(rename = "platformVersion")]
+    pub platform_version: Option<String>,
+    pub architecture: Option<String>,
+    pub bitness: Option<String>,
+    pub mobile: Option<bool>,
+    pub model: Option<String>,
+}
+
+impl UaMetadata {
+    /// Field-wise merge: `Some` in `over` wins, `None` inherits from `self`.
+    #[must_use]
+    pub fn overlay(self, over: UaMetadata) -> UaMetadata {
+        UaMetadata {
+            brands: over.brands.or(self.brands),
+            full_version_list: over.full_version_list.or(self.full_version_list),
+            platform: over.platform.or(self.platform),
+            platform_version: over.platform_version.or(self.platform_version),
+            architecture: over.architecture.or(self.architecture),
+            bitness: over.bitness.or(self.bitness),
+            mobile: over.mobile.or(self.mobile),
+            model: over.model.or(self.model),
+        }
+    }
+
+    /// Resolve into a complete [`UserAgentMetadata`], filling any unset
+    /// sub-field from `base` (the fingerprint-derived value). `wow64` always
+    /// comes from `base` — it has no override surface on [`UaMetadata`].
+    #[must_use]
+    pub fn resolve(&self, base: &UserAgentMetadata) -> UserAgentMetadata {
+        UserAgentMetadata {
+            brands: self.brands.clone().unwrap_or_else(|| base.brands.clone()),
+            full_version_list: self
+                .full_version_list
+                .clone()
+                .unwrap_or_else(|| base.full_version_list.clone()),
+            platform: self
+                .platform
+                .clone()
+                .unwrap_or_else(|| base.platform.clone()),
+            platform_version: self
+                .platform_version
+                .clone()
+                .unwrap_or_else(|| base.platform_version.clone()),
+            architecture: self
+                .architecture
+                .clone()
+                .unwrap_or_else(|| base.architecture.clone()),
+            bitness: self.bitness.clone().unwrap_or_else(|| base.bitness.clone()),
+            wow64: base.wow64,
+            mobile: self.mobile.unwrap_or(base.mobile),
+            model: self.model.clone().unwrap_or_else(|| base.model.clone()),
+        }
+    }
+}
+
+/// Screen / device-metrics override (`Emulation.setDeviceMetricsOverride`).
+/// Whole-value at [`Persona::overlay`](super::Persona::overlay) — composing
+/// two personas has the higher-priority persona's screen win outright when
+/// set, same as every other spec field (a screen is one coherent artifact,
+/// not sub-field patchable the way [`UaMetadata`] is).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct ScreenSpec {
+    pub width: u32,
+    pub height: u32,
+    pub device_pixel_ratio: f64,
 }
 
 /// WebGL value substitution.
@@ -53,6 +157,7 @@ pub struct HardwareSpec {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -66,6 +171,127 @@ mod tests {
         let s = serde_json::to_string(&w).unwrap();
         let back: WebglSpec = serde_json::from_str(&s).unwrap();
         assert_eq!(w, back);
+    }
+
+    #[test]
+    fn ua_metadata_round_trips_json_camelcase() {
+        let m = UaMetadata {
+            brands: Some(vec![Brand {
+                brand: "Not_A Brand".into(),
+                version: "8".into(),
+            }]),
+            full_version_list: Some(vec![Brand {
+                brand: "Chromium".into(),
+                version: "150.0.7500.0".into(),
+            }]),
+            platform: Some("Windows".into()),
+            platform_version: Some("15.0.0".into()),
+            architecture: Some("x86".into()),
+            bitness: Some("64".into()),
+            mobile: Some(false),
+            model: Some(String::new()),
+        };
+        let s = serde_json::to_string(&m).unwrap();
+        assert!(
+            s.contains("\"fullVersionList\""),
+            "expected camelCase key, got: {s}"
+        );
+        assert!(
+            s.contains("\"platformVersion\""),
+            "expected camelCase key, got: {s}"
+        );
+        let back: UaMetadata = serde_json::from_str(&s).unwrap();
+        assert_eq!(m, back);
+    }
+
+    #[test]
+    fn ua_spec_round_trips_ua_metadata_under_camelcase_key() {
+        let spec = UaSpec {
+            ua_string: Some("Mozilla/5.0 (Windows NT 10.0; Win64; x64)".into()),
+            platform: Some("Windows".into()),
+            ua_metadata: Some(UaMetadata {
+                platform_version: Some("15.0.0".into()),
+                architecture: Some("arm".into()),
+                ..Default::default()
+            }),
+        };
+        let s = serde_json::to_string(&spec).unwrap();
+        assert!(
+            s.contains("\"userAgentMetadata\""),
+            "expected camelCase field key, got: {s}"
+        );
+        let back: UaSpec = serde_json::from_str(&s).unwrap();
+        assert_eq!(spec, back);
+    }
+
+    #[test]
+    fn ua_spec_overlay_composes_ua_metadata_field_wise() {
+        let base = UaSpec {
+            platform: Some("Windows".into()),
+            ua_metadata: Some(UaMetadata {
+                brands: Some(vec![Brand {
+                    brand: "X".into(),
+                    version: "1".into(),
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let over = UaSpec {
+            ua_metadata: Some(UaMetadata {
+                platform_version: Some("11.0.0".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let merged = base.overlay(over);
+        // Non-`ua` top-level field inherited unchanged (`over` didn't set it).
+        assert_eq!(merged.platform.as_deref(), Some("Windows"));
+        let uam = merged.ua_metadata.expect("ua_metadata merged");
+        assert!(uam.brands.is_some(), "brands inherited from base");
+        assert_eq!(uam.platform_version.as_deref(), Some("11.0.0")); // over wins
+    }
+
+    #[test]
+    fn ua_spec_overlay_one_sided_is_a_no_op_merge() {
+        let base = UaSpec {
+            ua_string: Some("base-ua".into()),
+            ..Default::default()
+        };
+        let merged = base.clone().overlay(UaSpec::default());
+        assert_eq!(merged, base);
+    }
+
+    #[test]
+    fn ua_metadata_resolve_fills_unset_fields_from_base() {
+        let base = UserAgentMetadata::realistic(crate::Platform::Win32, 150, "150.0.7500.0");
+        let custom = UaMetadata {
+            platform_version: Some("11.0.0".into()),
+            ..Default::default()
+        };
+        let resolved = custom.resolve(&base);
+        assert_eq!(resolved.platform_version, "11.0.0"); // custom wins
+        assert_eq!(resolved.brands, base.brands); // fell back to base
+        assert_eq!(resolved.wow64, base.wow64); // no override surface, always base
+    }
+
+    #[test]
+    fn ua_metadata_resolve_empty_equals_base_exactly() {
+        let base = UserAgentMetadata::realistic(crate::Platform::MacIntel, 148, "148.0.7778.181");
+        let resolved = UaMetadata::default().resolve(&base);
+        assert_eq!(resolved, base);
+    }
+
+    #[test]
+    fn screen_spec_round_trips_json() {
+        let s = ScreenSpec {
+            width: 1536,
+            height: 864,
+            device_pixel_ratio: 1.25,
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let back: ScreenSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(s, back);
     }
 
     #[test]

--- a/crates/zendriver-stealth/src/profile.rs
+++ b/crates/zendriver-stealth/src/profile.rs
@@ -4,7 +4,8 @@
 use std::path::{Path, PathBuf};
 
 use crate::error::StealthError;
-use crate::fingerprint::Fingerprint;
+use crate::fingerprint::{Fingerprint, UserAgentMetadata};
+use crate::persona::specs::ScreenSpec;
 
 /// Stealth modes shipped by the library.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,6 +71,8 @@ pub(crate) struct PerFieldOverride {
     pub locale: Option<String>,
     pub languages: Option<Vec<String>>,
     pub ua_string: Option<String>,
+    pub ua_metadata: Option<UserAgentMetadata>,
+    pub screen: Option<ScreenSpec>,
 }
 
 /// Stealth configuration passed to `BrowserBuilder::stealth(...)`.
@@ -245,6 +248,36 @@ impl StealthProfile {
         self.per_field.ua_string = Some(ua.into());
         self
     }
+    /// Override the reported UA-CH (`userAgentMetadata`) wholesale.
+    ///
+    /// Skips the composed-from-fingerprint step entirely — the resolved
+    /// [`Fingerprint::ua_metadata`] equals exactly what's passed here.
+    /// Prefer this over hand-composing individual UA-CH fields when you
+    /// need an exact, pre-built [`UserAgentMetadata`] (e.g. captured from a
+    /// real browser). For persona-driven, field-wise UA-CH overrides that
+    /// fall back to the derived value per sub-field, use a
+    /// [`Persona`](crate::Persona)'s `ua.ua_metadata`
+    /// ([`UaMetadata`](crate::UaMetadata)) instead, threaded via
+    /// [`StealthObserver::with_persona`](crate::StealthObserver::with_persona).
+    #[must_use]
+    pub fn user_agent_metadata(mut self, m: UserAgentMetadata) -> Self {
+        self.per_field.ua_metadata = Some(m);
+        self
+    }
+    /// Override the reported screen / device-metrics
+    /// (`Emulation.setDeviceMetricsOverride`) wholesale.
+    ///
+    /// Replaces the observer's fixed 1920x1080 default. Like
+    /// [`user_agent_metadata`](Self::user_agent_metadata), this is a
+    /// profile-level pin; a [`Persona`](crate::Persona)'s `screen` field
+    /// (threaded via
+    /// [`StealthObserver::with_persona`](crate::StealthObserver::with_persona))
+    /// takes precedence when both are set.
+    #[must_use]
+    pub fn screen(mut self, s: ScreenSpec) -> Self {
+        self.per_field.screen = Some(s);
+        self
+    }
     /// Toggle `Page.setBypassCSP`. Default `true` for [`spoofed`](Self::spoofed),
     /// `false` for [`native`](Self::native) / [`off`](Self::off).
     #[must_use]
@@ -333,6 +366,19 @@ impl StealthProfile {
         fp.recompose();
         if let Some(ref ua) = self.per_field.ua_string {
             fp.ua_string = ua.clone();
+        }
+        // Wholesale UA-CH pin: mirrors the `ua_string` override immediately
+        // above — when set, it REPLACES the recompose()-derived UAM outright
+        // (no field-wise fallback; that's what `Persona`'s `ua_metadata` is
+        // for, resolved in the observer against this fingerprint instead).
+        if let Some(ref uam) = self.per_field.ua_metadata {
+            fp.ua_metadata = uam.clone();
+        }
+        // Screen has no "derived" baseline (unlike UA-CH) — `Fingerprint`
+        // never had a screen concept before this, so leaving it `None` here
+        // is exactly today's behavior (the observer's fixed 1920x1080).
+        if let Some(s) = self.per_field.screen {
+            fp.screen = Some(s);
         }
         if let Some(ref tz) = self.per_field.timezone {
             fp.timezone = Some(tz.clone());
@@ -541,5 +587,76 @@ mod profile_tests {
             .resolve_fingerprint(std::path::Path::new("/nonexistent-chrome"))
             .expect("resolve ok");
         assert_eq!(resolved.languages.unwrap(), vec!["fr-FR", "fr"]);
+    }
+
+    fn bare_fp() -> Fingerprint {
+        Fingerprint {
+            platform: Platform::Win32,
+            chrome_major: 120,
+            chrome_full: "120.0.6099.234".into(),
+            cpu_count: 8,
+            memory_gb: 8,
+            ua_string: String::new(),
+            ua_metadata: UserAgentMetadata::realistic(Platform::Win32, 120, "120.0.6099.234"),
+            timezone: None,
+            locale: None,
+            languages: None,
+            screen: None,
+        }
+    }
+
+    #[test]
+    fn custom_ua_metadata_replaces_recompose_derived_when_supplied() {
+        let custom = UserAgentMetadata::realistic(Platform::MacIntel, 150, "150.0.7500.0");
+        let profile = StealthProfile::native()
+            .fingerprint(bare_fp())
+            .user_agent_metadata(custom.clone());
+        let resolved = profile
+            .resolve_fingerprint(std::path::Path::new("/nonexistent"))
+            .unwrap();
+        // Equals the SUPPLIED value exactly, not the recompose()-derived one
+        // (which would be `realistic(Win32, 120, ...)` from `bare_fp()`).
+        assert_eq!(resolved.ua_metadata, custom);
+    }
+
+    #[test]
+    fn absent_ua_metadata_override_keeps_recompose_derived_behavior() {
+        let profile = StealthProfile::native().fingerprint(bare_fp());
+        let resolved = profile
+            .resolve_fingerprint(std::path::Path::new("/nonexistent"))
+            .unwrap();
+        // No override → today's behavior: recompose()-derived from platform
+        // + chrome_major, i.e. matches `UserAgentMetadata::realistic` for the
+        // fingerprint's own (unoverridden) platform/version.
+        assert_eq!(
+            resolved.ua_metadata,
+            UserAgentMetadata::realistic(Platform::Win32, 120, "120.0.6099.234")
+        );
+    }
+
+    #[test]
+    fn custom_screen_resolves_onto_fingerprint_when_supplied() {
+        let screen = ScreenSpec {
+            width: 1536,
+            height: 864,
+            device_pixel_ratio: 1.25,
+        };
+        let profile = StealthProfile::native()
+            .fingerprint(bare_fp())
+            .screen(screen);
+        let resolved = profile
+            .resolve_fingerprint(std::path::Path::new("/nonexistent"))
+            .unwrap();
+        assert_eq!(resolved.screen, Some(screen));
+    }
+
+    #[test]
+    fn absent_screen_override_leaves_fingerprint_screen_none() {
+        let profile = StealthProfile::native().fingerprint(bare_fp());
+        let resolved = profile
+            .resolve_fingerprint(std::path::Path::new("/nonexistent"))
+            .unwrap();
+        // No override → today's behavior: no screen field influence at all.
+        assert_eq!(resolved.screen, None);
     }
 }

--- a/crates/zendriver-stealth/src/profile.rs
+++ b/crates/zendriver-stealth/src/profile.rs
@@ -508,6 +508,7 @@ mod profile_tests {
             timezone: None,
             locale: None,
             languages: None,
+            screen: None,
         };
         let p = StealthProfile::native()
             .fingerprint(fp.clone())
@@ -533,6 +534,7 @@ mod profile_tests {
             timezone: None,
             locale: None,
             languages: None,
+            screen: None,
         };
         let profile = profile.fingerprint(fp);
         let resolved = profile

--- a/crates/zendriver-stealth/tests/snapshots/persona_snapshot__persona_full_wire_shape.snap
+++ b/crates/zendriver-stealth/tests/snapshots/persona_snapshot__persona_full_wire_shape.snap
@@ -11,6 +11,7 @@ expression: p
   "locale": null,
   "languages": null,
   "geolocation": null,
+  "screen": null,
   "webgl": null,
   "webgpu": null,
   "canvas": null,


### PR DESCRIPTION
## What
Lets a `Persona` carry an arbitrary UA-CH (`userAgentMetadata`) **and** device-metrics (`ScreenSpec`), and has the observer emit them via `Emulation.setUserAgentOverride`/`setDeviceMetricsOverride`. Until now UA-CH was always **platform-derived** and device-metrics fixed at 1920×1080 — `persona.ua` was architecturally inert in the observer.

## Why
A downstream consumer (a persona-variety library) needs to present a specific real-data fingerprint's UA-CH sub-details (platformVersion / architecture / bitness) + screen **per persona**, coherently, without a bare UA-string override desyncing UA from sec-ch-ua.

## Changes
- `UaSpec` gains `ua_metadata: Option<UaMetadata>` (`brands`/`full_version_list`/`platform`/`platform_version`/`architecture`/`bitness`/`mobile`/`model`).
- New `ScreenSpec`; `Persona.screen`; `overlay()` composes both field-wise (`over.field.or(self.field)`).
- `resolve_fingerprint` uses the persona's `ua_metadata`/screen over the `recompose()`-derived defaults when present.
- Observer emits them; **absent → today's exact behavior** (no regression, asserted).

## Testing
`cargo test -p zendriver-stealth` green; new mock-transport tests mirror the existing geolocation test. Rebased on latest `main` (0.5.3).
