### PR TITLE
Split native_isolation's two stealth axes; give fabricated WebGPU objects real prototype chains

### DIFF
--- a/crates/zendriver-mcp/src/state.rs
+++ b/crates/zendriver-mcp/src/state.rs
@@ -104,14 +104,23 @@ pub struct StealthOverrides {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bypass_csp: Option<bool>,
     /// Opt in to Chrome's real site isolation (`IsolateOrigins`/
-    /// `site-per-process` stay enabled) and, for `spoof_*` profiles, skip
-    /// the WebGL vendor/renderer patch — the host's real WebGL renderer
-    /// passes through unpatched. **Trade-off, not a strict stealth
-    /// improvement**: dropping the WebGL patch removes an anti-WAF
-    /// coherence defense (see `StealthProfile::native_isolation` rustdoc).
+    /// `site-per-process` stay enabled). Affects **only** the launch flags — a
+    /// test-harness knob for Chrome's stock process-isolation boundary, not a
+    /// stealth axis (see `StealthProfile::native_isolation` rustdoc). To skip
+    /// the WebGL/WebGPU identity patch, use [`native_webgl`](Self::native_webgl).
     /// Off (`false`/unset) by default — existing behavior unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub native_isolation: Option<bool>,
+    /// For `spoof_*` profiles, skip the WebGL vendor/renderer patch (and the
+    /// coupled WebGPU value/fabrication spoof) — the host's real WebGL/WebGPU
+    /// identity passes through unpatched. **Trade-off, not a strict stealth
+    /// improvement**: dropping the patch removes an anti-WAF coherence defense
+    /// (see `StealthProfile::native_webgl` rustdoc). Independent of
+    /// [`native_isolation`](Self::native_isolation); set both to reproduce the
+    /// pre-split bundle. Off (`false`/unset) by default — existing behavior
+    /// unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native_webgl: Option<bool>,
     /// Derive a coherent `locale` + `languages` from a country code
     /// (ISO 3166-1 alpha-2, e.g. `"US"`). Overridden by an explicit `locale`.
     ///

--- a/crates/zendriver-mcp/src/tools/lifecycle.rs
+++ b/crates/zendriver-mcp/src/tools/lifecycle.rs
@@ -392,6 +392,9 @@ fn apply_overrides(mut profile: StealthProfile, overrides: &StealthOverrides) ->
     if let Some(native_isolation) = overrides.native_isolation {
         profile = profile.native_isolation(native_isolation);
     }
+    if let Some(native_webgl) = overrides.native_webgl {
+        profile = profile.native_webgl(native_webgl);
+    }
     profile
 }
 
@@ -659,6 +662,29 @@ mod tests {
         assert!(!profile.native_isolation_enabled());
         let flags = profile.build_flags();
         assert!(flags.iter().any(|f| f.contains("IsolateOrigins")));
+    }
+
+    #[test]
+    fn native_webgl_override_wires_through_to_profile() {
+        let overrides = StealthOverrides {
+            native_webgl: Some(true),
+            ..Default::default()
+        };
+        let profile = apply_overrides(StealthProfile::spoofed(), &overrides);
+        assert!(profile.native_webgl_enabled());
+        // Axis 2 only — the launch flags stay as a plain spoofed profile's.
+        let flags = profile.build_flags();
+        assert!(
+            flags.iter().any(|f| f.contains("IsolateOrigins")),
+            "native_webgl override must not touch the launch flags: {flags:?}"
+        );
+    }
+
+    #[test]
+    fn absent_native_webgl_override_leaves_default_profile_unchanged() {
+        let overrides = StealthOverrides::default();
+        let profile = apply_overrides(StealthProfile::spoofed(), &overrides);
+        assert!(!profile.native_webgl_enabled());
     }
 
     #[cfg(feature = "interception")]

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__stealth_set_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__stealth_set_in.snap
@@ -59,7 +59,12 @@ $defs:
         format: uint32
         minimum: 0
       native_isolation:
-        description: "Opt in to Chrome's real site isolation (`IsolateOrigins`/\n`site-per-process` stay enabled) and, for `spoof_*` profiles, skip\nthe WebGL vendor/renderer patch — the host's real WebGL renderer\npasses through unpatched. **Trade-off, not a strict stealth\nimprovement**: dropping the WebGL patch removes an anti-WAF\ncoherence defense (see `StealthProfile::native_isolation` rustdoc).\nOff (`false`/unset) by default — existing behavior unchanged."
+        description: "Opt in to Chrome's real site isolation (`IsolateOrigins`/\n`site-per-process` stay enabled). Affects **only** the launch flags — a\ntest-harness knob for Chrome's stock process-isolation boundary, not a\nstealth axis (see `StealthProfile::native_isolation` rustdoc). To skip\nthe WebGL/WebGPU identity patch, use [`native_webgl`](Self::native_webgl).\nOff (`false`/unset) by default — existing behavior unchanged."
+        type:
+          - boolean
+          - "null"
+      native_webgl:
+        description: "For `spoof_*` profiles, skip the WebGL vendor/renderer patch (and the\ncoupled WebGPU value/fabrication spoof) — the host's real WebGL/WebGPU\nidentity passes through unpatched. **Trade-off, not a strict stealth\nimprovement**: dropping the patch removes an anti-WAF coherence defense\n(see `StealthProfile::native_webgl` rustdoc). Independent of\n[`native_isolation`](Self::native_isolation); set both to reproduce the\npre-split bundle. Off (`false`/unset) by default — existing behavior\nunchanged."
         type:
           - boolean
           - "null"

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__stealth_set_out.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__stealth_set_out.snap
@@ -62,7 +62,12 @@ $defs:
         format: uint32
         minimum: 0
       native_isolation:
-        description: "Opt in to Chrome's real site isolation (`IsolateOrigins`/\n`site-per-process` stay enabled) and, for `spoof_*` profiles, skip\nthe WebGL vendor/renderer patch — the host's real WebGL renderer\npasses through unpatched. **Trade-off, not a strict stealth\nimprovement**: dropping the WebGL patch removes an anti-WAF\ncoherence defense (see `StealthProfile::native_isolation` rustdoc).\nOff (`false`/unset) by default — existing behavior unchanged."
+        description: "Opt in to Chrome's real site isolation (`IsolateOrigins`/\n`site-per-process` stay enabled). Affects **only** the launch flags — a\ntest-harness knob for Chrome's stock process-isolation boundary, not a\nstealth axis (see `StealthProfile::native_isolation` rustdoc). To skip\nthe WebGL/WebGPU identity patch, use [`native_webgl`](Self::native_webgl).\nOff (`false`/unset) by default — existing behavior unchanged."
+        type:
+          - boolean
+          - "null"
+      native_webgl:
+        description: "For `spoof_*` profiles, skip the WebGL vendor/renderer patch (and the\ncoupled WebGPU value/fabrication spoof) — the host's real WebGL/WebGPU\nidentity passes through unpatched. **Trade-off, not a strict stealth\nimprovement**: dropping the patch removes an anti-WAF coherence defense\n(see `StealthProfile::native_webgl` rustdoc). Independent of\n[`native_isolation`](Self::native_isolation); set both to reproduce the\npre-split bundle. Off (`false`/unset) by default — existing behavior\nunchanged."
         type:
           - boolean
           - "null"

--- a/crates/zendriver-stealth/src/observer.rs
+++ b/crates/zendriver-stealth/src/observer.rs
@@ -67,7 +67,7 @@ impl StealthObserver {
         persona: Persona,
     ) -> Self {
         let bootstrap = if profile.kind() == ProfileKind::Spoofed {
-            if profile.native_isolation_enabled() {
+            if profile.native_webgl_enabled() {
                 bootstrap_script_native_webgl(&persona, &fingerprint)
             } else {
                 bootstrap_script(&persona, &fingerprint)
@@ -508,10 +508,81 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn native_isolation_spoofed_observer_omits_webgl_patch_in_bootstrap() {
-        // End-to-end wiring check (Task 10): a spoofed profile with the
-        // native_isolation opt-in must send a bootstrap script that omits
-        // the WebGL vendor/renderer patch, over the actual CDP payload.
+    async fn native_webgl_spoofed_observer_omits_webgl_patch_in_bootstrap() {
+        // End-to-end wiring check: a spoofed profile with the native_webgl
+        // opt-in must send a bootstrap script that omits the WebGL
+        // vendor/renderer patch, over the actual CDP payload.
+        let fp = Fingerprint {
+            platform: Platform::MacIntel,
+            chrome_major: 120,
+            chrome_full: "120.0.6099.234".into(),
+            cpu_count: 10,
+            memory_gb: 8,
+            ua_string: crate::ua::compose_ua_string(Platform::MacIntel, "120.0.6099.234"),
+            ua_metadata: crate::UserAgentMetadata::realistic(
+                Platform::MacIntel,
+                120,
+                "120.0.6099.234",
+            ),
+            timezone: None,
+            locale: None,
+            languages: None,
+            screen: None,
+        };
+        let profile = StealthProfile::spoofed().native_webgl(true);
+        let observer = std::sync::Arc::new(StealthObserver::new(profile, fp));
+
+        let (mut mock, conn) = MockConnection::pair_with_observers(vec![observer.clone()]);
+
+        mock.emit_event(
+            "Target.attachedToTarget",
+            json!({
+                "sessionId": "S1",
+                "targetInfo": {
+                    "targetId": "T1",
+                    "type": "page",
+                    "url": "about:blank",
+                    "attached": true,
+                },
+                "waitingForDebugger": true,
+            }),
+        )
+        .await;
+
+        for expected in [
+            "Page.enable",
+            "Emulation.setUserAgentOverride",
+            "Emulation.setDeviceMetricsOverride",
+            "Emulation.setFocusEmulationEnabled",
+            "Page.setBypassCSP",
+            "Page.addScriptToEvaluateOnNewDocument",
+            "Runtime.runIfWaitingForDebugger",
+        ] {
+            let id =
+                tokio::time::timeout(std::time::Duration::from_secs(2), mock.expect_cmd(expected))
+                    .await
+                    .unwrap_or_else(|_| panic!("did not see {expected} within 2s"));
+            if expected == "Page.addScriptToEvaluateOnNewDocument" {
+                let source = mock.last_sent()["params"]["source"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string();
+                assert!(
+                    !source.contains("UNMASKED_VENDOR_WEBGL") && !source.contains("37445"),
+                    "native_webgl bootstrap must omit the webgl patch block"
+                );
+            }
+            mock.reply(id, json!({})).await;
+        }
+
+        conn.shutdown();
+    }
+
+    #[tokio::test]
+    async fn native_isolation_alone_does_not_omit_webgl_patch_in_bootstrap() {
+        // The split's other half: `native_isolation(true)` on its own (axis 1,
+        // launch flags) must NOT silently drop the WebGL identity patch — the
+        // emitted bootstrap must still carry it, since `native_webgl` is unset.
         let fp = Fingerprint {
             platform: Platform::MacIntel,
             chrome_major: 120,
@@ -568,8 +639,8 @@ mod tests {
                     .unwrap_or_default()
                     .to_string();
                 assert!(
-                    !source.contains("UNMASKED_VENDOR_WEBGL") && !source.contains("37445"),
-                    "native_isolation bootstrap must omit the webgl patch block"
+                    source.contains("UNMASKED_VENDOR_WEBGL") || source.contains("37445"),
+                    "native_isolation alone must keep the webgl patch block"
                 );
             }
             mock.reply(id, json!({})).await;

--- a/crates/zendriver-stealth/src/patches.rs
+++ b/crates/zendriver-stealth/src/patches.rs
@@ -926,6 +926,31 @@ mod tests {
     }
 
     #[test]
+    fn webgpu_objects_built_via_prototype_helper_for_instanceof() {
+        // GPU objects must be built through the __zdGpuProto prototype helper so
+        // `instanceof` holds — not the old bare `var info = { vendor: ... }`
+        // object literal. All three helper calls are static template text
+        // (present regardless of the runtime fabricate flag).
+        let s = bootstrap_script(&Persona::default(), &mock_identity());
+        assert!(
+            s.contains("__zdGpuProto('GPUAdapterInfo')"),
+            "info must inherit GPUAdapterInfo.prototype: {s}"
+        );
+        assert!(
+            s.contains("__zdGpuProto('GPUAdapter')"),
+            "fabricated adapter must inherit GPUAdapter.prototype"
+        );
+        assert!(
+            s.contains("__zdGpuProto('GPU')"),
+            "synthetic navigator.gpu must inherit GPU.prototype"
+        );
+        assert!(
+            !s.contains("var info = { vendor:"),
+            "old plain-object info literal must be gone"
+        );
+    }
+
+    #[test]
     fn webgpu_none_everywhere_is_byte_for_byte_regression_guard() {
         // A `WebgpuSpec::default()` (all-None) must produce the exact same
         // bootstrap output as no spec at all (`persona.webgpu = None`) — the

--- a/crates/zendriver-stealth/src/patches/webgpu.js
+++ b/crates/zendriver-stealth/src/patches/webgpu.js
@@ -29,10 +29,18 @@
 //       no usable GPU (there `requestAdapter()` just resolves null). Restoring
 //       that presence is the caller's explicit opt-in.
 //
-// Known v1 limitations (acceptable per scope):
-//   - the returned info / limits / features are plain objects, not real
-//     GPUAdapterInfo / GPUSupportedLimits / GPUSupportedFeatures instances
-//     (an `instanceof` check would tell); info omits
+// Coherence notes / remaining limitations (acceptable per scope):
+//   - `navigator.gpu`, the fabricated adapter, and its `.info` inherit the real
+//     GPU / GPUAdapter / GPUAdapterInfo prototypes (or a synthesized same-named
+//     constructor, installed as a global, when the WebGPU IDL is absent), so
+//     `instanceof` holds for all three. Their VALUES are own getters, not
+//     prototype getters like a genuine instance — a deeper
+//     Object.getOwnPropertyDescriptor probe still tells (unchanged from before);
+//   - `.limits` / `.features` are still a plain object / Set, not real
+//     GPUSupportedLimits / GPUSupportedFeatures instances — rebinding a
+//     caller-supplied SUBSET of ~30 limit fields to those classes risks a
+//     genuine brand-check throwing on the fields we did not override, a bigger
+//     change than this closes (tracked as a follow-up); info omits
 //     subgroupMinSize/subgroupMaxSize;
 //   - the Block path can only shadow navigator.gpu, it cannot make
 //     `'gpu' in navigator` false;
@@ -41,9 +49,7 @@
 //     cannot provide, so fabrication only makes `requestAdapter()` resolve a
 //     coherent adapter for detection scripts that stop there, never actual
 //     WebGPU rendering on a GPU-less host;
-//   - when case (b) synthesizes `navigator.gpu`, the synthetic object is a
-//     plain object, so `navigator.gpu instanceof GPU` is false (same class of
-//     limitation as the plain-object adapter above), and fabrication flips
+//   - when case (b) synthesizes `navigator.gpu`, fabrication flips
 //     `'gpu' in navigator` to true (coherent for a modern-Chrome persona, the
 //     caller's explicit choice — see case (b) above).
 (function (vendor, architecture, device, description, limits, features, mode, fabricate) {
@@ -59,8 +65,40 @@
 
   if (vendor === null) return;
 
+  // Get (or synthesize + install) the named WebGPU constructor's prototype so
+  // objects built with Object.create(...) pass `instanceof` (see the header's
+  // limitations note). When the real class exists — the WebGPU IDL is compiled
+  // into this Chrome build, even with no hardware adapter behind it — its
+  // prototype is reused directly. When the class is absent entirely, synthesize
+  // a minimal same-named constructor and install it as a (non-enumerable)
+  // global, mirroring how real Chrome always exposes the constructor whether or
+  // not a usable instance is available (so `typeof window.GPU === 'function'`
+  // stays true, coherent for a modern-Chrome persona). Values stay OWN getters
+  // on each instance below — we deliberately do NOT override getters on a real
+  // prototype here, so a real adapter passing through the case-(a) wrapper keeps
+  // its own limits/features.
+  function __zdGpuProto(globalName) {
+    var root = (typeof self !== 'undefined') ? self : window;
+    var Ctor = root[globalName];
+    if (typeof Ctor === 'function' && Ctor.prototype) return Ctor.prototype;
+    Ctor = __zdMark(function () {}, globalName, 0);
+    Ctor.prototype = {};
+    try {
+      Object.defineProperty(root, globalName, { value: Ctor, writable: true, enumerable: false, configurable: true });
+    } catch (e) {}
+    return Ctor.prototype;
+  }
+
   // Shared synthetic info / feature set used by both decorate and fabricate.
-  var info = { vendor: vendor, architecture: architecture, device: device || '', description: description || '', isFallbackAdapter: false };
+  // `info` inherits GPUAdapterInfo.prototype so `info instanceof GPUAdapterInfo`
+  // holds (closing the cheapest deep probe); its fields are own getters, whose
+  // values are always defined.
+  var info = Object.create(__zdGpuProto('GPUAdapterInfo'));
+  __zdGetter(info, 'vendor', function () { return vendor; }, { enumerable: true });
+  __zdGetter(info, 'architecture', function () { return architecture; }, { enumerable: true });
+  __zdGetter(info, 'device', function () { return device || ''; }, { enumerable: true });
+  __zdGetter(info, 'description', function () { return description || ''; }, { enumerable: true });
+  __zdGetter(info, 'isFallbackAdapter', function () { return false; }, { enumerable: true });
   var featureSet = null;
   if (features) {
     try { featureSet = new Set(features); } catch (e) { featureSet = null; }
@@ -96,11 +134,14 @@
   // absent, we simply fall through and return — no auto behavior.
   if (!fabricate) return;
   try {
-    // The synthetic adapter, shared by both fabrication cases.
-    var synthetic = { isFallbackAdapter: false };
+    // The synthetic adapter, shared by both fabrication cases. Inherits
+    // GPUAdapter.prototype (real or synthesized) so `synthetic instanceof
+    // GPUAdapter` holds; info/limits/features stay own getters.
+    var synthetic = Object.create(__zdGpuProto('GPUAdapter'));
     __zdGetter(synthetic, 'info', function () { return info; }, { enumerable: false });
     __zdGetter(synthetic, 'limits', function () { return limits || {}; }, { enumerable: false });
     __zdGetter(synthetic, 'features', function () { return featureSet || new Set(); }, { enumerable: false });
+    __zdGetter(synthetic, 'isFallbackAdapter', function () { return false; }, { enumerable: false });
     synthetic.requestDevice = __zdMark(function requestDevice() {
       return Promise.reject(new DOMException(
         'WebGPU device creation is not supported for this adapter.',
@@ -112,7 +153,11 @@
       // Case (b): navigator.gpu entirely absent → define a synthetic one on
       // Navigator.prototype (prototype accessor, like real Chrome — so
       // Object.getOwnPropertyDescriptor(navigator,'gpu') stays undefined).
-      var syntheticGpu = {};
+      // Inherits GPU.prototype (real or synthesized) so `navigator.gpu
+      // instanceof GPU` holds. requestAdapter / getPreferredCanvasFormat stay
+      // own methods — moving them onto GPU.prototype would mutate the real
+      // class globally; instanceof holds regardless.
+      var syntheticGpu = Object.create(__zdGpuProto('GPU'));
       syntheticGpu.requestAdapter = __zdMark(function requestAdapter() {
         return Promise.resolve(synthetic);
       }, 'requestAdapter', 0);

--- a/crates/zendriver-stealth/src/persona/specs.rs
+++ b/crates/zendriver-stealth/src/persona/specs.rs
@@ -174,11 +174,12 @@ pub struct WebglSpec {
 ///
 /// # v1 limitations
 ///
-/// - The decorated / fabricated `.info`, `.limits`, `.features` are **plain
-///   objects**, not real `GPUAdapterInfo` / `GPUSupportedLimits` /
-///   `GPUSupportedFeatures` instances — an `instanceof` check would tell.
-///   Likewise a synthesized `navigator.gpu` is a plain object, so
-///   `navigator.gpu instanceof GPU` is `false`.
+/// - `navigator.gpu`, the fabricated adapter, and its `.info` inherit the real
+///   `GPU` / `GPUAdapter` / `GPUAdapterInfo` prototypes (or a synthesized
+///   same-named constructor when the WebGPU IDL is absent), so `instanceof`
+///   holds for all three. Their `.limits` / `.features` are still a plain
+///   object / `Set`, not real `GPUSupportedLimits` / `GPUSupportedFeatures`
+///   instances — an `instanceof` check on those two still tells.
 /// - [`fabricate_when_absent`](Self::fabricate_when_absent)'s synthetic
 ///   adapter's `requestDevice()` **always rejects**. Faking a working
 ///   `GPUDevice` needs a real GPU behind it, which this patch cannot
@@ -249,7 +250,7 @@ pub struct WebgpuSpec {
     /// with nothing else is refused (silently, no-op) because there is nothing
     /// coherent to fabricate; this project never auto-invents fingerprint
     /// values. See the v1 limitations above for what fabrication does NOT
-    /// cover (no working `GPUDevice`; plain-object `instanceof`).
+    /// cover (no working `GPUDevice`; `limits`/`features` `instanceof`).
     pub fabricate_when_absent: Option<bool>,
 }
 

--- a/crates/zendriver-stealth/src/profile.rs
+++ b/crates/zendriver-stealth/src/profile.rs
@@ -84,6 +84,11 @@ pub struct StealthProfile {
     pub(crate) per_field: PerFieldOverride,
     pub(crate) bypass_csp: bool,
     pub(crate) native_isolation: bool,
+    /// Skip the WebGL vendor/renderer identity patch (and the coupled WebGPU
+    /// value/fabrication spoof) for `spoofed`, independent of the real
+    /// render-process site-isolation launch flags. See
+    /// [`native_webgl`](Self::native_webgl) for the caller-facing setter.
+    pub(crate) native_webgl: bool,
     // Wired by `BrowserBuilder::stealth` in Task 17.
     #[allow(dead_code)]
     pub(crate) user_data_dir: Option<PathBuf>,
@@ -110,6 +115,7 @@ impl StealthProfile {
             per_field: PerFieldOverride::default(),
             bypass_csp: false,
             native_isolation: false,
+            native_webgl: false,
             user_data_dir: None,
         }
     }
@@ -133,6 +139,7 @@ impl StealthProfile {
             per_field: PerFieldOverride::default(),
             bypass_csp: false,
             native_isolation: false,
+            native_webgl: false,
             user_data_dir: None,
         }
     }
@@ -157,6 +164,7 @@ impl StealthProfile {
             per_field: PerFieldOverride::default(),
             bypass_csp: true, // default ON for spoofed; see spec assumption #2
             native_isolation: false,
+            native_webgl: false,
             user_data_dir: None,
         }
     }
@@ -289,42 +297,27 @@ impl StealthProfile {
         self.bypass_csp = on;
         self
     }
-    /// Opt in to Chrome's **real** render-process site isolation
-    /// (`IsolateOrigins`/`site-per-process` stay enabled — the launch flags
-    /// omit the isolation-disabling `--disable-features=...` entries) and,
-    /// for [`spoofed`](Self::spoofed), skip the WebGL vendor/renderer
-    /// value-substitution patch entirely — the host's real
-    /// `WebGLRenderingContext.getParameter`/`getSupportedExtensions` values
-    /// pass through unpatched instead of reporting the coherent
-    /// ANGLE/Direct3D11 Intel identity `patches/webgl.js` spoofs by default.
+    /// Opt in to Chrome's **real** render-process site isolation:
+    /// `IsolateOrigins`/`site-per-process` stay enabled — the launch flags
+    /// omit the isolation-disabling `--disable-features=...` entries the
+    /// library applies by default. Affects **only** the launch flags.
     ///
     /// # This is a trade-off, not a strict improvement
     ///
-    /// The defaults this opts out of exist for a reason: disabling site
-    /// isolation keeps every frame in one render process (simpler CDP target
-    /// attachment), and the WebGL patch is itself an anti-WAF *coherence*
-    /// defense — some WAFs (Imperva/Incapsula) cross-check the WebGL
-    /// identity against other signals and flag a real, host-specific
-    /// renderer string as a bot tell when it doesn't match the rest of the
-    /// spoofed fingerprint. Turning this on trades that coherence-with-a-
-    /// fake-identity for coherence-with-the-real-host: useful when you need
-    /// the host's actual GPU behavior (WebGL-heavy rendering/testing,
-    /// screenshot fidelity) or want Chrome's stock process-isolation
-    /// security boundary, and evasion is not the priority. It is **not**
-    /// "more stealthy" than the default — it removes an anti-detection
-    /// defense.
+    /// The default this opts out of exists for a reason: disabling site
+    /// isolation keeps every frame in one render process, which makes CDP
+    /// target attachment simpler. Turning real isolation back on is useful
+    /// when you want Chrome's stock process-isolation security boundary for a
+    /// test harness. It is orthogonal to stealth — it changes no JS
+    /// fingerprint surface.
+    ///
+    /// To skip the WebGL/WebGPU identity patch — a separate stealth axis this
+    /// setter used to bundle in — use [`native_webgl`](Self::native_webgl).
+    /// Set both to reproduce the pre-split `native_isolation(true)` behavior.
     ///
     /// Off by default. [`native`](Self::native) and [`spoofed`](Self::spoofed)
     /// are unaffected unless you call this explicitly, so existing callers
     /// see no behavior change.
-    ///
-    /// WebGL/WebGPU stay coherent: when this drops the WebGL patch, the
-    /// separate WebGPU **value** adapter spoof (driven by the
-    /// [`Persona`](crate::Persona) `webgpu` surface, `Value` by default) is
-    /// skipped too, so `navigator.gpu` reports the real host adapter rather
-    /// than one derived from a renderer the WebGL patch no longer applies. An
-    /// explicit WebGPU [`Strategy::Block`](crate::Strategy) (hiding
-    /// `navigator.gpu`) is renderer-neutral and is still honored.
     ///
     /// ```
     /// use zendriver_stealth::StealthProfile;
@@ -335,6 +328,54 @@ impl StealthProfile {
     #[must_use]
     pub fn native_isolation(mut self, on: bool) -> Self {
         self.native_isolation = on;
+        self
+    }
+
+    /// Skip the WebGL vendor/renderer value-substitution patch (and the
+    /// coupled WebGPU value/fabrication spoof, kept coherent with it) for the
+    /// [`spoofed`](Self::spoofed) profile — the host's real
+    /// `WebGLRenderingContext.getParameter`/`getSupportedExtensions` (and
+    /// `navigator.gpu`) values pass through unpatched instead of reporting the
+    /// coherent ANGLE/Direct3D11 Intel identity `patches/webgl.js` spoofs by
+    /// default.
+    ///
+    /// # This is a trade-off, not a strict improvement
+    ///
+    /// The WebGL patch is itself an anti-WAF *coherence* defense — some WAFs
+    /// (Imperva/Incapsula) cross-check the WebGL identity against other
+    /// signals and flag a real, host-specific renderer string as a bot tell
+    /// when it doesn't match the rest of the spoofed fingerprint. Turning this
+    /// on trades that coherence-with-a-fake-identity for coherence-with-the-
+    /// real-host: useful when you need the host's actual GPU behavior
+    /// (WebGL-heavy rendering/testing, screenshot fidelity) and evasion is not
+    /// the priority. It is **not** "more stealthy" than the default — it
+    /// removes an anti-detection defense.
+    ///
+    /// WebGL/WebGPU stay coherent: when this drops the WebGL patch, the
+    /// separate WebGPU **value** adapter spoof (driven by the
+    /// [`Persona`](crate::Persona) `webgpu` surface, `Value` by default) is
+    /// skipped too, so `navigator.gpu` reports the real host adapter rather
+    /// than one derived from a renderer the WebGL patch no longer applies. An
+    /// explicit WebGPU [`Strategy::Block`](crate::Strategy) (hiding
+    /// `navigator.gpu`) is renderer-neutral and is still honored.
+    ///
+    /// Independent of [`native_isolation`](Self::native_isolation), which only
+    /// changes Chrome's launch flags. Set both to reproduce the pre-split
+    /// `native_isolation(true)` bundle.
+    ///
+    /// Off by default — existing callers see no behavior change.
+    ///
+    /// ```
+    /// use zendriver_stealth::StealthProfile;
+    /// let p = StealthProfile::spoofed().native_webgl(true);
+    /// // Axis 2 only: the launch flags are unchanged from a plain spoofed
+    /// // profile — real site isolation stays disabled by default.
+    /// assert!(p.build_flags().iter().any(|f| f.contains("IsolateOrigins")));
+    /// assert!(p.native_webgl_enabled());
+    /// ```
+    #[must_use]
+    pub fn native_webgl(mut self, on: bool) -> Self {
+        self.native_webgl = on;
         self
     }
     /// Add a single extra Chrome launch flag (e.g. `"--proxy-server=..."`).
@@ -494,6 +535,13 @@ impl StealthProfile {
         self.native_isolation
     }
 
+    /// Whether the [`native_webgl`](Self::native_webgl) opt-in is active for
+    /// this profile. `false` unless explicitly set.
+    #[must_use]
+    pub fn native_webgl_enabled(&self) -> bool {
+        self.native_webgl
+    }
+
     /// Returns the input-realism profile appropriate for this stealth profile.
     /// `spoofed` returns realistic timings; `native` and `off` return zero-overhead.
     #[must_use]
@@ -580,6 +628,42 @@ mod profile_tests {
         // Existing default (no opt-in) must be unchanged.
         let flags = StealthProfile::native().build_flags();
         assert!(flags.iter().any(|f| f.contains("IsolateOrigins")));
+    }
+
+    #[test]
+    fn native_webgl_off_by_default_on_every_profile() {
+        assert!(!StealthProfile::off().native_webgl_enabled());
+        assert!(!StealthProfile::native().native_webgl_enabled());
+        assert!(!StealthProfile::spoofed().native_webgl_enabled());
+    }
+
+    #[test]
+    fn native_webgl_toggle_sets_flag() {
+        let p = StealthProfile::spoofed().native_webgl(true);
+        assert!(p.native_webgl_enabled());
+        // The WebGL axis is independent — it must not flip the isolation axis.
+        assert!(!p.native_isolation_enabled());
+    }
+
+    #[test]
+    fn native_webgl_true_native_isolation_false_build_flags_unaffected() {
+        // The split is real, not cosmetic: toggling axis 2 (WebGL patch skip)
+        // alone must leave the launch-flag list (axis 1) byte-for-byte equal to
+        // a plain spoofed profile.
+        let baseline = StealthProfile::spoofed().build_flags();
+        let webgl_only = StealthProfile::spoofed().native_webgl(true).build_flags();
+        assert_eq!(baseline, webgl_only);
+    }
+
+    #[test]
+    fn native_isolation_true_native_webgl_false_build_flags_omit_isolate_origins() {
+        // Axis 1 alone still drops the isolation-disabling features from the
+        // launch flags, matching the pre-split behavior.
+        let flags = StealthProfile::spoofed()
+            .native_isolation(true)
+            .build_flags();
+        assert!(!flags.iter().any(|f| f.contains("IsolateOrigins")));
+        assert!(!flags.iter().any(|f| f.contains("site-per-process")));
     }
 
     #[test]

--- a/crates/zendriver/tests/fingerprint_integration.rs
+++ b/crates/zendriver/tests/fingerprint_integration.rs
@@ -14,6 +14,9 @@
 //! ```
 
 #![cfg(feature = "integration-tests")]
+// Test-only: these headful checks panic!/assert on failure to surface a broken
+// shim loudly. Matches the convention on the other test files in this repo.
+#![allow(clippy::panic)]
 
 use std::time::Duration;
 
@@ -249,6 +252,16 @@ async fn fabricate_when_absent_synthesizes_navigator_gpu() {
               deviceRejected,
               preferredFormat: typeof navigator.gpu.getPreferredCanvasFormat === 'function'
                 ? navigator.gpu.getPreferredCanvasFormat() : null,
+              // Item 2: fabricated objects carry real prototype chains.
+              gpuIsInstance: (typeof GPU !== 'undefined' && navigator.gpu)
+                ? (navigator.gpu instanceof GPU) : null,
+              adapterIsInstance: (typeof GPUAdapter !== 'undefined' && a)
+                ? (a instanceof GPUAdapter) : null,
+              infoIsInstance: (typeof GPUAdapterInfo !== 'undefined' && a && a.info)
+                ? (a.info instanceof GPUAdapterInfo) : null,
+              // The patch installs the GPU constructor even when the IDL didn't
+              // expose it before, so this is a function after the patch runs.
+              gpuCtor: (typeof GPU === 'function'),
             };
         })()"#;
     let mut v = serde_json::Value::Null;
@@ -267,6 +280,23 @@ async fn fabricate_when_absent_synthesizes_navigator_gpu() {
     assert_eq!(
         v["present"], true,
         "fabricate_when_absent must make 'gpu' in navigator true: {v}"
+    );
+
+    // Item 2: the fabricated objects carry real prototype chains. When the
+    // WebGPU IDL exposes each class, `instanceof` must hold; the GPU
+    // constructor is installed by the patch even if the IDL did not expose it.
+    for (key, label) in [
+        ("gpuIsInstance", "navigator.gpu instanceof GPU"),
+        ("adapterIsInstance", "adapter instanceof GPUAdapter"),
+        ("infoIsInstance", "adapter.info instanceof GPUAdapterInfo"),
+    ] {
+        if !v[key].is_null() {
+            assert_eq!(v[key], true, "{label} must hold after fabrication: {v}");
+        }
+    }
+    assert_eq!(
+        v["gpuCtor"], true,
+        "the GPU constructor must be present after the patch runs: {v}"
     );
 
     // On a GPU-less host the synthetic adapter is what `requestAdapter()`


### PR DESCRIPTION
## Summary

Two independent stealth-realism fixes to `zendriver-stealth`, one PR (separate commits) to save a release cycle.

**1. Split `StealthProfile::native_isolation(bool)` into two opt-ins** (`feat(stealth)!`). One boolean silently controlled two unrelated axes: (a) whether Chrome's real render-process site-isolation launch flags stay on, and (b) whether the WebGL/WebGPU vendor-identity patch is skipped for `spoofed`. A caller who wanted real process isolation for a test harness could not keep the WebGL/WebGPU coherence patch, and vice versa. `native_isolation(bool)` now controls **only** the launch flags; a new `native_webgl(bool)` controls the identity-patch skip. Set both to reproduce the old bundle.

**Breaking:** `spoofed().native_isolation(true)` alone no longer drops the WebGL/WebGPU patch — add `.native_webgl(true)` for the pre-split behavior. The MCP `StealthOverrides` gains a sibling `native_webgl: Option<bool>` (additive JSON-schema field), wired the same way.

**2. Give fabricated WebGPU objects real prototype chains** (`feat(stealth)`). The `WebgpuSpec::fabricate_when_absent` patch (and the value-decorate path) built `navigator.gpu` / `GPUAdapter` / `.info` as plain object literals — a single `instanceof GPU` / `instanceof GPUAdapter` / `instanceof GPUAdapterInfo` probe unmasked the patch regardless of value coherence. They now inherit the real classes when the host's WebGPU IDL exposes them (even with no hardware adapter), and from a synthesized same-named global constructor when it doesn't. Values stay own getters, so a real adapter passing through the case-(a) wrapper keeps its own limits/features — no global prototype-getter override. No Rust API change.

Out of scope, unchanged (documented, accepted limitations): `GPUSupportedLimits`/`GPUSupportedFeatures` `instanceof` (rebinding a caller-supplied limit subset risks a genuine brand-check throwing), and the fabricated adapter's `requestDevice()` always rejecting.

## Testing

- `cargo test -p zendriver-stealth` — new + updated unit tests (string assertions on the rendered bootstrap/flags; observer CDP-payload checks for both split halves; the WebGPU prototype-helper render).
- `cargo test -p zendriver-mcp --lib` — `native_webgl` override wiring.
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean.
- `cargo test -p zendriver --test fingerprint_integration --features integration-tests -- --ignored` — extended headful `instanceof` + synthesized-constructor read-back (manual; needs local Chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)