### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.2.16"
+version = "0.3.0"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,10 @@ zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.8.1"
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.9" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.11" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.12" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.13.0" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.13.1" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.12" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.14" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.2.16" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.0" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.0] - 2026-07-19
+
+### Added
+
+- Add cache-TTL + force_refresh to pool/generative download caches
+
+
 ## [0.2.16] - 2026-07-19
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.2.16"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.13.1] - 2026-07-19
+
+### Added
+
+- Add cache-TTL + force_refresh to pool/generative download caches
+
+
 ## [0.13.0] - 2026-07-19
 
 ### Added

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-fingerprints`: 0.2.16 -> 0.3.0 (⚠ API breaking changes)
* `zendriver-mcp`: 0.13.0 -> 0.13.1 (✓ API compatible changes)

### ⚠ `zendriver-fingerprints` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_parameter_count_changed.ron

Failed in:
  zendriver_fingerprints::pool::load_or_download now takes 2 parameters instead of 1, in /tmp/.tmpUGQqDj/zendriver-rs/crates/zendriver-fingerprints/src/pool/mod.rs:99

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/method_parameter_count_changed.ron

Failed in:
  zendriver_fingerprints::generative::Generator::load_or_download takes 1 parameters in /tmp/.tmp0rYRsY/zendriver-fingerprints/src/generative/mod.rs:94, but now takes 2 parameters in /tmp/.tmpUGQqDj/zendriver-rs/crates/zendriver-fingerprints/src/generative/mod.rs:113
  zendriver_fingerprints::generative::Generator::load_or_download_default takes 0 parameters in /tmp/.tmp0rYRsY/zendriver-fingerprints/src/generative/mod.rs:102, but now takes 1 parameters in /tmp/.tmpUGQqDj/zendriver-rs/crates/zendriver-fingerprints/src/generative/mod.rs:121
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-fingerprints`

<blockquote>

## [0.3.0] - 2026-07-19

### Added

- Add cache-TTL + force_refresh to pool/generative download caches
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.13.1] - 2026-07-19

### Added

- Add cache-TTL + force_refresh to pool/generative download caches
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).