### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.2.30"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-cloudflare"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "futures",
  "psl",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fetcher"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "dirs",
  "futures",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "futures",
  "serde",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "async-trait",
  "base64",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-transport"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.2.30", default-features = false }
-zendriver-transport     = { path = "crates/zendriver-transport", version = "0.1.11" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.7.0" }
-zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.7" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.9" }
-zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.10" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.7.7" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.10" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.12" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.14" }
+zendriver               = { path = "crates/zendriver", version = "0.3.0", default-features = false }
+zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.0" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.8.0" }
+zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.8" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.10" }
+zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.11" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.8.0" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.11" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.13" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.15" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-cloudflare/CHANGELOG.md
+++ b/crates/zendriver-cloudflare/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-07-18
+
+### Added
+
+- Opt-in coherent input profile decoupled from stealth selection
+
+
 ## [0.2.7] - 2026-07-17
 
 

--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-cloudflare"
 description = "Cloudflare Turnstile bypass for zendriver"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.13] - 2026-07-18
+
+### Added
+
+- Opt-in coherent input profile decoupled from stealth selection
+
+
 ## [0.1.12] - 2026-07-17
 
 

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.12"
+version = "0.1.13"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fetcher/CHANGELOG.md
+++ b/crates/zendriver-fetcher/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.11] - 2026-07-18
+
+### Added
+
+- Opt-in coherent input profile decoupled from stealth selection
+
+
 ## [0.1.10] - 2026-07-17
 
 

--- a/crates/zendriver-fetcher/Cargo.toml
+++ b/crates/zendriver-fetcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fetcher"
 description = "Chrome binary downloader for zendriver"
-version = "0.1.10"
+version = "0.1.11"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.15] - 2026-07-18
+
+
 ## [0.2.14] - 2026-07-17
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.2.14"
+version = "0.2.15"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.11] - 2026-07-18
+
+### Added
+
+- Opt-in coherent input profile decoupled from stealth selection
+
+
 ## [0.2.10] - 2026-07-17
 
 

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.2.10"
+version = "0.2.11"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.10] - 2026-07-18
+
+### Added
+
+- Opt-in coherent input profile decoupled from stealth selection
+
+
 ## [0.3.9] - 2026-07-17
 
 

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.3.9"
+version = "0.3.10"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.8.0] - 2026-07-18
+
+### Added
+
+- Add loss-accounted raw event stream (opt-in)
+- Add BoundedBody bounded capture with explicit truncation
+- Surface delivery-loss boundaries and bounded bodies instead of silent gaps
+- Opt-in coherent input profile decoupled from stealth selection
+- Add opt-in native-isolation/real-WebGL profile (default unchanged)
+
+### Changed
+
+- Rename BoundedBody.encoded_len/body_encoded_bytes to full_len/body_full_bytes **(BREAKING)**
+
+### Fixed
+
+- Treat responseReceived as headers-only; add opt-in strict loss policy
+- Ready-barrier tab handoff, atomic seed, fail-closed on corrupt identity **(BREAKING)**
+- Browser_open input profile follows stealth by default
+- Default capture_body_max_bytes to 0 (unbounded)
+
+
 ## [0.7.7] - 2026-07-17
 
 ### Added

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.7.7"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.8.0] - 2026-07-18
+
+### Added
+
+- Opt-in coherent input profile decoupled from stealth selection
+- Add opt-in native-isolation/real-WebGL profile (default unchanged)
+
+### Fixed
+
+- Default input profile follows stealth selection (no silent regression)
+- Keep WebGPU coherent with real WebGL under native_isolation
+- Derive locale override from pinned languages for cross-surface coherence
+
+
 ## [0.7.0] - 2026-07-17
 
 ### Added

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-transport/CHANGELOG.md
+++ b/crates/zendriver-transport/CHANGELOG.md
@@ -5,6 +5,24 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-18
+
+### Added
+
+- Add loss-accounted raw event stream (opt-in)
+- Observer timeout fails closed by default (BestEffort opt-out) **(BREAKING)**
+- Opt-in coherent input profile decoupled from stealth selection
+
+### Changed
+
+- Log Required-observer timeout at error!, matching its fail-closed peers
+
+### Fixed
+
+- Treat responseReceived as headers-only; add opt-in strict loss policy
+- BestEffort timeout continues the observer chain (no orphaned target)
+
+
 ## [0.1.11] - 2026-07-17
 
 

--- a/crates/zendriver-transport/Cargo.toml
+++ b/crates/zendriver-transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-transport"
 description = "Internal: WebSocket + CDP routing actor for zendriver"
-version = "0.1.11"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,30 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-18
+
+### Added
+
+- Add loss-accounted raw event stream (opt-in)
+- Add EventStreamIncomplete to distinguish lost-observation from timeout
+- Add BoundedBody bounded capture with explicit truncation
+- Surface delivery-loss boundaries and bounded bodies instead of silent gaps
+- Opt-in coherent input profile decoupled from stealth selection
+
+### Changed
+
+- Rename BoundedBody.encoded_len/body_encoded_bytes to full_len/body_full_bytes **(BREAKING)**
+
+### Fixed
+
+- Treat responseReceived as headers-only; add opt-in strict loss policy
+- Ready-barrier tab handoff, atomic seed, fail-closed on corrupt identity **(BREAKING)**
+- BestEffort timeout continues the observer chain (no orphaned target)
+- Report EventStreamIncomplete on transport teardown instead of Timeout
+- Default input profile follows stealth selection (no silent regression)
+- Evict oldest tracked request (FIFO) instead of an arbitrary one
+
+
 ## [0.2.30] - 2026-07-17
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.2.30"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-transport`: 0.1.11 -> 0.2.0 (✓ API compatible changes)
* `zendriver-cloudflare`: 0.2.7 -> 0.2.8 (✓ API compatible changes)
* `zendriver-interception`: 0.3.9 -> 0.3.10 (✓ API compatible changes)
* `zendriver-datadome`: 0.1.12 -> 0.1.13 (✓ API compatible changes)
* `zendriver-fetcher`: 0.1.10 -> 0.1.11 (✓ API compatible changes)
* `zendriver-imperva`: 0.2.10 -> 0.2.11 (✓ API compatible changes)
* `zendriver-stealth`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `zendriver`: 0.2.30 -> 0.3.0 (⚠ API breaking changes)
* `zendriver-mcp`: 0.7.7 -> 0.8.0 (⚠ API breaking changes)
* `zendriver-fingerprints`: 0.2.14 -> 0.2.15

### ⚠ `zendriver-stealth` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_parameter_count_changed.ron

Failed in:
  zendriver_stealth::flags::flags_for_profile now takes 2 parameters instead of 1, in /tmp/.tmpnEpwRA/zendriver-rs/crates/zendriver-stealth/src/flags.rs:66
```

### ⚠ `zendriver` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field IdleOptions.loss_policy in /tmp/.tmpnEpwRA/zendriver-rs/crates/zendriver/src/tab.rs:411
  field IdleOptions.loss_policy in /tmp/.tmpnEpwRA/zendriver-rs/crates/zendriver/src/tab.rs:411

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant NetworkEvent:DeliveryBoundary in /tmp/.tmpnEpwRA/zendriver-rs/crates/zendriver/src/monitor/mod.rs:95
  variant NetworkEvent:DeliveryBoundary in /tmp/.tmpnEpwRA/zendriver-rs/crates/zendriver/src/monitor/mod.rs:95
```

### ⚠ `zendriver-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field OpenInput.input_profile in /tmp/.tmpnEpwRA/zendriver-rs/crates/zendriver-mcp/src/tools/lifecycle.rs:48
  field IdleInput.strict in /tmp/.tmpnEpwRA/zendriver-rs/crates/zendriver-mcp/src/tools/navigation.rs:294
  field StartInput.capture_body_max_bytes in /tmp/.tmpnEpwRA/zendriver-rs/crates/zendriver-mcp/src/tools/monitor.rs:83
  field StealthOverrides.native_isolation in /tmp/.tmpnEpwRA/zendriver-rs/crates/zendriver-mcp/src/state.rs:114
  field OpenOutput.input_profile in /tmp/.tmpnEpwRA/zendriver-rs/crates/zendriver-mcp/src/tools/lifecycle.rs:133

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field body_truncated of variant MonitorEvent::Http in /tmp/.tmpnEpwRA/zendriver-rs/crates/zendriver-mcp/src/state.rs:237
  field body_full_bytes of variant MonitorEvent::Http in /tmp/.tmpnEpwRA/zendriver-rs/crates/zendriver-mcp/src/state.rs:242
  field body_capture_error of variant MonitorEvent::Http in /tmp/.tmpnEpwRA/zendriver-rs/crates/zendriver-mcp/src/state.rs:249

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant MonitorEvent:DeliveryBoundary in /tmp/.tmpnEpwRA/zendriver-rs/crates/zendriver-mcp/src/state.rs:292
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-transport`

<blockquote>

## [0.2.0] - 2026-07-18

### Added

- Add loss-accounted raw event stream (opt-in)
- Observer timeout fails closed by default (BestEffort opt-out) **(BREAKING)**
- Opt-in coherent input profile decoupled from stealth selection

### Changed

- Log Required-observer timeout at error!, matching its fail-closed peers

### Fixed

- Treat responseReceived as headers-only; add opt-in strict loss policy
- BestEffort timeout continues the observer chain (no orphaned target)
</blockquote>

## `zendriver-cloudflare`

<blockquote>

## [0.2.8] - 2026-07-18

### Added

- Opt-in coherent input profile decoupled from stealth selection
</blockquote>

## `zendriver-interception`

<blockquote>

## [0.3.10] - 2026-07-18

### Added

- Opt-in coherent input profile decoupled from stealth selection
</blockquote>

## `zendriver-datadome`

<blockquote>

## [0.1.13] - 2026-07-18

### Added

- Opt-in coherent input profile decoupled from stealth selection
</blockquote>

## `zendriver-fetcher`

<blockquote>

## [0.1.11] - 2026-07-18

### Added

- Opt-in coherent input profile decoupled from stealth selection
</blockquote>

## `zendriver-imperva`

<blockquote>

## [0.2.11] - 2026-07-18

### Added

- Opt-in coherent input profile decoupled from stealth selection
</blockquote>

## `zendriver-stealth`

<blockquote>

## [0.8.0] - 2026-07-18

### Added

- Opt-in coherent input profile decoupled from stealth selection
- Add opt-in native-isolation/real-WebGL profile (default unchanged)

### Fixed

- Default input profile follows stealth selection (no silent regression)
- Keep WebGPU coherent with real WebGL under native_isolation
- Derive locale override from pinned languages for cross-surface coherence
</blockquote>

## `zendriver`

<blockquote>

## [0.3.0] - 2026-07-18

### Added

- Add loss-accounted raw event stream (opt-in)
- Add EventStreamIncomplete to distinguish lost-observation from timeout
- Add BoundedBody bounded capture with explicit truncation
- Surface delivery-loss boundaries and bounded bodies instead of silent gaps
- Opt-in coherent input profile decoupled from stealth selection

### Changed

- Rename BoundedBody.encoded_len/body_encoded_bytes to full_len/body_full_bytes **(BREAKING)**

### Fixed

- Treat responseReceived as headers-only; add opt-in strict loss policy
- Ready-barrier tab handoff, atomic seed, fail-closed on corrupt identity **(BREAKING)**
- BestEffort timeout continues the observer chain (no orphaned target)
- Report EventStreamIncomplete on transport teardown instead of Timeout
- Default input profile follows stealth selection (no silent regression)
- Evict oldest tracked request (FIFO) instead of an arbitrary one
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.8.0] - 2026-07-18

### Added

- Add loss-accounted raw event stream (opt-in)
- Add BoundedBody bounded capture with explicit truncation
- Surface delivery-loss boundaries and bounded bodies instead of silent gaps
- Opt-in coherent input profile decoupled from stealth selection
- Add opt-in native-isolation/real-WebGL profile (default unchanged)

### Changed

- Rename BoundedBody.encoded_len/body_encoded_bytes to full_len/body_full_bytes **(BREAKING)**

### Fixed

- Treat responseReceived as headers-only; add opt-in strict loss policy
- Ready-barrier tab handoff, atomic seed, fail-closed on corrupt identity **(BREAKING)**
- Browser_open input profile follows stealth by default
- Default capture_body_max_bytes to 0 (unbounded)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).