### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -3529,7 +3529,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.4.5", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.4.6", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.3" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.11.0" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.11.1" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.11" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.14" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.14" }
 zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.1" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.0" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.17" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.8" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.9" }
 
 # MCP server
 rmcp        = { version = "1.7", default-features = false }

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.9] - 2026-07-29
+
+
 ## [0.3.8] - 2026-07-29
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.11.1] - 2026-07-29
+
+
 ## [0.11.0] - 2026-07-29
 
 ### Added

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-07-29
+
+
 ## [0.4.5] - 2026-07-29
 
 ### Added

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.4.5"
+version = "0.4.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `zendriver`: 0.4.5 -> 0.4.6 (✓ API compatible changes)
* `zendriver-mcp`: 0.16.0 -> 0.16.1
* `zendriver-fingerprints`: 0.3.8 -> 0.3.9

<details><summary><i><b>Changelog</b></i></summary><p>



## `zendriver-mcp`

<blockquote>

## [0.16.1] - 2026-07-29

### Added

- Re-export GpuProfile and its value types
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).