### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.11.1
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.11" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.14" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.14" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.1" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.2" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.0" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.17" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.9" }

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.16.2] - 2026-07-29
+
+
 ## [0.16.1] - 2026-07-29
 
 ### Added

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.16.1"
+version = "0.16.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.11.0 -> 0.11.1
* `zendriver`: 0.4.5 -> 0.4.6
* `zendriver-fingerprints`: 0.3.8 -> 0.3.9
* `zendriver-mcp`: 0.16.1 -> 0.16.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).