### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "async-trait",
  "base64",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.29", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.2.30", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.11" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.7.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.7" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.9" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.10" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.7.6" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.7.7" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.10" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.12" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.14" }

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.7.7] - 2026-07-17
+
+### Added
+
+- Model partition_key as a structured CookiePartitionKey (CDP M119+)
+
+
 ## [0.7.6] - 2026-07-17
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.7.6"
+version = "0.7.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.30] - 2026-07-17
+
+### Added
+
+- Model partition_key as a structured CookiePartitionKey (CDP M119+)
+
+
 ## [0.2.29] - 2026-07-17
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first, undetectable browser automation via the Chrome DevTools Protocol"
-version = "0.2.29"
+version = "0.2.30"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver`: 0.2.29 -> 0.2.30 (✓ API compatible changes)
* `zendriver-mcp`: 0.7.6 -> 0.7.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver`

<blockquote>

## [0.2.30] - 2026-07-17

### Added

- Model partition_key as a structured CookiePartitionKey (CDP M119+)
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.7.7] - 2026-07-17

### Added

- Model partition_key as a structured CookiePartitionKey (CDP M119+)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).