### PR TITLE
fix: scope Tab::cookies() to the tab's BrowserContext, and bound the whole Browser::close() under one deadline

### DIFF
--- a/crates/zendriver-mcp/mcp-coverage-ledger.toml
+++ b/crates/zendriver-mcp/mcp-coverage-ledger.toml
@@ -826,3 +826,14 @@ excluded = "signature grew a CachePolicy param (lib-only cache-freshness knob); 
 [[entry]]
 api = "zendriver_fingerprints::generative::Generator::load_or_download_default"
 excluded = "signature grew a CachePolicy param (lib-only cache-freshness knob); not called by zendriver-mcp today"
+
+# ── CookieJar::for_session (Tab::cookies() BrowserContext scoping) ──────────
+# `Tab::cookies()` now builds its jar via `CookieJar::for_session` so cookie
+# CDP calls route with the tab's own `sessionId` (its own BrowserContext)
+# instead of the browser-wide default context. Same rationale as
+# `CookieJar::new` (lib-internal, baseline-grandfathered, unledgered): a jar
+# CONSTRUCTOR is plumbing, not an MCP tool — cookie operations reach MCP
+# through the tab/browser surfaces that own the jar, never jar construction.
+[[entry]]
+api = "zendriver::cookies::CookieJar::for_session"
+excluded = "internal jar constructor (session-scoped variant of CookieJar::new, itself lib-internal/baseline-grandfathered); scopes Tab::cookies() to the tab's own BrowserContext — no distinct MCP request/response surface"

--- a/crates/zendriver-mcp/public-api-baseline.txt
+++ b/crates/zendriver-mcp/public-api-baseline.txt
@@ -679,6 +679,7 @@ impl zendriver::cookies::CookieJar
 pub async fn zendriver::cookies::CookieJar::all(&self) -> zendriver::error::Result<alloc::vec::Vec<zendriver::cookies::Cookie>>
 pub async fn zendriver::cookies::CookieJar::clear(&self) -> zendriver::error::Result<()>
 pub async fn zendriver::cookies::CookieJar::delete(&self, &str, core::option::Option<&str>, core::option::Option<&str>) -> zendriver::error::Result<()>
+pub fn zendriver::cookies::CookieJar::for_session(zendriver_transport::connection::Connection, impl core::convert::Into<alloc::string::String>) -> Self
 pub async fn zendriver::cookies::CookieJar::for_url(&self, &url::Url) -> zendriver::error::Result<alloc::vec::Vec<zendriver::cookies::Cookie>>
 pub fn zendriver::cookies::CookieJar::new(zendriver_transport::connection::Connection) -> Self
 pub async fn zendriver::cookies::CookieJar::set(&self, zendriver::cookies::Cookie) -> zendriver::error::Result<()>
@@ -6573,6 +6574,7 @@ impl zendriver::cookies::CookieJar
 pub async fn zendriver::cookies::CookieJar::all(&self) -> zendriver::error::Result<alloc::vec::Vec<zendriver::cookies::Cookie>>
 pub async fn zendriver::cookies::CookieJar::clear(&self) -> zendriver::error::Result<()>
 pub async fn zendriver::cookies::CookieJar::delete(&self, &str, core::option::Option<&str>, core::option::Option<&str>) -> zendriver::error::Result<()>
+pub fn zendriver::cookies::CookieJar::for_session(zendriver_transport::connection::Connection, impl core::convert::Into<alloc::string::String>) -> Self
 pub async fn zendriver::cookies::CookieJar::for_url(&self, &url::Url) -> zendriver::error::Result<alloc::vec::Vec<zendriver::cookies::Cookie>>
 pub fn zendriver::cookies::CookieJar::new(zendriver_transport::connection::Connection) -> Self
 pub async fn zendriver::cookies::CookieJar::set(&self, zendriver::cookies::Cookie) -> zendriver::error::Result<()>

--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -2067,6 +2067,18 @@ const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 /// exists for — must not stall teardown for long. `SHUTDOWN_GRACE` still
 /// governs how long Chrome then gets to actually exit.
 const BROWSER_CLOSE_TIMEOUT: Duration = Duration::from_secs(3);
+/// Hard upper bound on the **entire** [`Browser::close`] teardown of an owned
+/// Chrome — the CDP quit, acquiring the child lock, the grace waits, and the
+/// final reap, combined.
+///
+/// The per-phase timeouts ([`BROWSER_CLOSE_TIMEOUT`], [`SHUTDOWN_GRACE`]) shape
+/// the happy path; this deadline is the backstop that guarantees `close()`
+/// returns even when a phase that is otherwise unbounded — acquiring the child
+/// lock, or reaping a process wedged in uninterruptible sleep that never
+/// exits — would block forever. Sized comfortably above the sum of the
+/// intended per-phase waits, so it only bites on a genuine wedge, never on a
+/// close that is merely slow but still making progress.
+const BROWSER_CLOSE_DEADLINE: Duration = Duration::from_secs(15);
 /// How long [`resolve_ws_from_http`] waits for the `/json/version` round-trip.
 const JSON_VERSION_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -3949,6 +3961,13 @@ impl Browser {
     /// does not exit. Cleans up the `user_data_dir` tempdir if one was
     /// allocated at launch time.
     ///
+    /// The whole teardown — the CDP quit, acquiring the internal child lock,
+    /// the grace waits, and the final reap — is bounded by a single hard
+    /// deadline ([`BROWSER_CLOSE_DEADLINE`]), so `close()` always returns even
+    /// if a phase wedges (an un-acquirable lock, a process stuck in
+    /// uninterruptible sleep that never reaps). Callers do not need to wrap
+    /// `close()` in their own timeout.
+    ///
     /// The CDP quit matters because the signal path only ever targets the
     /// single `chrome.exe` PID we tracked at spawn. Any *other* window Chrome
     /// opened (a first-run window, a `chrome://newtab/`) is not that PID's
@@ -3981,13 +4000,50 @@ impl Browser {
         self,
         browser_close_budget: Duration,
     ) -> Result<(), ZendriverError> {
+        self.close_within_deadline(browser_close_budget, BROWSER_CLOSE_DEADLINE)
+            .await
+    }
+
+    /// [`Browser::close_within`] with the overall hard deadline also injectable,
+    /// so tests can prove the whole close stays bounded when an inner phase
+    /// (lock acquisition, the final reap) would otherwise block forever,
+    /// without waiting out the real [`BROWSER_CLOSE_DEADLINE`].
+    pub(crate) async fn close_within_deadline(
+        self,
+        browser_close_budget: Duration,
+        overall_deadline: Duration,
+    ) -> Result<(), ZendriverError> {
         // Attached (non-owning) sessions must never terminate the process we
         // connected to — only the transport is torn down. Spawn-only below.
+        // Bounded and non-blocking, so it needs no deadline.
         if !self.inner.owns_process {
             self.inner.conn.shutdown();
             return Ok(());
         }
 
+        // Bound the ENTIRE owning teardown under one deadline. Previously only
+        // the `Browser.close` round-trip was bounded; the child-lock
+        // acquisition and the post-signal reap were not, so a wedge in either
+        // hung the caller forever. The single outer timeout covers every phase
+        // — quit, lock, grace waits, reap — while the per-phase budgets inside
+        // still return the common case promptly.
+        match timeout(overall_deadline, self.close_owning(browser_close_budget)).await {
+            Ok(res) => res,
+            Err(_elapsed) => {
+                warn!(
+                    deadline = ?overall_deadline,
+                    "browser close exceeded its hard deadline; abandoning teardown (process may be left behind)",
+                );
+                Ok(())
+            }
+        }
+    }
+
+    /// The owning-process teardown body, run under the deadline established by
+    /// [`Browser::close_within_deadline`]. Split out so a single `timeout`
+    /// bounds every phase; borrows `&self` because the outer wrapper owns the
+    /// `Browser` for the duration of the call.
+    async fn close_owning(&self, browser_close_budget: Duration) -> Result<(), ZendriverError> {
         // Ask Chrome to quit over the protocol first. This must precede
         // `conn.shutdown()` — that tears down the very transport the command
         // travels over.
@@ -6951,6 +7007,59 @@ mod tests {
             "a Browser.close timeout must still hard-kill the process (pid {pid} alive)",
         );
         drop(mock);
+    }
+
+    /// The whole close must stay bounded even when a phase that is otherwise
+    /// unbounded would block forever. Here we wedge the child-lock acquisition
+    /// (previously an unbounded `child.lock().await`) by holding the lock for
+    /// the entire close attempt; the overall deadline must still make
+    /// `close()` return promptly instead of hanging the caller.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn close_stays_bounded_when_child_lock_is_wedged() {
+        let (child, pid) = spawn_stand_in_chrome();
+        // `_mock` (named, not bare `_`) is held to end of scope so the
+        // transport stays up and the unanswered `Browser.close` times out at
+        // its budget rather than draining early.
+        let (_mock, browser) = owning_browser_with_child(Some(child)).await;
+
+        // Wedge the lock-acquisition phase: hold the child lock via a second
+        // handle to the same inner state for the whole close attempt.
+        let inner = browser.inner.clone();
+        let held = inner.child.lock().await;
+
+        // Tiny quit budget (unanswered → falls through fast) + tiny overall
+        // deadline. Without deadline-bounded lock acquisition this would block
+        // forever on `child.lock().await`; the outer 5s guard would then fire
+        // and fail the test.
+        let start = tokio::time::Instant::now();
+        let closed = tokio::time::timeout(
+            Duration::from_secs(5),
+            browser.close_within_deadline(Duration::from_millis(50), Duration::from_millis(300)),
+        )
+        .await;
+
+        assert!(
+            closed.is_ok(),
+            "close() hung past its deadline while the child lock was held",
+        );
+        closed
+            .unwrap()
+            .expect("a deadline-bounded close returns Ok (best-effort teardown)");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "close() should return shortly after its 300ms deadline, took {:?}",
+            start.elapsed(),
+        );
+
+        // The reap was abandoned (the lock was never acquired), so the
+        // stand-in is still alive under our held guard — clean it up.
+        drop(held);
+        drop(inner);
+        #[allow(unsafe_code)]
+        unsafe {
+            libc::kill(pid, libc::SIGKILL);
+        }
     }
 
     /// T2 safety: a browser produced by `connect()` was attached to, not

--- a/crates/zendriver/src/cookies/mod.rs
+++ b/crates/zendriver/src/cookies/mod.rs
@@ -2,10 +2,15 @@
 //!
 //! [`CookieJar`] wraps a [`Connection`] and exposes ergonomic CRUD over
 //! Chrome's cookie store. The jar is cheap to clone — internally an `Arc`
-//! over a thin inner struct — so it can be passed around freely and is
-//! suitable as both [`crate::Browser::cookies`] and [`crate::Tab::cookies`]
-//! (both bind to the same browser-scope connection, since Chrome's cookie
-//! store is browser-wide).
+//! over a thin inner struct — so it can be passed around freely.
+//!
+//! A jar is either **browser-scoped** ([`CookieJar::new`], via
+//! [`crate::Browser::cookies`]) — reading/writing the default
+//! `BrowserContext` — or **session-scoped** ([`CookieJar::for_session`], via
+//! [`crate::Tab::cookies`]) — routing each command with the tab's `sessionId`
+//! so it resolves against that tab's own `BrowserContext`. The two are
+//! equivalent when every tab shares the default context, and differ only
+//! when a caller opens tabs under per-target isolated `BrowserContext`s.
 //!
 //! ```no_run
 //! # async fn ex() -> zendriver::Result<()> {
@@ -265,15 +270,30 @@ impl From<CdpCookie> for Cookie {
     }
 }
 
-/// Cheap-to-clone handle to the browser's cookie store.
+/// Cheap-to-clone handle to a Chrome cookie store.
 ///
 /// Wraps a [`Connection`] in an [`Arc`]; cloning is reference-bump cheap.
 ///
-/// All methods send commands at browser scope (no `sessionId`) — Chrome's
-/// cookie store is shared across all tabs in the browser, so per-tab
-/// scoping is meaningless for cookies. Construct via
-/// [`crate::Browser::cookies`] or [`crate::Tab::cookies`] — both produce
-/// jars bound to the same underlying store.
+/// ## Scoping — default vs. per-target `BrowserContext`
+///
+/// A jar dispatches its `Storage.*`/`Network.*` cookie commands either at
+/// **browser scope** (no `sessionId`) or scoped to a **specific target's
+/// session** (`sessionId` attached):
+///
+/// - [`CookieJar::new`] — browser scope, no `sessionId`. Reads and writes
+///   the **default** `BrowserContext`. This is what [`crate::Browser::cookies`]
+///   returns.
+/// - [`CookieJar::for_session`] — carries a target's `sessionId`, so the
+///   command resolves against **that target's own `BrowserContext`**. This is
+///   what [`crate::Tab::cookies`] returns.
+///
+/// The distinction matters for callers that open pages under **per-target
+/// isolated `BrowserContext`s** (`Target.createBrowserContext`): the default
+/// context and an isolated context have **separate** cookie stores, so a
+/// browser-scope read returns the wrong context's cookies for such a tab.
+/// Routing the command through the tab's own session fixes this — Chrome
+/// resolves the cookie store from the session's target. For the common case
+/// (a single default context shared by every tab), the two are equivalent.
 #[derive(Clone, Debug)]
 pub struct CookieJar {
     inner: Arc<CookieJarInner>,
@@ -282,18 +302,48 @@ pub struct CookieJar {
 #[derive(Debug)]
 struct CookieJarInner {
     conn: Connection,
+    /// When `Some`, every cookie command is routed with this CDP `sessionId`
+    /// so it resolves against the session's target `BrowserContext`. When
+    /// `None`, commands go at browser scope (the default `BrowserContext`).
+    session_id: Option<String>,
 }
 
 impl CookieJar {
-    /// Construct a jar around a [`Connection`].
+    /// Construct a browser-scope jar around a [`Connection`].
     ///
-    /// Typically called by [`crate::Browser::cookies`] /
-    /// [`crate::Tab::cookies`] rather than user code.
+    /// Cookie commands dispatch with **no** `sessionId`, so they read and
+    /// write the **default** `BrowserContext`. Typically called by
+    /// [`crate::Browser::cookies`] rather than user code.
     #[must_use]
     pub fn new(conn: Connection) -> Self {
         Self {
-            inner: Arc::new(CookieJarInner { conn }),
+            inner: Arc::new(CookieJarInner {
+                conn,
+                session_id: None,
+            }),
         }
+    }
+
+    /// Construct a jar scoped to a specific target's CDP `session_id`.
+    ///
+    /// Cookie commands dispatch **with** that `sessionId`, so Chrome resolves
+    /// them against the session's target `BrowserContext` — the correct store
+    /// for a tab opened under a per-target isolated `BrowserContext`.
+    /// Typically called by [`crate::Tab::cookies`] rather than user code.
+    #[must_use]
+    pub fn for_session(conn: Connection, session_id: impl Into<String>) -> Self {
+        Self {
+            inner: Arc::new(CookieJarInner {
+                conn,
+                session_id: Some(session_id.into()),
+            }),
+        }
+    }
+
+    /// The `sessionId` (if any) every cookie command is routed with. Cloned
+    /// per call because [`Connection::call_raw`] takes an owned `Option`.
+    fn session(&self) -> Option<String> {
+        self.inner.session_id.clone()
     }
 
     /// Return every cookie in the browser's store.
@@ -315,7 +365,7 @@ impl CookieJar {
         let resp = self
             .inner
             .conn
-            .call_raw("Storage.getCookies", json!({}), None)
+            .call_raw("Storage.getCookies", json!({}), self.session())
             .await?;
         parse_cookies(&resp)
     }
@@ -344,7 +394,7 @@ impl CookieJar {
             .call_raw(
                 "Network.getCookies",
                 json!({ "urls": [url.as_str()] }),
-                None,
+                self.session(),
             )
             .await?;
         parse_cookies(&resp)
@@ -385,7 +435,11 @@ impl CookieJar {
         let cdp_json = serde_json::to_value(&cdp).map_err(ZendriverError::Serde)?;
         self.inner
             .conn
-            .call_raw("Storage.setCookies", json!({ "cookies": [cdp_json] }), None)
+            .call_raw(
+                "Storage.setCookies",
+                json!({ "cookies": [cdp_json] }),
+                self.session(),
+            )
             .await?;
         Ok(())
     }
@@ -412,7 +466,11 @@ impl CookieJar {
         let cdp: Vec<CdpCookie> = cookies.into_iter().map(CdpCookie::from).collect();
         self.inner
             .conn
-            .call_raw("Storage.setCookies", json!({ "cookies": cdp }), None)
+            .call_raw(
+                "Storage.setCookies",
+                json!({ "cookies": cdp }),
+                self.session(),
+            )
             .await?;
         Ok(())
     }
@@ -441,7 +499,7 @@ impl CookieJar {
         }
         self.inner
             .conn
-            .call_raw("Network.deleteCookies", params, None)
+            .call_raw("Network.deleteCookies", params, self.session())
             .await?;
         Ok(())
     }
@@ -463,7 +521,7 @@ impl CookieJar {
     pub async fn clear(&self) -> Result<()> {
         self.inner
             .conn
-            .call_raw("Storage.clearCookies", json!({}), None)
+            .call_raw("Storage.clearCookies", json!({}), self.session())
             .await?;
         Ok(())
     }
@@ -546,6 +604,112 @@ mod tests {
         assert!(!cookies[1].http_only);
         assert_eq!(cookies[1].expires, None);
         assert_eq!(cookies[1].same_site, None);
+
+        conn.shutdown();
+    }
+
+    /// A **session-scoped** jar ([`CookieJar::for_session`]) must attach the
+    /// target's `sessionId` to `Storage.getCookies`, so Chrome resolves the
+    /// read against that tab's own `BrowserContext` — not the browser-wide
+    /// default. This is the isolated-`BrowserContext` correctness fix: a
+    /// caller opening tabs under `Target.createBrowserContext` would otherwise
+    /// read the wrong context's cookies.
+    #[tokio::test]
+    async fn for_session_scopes_get_cookies_to_the_tabs_session() {
+        let (mut mock, conn) = MockConnection::pair();
+        let jar = CookieJar::for_session(conn.clone(), "SESSION-42");
+
+        let call = tokio::spawn({
+            let j = jar.clone();
+            async move { j.all().await }
+        });
+
+        let id = mock.expect_cmd("Storage.getCookies").await;
+        // The command frame must carry the tab's sessionId — this is what
+        // routes the cookie read to the tab's own BrowserContext.
+        assert_eq!(
+            mock.last_sent()["sessionId"],
+            "SESSION-42",
+            "session-scoped jar must attach the tab's sessionId"
+        );
+        mock.reply(id, json!({ "cookies": [] })).await;
+        call.await.unwrap().unwrap();
+
+        conn.shutdown();
+    }
+
+    /// A **browser-scoped** jar ([`CookieJar::new`]) must NOT attach any
+    /// `sessionId` — it operates on the default `BrowserContext` at browser
+    /// scope. This pins the contract that [`crate::Browser::cookies`] keeps
+    /// its browser-wide semantics while [`crate::Tab::cookies`] is
+    /// context-scoped.
+    #[tokio::test]
+    async fn browser_scoped_jar_omits_session_id() {
+        let (mut mock, conn) = MockConnection::pair();
+        let jar = CookieJar::new(conn.clone());
+
+        let call = tokio::spawn({
+            let j = jar.clone();
+            async move { j.all().await }
+        });
+
+        let id = mock.expect_cmd("Storage.getCookies").await;
+        assert!(
+            mock.last_sent().get("sessionId").is_none(),
+            "browser-scoped jar must not attach a sessionId"
+        );
+        mock.reply(id, json!({ "cookies": [] })).await;
+        call.await.unwrap().unwrap();
+
+        conn.shutdown();
+    }
+
+    /// Every mutating cookie command on a session-scoped jar must also carry
+    /// the `sessionId`, so writes/clears land in the tab's own
+    /// `BrowserContext` rather than the default one.
+    #[tokio::test]
+    async fn for_session_scopes_all_mutations_to_the_tabs_session() {
+        let (mut mock, conn) = MockConnection::pair();
+        let jar = CookieJar::for_session(conn.clone(), "S9");
+
+        // set -> Storage.setCookies
+        let set = tokio::spawn({
+            let j = jar.clone();
+            async move {
+                j.set(Cookie {
+                    name: "a".into(),
+                    value: "1".into(),
+                    domain: ".x.com".into(),
+                    path: "/".into(),
+                    ..Default::default()
+                })
+                .await
+            }
+        });
+        let id = mock.expect_cmd("Storage.setCookies").await;
+        assert_eq!(mock.last_sent()["sessionId"], "S9");
+        mock.reply(id, json!({})).await;
+        set.await.unwrap().unwrap();
+
+        // delete -> Network.deleteCookies
+        let del = tokio::spawn({
+            let j = jar.clone();
+            async move { j.delete("a", None, None).await }
+        });
+        let id = mock.expect_cmd("Network.deleteCookies").await;
+        assert_eq!(mock.last_sent()["sessionId"], "S9");
+        mock.reply(id, json!({})).await;
+        del.await.unwrap().unwrap();
+
+        // clear -> Storage.clearCookies
+        let clr = tokio::spawn({
+            let j = jar.clone();
+            async move { j.clear().await }
+        });
+        let id = mock.expect_cmd("Storage.clearCookies").await;
+        assert_eq!(mock.last_sent()["sessionId"], "S9");
+        mock.reply(id, json!({})).await;
+        clr.await.unwrap().unwrap();
 
         conn.shutdown();
     }

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -789,17 +789,19 @@ impl Tab {
         Ok(map.values().find(|f| f.name() == Some(name)).cloned())
     }
 
-    /// Browser-wide cookie store handle.
+    /// Cookie store handle scoped to **this tab's own `BrowserContext`**.
     ///
-    /// Convenience accessor that delegates to the owning [`crate::Browser`]'s
-    /// root [`zendriver_transport::Connection`] — Chrome's cookie store is
-    /// browser-scoped, so this jar is functionally identical to
-    /// [`crate::Browser::cookies`] for the same browser.
+    /// The jar routes every `Storage.*`/`Network.*` cookie command with this
+    /// tab's CDP `sessionId` (via [`crate::CookieJar::for_session`]), so Chrome
+    /// resolves it against the `BrowserContext` the tab actually lives in —
+    /// not necessarily the browser-wide default one.
     ///
-    /// If the owning Browser has already been dropped (which shouldn't happen
-    /// in practice because Drop ordering keeps it alive while any Tab clone
-    /// exists, but is handled defensively here), the jar falls back to the
-    /// Tab's session-level connection.
+    /// This matters when the tab was opened under a **per-target isolated**
+    /// `BrowserContext` (`Target.createBrowserContext`): the default context
+    /// and an isolated context have separate cookie stores, so a browser-scope
+    /// read would return the wrong context's cookies. For the common case (a
+    /// single default context shared by every tab), this is equivalent to
+    /// [`crate::Browser::cookies`].
     ///
     /// # Examples
     ///
@@ -815,11 +817,10 @@ impl Tab {
     /// ```
     #[must_use]
     pub fn cookies(&self) -> crate::CookieJar {
-        let conn = self.inner.browser.upgrade().map_or_else(
-            || self.inner.session.connection().clone(),
-            |b| b.conn.clone(),
-        );
-        crate::CookieJar::new(conn)
+        crate::CookieJar::for_session(
+            self.inner.session.connection().clone(),
+            self.inner.session.session_id(),
+        )
     }
 
     /// Per-tab `localStorage` accessor.
@@ -3069,6 +3070,34 @@ mod tests {
     use super::*;
     use zendriver_transport::testing::MockConnection;
 
+    /// `Tab::cookies()` must hand back a jar scoped to the tab's own session,
+    /// so `Storage.getCookies` carries the tab's `sessionId` and resolves
+    /// against the tab's `BrowserContext` (correct for tabs opened under a
+    /// per-target isolated `BrowserContext`) rather than the browser-wide
+    /// default context.
+    #[tokio::test]
+    async fn cookies_reads_from_the_tabs_own_session_context() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "TAB-SESSION");
+        let tab = Tab::new_for_test(sess);
+
+        let call = tokio::spawn({
+            let jar = tab.cookies();
+            async move { jar.all().await }
+        });
+
+        let id = mock.expect_cmd("Storage.getCookies").await;
+        assert_eq!(
+            mock.last_sent()["sessionId"],
+            "TAB-SESSION",
+            "tab.cookies() must scope the read to the tab's own session"
+        );
+        mock.reply(id, json!({ "cookies": [] })).await;
+        call.await.unwrap().unwrap();
+
+        conn.shutdown();
+    }
+
     #[tokio::test]
     async fn goto_sends_page_enable_then_page_navigate_with_url() {
         let (mut mock, conn) = MockConnection::pair();
@@ -3790,51 +3819,18 @@ mod tests {
 
     // --- Tab::cookies (P4 T10) ----------------------------------------
 
-    /// [`Tab::cookies`] returns a [`crate::CookieJar`] bound to the owning
-    /// browser's root connection — discovered via the cached `Weak<BrowserInner>`
-    /// upgrade. The test builds a synthetic `BrowserInner` with a known
-    /// connection, attaches a Tab whose Weak ref points at it, and asserts
-    /// that calling `.set(...)` dispatches `Storage.setCookies` on that
-    /// browser-level connection (not the Tab's session channel).
+    /// [`Tab::cookies`] returns a [`crate::CookieJar`] scoped to the tab's own
+    /// session, so a **write** through it (`.set(...)` → `Storage.setCookies`)
+    /// carries the tab's `sessionId` and lands in the tab's own
+    /// `BrowserContext` — not the browser-wide default one. This is the
+    /// isolated-`BrowserContext` correctness contract on the mutation path.
     #[tokio::test]
-    async fn tab_cookies_dispatches_through_browser_connection_via_weak_upgrade() {
-        use crate::browser::BrowserInner;
+    async fn tab_cookies_mutations_dispatch_through_the_tabs_session() {
         use crate::cookies::Cookie;
-        use std::collections::HashMap;
-        use std::sync::{Arc, Weak};
 
-        let input_profile = zendriver_stealth::InputProfile::native();
         let (mut mock, conn) = MockConnection::pair();
-
-        let inner = Arc::new_cyclic(|weak: &Weak<BrowserInner>| {
-            let main_session = SessionHandle::new(conn.clone(), "S1");
-            let main_input = crate::input::InputController::new(input_profile.clone());
-            let main_tab = Tab::new(main_session, weak.clone(), main_input, "T1".to_string());
-            let mut map = HashMap::new();
-            map.insert("S1".to_string(), main_tab.clone());
-            BrowserInner {
-                conn: conn.clone(),
-                main_tab,
-                child: tokio::sync::Mutex::new(None),
-                job: crate::browser::ProcessJob::none(),
-                _user_data: None,
-                _extension_dirs: Vec::new(),
-                owns_process: false,
-                tabs: tokio::sync::RwLock::new(map),
-                debug_host_port: None,
-                ws_url: None,
-                tabs_changed: tokio::sync::Notify::new(),
-                #[cfg(feature = "interception")]
-                proxy_auth_handle: std::sync::OnceLock::new(),
-                #[cfg(feature = "interception")]
-                context_proxy_auth: tokio::sync::Mutex::new(HashMap::new()),
-                #[cfg(feature = "tracker-blocking")]
-                tracker_matcher: None,
-                #[cfg(feature = "interception")]
-                session_intercept_handles: tokio::sync::Mutex::new(std::collections::HashMap::new()),
-            }
-        });
-        let tab = inner.main_tab.clone();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
         let jar = tab.cookies();
 
         let fut = tokio::spawn(async move {
@@ -3843,11 +3839,6 @@ mod tests {
                 value: "abc".into(),
                 domain: ".example.com".into(),
                 path: "/".into(),
-                expires: None,
-                http_only: false,
-                secure: false,
-                same_site: None,
-                url: None,
                 ..Default::default()
             })
             .await
@@ -3860,15 +3851,12 @@ mod tests {
             .expect("setCookies payload must carry a cookies array");
         assert_eq!(arr.len(), 1);
         assert_eq!(arr[0]["name"], "sid");
-        // Browser-scope command — no session_id (jar dispatches against
-        // the browser's connection, not the tab's session).
-        assert!(mock.last_sent().get("sessionId").is_none());
+        // Session-scope command — the tab's session_id rides on the wire so
+        // the write resolves against the tab's own BrowserContext.
+        assert_eq!(mock.last_sent()["sessionId"], "S1");
         mock.reply(id, json!({})).await;
 
         fut.await.unwrap().unwrap();
-        // Keep `inner` alive until after the dispatch so the Weak upgrade
-        // succeeds — that's the path under test.
-        drop(inner);
         conn.shutdown();
     }
 


### PR DESCRIPTION
Two independent robustness fixes for consumers that run isolated browser contexts and need a close() that can't hang. Each is its own commit.

## 1. `Tab::cookies()` reads the wrong `BrowserContext` (commit 1)

`Tab::cookies()` built its `CookieJar` around the browser-wide root connection, so every cookie command dispatched at **browser scope** (no `sessionId`) and resolved against the **default** `BrowserContext`. A caller that opens tabs under per-target isolated `BrowserContext`s (`Target.createBrowserContext`) therefore read and wrote the *wrong* context's cookies — the default one's — and had to hand-roll a raw `Storage.getCookies` on the tab's own session to work around it.

`CookieJar` now carries an optional `session_id`, and `Tab::cookies()` builds it via a new `CookieJar::for_session(conn, session_id)` so every command routes with the tab's `sessionId` and Chrome resolves it against **that tab's own** `BrowserContext`. `Browser::cookies()` keeps its browser-wide semantics (`CookieJar::new`, no `sessionId`). The two are equivalent when every tab shares the default context, and differ only under per-target isolation.

Tests (offline, `MockConnection`): a session-scoped jar attaches the `sessionId` to `Storage.getCookies` and to every mutation; a browser-scoped jar omits it; and `Tab::cookies()` wires the tab's own session through on both reads and writes.

## 2. `Browser::close()` can hang forever (commit 2)

`Browser::close()` only bounded the CDP-quit round-trip (`Browser.close`). The two phases around it were unbounded: acquiring the internal child lock **before** the SIGTERM/grace/SIGKILL dance, and the final reap (`child.kill().await`) **after** it. If either wedged — an un-acquirable lock, or a process stuck in uninterruptible sleep that never reaps — `close()` hung the caller forever, forcing an external timeout wrapper.

The whole owning-process teardown is now wrapped in a single `timeout` (`BROWSER_CLOSE_DEADLINE`), so **one** deadline bounds every phase — quit, lock, grace waits, and reap. On elapse it logs and returns `Ok` (best-effort teardown), matching the existing signal-fallback philosophy; the per-phase budgets still return the common case promptly, and the deadline only bites on a genuine wedge. The CDP `Browser.close`-first ("T2") ordering already shipped and is preserved unchanged.

Test (offline): holding the child lock wedges the lock-acquisition phase; `close()` still returns within its deadline instead of hanging.

## Verification
`cargo build --all-features` + `cargo test --all-features` + `cargo fmt --all --check` all green (all offline unit/integration suites pass; the only red is a pre-existing live third-party bot-detector test that is environment-bound and unrelated to this change).
