### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.3.1", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.3.2", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.0" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.8.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.8" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.10" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.11" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.10.0" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.11.0" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.11" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.13" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.15" }

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.11.0] - 2026-07-19
+
+### Added
+
+- Expose case-insensitive predicate matching on browser_find/browser_find_all
+
+
 ## [0.10.0] - 2026-07-19
 
 ### Added

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-19
+
+### Added
+
+- Add case-insensitive predicate matchers (attr_i/attr_contains_i/attr_starts_with_i/attr_ends_with_i/containing_text_i/text_equals_i)
+
+
 ## [0.3.1] - 2026-07-19
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `zendriver-mcp`: 0.10.0 -> 0.11.0 (⚠ API breaking changes)

### ⚠ `zendriver-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field AttrPredicate.case_insensitive in /tmp/.tmpWtfhvW/zendriver-rs/crates/zendriver-mcp/src/selectors.rs:50
  field Selector.text_case_insensitive in /tmp/.tmpWtfhvW/zendriver-rs/crates/zendriver-mcp/src/selectors.rs:97

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant SelectorError:CaseInsensitiveNotApplicable in /tmp/.tmpWtfhvW/zendriver-rs/crates/zendriver-mcp/src/selectors.rs:144
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver`

<blockquote>

## [0.3.2] - 2026-07-19

### Added

- Add case-insensitive predicate matchers (attr_i/attr_contains_i/attr_starts_with_i/attr_ends_with_i/containing_text_i/text_equals_i)
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.11.0] - 2026-07-19

### Added

- Expose case-insensitive predicate matching on browser_find/browser_find_all
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).