### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.3.0", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.3.1", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.0" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.8.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.8" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.10" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.11" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.9.0" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.10.0" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.11" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.13" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.15" }

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.10.0] - 2026-07-19
+
+### Added
+
+- Expose extended cookie fields (partition_key, priority, ...)
+- Expose method/post_data overrides in intercept modify_request
+- Add Browser::version() (CDP Browser.getVersion); wire MCP chrome_version
+- Mirror the browser proxy into a custom geo_endpoint resolver
+
+
 ## [0.9.0] - 2026-07-19
 
 ### Fixed

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,14 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-19
+
+### Added
+
+- Add Browser::version() (CDP Browser.getVersion); wire MCP chrome_version
+- Mirror the browser proxy into a custom geo_endpoint resolver
+
+
 ## [0.3.0] - 2026-07-18
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `zendriver-mcp`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)

### ⚠ `zendriver-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CookieDto.priority in /tmp/.tmp5x0hOg/zendriver-rs/crates/zendriver-mcp/src/tools/cookies.rs:203
  field CookieDto.same_party in /tmp/.tmp5x0hOg/zendriver-rs/crates/zendriver-mcp/src/tools/cookies.rs:207
  field CookieDto.source_scheme in /tmp/.tmp5x0hOg/zendriver-rs/crates/zendriver-mcp/src/tools/cookies.rs:211
  field CookieDto.source_port in /tmp/.tmp5x0hOg/zendriver-rs/crates/zendriver-mcp/src/tools/cookies.rs:215
  field CookieDto.partition_key in /tmp/.tmp5x0hOg/zendriver-rs/crates/zendriver-mcp/src/tools/cookies.rs:220

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field url of variant InterceptAction::ModifyRequest in /tmp/.tmp5x0hOg/zendriver-rs/crates/zendriver-mcp/src/tools/intercept.rs:99
  field method of variant InterceptAction::ModifyRequest in /tmp/.tmp5x0hOg/zendriver-rs/crates/zendriver-mcp/src/tools/intercept.rs:103
  field post_data of variant InterceptAction::ModifyRequest in /tmp/.tmp5x0hOg/zendriver-rs/crates/zendriver-mcp/src/tools/intercept.rs:109
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver`

<blockquote>

## [0.3.1] - 2026-07-19

### Added

- Add Browser::version() (CDP Browser.getVersion); wire MCP chrome_version
- Mirror the browser proxy into a custom geo_endpoint resolver
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.10.0] - 2026-07-19

### Added

- Expose extended cookie fields (partition_key, priority, ...)
- Expose method/post_data overrides in intercept modify_request
- Add Browser::version() (CDP Browser.getVersion); wire MCP chrome_version
- Mirror the browser proxy into a custom geo_endpoint resolver
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).