### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "futures",
  "psl",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "futures",
  "serde",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "async-trait",
  "base64",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.8.6"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.4.2", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.4.3", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.3" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.8.6" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.9.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.11" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.13" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.14" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.14" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.14.2" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.2.14" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.16" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.5" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.15.0" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.0" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.17" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.6" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.17] - 2026-07-23
+
+
 ## [0.1.16] - 2026-07-23
 
 

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.16"
+version = "0.1.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.6] - 2026-07-23
+
+
 ## [0.3.5] - 2026-07-23
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.0] - 2026-07-23
+
+
 ## [0.2.14] - 2026-07-23
 
 

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.2.14"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.14] - 2026-07-23
+
+
 ## [0.3.13] - 2026-07-23
 
 

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.3.13"
+version = "0.3.14"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.15.0] - 2026-07-23
+
+### Added
+
+- Split native_isolation's two concerns into separate opt-ins **(BREAKING)**
+
+
 ## [0.14.2] - 2026-07-23
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.14.2"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.9.0] - 2026-07-23
+
+### Added
+
+- Split native_isolation's two concerns into separate opt-ins **(BREAKING)**
+- Give fabricated WebGPU objects real prototype chains
+
+
 ## [0.8.6] - 2026-07-23
 
 

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.8.6"
+version = "0.9.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-07-23
+
+### Added
+
+- Give fabricated WebGPU objects real prototype chains
+
+
 ## [0.4.2] - 2026-07-23
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-interception`: 0.3.13 -> 0.3.14 (✓ API compatible changes)
* `zendriver-imperva`: 0.2.14 -> 0.3.0 (⚠ API breaking changes)
* `zendriver-stealth`: 0.8.6 -> 0.9.0 (✓ API compatible changes)
* `zendriver`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `zendriver-mcp`: 0.14.2 -> 0.15.0 (⚠ API breaking changes)
* `zendriver-datadome`: 0.1.16 -> 0.1.17
* `zendriver-fingerprints`: 0.3.5 -> 0.3.6

### ⚠ `zendriver-imperva` breaking changes

```text
--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant ClearanceOutcome::AlreadyClear in /tmp/.tmpm7Qyg7/zendriver-rs/crates/zendriver-imperva/src/bypass.rs:57
  variant ClearanceOutcome::AlreadyClear in /tmp/.tmpm7Qyg7/zendriver-rs/crates/zendriver-imperva/src/bypass.rs:57
```

### ⚠ `zendriver-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field StealthOverrides.native_webgl in /tmp/.tmpm7Qyg7/zendriver-rs/crates/zendriver-mcp/src/state.rs:123
```

<details><summary><i><b>Changelog</b></i></summary><p>



## `zendriver-stealth`

<blockquote>

## [0.9.0] - 2026-07-23

### Added

- Split native_isolation's two concerns into separate opt-ins **(BREAKING)**
- Give fabricated WebGPU objects real prototype chains
</blockquote>

## `zendriver`

<blockquote>

## [0.4.3] - 2026-07-23

### Added

- Give fabricated WebGPU objects real prototype chains
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.15.0] - 2026-07-23

### Added

- Split native_isolation's two concerns into separate opt-ins **(BREAKING)**
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).