### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "async-trait",
  "base64",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.24", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.25", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.10" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.5.3" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.6.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.6" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.8" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.8" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.7.1" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.7.2" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.9" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.10" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.12" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.13" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.13] - 2026-07-17
+
+
 ## [0.2.12] - 2026-07-17
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.2.12"
+version = "0.2.13"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.7.2] - 2026-07-17
+
+
 ## [0.7.1] - 2026-07-17
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.6.0] - 2026-07-17
+
+### Added
+
+- Persona carries custom UA-CH metadata + screen spec
+- Resolve custom UA-CH + screen from persona over the derived defaults
+- Observer emits custom UA-CH + device-metrics from persona
+
+
 ## [0.5.3] - 2026-07-17
 
 ### Added

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.25] - 2026-07-17
+
+
 ## [0.2.24] - 2026-07-17
 
 ### Fixed

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.24"
+version = "0.2.25"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.5.3 -> 0.6.0 (⚠ API breaking changes)
* `zendriver`: 0.2.24 -> 0.2.25
* `zendriver-fingerprints`: 0.2.12 -> 0.2.13
* `zendriver-mcp`: 0.7.1 -> 0.7.2

### ⚠ `zendriver-stealth` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field UaSpec.ua_metadata in /tmp/.tmpKoFely/zendriver-rs/crates/zendriver-stealth/src/persona/specs.rs:27
  field UaSpec.ua_metadata in /tmp/.tmpKoFely/zendriver-rs/crates/zendriver-stealth/src/persona/specs.rs:27
  field UaSpec.ua_metadata in /tmp/.tmpKoFely/zendriver-rs/crates/zendriver-stealth/src/persona/specs.rs:27
  field Fingerprint.screen in /tmp/.tmpKoFely/zendriver-rs/crates/zendriver-stealth/src/fingerprint.rs:110
  field Fingerprint.screen in /tmp/.tmpKoFely/zendriver-rs/crates/zendriver-stealth/src/fingerprint.rs:110
  field Persona.screen in /tmp/.tmpKoFely/zendriver-rs/crates/zendriver-stealth/src/persona/mod.rs:56
  field Persona.screen in /tmp/.tmpKoFely/zendriver-rs/crates/zendriver-stealth/src/persona/mod.rs:56
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-stealth`

<blockquote>

## [0.6.0] - 2026-07-17

### Added

- Persona carries custom UA-CH metadata + screen spec
- Resolve custom UA-CH + screen from persona over the derived defaults
- Observer emits custom UA-CH + device-metrics from persona
</blockquote>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).