### PR TITLE
chore(repo): stop changelog cross-attribution across sibling crates; steer consumers off zendriver-transport's raw API

### DIFF
--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -7,7 +7,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-readme = "../../README.md"
 homepage = "https://github.com/TurtIeSocks/zendriver-rs"
 documentation = "https://docs.rs/zendriver-cloudflare"
 keywords = ["cloudflare", "turnstile", "bypass", "browser", "zendriver"]

--- a/crates/zendriver-cloudflare/README.md
+++ b/crates/zendriver-cloudflare/README.md
@@ -1,0 +1,7 @@
+# zendriver-cloudflare
+
+Cloudflare Turnstile bypass for zendriver.
+
+Part of the [zendriver-rs](https://github.com/TurtIeSocks/zendriver-rs) workspace.
+See the [`zendriver`](https://crates.io/crates/zendriver) crate and the
+[user guide](https://turtiesocks.github.io/zendriver-rs/) for full documentation.

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -7,7 +7,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-readme = "../../README.md"
 homepage = "https://github.com/TurtIeSocks/zendriver-rs"
 documentation = "https://docs.rs/zendriver-datadome"
 keywords = ["datadome", "anti-bot", "bypass", "browser", "zendriver"]

--- a/crates/zendriver-datadome/README.md
+++ b/crates/zendriver-datadome/README.md
@@ -1,0 +1,7 @@
+# zendriver-datadome
+
+DataDome anti-bot bypass for zendriver.
+
+Part of the [zendriver-rs](https://github.com/TurtIeSocks/zendriver-rs) workspace.
+See the [`zendriver`](https://crates.io/crates/zendriver) crate and the
+[user guide](https://turtiesocks.github.io/zendriver-rs/) for full documentation.

--- a/crates/zendriver-fetcher/Cargo.toml
+++ b/crates/zendriver-fetcher/Cargo.toml
@@ -7,7 +7,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-readme = "../../README.md"
 homepage = "https://github.com/TurtIeSocks/zendriver-rs"
 documentation = "https://docs.rs/zendriver-fetcher"
 keywords = ["chrome", "download", "fetcher", "browser", "zendriver"]

--- a/crates/zendriver-fetcher/README.md
+++ b/crates/zendriver-fetcher/README.md
@@ -1,0 +1,7 @@
+# zendriver-fetcher
+
+Chrome binary downloader for zendriver.
+
+Part of the [zendriver-rs](https://github.com/TurtIeSocks/zendriver-rs) workspace.
+See the [`zendriver`](https://crates.io/crates/zendriver) crate and the
+[user guide](https://turtiesocks.github.io/zendriver-rs/) for full documentation.

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -7,7 +7,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-readme = "../../README.md"
 homepage = "https://github.com/TurtIeSocks/zendriver-rs"
 documentation = "https://docs.rs/zendriver-imperva"
 keywords = ["imperva", "incapsula", "waf", "bypass", "zendriver"]

--- a/crates/zendriver-imperva/README.md
+++ b/crates/zendriver-imperva/README.md
@@ -1,0 +1,7 @@
+# zendriver-imperva
+
+Imperva WAF / Incapsula bypass for zendriver.
+
+Part of the [zendriver-rs](https://github.com/TurtIeSocks/zendriver-rs) workspace.
+See the [`zendriver`](https://crates.io/crates/zendriver) crate and the
+[user guide](https://turtiesocks.github.io/zendriver-rs/) for full documentation.

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -7,7 +7,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-readme = "../../README.md"
 homepage = "https://github.com/TurtIeSocks/zendriver-rs"
 documentation = "https://docs.rs/zendriver-interception"
 keywords = ["interception", "network", "fetch", "cdp", "zendriver"]

--- a/crates/zendriver-interception/README.md
+++ b/crates/zendriver-interception/README.md
@@ -1,0 +1,7 @@
+# zendriver-interception
+
+Network interception (Fetch.* CDP domain) for zendriver.
+
+Part of the [zendriver-rs](https://github.com/TurtIeSocks/zendriver-rs) workspace.
+See the [`zendriver`](https://crates.io/crates/zendriver) crate and the
+[user guide](https://turtiesocks.github.io/zendriver-rs/) for full documentation.

--- a/crates/zendriver-mcp/mcp-coverage-ledger.toml
+++ b/crates/zendriver-mcp/mcp-coverage-ledger.toml
@@ -837,3 +837,28 @@ excluded = "signature grew a CachePolicy param (lib-only cache-freshness knob); 
 [[entry]]
 api = "zendriver::cookies::CookieJar::for_session"
 excluded = "internal jar constructor (session-scoped variant of CookieJar::new, itself lib-internal/baseline-grandfathered); scopes Tab::cookies() to the tab's own BrowserContext — no distinct MCP request/response surface"
+
+# ── observer surface hoisted into the facade ────────────────────────────────
+# The TargetObserver trait + supporting types, re-exported so a consumer can
+# implement a custom target-attach hook via the facade instead of depending on
+# zendriver-transport directly. Not an MCP tool surface — the MCP server exposes
+# high-level browser actions, not in-process custom-observer registration.
+[[entry]]
+api = "zendriver::TargetObserver"
+excluded = "advanced transport trait for custom target-attach hooks (in-process); no MCP tool — the server exposes browser actions, not observer registration"
+
+[[entry]]
+api = "zendriver::ObserverError"
+excluded = "error type of the TargetObserver trait; advanced transport surface, no distinct MCP tool"
+
+[[entry]]
+api = "zendriver::ObserverFailurePolicy"
+excluded = "timeout-policy enum for the TargetObserver trait; advanced transport surface, no distinct MCP tool"
+
+[[entry]]
+api = "zendriver::PausedSession"
+excluded = "argument of TargetObserver::on_target_attached; advanced transport surface, no distinct MCP tool"
+
+[[entry]]
+api = "zendriver::TargetInfo"
+excluded = "target metadata passed to the observer surface; advanced transport type, no distinct MCP tool"

--- a/crates/zendriver-mcp/public-api-baseline.txt
+++ b/crates/zendriver-mcp/public-api-baseline.txt
@@ -30,7 +30,10 @@ pub use zendriver::ImpervaSurface
 pub use zendriver::InterceptBuilder
 pub use zendriver::InterceptHandle
 pub use zendriver::InterceptionError
+pub use zendriver::ObserverError
+pub use zendriver::ObserverFailurePolicy
 pub use zendriver::PausedRequest
+pub use zendriver::PausedSession
 pub use zendriver::Persona
 pub use zendriver::PersonaBuilder
 pub use zendriver::Platform
@@ -44,6 +47,8 @@ pub use zendriver::Seed
 pub use zendriver::SessionHandle
 pub use zendriver::Strategy
 pub use zendriver::Surface
+pub use zendriver::TargetInfo
+pub use zendriver::TargetObserver
 pub use zendriver::TransportError
 pub use zendriver::VersionSpec
 pub use zendriver::WebgpuSpec

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -7,7 +7,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-readme = "../../README.md"
 homepage = "https://github.com/TurtIeSocks/zendriver-rs"
 documentation = "https://docs.rs/zendriver-stealth"
 keywords = ["stealth", "anti-detection", "browser", "cdp", "zendriver"]

--- a/crates/zendriver-stealth/README.md
+++ b/crates/zendriver-stealth/README.md
@@ -1,0 +1,7 @@
+# zendriver-stealth
+
+Anti-detection patches and profiles for zendriver.
+
+Part of the [zendriver-rs](https://github.com/TurtIeSocks/zendriver-rs) workspace.
+See the [`zendriver`](https://crates.io/crates/zendriver) crate and the
+[user guide](https://turtiesocks.github.io/zendriver-rs/) for full documentation.

--- a/crates/zendriver-transport/Cargo.toml
+++ b/crates/zendriver-transport/Cargo.toml
@@ -7,7 +7,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-readme = "../../README.md"
 homepage = "https://github.com/TurtIeSocks/zendriver-rs"
 documentation = "https://docs.rs/zendriver-transport"
 keywords = ["cdp", "chrome", "devtools", "websocket", "zendriver"]

--- a/crates/zendriver-transport/README.md
+++ b/crates/zendriver-transport/README.md
@@ -1,0 +1,9 @@
+# zendriver-transport
+
+Internal: WebSocket + CDP routing actor for zendriver.
+
+Part of the [zendriver-rs](https://github.com/TurtIeSocks/zendriver-rs) workspace.
+See the [`zendriver`](https://crates.io/crates/zendriver) crate and the
+[user guide](https://turtiesocks.github.io/zendriver-rs/) for full documentation —
+this crate has no independent SemVer contract; see
+[SEMVER.md](https://github.com/TurtIeSocks/zendriver-rs/blob/main/SEMVER.md#internal-crates).

--- a/crates/zendriver-transport/src/lib.rs
+++ b/crates/zendriver-transport/src/lib.rs
@@ -1,10 +1,10 @@
 //! Internal CDP transport for `zendriver`: WebSocket I/O, command/response
 //! routing, event broadcast.
 //!
-//! **Use via the `zendriver` crate's re-exports.** This crate is published so
-//! the workspace can compile end-to-end but its surface is not covered by the
-//! same SemVer guarantees as `zendriver`; expect minor versions to rearrange
-//! types here freely. See [`SEMVER.md`] in the repo root for the policy.
+//! > [!WARNING]
+//! > This crate has **no independent SemVer contract** — its surface may
+//! > rearrange in any minor release. Depend on the [`zendriver`] crate's
+//! > re-exports instead; see [`SEMVER.md`] for the policy.
 //!
 //! For a high-level walkthrough of the actor/observer model see the
 //! [Architecture chapter](https://turtiesocks.github.io/zendriver-rs/architecture.html)
@@ -28,7 +28,8 @@
 //! - [`CallError`] / [`TransportError`] — error types surfaced via
 //!   `zendriver`'s `ZendriverError::Transport` / `Cdp` variants.
 //!
-//! [`SEMVER.md`]: https://github.com/TurtIeSocks/zendriver-rs/blob/main/SEMVER.md
+//! [`zendriver`]: https://docs.rs/zendriver
+//! [`SEMVER.md`]: https://github.com/TurtIeSocks/zendriver-rs/blob/main/SEMVER.md#internal-crates
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/crates/zendriver-transport/src/observer.rs
+++ b/crates/zendriver-transport/src/observer.rs
@@ -24,6 +24,9 @@ use crate::error::CallError;
 /// `zendriver-stealth::StealthObserver` implements this trait to install
 /// patches on every new page target before the page's first script runs.
 ///
+/// Reachable via `zendriver`'s re-exports (`zendriver::TargetObserver`) — prefer
+/// that over depending on this crate directly; see the crate-root docs.
+///
 /// [`Target.attachedToTarget`]: https://chromedevtools.github.io/devtools-protocol/tot/Target/#event-attachedToTarget
 #[async_trait::async_trait]
 pub trait TargetObserver: Send + Sync {

--- a/crates/zendriver/src/lib.rs
+++ b/crates/zendriver/src/lib.rs
@@ -138,9 +138,13 @@ pub use window::{WindowBounds, WindowState};
 // opt-in knob whose whole point is caller discoverability — see its rustdoc.
 pub use zendriver_stealth::{Persona, PersonaBuilder, Seed, Strategy, Surface, WebgpuSpec};
 
-// Re-export selected transport types for advanced users.
+// Re-export selected transport types for advanced users. Includes the observer
+// surface (TargetObserver + supporting types) so a consumer can implement a
+// custom target-attach hook without depending on zendriver-transport directly —
+// the crate SEMVER.md steers them away from.
 pub use zendriver_transport::{
-    AccountedRawEvent, CallError, Connection, SessionHandle, TransportError,
+    AccountedRawEvent, CallError, Connection, ObserverError, ObserverFailurePolicy, PausedSession,
+    SessionHandle, TargetInfo, TargetObserver, TransportError,
 };
 
 /// Network interception API re-exports.

--- a/crates/zendriver/tests/facade_observer_reexports.rs
+++ b/crates/zendriver/tests/facade_observer_reexports.rs
@@ -1,0 +1,33 @@
+//! Proves a caller can implement a custom `TargetObserver` using only
+//! `zendriver`'s public re-exports, without depending on `zendriver-transport`
+//! directly — the exact use case SEMVER.md's "depend on zendriver instead"
+//! guidance previously couldn't satisfy (the observer surface wasn't hoisted).
+//!
+//! This is a compile-time proof as much as a runtime one: if any of the hoisted
+//! observer types were missing from the facade, this file would fail to compile.
+
+use zendriver::{ObserverError, ObserverFailurePolicy, PausedSession, TargetObserver};
+
+struct NoOpObserver;
+
+#[async_trait::async_trait]
+impl TargetObserver for NoOpObserver {
+    async fn on_target_attached(&self, _session: PausedSession<'_>) -> Result<(), ObserverError> {
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "noop-observer-facade-smoke-test"
+    }
+
+    fn failure_policy(&self) -> ObserverFailurePolicy {
+        ObserverFailurePolicy::BestEffort
+    }
+}
+
+#[test]
+fn target_observer_is_implementable_via_the_facade_alone() {
+    let observer = NoOpObserver;
+    assert_eq!(observer.name(), "noop-observer-facade-smoke-test");
+    assert_eq!(observer.failure_policy(), ObserverFailurePolicy::BestEffort);
+}

--- a/crates/zendriver/tests/workspace_hygiene.rs
+++ b/crates/zendriver/tests/workspace_hygiene.rs
@@ -8,6 +8,9 @@
 //! their `CHANGELOG.md`s with entries for features they never received. Each crate
 //! now has its own short README; these tests fail if the shared pointer returns.
 
+// Setup failures in a hygiene test legitimately panic to fail the test loudly.
+#![allow(clippy::panic)]
+
 use std::path::Path;
 
 const SIBLING_CRATES: &[&str] = &[

--- a/crates/zendriver/tests/workspace_hygiene.rs
+++ b/crates/zendriver/tests/workspace_hygiene.rs
@@ -1,0 +1,70 @@
+//! Guards against re-introducing the shared-README changelog-misattribution bug.
+//!
+//! Seven sibling crates used to point their Cargo `readme` field at the shared
+//! workspace-root `README.md`. release-plz scopes each crate's changelog to
+//! commits whose changed files intersect that crate's *published file set*
+//! (`cargo package --list`, which includes the `readme` target) — so every commit
+//! touching the root README looked like a change to all seven crates, polluting
+//! their `CHANGELOG.md`s with entries for features they never received. Each crate
+//! now has its own short README; these tests fail if the shared pointer returns.
+
+use std::path::Path;
+
+const SIBLING_CRATES: &[&str] = &[
+    "zendriver-transport",
+    "zendriver-stealth",
+    "zendriver-interception",
+    "zendriver-fetcher",
+    "zendriver-imperva",
+    "zendriver-cloudflare",
+    "zendriver-datadome",
+];
+
+#[test]
+fn sibling_crates_have_their_own_readme_not_the_shared_root_one() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    for crate_name in SIBLING_CRATES {
+        let manifest_path = workspace_root
+            .join("crates")
+            .join(crate_name)
+            .join("Cargo.toml");
+        let manifest = std::fs::read_to_string(&manifest_path)
+            .unwrap_or_else(|e| panic!("failed to read {manifest_path:?}: {e}"));
+        assert!(
+            !manifest.contains(r#"readme = "../../README.md""#),
+            "{crate_name} points `readme` at the shared workspace README again — \
+             this makes release-plz misattribute changelog entries to it. \
+             Give it its own README.md instead."
+        );
+        let own_readme = workspace_root
+            .join("crates")
+            .join(crate_name)
+            .join("README.md");
+        assert!(
+            own_readme.exists(),
+            "{crate_name} is missing its own README.md"
+        );
+    }
+}
+
+#[test]
+fn dependency_only_bumps_get_a_labeled_changelog_entry_not_silence() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let config = std::fs::read_to_string(workspace_root.join("release-plz-changelog.toml"))
+        .expect("release-plz-changelog.toml must exist at the workspace root");
+    // Quote-agnostic (the regex is a TOML literal string, single-quoted): match
+    // the regex content itself, not the `message = "…"` wrapper.
+    let specific_rule = r#"^chore: update Cargo\.(toml|lock) dependencies$"#;
+    assert!(
+        config.contains(specific_rule),
+        "missing the labeled commit_parser rule for release-plz's synthetic \
+         dependency-only-bump commit messages"
+    );
+    let specific_pos = config.find(specific_rule).unwrap();
+    let generic_skip_pos = config.find(r#"message = "^chore""#).unwrap();
+    assert!(
+        specific_pos < generic_skip_pos,
+        "the labeled dependency-bump rule must come BEFORE the generic ^chore skip \
+         rule — commit_parsers is first-match-wins"
+    );
+}

--- a/release-plz-changelog.toml
+++ b/release-plz-changelog.toml
@@ -33,6 +33,10 @@ commit_parsers = [
     { message = "^fix", group = "Fixed" },
     { message = "^perf", group = "Performance" },
     { message = "^refactor", group = "Changed" },
+    # Label release-plz's synthetic dependency-only-bump commit (first-match-wins,
+    # so it must precede the generic ^chore skip) instead of leaving a pure
+    # lockstep version bump as a silent, contentless version header.
+    { message = '^chore: update Cargo\.(toml|lock) dependencies$', group = "Internal" },
     { message = "^docs", skip = true },
     { message = "^test", skip = true },
     { message = "^ci", skip = true },


### PR DESCRIPTION
## Summary

Two independent repo-hygiene fixes, bundled to save a release cycle. Each is its own commit; neither depends on the other.

**1. Fix changelog cross-attribution across sibling crates.** Seven workspace crates point their Cargo `readme` field at the shared workspace-root `README.md`. release-plz scopes each crate's changelog by intersecting a commit's changed files against that crate's *published file set* (`cargo package --list`, which includes the `readme` target) — and the root README is touched by nearly every feature commit, so those seven crates' `CHANGELOG.md`s have been listing entries for features they never received. Verified with `git show --stat` against real commits, each touching zero files under the affected crates' own `src/` yet appearing verbatim in all seven changelogs. Fix: give each crate its own short `README.md` (breaks the shared-file collision); `zendriver` keeps the root README. Plus a `commit_parsers` rule so a genuinely version-only lockstep bump renders as an honest `Internal: dependency update` line instead of silence.

**2. Steer consumers off `zendriver-transport`'s raw API.** The crate is documented in `SEMVER.md` as carrying no independent SemVer contract, and its doc already said "depend on `zendriver`'s re-exports instead" — but that was a single bolded sentence, and following it was impossible for the one type most plausibly reached directly: `TargetObserver` (a custom target-attach hook) wasn't re-exported by the facade at all. Fix: promote the guidance to a GFM `[!WARNING]` callout, add a pointer on `TargetObserver` itself, and hoist the observer surface (`TargetObserver`, `ObserverError`, `ObserverFailurePolicy`, `PausedSession`, `TargetInfo`) into `zendriver`'s existing transport re-export block.

## Backward compatibility

Purely additive. No existing public item moves, is removed, or changes signature. `zendriver-transport` gets docs-only changes; `zendriver` gets a minor bump for the new re-exports (pre-1.0, `feat`-scoped per this project's SemVer policy). Both hoisted enums are already `#[non_exhaustive]`; `PausedSession` already has a `pub(crate)` field — no new future-breaking exposure.

## Test plan

- [x] `cargo test --workspace` (435 + 2 new tests, offline — no network/mock-server)
- New: `crates/zendriver/tests/workspace_hygiene.rs` (guards the shared-README regression + the changelog rule ordering), `crates/zendriver/tests/facade_observer_reexports.rs` (compile-proof a custom `TargetObserver` is implementable via the facade alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)