### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-cloudflare"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "futures",
  "psl",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fetcher"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "dirs",
  "futures",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "futures",
  "serde",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "async-trait",
  "base64",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",
@@ -3621,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-transport"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.3.3", default-features = false }
-zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.0" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.8.0" }
-zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.8" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.10" }
-zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.11" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.12.0" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.11" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.13" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.15" }
+zendriver               = { path = "crates/zendriver", version = "0.3.4", default-features = false }
+zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.1" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.8.1" }
+zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.9" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.11" }
+zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.12" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.13.0" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.12" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.14" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.16" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-cloudflare/CHANGELOG.md
+++ b/crates/zendriver-cloudflare/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-07-19
+
+### Added
+
+- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
+
+
 ## [0.2.8] - 2026-07-18
 
 ### Added

--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-cloudflare"
 description = "Cloudflare Turnstile bypass for zendriver"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.14] - 2026-07-19
+
+### Added
+
+- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
+
+
 ## [0.1.13] - 2026-07-18
 
 ### Added

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.13"
+version = "0.1.14"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fetcher/CHANGELOG.md
+++ b/crates/zendriver-fetcher/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.12] - 2026-07-19
+
+### Added
+
+- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
+
+
 ## [0.1.11] - 2026-07-18
 
 ### Added

--- a/crates/zendriver-fetcher/Cargo.toml
+++ b/crates/zendriver-fetcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fetcher"
 description = "Chrome binary downloader for zendriver"
-version = "0.1.11"
+version = "0.1.12"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.16] - 2026-07-19
+
+
 ## [0.2.15] - 2026-07-18
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.2.15"
+version = "0.2.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.12] - 2026-07-19
+
+### Added
+
+- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
+
+
 ## [0.2.11] - 2026-07-18
 
 ### Added

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.2.11"
+version = "0.2.12"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.11] - 2026-07-19
+
+### Added
+
+- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
+
+
 ## [0.3.10] - 2026-07-18
 
 ### Added

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.3.10"
+version = "0.3.11"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.13.0] - 2026-07-19
+
+### Added
+
+- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
+
+
 ## [0.12.0] - 2026-07-19
 
 ### Added

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.8.1] - 2026-07-19
+
+### Added
+
+- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
+
+
 ## [0.8.0] - 2026-07-18
 
 ### Added

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-transport/CHANGELOG.md
+++ b/crates/zendriver-transport/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-19
+
+### Added
+
+- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
+
+
 ## [0.2.0] - 2026-07-18
 
 ### Added

--- a/crates/zendriver-transport/Cargo.toml
+++ b/crates/zendriver-transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-transport"
 description = "Internal: WebSocket + CDP routing actor for zendriver"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-07-19
+
+### Added
+
+- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
+
+
 ## [0.3.3] - 2026-07-19
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-transport`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `zendriver-cloudflare`: 0.2.8 -> 0.2.9 (✓ API compatible changes)
* `zendriver-interception`: 0.3.10 -> 0.3.11 (✓ API compatible changes)
* `zendriver-datadome`: 0.1.13 -> 0.1.14 (✓ API compatible changes)
* `zendriver-fetcher`: 0.1.11 -> 0.1.12 (✓ API compatible changes)
* `zendriver-imperva`: 0.2.11 -> 0.2.12 (✓ API compatible changes)
* `zendriver-stealth`: 0.8.0 -> 0.8.1 (✓ API compatible changes)
* `zendriver`: 0.3.3 -> 0.3.4 (✓ API compatible changes)
* `zendriver-mcp`: 0.12.0 -> 0.13.0 (⚠ API breaking changes)
* `zendriver-fingerprints`: 0.2.15 -> 0.2.16

### ⚠ `zendriver-mcp` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant MouseAction:Tap in /tmp/.tmpEkXLc8/zendriver-rs/crates/zendriver-mcp/src/tools/mouse.rs:34
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-transport`

<blockquote>

## [0.2.1] - 2026-07-19

### Added

- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
</blockquote>

## `zendriver-cloudflare`

<blockquote>

## [0.2.9] - 2026-07-19

### Added

- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
</blockquote>

## `zendriver-interception`

<blockquote>

## [0.3.11] - 2026-07-19

### Added

- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
</blockquote>

## `zendriver-datadome`

<blockquote>

## [0.1.14] - 2026-07-19

### Added

- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
</blockquote>

## `zendriver-fetcher`

<blockquote>

## [0.1.12] - 2026-07-19

### Added

- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
</blockquote>

## `zendriver-imperva`

<blockquote>

## [0.2.12] - 2026-07-19

### Added

- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
</blockquote>

## `zendriver-stealth`

<blockquote>

## [0.8.1] - 2026-07-19

### Added

- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
</blockquote>

## `zendriver`

<blockquote>

## [0.3.4] - 2026-07-19

### Added

- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.13.0] - 2026-07-19

### Added

- Add Tab::tap/Element::tap for touch dispatch (Input.dispatchTouchEvent)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).