### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.4.3", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.4.4", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.3" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.9.0" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.10.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.11" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.14" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.14" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.15.0" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.0" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.0" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.17" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.6" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.7" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.7] - 2026-07-25
+
+
 ## [0.3.6] - 2026-07-23
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.16.0] - 2026-07-25
+
+### Added
+
+- Expose gpu_backend on browser_open
+
+### Fixed
+
+- Make the gpu_backend shadow schema fail closed on drift
+- Stop leaking schemars implementation rationale onto the wire
+
+
 ## [0.15.0] - 2026-07-23
 
 ### Added

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.10.0] - 2026-07-25
+
+### Added
+
+- Add GpuBackend with per-OS ANGLE flag mapping
+- Thread GpuBackend through flags_for_profile and StealthProfile **(BREAKING)**
+
+### Fixed
+
+- Resolve the GPU backend from the stealth profile too
+- Correct retracted --disable-gpu claim in WebGPU patch comments
+- Scope the Off-profile GPU-backend no-op comment
+
+
 ## [0.9.0] - 2026-07-23
 
 ### Added

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,22 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-07-25
+
+### Added
+
+- Add BrowserBuilder::gpu_backend with coupled --disable-gpu suppression
+- Name the GPU backend in launch-timeout errors
+- Add probe_gpu example dumping the GPU surface as JSON
+
+### Fixed
+
+- Resolve the GPU backend from the stealth profile too
+- Probe from a secure context so WebGPU is visible
+- Always emit adapter and deviceOk in the probe output
+- Scope the ANGLE-flag dedup to the ANGLE pair only
+
+
 ## [0.4.3] - 2026-07-23
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.4.3"
+version = "0.4.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)
* `zendriver`: 0.4.3 -> 0.4.4 (✓ API compatible changes)
* `zendriver-mcp`: 0.15.0 -> 0.16.0 (⚠ API breaking changes)
* `zendriver-fingerprints`: 0.3.6 -> 0.3.7

### ⚠ `zendriver-stealth` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_parameter_count_changed.ron

Failed in:
  zendriver_stealth::flags::flags_for_profile now takes 3 parameters instead of 2, in /tmp/.tmpSs60TV/zendriver-rs/crates/zendriver-stealth/src/flags.rs:167
```

### ⚠ `zendriver-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field OpenInput.gpu_backend in /tmp/.tmpSs60TV/zendriver-rs/crates/zendriver-mcp/src/tools/lifecycle.rs:42
  field OpenOutput.gpu_backend in /tmp/.tmpSs60TV/zendriver-rs/crates/zendriver-mcp/src/tools/lifecycle.rs:189
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-stealth`

<blockquote>

## [0.10.0] - 2026-07-25

### Added

- Add GpuBackend with per-OS ANGLE flag mapping
- Thread GpuBackend through flags_for_profile and StealthProfile **(BREAKING)**

### Fixed

- Resolve the GPU backend from the stealth profile too
- Correct retracted --disable-gpu claim in WebGPU patch comments
- Scope the Off-profile GPU-backend no-op comment
</blockquote>

## `zendriver`

<blockquote>

## [0.4.4] - 2026-07-25

### Added

- Add BrowserBuilder::gpu_backend with coupled --disable-gpu suppression
- Name the GPU backend in launch-timeout errors
- Add probe_gpu example dumping the GPU surface as JSON

### Fixed

- Resolve the GPU backend from the stealth profile too
- Probe from a secure context so WebGPU is visible
- Always emit adapter and deviceOk in the probe output
- Scope the ANGLE-flag dedup to the ANGLE pair only
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.16.0] - 2026-07-25

### Added

- Expose gpu_backend on browser_open

### Fixed

- Make the gpu_backend shadow schema fail closed on drift
- Stop leaking schemars implementation rationale onto the wire
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).