### PR TITLE
fix(stealth): repair window geometry on the native profile

### DIFF
--- a/crates/zendriver-stealth/src/observer.rs
+++ b/crates/zendriver-stealth/src/observer.rs
@@ -11,7 +11,7 @@
 use serde_json::json;
 use zendriver_transport::{CallError, ObserverError, PausedSession, TargetObserver};
 
-use crate::patches::{bootstrap_script, bootstrap_script_native_webgl};
+use crate::patches::{bootstrap_script, bootstrap_script_native_webgl, geometry_bootstrap};
 use crate::persona::GeoPos;
 use crate::persona::specs::{ScreenSpec, UaMetadata};
 use crate::{Fingerprint, Persona, ProfileKind, StealthProfile};
@@ -66,14 +66,23 @@ impl StealthObserver {
         fingerprint: Fingerprint,
         persona: Persona,
     ) -> Self {
-        let bootstrap = if profile.kind() == ProfileKind::Spoofed {
-            if profile.native_webgl_enabled() {
-                bootstrap_script_native_webgl(&persona, &fingerprint)
-            } else {
-                bootstrap_script(&persona, &fingerprint)
+        let bootstrap = match profile.kind() {
+            ProfileKind::Spoofed => {
+                if profile.native_webgl_enabled() {
+                    bootstrap_script_native_webgl(&persona, &fingerprint)
+                } else {
+                    bootstrap_script(&persona, &fingerprint)
+                }
             }
-        } else {
-            String::new()
+            // `Native` gets the geometry repair and nothing else. It still receives
+            // `Emulation.setDeviceMetricsOverride` below, which sets `inner*` and
+            // `screen.width`/`height` but cannot reach `outer*`/`avail*` — leaving
+            // `outerWidth` at the OS default under a 1920 `innerWidth` (content wider than
+            // its own window) and `availHeight === height` (no taskbar inset). Those are
+            // artifacts this library introduces, not properties of the host, so repairing
+            // them keeps `Native` native rather than spoofing anything.
+            ProfileKind::Native => geometry_bootstrap(),
+            ProfileKind::Off => String::new(),
         };
         let geolocation = persona.geolocation;
         let ua_metadata = persona.ua.as_ref().and_then(|u| u.ua_metadata.clone());
@@ -245,12 +254,19 @@ impl TargetObserver for StealthObserver {
                 .await?;
         }
 
-        if self.profile.kind() == ProfileKind::Spoofed {
-            if self.profile.bypass_csp_enabled() {
-                session
-                    .call("Page.setBypassCSP", json!({ "enabled": true }))
-                    .await?;
-            }
+        // CSP bypass stays SPOOFED-only: it weakens the page's own security policy, which is
+        // only justified by the full identity bootstrap needing to run.
+        if self.profile.kind() == ProfileKind::Spoofed && self.profile.bypass_csp_enabled() {
+            session
+                .call("Page.setBypassCSP", json!({ "enabled": true }))
+                .await?;
+        }
+
+        // Injection is driven by whether there IS a bootstrap, not by the profile kind.
+        // `Native` now carries the geometry repair (and nothing else), and gating the send on
+        // `Spoofed` was a second, independent gate that would have left that repair assembled
+        // but never sent. `Off` still produces an empty bootstrap and so still sends nothing.
+        if !self.bootstrap.is_empty() {
             // Inject into the MAIN world (no `worldName`). The bootstrap's
             // patches mutate `Navigator.prototype`, `window.chrome`,
             // `WebGLRenderingContext.prototype`, etc. — every isolated
@@ -999,6 +1015,10 @@ mod tests {
             "Emulation.setDeviceMetricsOverride",
             "Emulation.setFocusEmulationEnabled",
             "Emulation.setGeolocationOverride",
+            // `Native` now also receives the geometry-coherence bootstrap. It repairs the
+            // `outer*`/`avail*` props that `setDeviceMetricsOverride` above cannot reach, and
+            // carries no identity spoofing — see `patches::geometry_bootstrap`.
+            "Page.addScriptToEvaluateOnNewDocument",
             "Runtime.runIfWaitingForDebugger",
         ] {
             let id =

--- a/crates/zendriver-stealth/src/patches.rs
+++ b/crates/zendriver-stealth/src/patches.rs
@@ -88,6 +88,38 @@ pub fn bootstrap_script_native_webgl(persona: &Persona, identity: &Fingerprint) 
     bootstrap_script_impl(persona, identity, false)
 }
 
+/// Geometry-coherence bootstrap for profiles that apply NO identity spoofing.
+///
+/// `Native` still receives `Emulation.setDeviceMetricsOverride` (see
+/// [`StealthObserver`](crate::StealthObserver)), and that command sets
+/// `window.inner*` and `screen.width`/`height` while being unable to touch
+/// `window.outer*` or `screen.avail*`. The result is a window a real browser cannot
+/// produce: `outerWidth` stays at the OS default (~756 headless) under an `innerWidth`
+/// of 1920, i.e. content wider than the window containing it, and
+/// `availHeight === height`, the kiosk signature. Both are cheap, deterministic,
+/// high-weight bot tells, and both are introduced BY THIS LIBRARY rather than by the
+/// host.
+///
+/// `patches/screen.js` exists to repair exactly that, but it only ever shipped inside
+/// the full identity bootstrap, which `Native` does not receive — so the mode that
+/// spoofs nothing was the one left visibly incoherent.
+///
+/// This emits the `__zdGetter` prelude plus the geometry patch and nothing else. It is
+/// identity-neutral by construction: it reads no persona and no fingerprint, and
+/// repairs an artifact rather than spoofing a device characteristic, so it does not
+/// make `Native` any less native.
+#[must_use]
+pub fn geometry_bootstrap() -> String {
+    let mut body = String::from(NATIVE);
+    body.push('\n');
+    body.push_str(SCREEN);
+    // Same single outer IIFE `bootstrap_script_impl` uses, and for the same two reasons:
+    // `_native.js` is written as a fragment that runs inside it, and `screen.js` reaches
+    // `__zdGetter` as a closure-local of that scope. Emitting the fragments bare leaves the
+    // helper out of scope and keeps nothing off `globalThis`.
+    format!("(function(){{\n{body}\n}})();")
+}
+
 /// Shared implementation for [`bootstrap_script`] /
 /// [`bootstrap_script_native_webgl`]. `spoof_webgl` gates the `push_webgl`
 /// call and, together with the persona's own WebGL strategy, the WebGPU
@@ -2092,5 +2124,38 @@ mod tests {
             s.contains("featuresServed") && s.contains("limitsServed"),
             "the plain-object/Set path must stay gated on the real classes being absent: {s}"
         );
+    }
+}
+
+#[cfg(test)]
+mod geometry_bootstrap_tests {
+    use super::*;
+
+    /// `Native` must ship the geometry repair. It receives
+    /// `Emulation.setDeviceMetricsOverride`, which cannot reach `outer*`/`avail*`, so without
+    /// this patch it reports `outerWidth` at the OS default under a 1920 `innerWidth` --
+    /// content wider than its own window, which no real browser can produce.
+    #[test]
+    fn geometry_bootstrap_carries_the_screen_patch_and_its_prelude() {
+        let js = geometry_bootstrap();
+        assert!(
+            js.contains("__zdGetter"),
+            "screen.js's only dependency must be present"
+        );
+        assert!(js.contains("outerWidth"), "must repair outerWidth");
+        assert!(js.contains("outerHeight"), "must repair outerHeight");
+        assert!(js.contains("availHeight"), "must repair the taskbar inset");
+    }
+
+    /// Identity-neutral by construction: pulling in an identity patch here would stop
+    /// `Native` being native, which is the whole reason callers choose it.
+    #[test]
+    fn geometry_bootstrap_carries_no_identity_patches() {
+        let js = geometry_bootstrap();
+        assert!(
+            !js.contains("navigator.webdriver"),
+            "must not spoof webdriver"
+        );
+        assert!(!js.contains("WEBGL_PROFILE"), "must not spoof WebGL");
     }
 }


### PR DESCRIPTION
## The problem

`ProfileKind::Native` receives `Emulation.setDeviceMetricsOverride`, which sets `inner*` and `screen.width`/`height` but cannot reach `outer*` or `avail*`. What the page ends up seeing is geometry no real browser can produce:

```
innerWidth 1920, outerWidth 756     // content wider than the window containing it
screenHeight 1080, availHeight 1080 // no taskbar inset, the headless/kiosk signature
```

`patches/screen.js` exists to repair precisely this, and its own header says it "runs unconditionally (no persona spec)". In practice it only ever shipped inside the `Spoofed` bootstrap, so `Native` got the damage without the repair. Both values are artifacts this library introduces. They are not properties of the host.

## The fix

`geometry_bootstrap()` composes the `_native.js` prelude plus `screen.js` in the same single outer IIFE that `bootstrap_script_impl` uses. The prelude is needed because `screen.js` reaches `__zdGetter` as a closure-local of that scope, and the wrapper is needed because both files are written as fragments of it. Emitting them bare leaves the helper out of scope.

Nothing else goes in, so `Native` stays native: no identity spoofing, no `Navigator.prototype` patching, nothing for a `Function.prototype.toString` probe to catch.

Injection is now gated on the bootstrap being non-empty instead of on `kind() == Spoofed`. There was a second, independent gate at the send site, so without that change the repair would be assembled and never sent. CSP bypass stays `Spoofed`-only, since it weakens the page's own security policy and only the full identity bootstrap justifies that. `Off` still produces an empty bootstrap and still sends nothing.

## Verification

Chrome launched through a caller's normal builder path, reading the **main** world. An isolated world has its own copy of every prototype and reports the pristine values either way, which is worth knowing if you go to reproduce this: `evaluate` shows no change and `evaluate_main` shows the fix.

| | outerWidth | outerHeight | innerHeight | availHeight | coherent |
|---|---|---|---|---|---|
| before | 756 | 556 | 1080 | 1080 | no |
| after | 1920 | 1080 | 994 | 1032 | yes |

`cargo clippy --workspace --all-targets --all-features` is clean and the suite passes, with two regression tests added for the new composition and the sequence test updated for the extra CDP call on `Native`. One pre-existing failure is unrelated: `spoofed_passes_areyouheadless` scrapes areyouheadless.com and the page's DOM has moved, so the selector returns null. It fails the same way on a clean `main`.

## Note, not addressed here

After the fix, `outerHeight` (1080) still exceeds `availHeight` (1032), so the window overlaps the taskbar area. That is existing `screen.js` behaviour and already applies to `Spoofed` today, so I left it alone rather than widening this PR.
