### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.3.5", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.3.6", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.1" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.8.2" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.8.3" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.9" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.11" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.12" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.13.2" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.13.3" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.12" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.14" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.1" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.2" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.2] - 2026-07-19
+
+
 ## [0.3.1] - 2026-07-19
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.13.3] - 2026-07-19
+
+### Added
+
+- Add opt-in WebgpuSpec adapter override + fabrication
+
+
 ## [0.13.2] - 2026-07-19
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.13.2"
+version = "0.13.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.8.3] - 2026-07-19
+
+### Added
+
+- Add opt-in WebgpuSpec adapter override + fabrication
+
+### Fixed
+
+- Make WebGPU fabricate handle entirely-absent navigator.gpu
+
+
 ## [0.8.2] - 2026-07-19
 
 ### Fixed

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.8.2"
+version = "0.8.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,17 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-07-19
+
+### Added
+
+- Add opt-in WebgpuSpec adapter override + fabrication
+
+### Fixed
+
+- Make WebGPU fabricate handle entirely-absent navigator.gpu
+
+
 ## [0.3.5] - 2026-07-19
 
 ### Fixed

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.8.2 -> 0.8.3 (✓ API compatible changes)
* `zendriver`: 0.3.5 -> 0.3.6 (✓ API compatible changes)
* `zendriver-mcp`: 0.13.2 -> 0.13.3 (✓ API compatible changes)
* `zendriver-fingerprints`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-stealth`

<blockquote>

## [0.8.3] - 2026-07-19

### Added

- Add opt-in WebgpuSpec adapter override + fabrication

### Fixed

- Make WebGPU fabricate handle entirely-absent navigator.gpu
</blockquote>

## `zendriver`

<blockquote>

## [0.3.6] - 2026-07-19

### Added

- Add opt-in WebgpuSpec adapter override + fabrication

### Fixed

- Make WebGPU fabricate handle entirely-absent navigator.gpu
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.13.3] - 2026-07-19

### Added

- Add opt-in WebgpuSpec adapter override + fabrication
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).