### PR TITLE
fix(stealth): derive screen geometry from the caller's metrics, not constants

### DIFF
--- a/crates/zendriver-stealth/src/patches/screen.js
+++ b/crates/zendriver-stealth/src/patches/screen.js
@@ -10,38 +10,52 @@
 // screen geometry in one pass; both are cheap, deterministic, high-weight bot
 // tells.
 //
-// Force one coherent desktop profile across EVERY geometry property (mirrors the
-// known-good xilriws-targetfp screen.js): outer >= inner, availHeight < height.
+// This patch REPAIRS those two gaps. It does not choose a resolution: the size
+// comes from whatever `setDeviceMetricsOverride` already established, so a caller
+// that configures 1366x768 gets a coherent 1366x768 and not a silent 1920x1080.
+// Earlier versions hardcoded 1920x1080 here, which overrode the caller's own
+// metrics — invisible while every caller happened to use 1920x1080, and wrong the
+// moment one did not.
 (function () {
-  const W = 1920;
-  const H = 1080;
+  // Read the size CDP already applied rather than asserting one. Falls back to the
+  // window's own inner size, then to a desktop default, so the patch still produces
+  // a coherent set if it somehow runs before the metrics override lands.
+  const W = window.screen.width || window.innerWidth || 1920;
+  const H = window.screen.height || window.innerHeight || 1080;
+
+  // Chrome inset (title + tabs + bookmarks + omnibox) and the OS taskbar/menu-bar
+  // inset. Both are shape constants, not resolution: they keep `inner < outer` and
+  // `availHeight < height` true at any size. They stay approximate on purpose —
+  // the tells are the RELATIONSHIPS, not the exact pixel counts.
+  const CHROME_H = 86;
+  const TASKBAR_H = 48;
+
   const set = (obj, prop, val) =>
     __zdGetter(obj, prop, () => val, { enumerable: true });
 
-  // screen.* — real monitor with a taskbar inset.
-  set(window.screen, 'width', W);
-  set(window.screen, 'height', H);
+  // screen.* — a real monitor has a work area smaller than the panel. width/height
+  // are deliberately NOT re-set: CDP owns them, and rewriting them here is what
+  // overrode the caller.
   set(window.screen, 'availWidth', W);
-  set(window.screen, 'availHeight', H - 48); // Windows taskbar
+  set(window.screen, 'availHeight', Math.max(1, H - TASKBAR_H));
   set(window.screen, 'availLeft', 0);
   set(window.screen, 'availTop', 0);
-  set(window.screen, 'colorDepth', 24);
-  set(window.screen, 'pixelDepth', 24);
 
-  // window.* — outer is the whole window; inner is smaller by the browser chrome
-  // (title + tabs + bookmarks + omnibox), so inner < outer always holds.
+  // window.* — outer is the whole window; inner is smaller by the browser chrome,
+  // so inner < outer always holds. outer is bounded by the screen so a window can
+  // never be reported larger than the display containing it.
   set(window, 'outerWidth', W);
   set(window, 'outerHeight', H);
   set(window, 'innerWidth', W);
-  set(window, 'innerHeight', H - 86);
+  set(window, 'innerHeight', Math.max(1, H - CHROME_H));
   set(window, 'screenX', 0);
   set(window, 'screenY', 0);
   set(window, 'screenLeft', 0);
   set(window, 'screenTop', 0);
-  set(window, 'devicePixelRatio', 1);
 
   if (window.screen.orientation) {
-    set(window.screen.orientation, 'type', 'landscape-primary');
+    const landscape = W >= H;
+    set(window.screen.orientation, 'type', landscape ? 'landscape-primary' : 'portrait-primary');
     set(window.screen.orientation, 'angle', 0);
   }
 })();

--- a/crates/zendriver/examples/screen_geometry.rs
+++ b/crates/zendriver/examples/screen_geometry.rs
@@ -1,0 +1,41 @@
+//! Does the geometry patch follow the CALLER's resolution, or assert its own?
+//!
+//! `cargo run -p zendriver --example screen_geometry -- 1366 768`
+use zendriver::{Browser, Persona, stealth::StealthProfile};
+use zendriver_stealth::ScreenSpec;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut a = std::env::args().skip(1);
+    let w: u32 = a.next().and_then(|v| v.parse().ok()).unwrap_or(1366);
+    let h: u32 = a.next().and_then(|v| v.parse().ok()).unwrap_or(768);
+
+    let browser = Browser::builder()
+        .headless(true)
+        .stealth(StealthProfile::native())
+        .persona_overlay(Persona {
+            screen: Some(ScreenSpec {
+                width: w,
+                height: h,
+                device_pixel_ratio: 1.0,
+            }),
+            ..Persona::default()
+        })
+        .launch()
+        .await?;
+    let tab = browser.new_tab().await?;
+    tab.goto("about:blank").await?;
+
+    let out: String = tab
+        .evaluate_main(
+            r#"(()=>{const s=screen,w=window;return JSON.stringify({
+                 screen:[s.width,s.height], avail:[s.availWidth,s.availHeight],
+                 outer:[w.outerWidth,w.outerHeight], inner:[w.innerWidth,w.innerHeight],
+                 coherent: w.outerWidth>=w.innerWidth && w.outerHeight>=w.innerHeight
+                           && s.availHeight<s.height && w.outerHeight<=s.height})})()"#,
+        )
+        .await?;
+    println!("requested {w}x{h}\n{out}");
+    browser.close().await.ok();
+    Ok(())
+}


### PR DESCRIPTION
## The problem

`patches/screen.js` hardcoded `W = 1920; H = 1080` and wrote them over `screen.width`,
`screen.height`, `devicePixelRatio` and `colorDepth` — properties that
`Emulation.setDeviceMetricsOverride` had **already set from the caller's own persona**
(`observer.rs`: *"Persona screen wins when supplied"*).

So a caller asking for 1366x768 got 1920x1080, silently:

```
BEFORE   requested 1366x768  ->  screen [1920,1080]  outer [1920,1080]  inner [1920,994]
AFTER    requested 1366x768  ->  screen [1366,768]   outer [1366,768]   inner [1366,682]
AFTER    requested 1920x1080 ->  screen [1920,1080]  outer [1920,1080]  inner [1920,994]
```

The patch was invisible while every caller happened to use 1920x1080, and wrong the moment one
did not. It also silently defeated `persona_overlay`'s screen for anyone using a persona library
with mixed resolutions.

## The fix

Derive the size from what CDP already established instead of asserting one:

```js
const W = window.screen.width || window.innerWidth || 1920;
const H = window.screen.height || window.innerHeight || 1080;
```

and stop re-setting the properties CDP owns. The patch now repairs only what the CDP command
genuinely cannot reach, which was always its stated purpose: `window.outer*` and `screen.avail*`.

The two remaining constants are the browser-chrome inset (86) and the taskbar inset (48). Those
are shape, not resolution: they keep `inner < outer` and `availHeight < height` true at any size.
They stay approximate on purpose, because the detectable tells are the relationships, not exact
pixel counts. `Math.max(1, ...)` keeps them sane on very small viewports, and orientation is now
derived rather than pinned to landscape.

## Verification

`cargo run -p zendriver --example screen_geometry -- <w> <h>` (added here) launches real Chrome,
reads the page back through `evaluate_main`, and asserts the four invariants: `outer >= inner`,
`availHeight < height`, `outerHeight <= screen.height`. The numbers above are its output, with the
before-row produced by stashing only this file.

`cargo test --workspace` passes, clippy is clean, fmt is clean.

## Why it mattered to us

We shipped #141, which extended this patch from `Spoofed` to `Native`. That was the right fix for
the incoherent geometry, but it also took a latent `Spoofed`-path assumption and applied it to
every session on the `native()` profile. Downstream, a persona library with mostly-1366x768 entries
had been presenting 1920x1080 on most launches without anyone noticing.
