### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.4.0", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.4.1", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.2" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.8.4" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.8.5" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.10" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.12" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.13" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.14.0" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.14.1" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.13" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.15" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.3" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.4" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.4] - 2026-07-22
+
+
 ## [0.3.3] - 2026-07-20
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.14.1] - 2026-07-22
+
+### Fixed
+
+- Ledger CookieJar::for_session + refresh public-api baseline
+
+
 ## [0.14.0] - 2026-07-20
 
 ### Added

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.8.5] - 2026-07-22
+
+### Fixed
+
+- Tolerate a browser-global locale override already set by another session
+
+
 ## [0.8.4] - 2026-07-20
 
 ### Added

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.8.4"
+version = "0.8.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,14 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-22
+
+### Fixed
+
+- Scope Tab::cookies() to the tab's own BrowserContext
+- Bound the entire Browser::close() under one deadline
+
+
 ## [0.4.0] - 2026-07-20
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.8.4 -> 0.8.5 (✓ API compatible changes)
* `zendriver`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `zendriver-mcp`: 0.14.0 -> 0.14.1 (✓ API compatible changes)
* `zendriver-fingerprints`: 0.3.3 -> 0.3.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-stealth`

<blockquote>

## [0.8.5] - 2026-07-22

### Fixed

- Tolerate a browser-global locale override already set by another session
</blockquote>

## `zendriver`

<blockquote>

## [0.4.1] - 2026-07-22

### Fixed

- Scope Tab::cookies() to the tab's own BrowserContext
- Bound the entire Browser::close() under one deadline
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.14.1] - 2026-07-22

### Fixed

- Ledger CookieJar::for_session + refresh public-api baseline
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).