### PR TITLE
ci(release-binaries): fix Windows binary build (shasum → sha256sum)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -71,9 +71,20 @@ jobs:
           echo "ASSET=$OUT" >> "$GITHUB_ENV"
           echo "RAWBIN=$BIN" >> "$GITHUB_ENV"
 
-      - name: Checksum
+      # `shasum` (a Perl script) ships on the Linux/macOS runners but NOT in
+      # Git-for-Windows bash (exit 127: "shasum: command not found"), which
+      # silently dropped the Windows binary from every release. Git-bash does
+      # bundle coreutils' `sha256sum`, whose `<hash>  <file>` output matches
+      # `shasum -a 256`, so the aggregated SHA256SUMS stays consistent.
+      - name: Checksum (unix)
+        if: matrix.os != 'windows-latest'
         shell: bash
         run: shasum -a 256 "$ASSET" > "$ASSET.sha256"
+
+      - name: Checksum (windows)
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: sha256sum "$ASSET" > "$ASSET.sha256"
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v1


### PR DESCRIPTION
## Problem

The `release-binaries` **Windows target** (`build (windows-latest, x86_64-pc-windows-msvc)`) has failed on **every release since v0.7.3** — all other targets (linux x2, macos x2) pass. So the prebuilt **Windows binary is missing from every recent release**, and the plugin's `/zendriver:setup` can't fetch it on Windows.

## Root cause

The cross-compile succeeds; the **`Checksum` step** fails:
```
shasum: command not found   (exit 127)
```
`shasum` is a Perl script present on the Linux/macOS runners but **not** in Git-for-Windows bash. The step ran `shasum -a 256` under `bash` on all OSes, so only Windows died.

## Fix

Split the step by OS (mirroring the existing `Package (unix)` / `Package (windows)` split): Windows uses coreutils' **`sha256sum`**, which Git-bash *does* bundle. Its `<hash>  <file>` output matches `shasum -a 256`, so the per-asset `.sha256` files and the aggregated `SHA256SUMS` stay consistent across all targets.

## Verification

CI-config change (no code). The real proof is a release run — after merge I can `workflow_dispatch` `release-binaries` against an existing tag (e.g. `zendriver-mcp-v0.8.0`) to confirm the Windows leg goes green **and backfill the Windows binary that's currently missing** from that release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)