### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "async-trait",
  "base64",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-cloudflare"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "futures",
  "psl",
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fetcher"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "dirs",
  "futures",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "futures",
  "serde",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "async-trait",
  "base64",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-transport"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.4.6", default-features = false }
-zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.3" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.11.1" }
-zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.11" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.14" }
-zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.14" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.2" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.0" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.17" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.9" }
+zendriver               = { path = "crates/zendriver", version = "0.4.7", default-features = false }
+zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.4" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.11.2" }
+zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.12" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.15" }
+zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.15" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.3" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.1" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.18" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.10" }
 
 # MCP server
 # Pinned exactly, matching proxybroker-rs: rmcp's macro and transport surface moves across

--- a/crates/zendriver-cloudflare/CHANGELOG.md
+++ b/crates/zendriver-cloudflare/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.12] - 2026-07-29
+
+### Internal
+
+- Update Cargo.toml dependencies
+
+
 ## [0.2.11] - 2026-07-23
 
 

--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-cloudflare"
 description = "Cloudflare Turnstile bypass for zendriver"
-version = "0.2.11"
+version = "0.2.12"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.18] - 2026-07-29
+
+### Internal
+
+- Update Cargo.toml dependencies
+
+
 ## [0.1.17] - 2026-07-23
 
 

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.17"
+version = "0.1.18"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fetcher/CHANGELOG.md
+++ b/crates/zendriver-fetcher/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.15] - 2026-07-29
+
+
 ## [0.1.14] - 2026-07-23
 
 

--- a/crates/zendriver-fetcher/Cargo.toml
+++ b/crates/zendriver-fetcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fetcher"
 description = "Chrome binary downloader for zendriver"
-version = "0.1.14"
+version = "0.1.15"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.10] - 2026-07-29
+
+
 ## [0.3.9] - 2026-07-29
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.3.9"
+version = "0.3.10"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.1] - 2026-07-29
+
+### Internal
+
+- Update Cargo.toml dependencies
+
+
 ## [0.3.0] - 2026-07-23
 
 

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.15] - 2026-07-29
+
+### Internal
+
+- Update Cargo.toml dependencies
+
+
 ## [0.3.14] - 2026-07-23
 
 

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.3.14"
+version = "0.3.15"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.16.3] - 2026-07-29
+
+
 ## [0.16.2] - 2026-07-29
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.11.2] - 2026-07-29
+
+### Internal
+
+- Update Cargo.toml dependencies
+
+
 ## [0.11.1] - 2026-07-29
 
 

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.11.1"
+version = "0.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-transport/CHANGELOG.md
+++ b/crates/zendriver-transport/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-07-29
+
+### Internal
+
+- Update Cargo.toml dependencies
+
+
 ## [0.2.3] - 2026-07-23
 
 ### Added

--- a/crates/zendriver-transport/Cargo.toml
+++ b/crates/zendriver-transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-transport"
 description = "Internal: WebSocket + CDP routing actor for zendriver"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-07-29
+
+
 ## [0.4.6] - 2026-07-29
 
 

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.4.6"
+version = "0.4.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-transport`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `zendriver-cloudflare`: 0.2.11 -> 0.2.12 (✓ API compatible changes)
* `zendriver-interception`: 0.3.14 -> 0.3.15 (✓ API compatible changes)
* `zendriver-datadome`: 0.1.17 -> 0.1.18 (✓ API compatible changes)
* `zendriver-fetcher`: 0.1.14 -> 0.1.15 (✓ API compatible changes)
* `zendriver-imperva`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `zendriver-stealth`: 0.11.1 -> 0.11.2 (✓ API compatible changes)
* `zendriver`: 0.4.6 -> 0.4.7 (✓ API compatible changes)
* `zendriver-fingerprints`: 0.3.9 -> 0.3.10 (✓ API compatible changes)
* `zendriver-mcp`: 0.16.2 -> 0.16.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-transport`

<blockquote>

## [0.2.4] - 2026-07-29

### Internal

- Update Cargo.toml dependencies
</blockquote>

## `zendriver-cloudflare`

<blockquote>

## [0.2.12] - 2026-07-29

### Internal

- Update Cargo.toml dependencies
</blockquote>

## `zendriver-interception`

<blockquote>

## [0.3.15] - 2026-07-29

### Internal

- Update Cargo.toml dependencies
</blockquote>

## `zendriver-datadome`

<blockquote>

## [0.1.18] - 2026-07-29

### Internal

- Update Cargo.toml dependencies
</blockquote>


## `zendriver-imperva`

<blockquote>

## [0.3.1] - 2026-07-29

### Internal

- Update Cargo.toml dependencies
</blockquote>

## `zendriver-stealth`

<blockquote>

## [0.11.2] - 2026-07-29

### Internal

- Update Cargo.toml dependencies
</blockquote>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).