### PR TITLE
fix(stealth): send navigator.platform's JS spelling to setUserAgentOverride

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,17 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SEMVER.md].
   `browser_close` tear them down at session end (which DOES drain
   both registries as of this release). Fix tracked for a follow-up.
 
+### Fixed
+
+- `Emulation.setUserAgentOverride` sent the **Client-Hints** platform spelling
+  (`Windows` / `macOS` / `Linux`) to the CDP parameter that sets `navigator.platform`,
+  which takes the legacy JS spelling (`Win32` / `MacIntel` / `Linux x86_64`). Every
+  session therefore reported a `navigator.platform` no real browser emits. `spoofed`
+  masked it — its bootstrap re-patches the property from `platformJs` — but that
+  bootstrap is empty for `Off`/`Native`, so **`native` profiles shipped the bad value
+  straight through**. `userAgentMetadata.platform` keeps the CH spelling, as it should.
+  A regression test asserts the two axes hold disjoint value sets.
+
 ## [0.1.0] - 2026-05-23
 
 First public release. Built across 6 phases of internal development.

--- a/crates/zendriver-stealth/src/observer.rs
+++ b/crates/zendriver-stealth/src/observer.rs
@@ -134,7 +134,20 @@ impl TargetObserver for StealthObserver {
                 json!({
                     "userAgent": &self.fingerprint.ua_string,
                     "acceptLanguage": accept_language,
-                    "platform": self.fingerprint.platform.ch_platform(),
+                    // `js_string()`, NOT `ch_platform()`. This CDP parameter is defined as "the
+                    // platform navigator.platform should return", so it takes the legacy JS value
+                    // (`Win32` / `MacIntel` / `Linux x86_64`). The Client-Hints spelling
+                    // (`Windows` / `macOS` / `Linux`) belongs to `userAgentMetadata.platform`,
+                    // which is sent separately just below and derives it in `Fingerprint::new`.
+                    //
+                    // Sending the CH spelling here made every session report a
+                    // `navigator.platform` no real browser emits. It was invisible under
+                    // `spoofed`, whose bootstrap re-patches `navigator.platform` from
+                    // `platformJs` and so happened to paper over it — but the bootstrap is
+                    // deliberately EMPTY for `Off`/`Native` (see `bootstrap` above), leaving
+                    // `native` profiles presenting `"macOS"` where Chrome reports `"MacIntel"`.
+                    // Measured against a real Chrome build, not inferred.
+                    "platform": self.fingerprint.platform.js_string(),
                     "userAgentMetadata": &user_agent_metadata,
                 }),
             )
@@ -271,6 +284,49 @@ mod tests {
     use serde_json::json;
     use zendriver_transport::testing::MockConnection;
 
+    /// `Emulation.setUserAgentOverride` carries the platform on TWO distinct axes, and they
+    /// must not be swapped:
+    ///
+    /// * top-level `platform` — CDP defines this as "the platform navigator.platform should
+    ///   return", so it takes the legacy JS spelling `Win32` / `MacIntel` / `Linux x86_64`
+    ///   ([`Platform::js_string`]).
+    /// * `userAgentMetadata.platform` — the Client-Hints spelling `Windows` / `macOS` /
+    ///   `Linux` ([`Platform::ch_platform`]).
+    ///
+    /// The two sets are disjoint, so this asserts membership rather than a fixture literal and
+    /// therefore catches the swap on whatever platform the test host happens to be.
+    ///
+    /// Regression guarded: the top-level param was sent as `ch_platform()`, so every session
+    /// reported a `navigator.platform` no real browser emits. It was invisible under `spoofed`,
+    /// whose bootstrap re-patches the property from `platformJs`, but that bootstrap is empty
+    /// for `Off`/`Native` — so `native` profiles shipped the bad value straight through.
+    fn assert_platform_axes_not_swapped(sent: &serde_json::Value) {
+        const JS_SPELLINGS: [&str; 3] = ["Win32", "MacIntel", "Linux x86_64"];
+        const CH_SPELLINGS: [&str; 3] = ["Windows", "macOS", "Linux"];
+
+        let top = sent["params"]["platform"]
+            .as_str()
+            .expect("setUserAgentOverride.platform must be sent");
+        assert!(
+            JS_SPELLINGS.contains(&top),
+            "setUserAgentOverride.platform sets navigator.platform, so it must be one of \
+             {JS_SPELLINGS:?} (Platform::js_string). Got {top:?} — if that is one of \
+             {CH_SPELLINGS:?} then the two platform axes are swapped, and no real browser \
+             reports those for navigator.platform."
+        );
+
+        // The CH axis must still carry the CH spelling: a fix that swapped both would just
+        // trade one impossible value for another.
+        let ch = sent["params"]["userAgentMetadata"]["platform"]
+            .as_str()
+            .expect("userAgentMetadata.platform must be sent");
+        assert!(
+            CH_SPELLINGS.contains(&ch),
+            "userAgentMetadata.platform is the Client-Hints axis and must be one of \
+             {CH_SPELLINGS:?} (Platform::ch_platform). Got {ch:?}."
+        );
+    }
+
     #[tokio::test]
     async fn spoofed_observer_sends_expected_sequence_for_page_target() {
         let fp = Fingerprint {
@@ -340,6 +396,7 @@ mod tests {
                     !al.contains(";q="),
                     "acceptLanguage must be a bare locale list (no q-weights); got: {al}"
                 );
+                assert_platform_axes_not_swapped(mock.last_sent());
             }
             mock.reply(id, json!({})).await;
         }
@@ -410,6 +467,7 @@ mod tests {
                 accept_language = mock.last_sent()["params"]["acceptLanguage"]
                     .as_str()
                     .map(String::from);
+                assert_platform_axes_not_swapped(mock.last_sent());
             }
             if expected == "Emulation.setLocaleOverride" {
                 locale_override = mock.last_sent()["params"]["locale"]


### PR DESCRIPTION
## The bug

`Emulation.setUserAgentOverride` carries the platform on two distinct axes:

| CDP field | meaning | correct values |
|---|---|---|
| top-level `platform` | what `navigator.platform` returns | `Win32` / `MacIntel` / `Linux x86_64` |
| `userAgentMetadata.platform` | Client Hints | `Windows` / `macOS` / `Linux` |

`observer.rs` sent the top-level param as `Platform::ch_platform()` — the Client-Hints spelling — where CDP documents it as *"the platform `navigator.platform` should return"*. So every session reported a `navigator.platform` no real browser emits:

| platform | was sent | Chrome actually reports |
|---|---|---|
| `Win32` | `"Windows"` | `"Win32"` |
| `MacIntel` | `"macOS"` | `"MacIntel"` |
| `LinuxX86_64` | `"Linux"` | `"Linux x86_64"` |

That is not a subtle cross-field incoherence — it is an impossible literal, readable with a single property get.

## Why it went unnoticed

`Platform::js_string()` already existed for precisely this, documented as *"Map to the `navigator.platform` string Chrome reports for that OS"*. It was reachable only from the spoofed-profile JS bootstrap (`patches.rs` → `"platformJs"`), which re-patches `navigator.platform` and so happened to paper the bug over.

But `StealthObserver::with_persona` builds that bootstrap only for `ProfileKind::Spoofed`:

```rust
let bootstrap = if profile.kind() == ProfileKind::Spoofed { ... } else { String::new() };
```

so **`native` profiles had nothing restoring the value and shipped it straight through** — the mode chosen precisely to avoid detectable JS patching was the one leaking an impossible value.

## Measured, not inferred

An instrumented `native`-profile session on macOS reported `navigator.platform === "macOS"`, while the same Chrome for Testing 146 binary on the same host reports `"MacIntel"` when launched directly.

## The fix

One line: `ch_platform()` → `js_string()`. `userAgentMetadata.platform` is untouched and still derives `ch_platform()` in `Fingerprint::new`, which was always correct. For `spoofed` the observable result is unchanged (the bootstrap already forced the right value); it now agrees with the CDP layer instead of contradicting it.

## Test

`assert_platform_axes_not_swapped` asserts the two axes hold **disjoint value sets** rather than a fixture literal, so it catches the swap on whatever platform the test host runs — and it checks both directions, since a fix that swapped both axes would only trade one impossible value for another. Wired into both existing CDP-sequence tests.

Verified it actually catches the regression by restoring the old line:

```
setUserAgentOverride.platform sets navigator.platform, so it must be one of
["Win32", "MacIntel", "Linux x86_64"] (Platform::js_string). Got "macOS" — ...
```

298 tests pass, clippy clean, workspace builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
