### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "async-trait",
  "base64",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "futures",
  "psl",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fetcher"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "dirs",
  "futures",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,15 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.27", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.28", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.10" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.6.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.6" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.8" }
-zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.8" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.7.4" }
+zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.9" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.7.5" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.9" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.10" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.11" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.13" }
 
 # MCP server

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.11] - 2026-07-17
+
+### Fixed
+
+- Use public-suffix list for cookie_domain (co.uk etc.)
+
+
 ## [0.1.10] - 2026-07-17
 
 

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.10"
+version = "0.1.11"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fetcher/CHANGELOG.md
+++ b/crates/zendriver-fetcher/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.9] - 2026-07-17
+
+### Fixed
+
+- Wire Beta/Dev/Canary channels
+
+
 ## [0.1.8] - 2026-07-17
 
 

--- a/crates/zendriver-fetcher/Cargo.toml
+++ b/crates/zendriver-fetcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fetcher"
 description = "Chrome binary downloader for zendriver"
-version = "0.1.8"
+version = "0.1.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.7.5] - 2026-07-17
+
+### Fixed
+
+- Wire Beta/Dev/Canary channels
+
+
 ## [0.7.4] - 2026-07-17
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.7.4"
+version = "0.7.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.28] - 2026-07-17
+
+### Fixed
+
+- Sort frames() by frame id for deterministic cross-frame results
+
+
 ## [0.2.27] - 2026-07-17
 
 ### Fixed

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.27"
+version = "0.2.28"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-datadome`: 0.1.10 -> 0.1.11 (✓ API compatible changes)
* `zendriver-fetcher`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `zendriver`: 0.2.27 -> 0.2.28 (✓ API compatible changes)
* `zendriver-mcp`: 0.7.4 -> 0.7.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-datadome`

<blockquote>

## [0.1.11] - 2026-07-17

### Fixed

- Use public-suffix list for cookie_domain (co.uk etc.)
</blockquote>

## `zendriver-fetcher`

<blockquote>

## [0.1.9] - 2026-07-17

### Fixed

- Wire Beta/Dev/Canary channels
</blockquote>

## `zendriver`

<blockquote>

## [0.2.28] - 2026-07-17

### Fixed

- Sort frames() by frame id for deterministic cross-frame results
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.7.5] - 2026-07-17

### Fixed

- Wire Beta/Dev/Canary channels
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).