### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "async-trait",
  "base64",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-cloudflare"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "futures",
  "psl",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fetcher"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "dirs",
  "futures",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "futures",
  "serde",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "base64",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-transport"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.28", default-features = false }
-zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.10" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.6.0" }
-zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.6" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.8" }
-zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.9" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.7.5" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.9" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.11" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.13" }
+zendriver               = { path = "crates/zendriver", version = "0.2.29", default-features = false }
+zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.11" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.7.0" }
+zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.7" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.9" }
+zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.10" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.7.6" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.10" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.12" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.14" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-cloudflare/CHANGELOG.md
+++ b/crates/zendriver-cloudflare/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-07-17
+
+
 ## [0.2.6] - 2026-07-17
 
 

--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-cloudflare"
 description = "Cloudflare Turnstile bypass for zendriver"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.12] - 2026-07-17
+
+
 ## [0.1.11] - 2026-07-17
 
 ### Fixed

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.11"
+version = "0.1.12"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fetcher/CHANGELOG.md
+++ b/crates/zendriver-fetcher/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.10] - 2026-07-17
+
+
 ## [0.1.9] - 2026-07-17
 
 ### Fixed

--- a/crates/zendriver-fetcher/Cargo.toml
+++ b/crates/zendriver-fetcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fetcher"
 description = "Chrome binary downloader for zendriver"
-version = "0.1.9"
+version = "0.1.10"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.14] - 2026-07-17
+
+
 ## [0.2.13] - 2026-07-17
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.2.13"
+version = "0.2.14"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.10] - 2026-07-17
+
+
 ## [0.2.9] - 2026-07-17
 
 

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.2.9"
+version = "0.2.10"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.9] - 2026-07-17
+
+
 ## [0.3.8] - 2026-07-17
 
 

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.7.6] - 2026-07-17
+
+
 ## [0.7.5] - 2026-07-17
 
 ### Fixed

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.7.5"
+version = "0.7.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.7.0] - 2026-07-17
+
+### Added
+
+- Geo_auto uses the exact timezone from the exit-IP probe
+
+
 ## [0.6.0] - 2026-07-17
 
 ### Added

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-transport/CHANGELOG.md
+++ b/crates/zendriver-transport/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.1.11] - 2026-07-17
+
+
 ## [0.1.10] - 2026-07-17
 
 

--- a/crates/zendriver-transport/Cargo.toml
+++ b/crates/zendriver-transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-transport"
 description = "Internal: WebSocket + CDP routing actor for zendriver"
-version = "0.1.10"
+version = "0.1.11"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.29] - 2026-07-17
+
+### Added
+
+- Geo_auto uses the exact timezone from the exit-IP probe
+
+
 ## [0.2.28] - 2026-07-17
 
 ### Fixed

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.28"
+version = "0.2.29"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-transport`: 0.1.10 -> 0.1.11 (✓ API compatible changes)
* `zendriver-cloudflare`: 0.2.6 -> 0.2.7 (✓ API compatible changes)
* `zendriver-interception`: 0.3.8 -> 0.3.9 (✓ API compatible changes)
* `zendriver-datadome`: 0.1.11 -> 0.1.12 (✓ API compatible changes)
* `zendriver-fetcher`: 0.1.9 -> 0.1.10 (✓ API compatible changes)
* `zendriver-imperva`: 0.2.9 -> 0.2.10 (✓ API compatible changes)
* `zendriver-stealth`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)
* `zendriver`: 0.2.28 -> 0.2.29 (✓ API compatible changes)
* `zendriver-mcp`: 0.7.5 -> 0.7.6 (✓ API compatible changes)
* `zendriver-fingerprints`: 0.2.13 -> 0.2.14

### ⚠ `zendriver-stealth` breaking changes

```text
--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/trait_method_added.ron

Failed in:
  trait method zendriver_stealth::geo::GeoResolver::resolve in file /tmp/.tmpOKE59n/zendriver-rs/crates/zendriver-stealth/src/geo/mod.rs:106

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/trait_method_missing.ron

Failed in:
  method country of trait GeoResolver, previously in file /tmp/.tmpOG6GoO/zendriver-stealth/src/geo/mod.rs:91
```

<details><summary><i><b>Changelog</b></i></summary><p>







## `zendriver-stealth`

<blockquote>

## [0.7.0] - 2026-07-17

### Added

- Geo_auto uses the exact timezone from the exit-IP probe
</blockquote>

## `zendriver`

<blockquote>

## [0.2.29] - 2026-07-17

### Added

- Geo_auto uses the exact timezone from the exit-IP probe
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).