### PR TITLE
Carry clearance snapshot on AlreadyClear; add a document-scoped auth-only interception preset

### DIFF
--- a/crates/zendriver-imperva/src/bypass.rs
+++ b/crates/zendriver-imperva/src/bypass.rs
@@ -51,7 +51,13 @@ pub enum ClearanceOutcome {
     /// Body markers gone but no reese84 token (e.g., legacy Incapsula flow).
     ChallengeGone,
     /// No Imperva surface present at call time. Fast path; no waiting.
-    AlreadyClear,
+    /// Carries whatever cookie state the single probe already collected —
+    /// `reese84` is `Some` if a (non-empty) token cookie was already present
+    /// on the page, `None` if this simply isn't an Imperva-fronted page.
+    AlreadyClear {
+        reese84: Option<String>,
+        sessions: Vec<crate::detection::CookieSnapshot>,
+    },
     /// Deadline elapsed without clearance. `last_surface` is the most recent
     /// surface the poll loop observed (`None` if the deadline won before the
     /// first probe completed).
@@ -221,7 +227,10 @@ impl<'tab> ImpervaBypass<'tab> {
         // Fast path: nothing to clear.
         if matches!(snapshot.surface, crate::detection::ImpervaSurface::None) && snapshot.body_clean
         {
-            return Ok(ClearanceOutcome::AlreadyClear);
+            return Ok(ClearanceOutcome::AlreadyClear {
+                reese84: snapshot.reese84.filter(|v| !v.is_empty()),
+                sessions: snapshot.sessions,
+            });
         }
 
         // CAPTCHA escalation: dispatch to solver or fast-fail.
@@ -450,7 +459,84 @@ mod tests {
         .await;
 
         let outcome = fut.await.unwrap().unwrap();
-        assert!(matches!(outcome, ClearanceOutcome::AlreadyClear));
+        match outcome {
+            ClearanceOutcome::AlreadyClear { reese84, sessions } => {
+                assert_eq!(reese84, None);
+                assert!(sessions.is_empty());
+            }
+            other => panic!("expected AlreadyClear, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn wait_for_clearance_already_clear_carries_existing_reese84_cookie() {
+        // Already-cleared page (e.g. warmed by an earlier bypass) that still
+        // carries the token: the fast path must surface it, not drop it.
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move { ImpervaBypass::new(&s).wait_for_clearance().await }
+        });
+
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id,
+            snapshot_reply(json!({
+                "surface": { "kind": "None" },
+                "reese84": "EXISTING_TOKEN",
+                "body_clean": true,
+                "sessions": [{ "name": "reese84", "value": "EXISTING_TOKEN" }],
+                "has_imperva_signal": false,
+            })),
+        )
+        .await;
+
+        let outcome = fut.await.unwrap().unwrap();
+        match outcome {
+            ClearanceOutcome::AlreadyClear { reese84, sessions } => {
+                assert_eq!(reese84.as_deref(), Some("EXISTING_TOKEN"));
+                assert_eq!(sessions.len(), 1);
+                assert_eq!(sessions[0].name, "reese84");
+                assert_eq!(sessions[0].value, "EXISTING_TOKEN");
+            }
+            other => panic!("expected AlreadyClear, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn wait_for_clearance_already_clear_treats_empty_reese84_as_unset() {
+        // Empty-string token cookie is treated as unset on the fast path too,
+        // matching the same convention on the TokenAcquired path.
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move { ImpervaBypass::new(&s).wait_for_clearance().await }
+        });
+
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id,
+            snapshot_reply(json!({
+                "surface": { "kind": "None" },
+                "reese84": "",
+                "body_clean": true,
+                "sessions": [],
+                "has_imperva_signal": false,
+            })),
+        )
+        .await;
+
+        let outcome = fut.await.unwrap().unwrap();
+        match outcome {
+            ClearanceOutcome::AlreadyClear { reese84, .. } => assert_eq!(reese84, None),
+            other => panic!("expected AlreadyClear, got {other:?}"),
+        }
         conn.shutdown();
     }
 

--- a/crates/zendriver-imperva/src/lib.rs
+++ b/crates/zendriver-imperva/src/lib.rs
@@ -53,7 +53,7 @@
 //!         println!("token: {reese84}")
 //!     }
 //!     ClearanceOutcome::ChallengeGone => println!("legacy cleared"),
-//!     ClearanceOutcome::AlreadyClear => println!("no challenge present"),
+//!     ClearanceOutcome::AlreadyClear { .. } => println!("no challenge present"),
 //!     ClearanceOutcome::TimedOut { last_surface } => {
 //!         println!("timed out; last_surface = {last_surface:?}")
 //!     }

--- a/crates/zendriver-interception/src/builder.rs
+++ b/crates/zendriver-interception/src/builder.rs
@@ -147,6 +147,34 @@ impl<'tab> InterceptBuilder<'tab> {
         self
     }
 
+    /// Auto-respond to `Fetch.authRequired` challenges with the given
+    /// credentials, scoped to `Document`-type requests only.
+    ///
+    /// Equivalent to [`handle_auth`](Self::handle_auth) plus
+    /// `.pattern("*").resource(ResourceType::Document)`, packaged as its own
+    /// preset so a proxy/HTTP-auth-only caller doesn't have to discover — by
+    /// reading [`start`](Self::start)'s source — that leaving patterns unset
+    /// pauses *every* request on the page, not just the one carrying the auth
+    /// challenge.
+    ///
+    /// Narrowing to `Document` means only the main-frame navigation pauses and
+    /// round-trips through the interception actor; other requests (XHR,
+    /// subresources, and any parallel/pipelined connection that also needs
+    /// credentials) are not paused and will not have their auth challenge
+    /// answered by this builder. Use plain [`handle_auth`](Self::handle_auth)
+    /// (which falls back to a match-all pattern in [`start`](Self::start)) if
+    /// you need every connection's 407 covered.
+    #[must_use]
+    pub fn handle_auth_scoped_to_document(
+        self,
+        user: impl Into<String>,
+        pass: impl Into<String>,
+    ) -> Self {
+        self.handle_auth(user, pass)
+            .pattern("*")
+            .resource(ResourceType::Document)
+    }
+
     /// Push a new pattern entry with the given URL pattern string.
     ///
     /// Subsequent [`at_request`](Self::at_request) /
@@ -602,6 +630,70 @@ mod tests {
             "auth-only must send exactly one match-all pattern, never an empty array"
         );
         assert_eq!(arr[0]["urlPattern"], "*");
+        mock.reply(enable_id, json!({})).await;
+
+        drop(handle);
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn start_auth_scoped_to_document_sends_single_document_pattern() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let handle = InterceptBuilder::new(&sess)
+            .handle_auth_scoped_to_document("puser", "ppass")
+            .start();
+
+        let enable_id =
+            tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Fetch.enable"))
+                .await
+                .expect("actor did not send Fetch.enable within 2s");
+        let params = mock.last_sent()["params"].clone();
+        assert_eq!(params["handleAuthRequests"], true);
+        let arr = params["patterns"]
+            .as_array()
+            .expect("patterns must be a JSON array");
+        assert_eq!(arr.len(), 1, "scoped preset must send exactly one pattern");
+        assert_eq!(arr[0]["urlPattern"], "*");
+        assert_eq!(
+            arr[0]["resourceType"], "Document",
+            "scoped preset must narrow to the Document navigation — the difference from plain handle_auth"
+        );
+        mock.reply(enable_id, json!({})).await;
+
+        drop(handle);
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn handle_auth_scoped_to_document_composes_with_rules() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let builder = InterceptBuilder::new(&sess)
+            .block("*/ads/*")
+            .unwrap()
+            .handle_auth_scoped_to_document("puser", "ppass");
+        assert_eq!(
+            builder.rules_count(),
+            1,
+            "the preset must not clobber a rule registered before it in the chain"
+        );
+        let handle = builder.start();
+
+        let enable_id =
+            tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Fetch.enable"))
+                .await
+                .expect("actor did not send Fetch.enable within 2s");
+        let params = mock.last_sent()["params"].clone();
+        let arr = params["patterns"]
+            .as_array()
+            .expect("patterns must be a JSON array");
+        assert!(
+            arr.iter().any(|p| p["resourceType"] == "Document"),
+            "the Document-scoped auth pattern must survive alongside the block rule: {arr:?}"
+        );
         mock.reply(enable_id, json!({})).await;
 
         drop(handle);

--- a/crates/zendriver-mcp/src/tools/imperva.rs
+++ b/crates/zendriver-mcp/src/tools/imperva.rs
@@ -131,9 +131,9 @@ pub async fn solve_imperva(
             outcome: Outcome::ChallengeGone,
             reese84: None,
         }),
-        Ok(ImpervaClearanceOutcome::AlreadyClear) => Ok(SolveImpervaOutput {
+        Ok(ImpervaClearanceOutcome::AlreadyClear { reese84, .. }) => Ok(SolveImpervaOutput {
             outcome: Outcome::AlreadyClear,
-            reese84: None,
+            reese84,
         }),
         // TimedOut is a lib-side success terminal; collapse it into the
         // success-channel `Outcome::Timeout` — see module docs.

--- a/crates/zendriver/tests/imperva_v0.rs
+++ b/crates/zendriver/tests/imperva_v0.rs
@@ -54,7 +54,7 @@ async fn imperva_bypass_env_driven_smoke() {
             outcome,
             ImpervaClearanceOutcome::TokenAcquired { .. }
                 | ImpervaClearanceOutcome::ChallengeGone
-                | ImpervaClearanceOutcome::AlreadyClear
+                | ImpervaClearanceOutcome::AlreadyClear { .. }
         ),
         "unexpected outcome: {outcome:?}"
     );


### PR DESCRIPTION
## Summary

Two small, independent ergonomics fixes on the clearance/interception surface, bundled into one PR to save a release cycle. Each is its own commit.

1. **`zendriver-imperva`: `ClearanceOutcome::AlreadyClear` now carries the snapshot it already collected.** The fast path in `wait_for_clearance` probes the page and reads a full detection snapshot (reese84 cookie + jar) before deciding there's nothing to clear — then discarded it, forcing a caller on an already-cleared page (a second nav in the same tab, or a tab warmed by an earlier bypass) to issue a second, redundant cookie read for data the crate already had. It now returns `AlreadyClear { reese84: Option<String>, sessions: Vec<CookieSnapshot> }`, mirroring the sibling `TokenAcquired` variant. The MCP `solve_imperva` tool is the first beneficiary — it surfaces the carried token instead of hardcoding `None`.

   **Breaking** (pre-1.0 minor per `SEMVER.md`): a bare `AlreadyClear` unit pattern now needs `{ .. }`. Fixed in-tree in the lib doctest, the bypass unit test, `zendriver/tests/imperva_v0.rs`, and the MCP imperva tool.

2. **`zendriver-interception`: new `handle_auth_scoped_to_document()` preset.** `start()` already injects a match-all `Fetch.enable` pattern on the auth-only path (modern Chrome rejects empty patterns with `handleAuthRequests: true`), which pauses **every** request through the interception actor — not just the one carrying the auth challenge. The narrower fix (scope to `resourceType: Document`, so only the main-frame navigation pauses) was already described in a code comment but never packaged as a usable API. This ships that preset: `handle_auth_scoped_to_document(user, pass)` = `handle_auth` + `.pattern("*").resource(ResourceType::Document)`.

   **Purely additive** — no existing behavior changes; `start()`'s match-all fallback is untouched. Trade-off documented on the method: auth challenges on XHR/subresource/parallel-connection requests aren't answered by this builder — callers needing full coverage keep plain `handle_auth()`.

## Test plan

- [x] `zendriver-imperva`: existing already-clear test destructures the fields; two new mock-driven tests (existing-cookie-carried, empty-string-treated-as-unset).
- [x] `zendriver-interception`: two new mock-driven tests (single `Document`-scoped pattern; composes with a block rule); the existing match-all fallback regression test left unchanged.
- [x] `cargo build --workspace --all-targets --all-features` (catches the 4 in-tree call sites for item 1).
- [x] `cargo test -p zendriver-imperva -p zendriver-interception` → 26 + 45 green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean; MCP API coverage unchanged (variant-field additions don't alter the public-api surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)