### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,16 +24,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.4.4", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.4.5", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.3" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.10.0" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.11.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.11" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.14" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.14" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.0" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.1" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.0" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.17" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.7" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.8" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.8] - 2026-07-29
+
+
 ## [0.3.7] - 2026-07-25
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.3.7"
+version = "0.3.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.16.1] - 2026-07-29
+
+### Added
+
+- Re-export GpuProfile and its value types
+
+
 ## [0.16.0] - 2026-07-25
 
 ### Added

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.16.0"
+version = "0.16.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,56 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.11.0] - 2026-07-29
+
+### Added
+
+- Add GPU profile value types
+- Add the capture reader and committed tier captures
+- Emit the tier tables and guard them against drift
+- Resolve a flat GpuProfile from the tier tables
+- Enforce GPU parameter coherence invariants
+- Carry a resolved GpuProfile on Persona
+- Drive webgl.js from the resolved GPU profile **(BREAKING)**
+- Resolve persona.gpu and report platform skew
+- Capture the d3d11-fl11 GPU capability tier
+- Serve each tier's measured WebGPU limits and features
+- Capture the Intel Iris Pro 580 Vulkan tier
+- Register the Mesa/Vulkan Intel Iris Pro 580 tier
+
+### Changed
+
+- Fold webgpu_adapter into the GPU device table
+- Rename the Metal tier to metal-macos
+
+### Fixed
+
+- Surface the enum-aliasing caveat in the emitted doc comment
+- Match renderers against an explicit token, not a derived key
+- Delegate WebGL reads on a lost context
+- Gate the unmasked pair on the debug extension
+- Build the inert extension stub over its real prototype
+- Cache the synthesized extension object per context
+- Move the precision-format accessors onto a prototype
+- Derive the WebGPU adapter from the served renderer
+- Suppress the WebGPU value spoof under a Native WebGL surface
+- Give spoofed precision formats the real prototype
+- Let getExtension() with no argument throw as Chrome does
+- Forget debug_renderer_info enablement on context loss
+- Serve only static device capabilities, delegate mutable state **(BREAKING)**
+- Keep Chrome's extension order instead of sorting
+- Derive the default GPU renderer from the persona's platform
+- Stop pairing an Intel WebGPU adapter with SwiftShader WebGL
+- Report SwiftShader's Subzero build on Linux personas
+- Fail a Native launch that has no hardware WebGL
+- Fill the DRAW_BUFFERn gap the served cap opens
+- Match the DRAW_BUFFERn gap fill to the bound framebuffer
+- Make requestDevice agree with the served adapter
+- Stop a comma-less renderer mangling the derived vendor
+- Split the D3D11 tier on ANGLE's NVIDIA-only workaround
+- Suppress DRAW_BUFFERn past the served cap
+
+
 ## [0.10.0] - 2026-07-25
 
 ### Added

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,32 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-07-29
+
+### Added
+
+- Record GL enum numbers in the probe output
+- Add capture-gpu-tier for probing a backend on other machines
+- Re-export GpuProfile and its value types
+- Capture the d3d11-fl11 GPU capability tier
+- Serve each tier's measured WebGPU limits and features
+- Register the Mesa/Vulkan Intel Iris Pro 580 tier
+- Write GPU tier captures from probe_gpu itself
+
+### Changed
+
+- Rename the Metal tier to metal-macos
+
+### Fixed
+
+- Derive the default GPU renderer from the persona's platform
+- Fail a Native launch that has no hardware WebGL
+- Fill the DRAW_BUFFERn gap the served cap opens
+- Match the DRAW_BUFFERn gap fill to the bound framebuffer
+- Make requestDevice agree with the served adapter
+- Report which Windows a GPU capture came from
+
+
 ## [0.4.4] - 2026-07-25
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.4.4"
+version = "0.4.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.10.0 -> 0.11.0 (⚠ API breaking changes)
* `zendriver`: 0.4.4 -> 0.4.5 (✓ API compatible changes)
* `zendriver-mcp`: 0.16.0 -> 0.16.1 (✓ API compatible changes)
* `zendriver-fingerprints`: 0.3.7 -> 0.3.8

### ⚠ `zendriver-stealth` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Persona.gpu in /tmp/.tmpiydUIr/zendriver-rs/crates/zendriver-stealth/src/persona/mod.rs:71
  field Persona.gpu in /tmp/.tmpiydUIr/zendriver-rs/crates/zendriver-stealth/src/persona/mod.rs:71
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-stealth`

<blockquote>

## [0.11.0] - 2026-07-29

### Added

- Add GPU profile value types
- Add the capture reader and committed tier captures
- Emit the tier tables and guard them against drift
- Resolve a flat GpuProfile from the tier tables
- Enforce GPU parameter coherence invariants
- Carry a resolved GpuProfile on Persona
- Drive webgl.js from the resolved GPU profile **(BREAKING)**
- Resolve persona.gpu and report platform skew
- Capture the d3d11-fl11 GPU capability tier
- Serve each tier's measured WebGPU limits and features
- Capture the Intel Iris Pro 580 Vulkan tier
- Register the Mesa/Vulkan Intel Iris Pro 580 tier

### Changed

- Fold webgpu_adapter into the GPU device table
- Rename the Metal tier to metal-macos

### Fixed

- Surface the enum-aliasing caveat in the emitted doc comment
- Match renderers against an explicit token, not a derived key
- Delegate WebGL reads on a lost context
- Gate the unmasked pair on the debug extension
- Build the inert extension stub over its real prototype
- Cache the synthesized extension object per context
- Move the precision-format accessors onto a prototype
- Derive the WebGPU adapter from the served renderer
- Suppress the WebGPU value spoof under a Native WebGL surface
- Give spoofed precision formats the real prototype
- Let getExtension() with no argument throw as Chrome does
- Forget debug_renderer_info enablement on context loss
- Serve only static device capabilities, delegate mutable state **(BREAKING)**
- Keep Chrome's extension order instead of sorting
- Derive the default GPU renderer from the persona's platform
- Stop pairing an Intel WebGPU adapter with SwiftShader WebGL
- Report SwiftShader's Subzero build on Linux personas
- Fail a Native launch that has no hardware WebGL
- Fill the DRAW_BUFFERn gap the served cap opens
- Match the DRAW_BUFFERn gap fill to the bound framebuffer
- Make requestDevice agree with the served adapter
- Stop a comma-less renderer mangling the derived vendor
- Split the D3D11 tier on ANGLE's NVIDIA-only workaround
- Suppress DRAW_BUFFERn past the served cap
</blockquote>

## `zendriver`

<blockquote>

## [0.4.5] - 2026-07-29

### Added

- Record GL enum numbers in the probe output
- Add capture-gpu-tier for probing a backend on other machines
- Re-export GpuProfile and its value types
- Capture the d3d11-fl11 GPU capability tier
- Serve each tier's measured WebGPU limits and features
- Register the Mesa/Vulkan Intel Iris Pro 580 tier
- Write GPU tier captures from probe_gpu itself

### Changed

- Rename the Metal tier to metal-macos

### Fixed

- Derive the default GPU renderer from the persona's platform
- Fail a Native launch that has no hardware WebGL
- Fill the DRAW_BUFFERn gap the served cap opens
- Match the DRAW_BUFFERn gap fill to the bound framebuffer
- Make requestDevice agree with the served adapter
- Report which Windows a GPU capture came from
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.16.1] - 2026-07-29

### Added

- Re-export GpuProfile and its value types
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).