### PR TITLE
fix: correctness sweep from the opinionated-defaults audit

### DIFF
--- a/crates/zendriver-cloudflare/src/bypass.rs
+++ b/crates/zendriver-cloudflare/src/bypass.rs
@@ -5,7 +5,7 @@
 //! single CDP poll loop that, per tick:
 //!
 //! 1. Re-evaluates a unified shadow-DOM walker in the page's main world
-//!    (private [`POLL_JS`]) returning, in one round-trip:
+//!    (private `POLL_JS`) returning, in one round-trip:
 //!    - the `cf-turnstile-response` (or legacy `cf_challenge_response`) token
 //!      if present,
 //!    - the Turnstile challenge iframe's bounding box if mounted,
@@ -15,13 +15,18 @@
 //!    non-empty token is observed — including the **invisible Turnstile**
 //!    path where the iframe never mounts and the token is populated
 //!    directly.
-//! 3. If the interactive checkbox iframe is mounted *and we have not yet
-//!    clicked*, dispatches a single raw left-click at the canonical
+//! 3. If a *clickable* challenge iframe is mounted (non-zero size and
+//!    visible), scrolls it into view, re-reads its box, and dispatches a raw
+//!    left-click at the canonical
 //!    `bbox.x + bbox.width * 0.15, bbox.y + bbox.height * 0.50` offset
 //!    (15% from left, 50% from top — Python's `cloudflare.py` convention).
-//! 4. If we previously observed an iframe + clicked, and the iframe is now
-//!    gone without a token, resolves to [`ClearanceOutcome::ChallengeGone`]
-//!    (clearance-cookie shortcut).
+//!    Up to `MAX_CLICK_ATTEMPTS` clicks are spent, spaced
+//!    `CLICK_RETRY_TICKS` ticks apart, so a swallowed first click is not
+//!    the end of the run.
+//! 4. Resolves to [`ClearanceOutcome::ChallengeGone`] when the challenge
+//!    disappears without yielding a token — either the iframe we clicked is
+//!    gone, or every challenge marker observed on an earlier tick has
+//!    vanished (the JS-only interstitial that clears itself).
 //! 5. Resolves to [`ClearanceOutcome::TimedOut`] on deadline, carrying
 //!    `saw_challenge` — `true` when challenge markers were seen but never
 //!    resolved, `false` when the entire timeout window elapsed without
@@ -44,7 +49,9 @@ use crate::error::CloudflareError;
 pub enum ClearanceOutcome {
     /// Turnstile produced a token (value of `cf-turnstile-response`).
     TokenAcquired(String),
-    /// The challenge container disappeared without yielding a token.
+    /// The challenge disappeared without yielding a token — the iframe we
+    /// clicked was torn down, or all challenge markers seen earlier in the
+    /// run have vanished (a JS-only interstitial that cleared itself).
     ChallengeGone,
     /// Deadline elapsed without a terminal clearance state. `saw_challenge`
     /// is `true` if any challenge marker (container, hidden input, or live
@@ -57,6 +64,15 @@ pub enum ClearanceOutcome {
 
 /// Default poll interval for `wait_for_clearance`.
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// How many clicks a single `wait_for_clearance` run may spend on the
+/// interactive widget. Cloudflare drops clicks that land while the widget is
+/// still booting, so one latched attempt strands the run until the deadline.
+const MAX_CLICK_ATTEMPTS: u32 = 3;
+
+/// Poll ticks to wait after a click before spending another attempt. At the
+/// default 500ms interval this leaves the widget ~2s to answer a click.
+const CLICK_RETRY_TICKS: u32 = 4;
 
 /// Drives a Cloudflare Turnstile clearance flow against a single tab's session.
 ///
@@ -98,10 +114,10 @@ impl<'a> CloudflareBypass<'a> {
     ///   `cf-turnstile-response` input picked up a non-empty value, either
     ///   after we clicked the interactive iframe or because the page uses
     ///   invisible Turnstile.
-    /// - `Ok(ClearanceOutcome::ChallengeGone)` — the interactive iframe was
-    ///   present, we clicked it, and the challenge container then
-    ///   disappeared without yielding a token (e.g. a clearance cookie
-    ///   shortcut).
+    /// - `Ok(ClearanceOutcome::ChallengeGone)` — the challenge went away
+    ///   without yielding a token (e.g. a clearance-cookie shortcut): either
+    ///   an iframe we clicked was torn down, or challenge markers observed on
+    ///   an earlier tick are all gone.
     /// - `Ok(ClearanceOutcome::TimedOut { saw_challenge })` — `timeout`
     ///   elapsed without a terminal clearance state. `saw_challenge` is
     ///   `true` if challenge markers were observed (markers present but
@@ -130,7 +146,8 @@ impl<'a> CloudflareBypass<'a> {
         timeout: Duration,
     ) -> Result<ClearanceOutcome, CloudflareError> {
         let deadline = Instant::now() + timeout;
-        let mut clicked = false;
+        let mut clicks: u32 = 0;
+        let mut ticks_since_click: u32 = 0;
         let mut ever_seen_markers = false;
 
         let mut stall_ticks: u32 = 0;
@@ -138,6 +155,10 @@ impl<'a> CloudflareBypass<'a> {
 
         loop {
             let state = poll_state(self.session).await?;
+            // Snapshot the latch *before* folding in this tick: the
+            // markers-vanished terminal below needs "seen on an earlier
+            // tick", not "seen including right now".
+            let seen_markers_before = ever_seen_markers;
             if state.has_markers {
                 ever_seen_markers = true;
             }
@@ -146,17 +167,27 @@ impl<'a> CloudflareBypass<'a> {
                 return Ok(ClearanceOutcome::TokenAcquired(token));
             }
 
+            let may_click = clicks < MAX_CLICK_ATTEMPTS
+                && (clicks == 0 || ticks_since_click >= CLICK_RETRY_TICKS);
+
             match state.bbox {
-                Some(bbox) if !clicked => {
-                    let click_x = bbox.x + bbox.width * 0.15;
-                    let click_y = bbox.y + bbox.height * 0.50;
-                    click_at(self.session, click_x, click_y).await?;
-                    clicked = true;
+                Some(_) if may_click => {
+                    // Raw `Input.dispatchMouseEvent` coordinates are viewport
+                    // relative, so a below-the-fold widget must be scrolled in
+                    // and re-measured before the click can land on it.
+                    if let Some(target) = scroll_into_view(self.session).await? {
+                        let click_x = target.x + target.width * 0.15;
+                        let click_y = target.y + target.height * 0.50;
+                        click_at(self.session, click_x, click_y).await?;
+                        clicks += 1;
+                        ticks_since_click = 0;
+                    }
                 }
-                None if clicked => {
-                    // Iframe was present, we clicked, and now the challenge
-                    // container has been torn down without a token — the
-                    // clearance-cookie shortcut.
+                // The challenge went away without a token: either the iframe
+                // we clicked was torn down, or markers seen on an earlier tick
+                // are all gone (a JS-only interstitial clearing itself). Both
+                // are the clearance-cookie shortcut.
+                None if clicks > 0 || (seen_markers_before && !state.has_markers) => {
                     return Ok(ClearanceOutcome::ChallengeGone);
                 }
                 _ => {
@@ -170,6 +201,8 @@ impl<'a> CloudflareBypass<'a> {
                     }
                 }
             }
+
+            ticks_since_click = ticks_since_click.saturating_add(1);
 
             if Instant::now() >= deadline {
                 return Ok(ClearanceOutcome::TimedOut {
@@ -194,8 +227,10 @@ struct PollState {
     /// any.
     #[serde(default)]
     token: Option<String>,
-    /// Bounding box of the Turnstile challenge iframe, if mounted. Walks
-    /// shadow roots so closed shadow trees still surface the iframe.
+    /// Bounding box of the Turnstile challenge iframe when it is a valid
+    /// click target — mounted, non-zero size, and visible. Walks shadow roots
+    /// so shadow-hosted widgets still surface. `None` for a hidden or 0×0
+    /// iframe, which must never be clicked.
     #[serde(default)]
     bbox: Option<BoundingBox>,
     /// `true` when the page has any of: a `.cf-turnstile` / `.turnstile`
@@ -206,56 +241,96 @@ struct PollState {
     has_markers: bool,
 }
 
-/// Unified in-page evaluator. Returns:
-/// - `token` — non-empty `cf-turnstile-response` (or legacy
-///   `cf_challenge_response`) input value, else null.
-/// - `bbox` — the Turnstile challenge iframe's bounding box (shadow-DOM
-///   aware walk), else null.
-/// - `hasMarkers` — true when *any* Cloudflare challenge marker is present
-///   (container, hidden input, or live iframe).
+/// Shared in-page prelude for the two evaluators below. Declares:
 ///
-/// The shadow-DOM walk is necessary because Cloudflare sometimes hosts the
-/// challenge iframe inside an open shadow root attached to a host element on
-/// the page. The token input itself is in light DOM by design (page JS reads
-/// it to submit forms), so `document.querySelector` is sufficient there.
-const POLL_JS: &str = r#"
-(function () {
-    function findBbox(root) {
-        var iframes = root.querySelectorAll ? root.querySelectorAll("iframe") : [];
-        for (var i = 0; i < iframes.length; i++) {
-            var f = iframes[i];
-            if (f.src && f.src.includes("challenges.cloudflare.com")) {
-                var r = f.getBoundingClientRect();
-                return { x: r.left, y: r.top, width: r.width, height: r.height };
-            }
+/// - `findChallengeIframe(root)` — the first `challenges.cloudflare.com`
+///   iframe reachable from `root`, descending into open shadow roots
+///   (Cloudflare sometimes hosts the widget inside a shadow root), else null.
+/// - `clickableRect(el)` — `el`'s viewport rect *only if it is a real click
+///   target*: non-zero size and not hidden by `visibility` / `display` /
+///   `opacity`. A zero-size or hidden iframe is not a target — invisible
+///   Turnstile mounts a 0×0 iframe whose token is populated with no click,
+///   and clicking it would dispatch mouse events at a meaningless point.
+const WALKER_JS: &str = r#"
+function findChallengeIframe(root) {
+    var iframes = root.querySelectorAll ? root.querySelectorAll("iframe") : [];
+    for (var i = 0; i < iframes.length; i++) {
+        var f = iframes[i];
+        if (f.src && f.src.includes("challenges.cloudflare.com")) return f;
+    }
+    var all = root.querySelectorAll ? root.querySelectorAll("*") : [];
+    for (var j = 0; j < all.length; j++) {
+        if (all[j].shadowRoot) {
+            var sub = findChallengeIframe(all[j].shadowRoot);
+            if (sub) return sub;
         }
-        var all = root.querySelectorAll ? root.querySelectorAll("*") : [];
-        for (var j = 0; j < all.length; j++) {
-            if (all[j].shadowRoot) {
-                var sub = findBbox(all[j].shadowRoot);
-                if (sub) return sub;
-            }
-        }
+    }
+    return null;
+}
+function clickableRect(el) {
+    if (!el) return null;
+    var r = el.getBoundingClientRect();
+    if (!(r.width > 0 && r.height > 0)) return null;
+    var view = el.ownerDocument && el.ownerDocument.defaultView;
+    var style = view && view.getComputedStyle ? view.getComputedStyle(el) : null;
+    if (style && (style.visibility === "hidden" || style.display === "none" || style.opacity === "0")) {
         return null;
     }
-    var bbox = findBbox(document);
+    return { x: r.left, y: r.top, width: r.width, height: r.height };
+}
+"#;
+
+/// Unified poll evaluator (appended to [`WALKER_JS`]). Returns:
+/// - `token` — non-empty `cf-turnstile-response` (or legacy
+///   `cf_challenge_response`) input value, else null.
+/// - `bbox` — the challenge iframe's rect when it is a valid click target,
+///   else null.
+/// - `hasMarkers` — true when *any* Cloudflare challenge marker is present
+///   (container, hidden input, or challenge iframe — visible or not).
+///
+/// The token input is in light DOM by design (page JS reads it to submit
+/// forms), so `document.querySelector` is sufficient there.
+const POLL_JS: &str = r#"
+(function () {
+    var iframe = findChallengeIframe(document);
+    var bbox = clickableRect(iframe);
     var input =
         document.querySelector('[name="cf-turnstile-response"]') ||
         document.querySelector('[name="cf_challenge_response"]');
     var token = (input && input.value) ? input.value : null;
     var hasContainer = !!document.querySelector('.cf-turnstile, .turnstile, [data-sitekey]');
-    var hasMarkers = hasContainer || !!input || !!bbox;
+    var hasMarkers = hasContainer || !!input || !!iframe;
     return { token: token, bbox: bbox, hasMarkers: hasMarkers };
 })()
 "#;
 
-/// Run [`POLL_JS`] against `session`'s main world and decode the result.
-async fn poll_state(session: &SessionHandle) -> Result<PollState, CloudflareError> {
+/// Scroll-into-view evaluator (appended to [`WALKER_JS`]). Brings the
+/// challenge iframe fully into the viewport when it isn't already, then
+/// returns its *post-scroll* rect — or null if the widget vanished or is not
+/// a valid click target.
+const SCROLL_JS: &str = r#"
+(function () {
+    var iframe = findChallengeIframe(document);
+    if (!iframe) return null;
+    var r = iframe.getBoundingClientRect();
+    var vw = window.innerWidth || document.documentElement.clientWidth;
+    var vh = window.innerHeight || document.documentElement.clientHeight;
+    var fullyVisible = r.top >= 0 && r.left >= 0 && r.bottom <= vh && r.right <= vw;
+    if (!fullyVisible && iframe.scrollIntoView) {
+        iframe.scrollIntoView({ block: "center", inline: "center" });
+    }
+    return clickableRect(iframe);
+})()
+"#;
+
+/// Evaluate `WALKER_JS` + `body` in `session`'s main world and return the
+/// result value (`Value::Null` when the script produced nothing).
+async fn eval_main_world(session: &SessionHandle, body: &str) -> Result<Value, CloudflareError> {
     let res = session
         .call(
             "Runtime.evaluate",
             json!({
-                "expression": POLL_JS,
+                "expression": format!("{WALKER_JS}{body}"),
                 "returnByValue": true,
                 "awaitPromise": true,
             }),
@@ -272,14 +347,31 @@ async fn poll_state(session: &SessionHandle) -> Result<PollState, CloudflareErro
         return Err(CloudflareError::JsError(msg));
     }
 
-    let value = res
+    Ok(res
         .get("result")
         .and_then(|r| r.get("value"))
         .cloned()
-        .unwrap_or(Value::Null);
+        .unwrap_or(Value::Null))
+}
 
+/// Run [`POLL_JS`] against `session`'s main world and decode the result.
+async fn poll_state(session: &SessionHandle) -> Result<PollState, CloudflareError> {
+    let value = eval_main_world(session, POLL_JS).await?;
     serde_json::from_value(value)
         .map_err(|e| CloudflareError::JsError(format!("invalid poll payload: {e}")))
+}
+
+/// Run [`SCROLL_JS`] against `session`'s main world: scroll the challenge
+/// iframe into view if needed and return the rect to click, or `None` when
+/// the widget is gone or not clickable.
+async fn scroll_into_view(session: &SessionHandle) -> Result<Option<BoundingBox>, CloudflareError> {
+    let value = eval_main_world(session, SCROLL_JS).await?;
+    if value.is_null() {
+        return Ok(None);
+    }
+    serde_json::from_value(value)
+        .map(Some)
+        .map_err(|e| CloudflareError::JsError(format!("invalid scroll payload: {e}")))
 }
 
 #[cfg(test)]
@@ -288,23 +380,92 @@ mod tests {
     use super::*;
     use zendriver_transport::testing::MockConnection;
 
-    /// Interactive happy path: poll #1 yields a bbox → click_at fires the
-    /// three mouse events at (15% × width, 50% × height) inside the bbox →
-    /// poll #2 observes the token → TokenAcquired.
+    /// Wrap an evaluator result value in the CDP `Runtime.evaluate` envelope.
+    fn eval_reply(value: Value) -> Value {
+        json!({ "result": { "type": "object", "value": value } })
+    }
+
+    /// One poll-evaluator payload.
+    fn poll_value(token: Option<&str>, bbox: Option<Value>, has_markers: bool) -> Value {
+        json!({
+            "token": token,
+            "bbox": bbox,
+            "hasMarkers": has_markers,
+        })
+    }
+
+    /// A rect payload, as either evaluator returns it.
+    fn rect(x: f64, y: f64, w: f64, h: f64) -> Value {
+        json!({ "x": x, "y": y, "width": w, "height": h })
+    }
+
+    /// Answer the next `Runtime.evaluate`, dispatching on which evaluator it
+    /// carries: the scroll helper gets `scroll`, the poll evaluator gets
+    /// `poll`. Returns `true` when the answered call was the scroll helper.
+    async fn answer_eval(mock: &mut MockConnection, poll: &Value, scroll: &Value) -> bool {
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        let expr = mock.last_sent()["params"]["expression"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let is_scroll = expr.contains("scrollIntoView");
+        let value = if is_scroll {
+            scroll.clone()
+        } else {
+            poll.clone()
+        };
+        mock.reply(id, eval_reply(value)).await;
+        is_scroll
+    }
+
+    /// Answer the three `Input.dispatchMouseEvent` calls of one click and
+    /// return the `(x, y)` they landed on.
+    async fn answer_click(mock: &mut MockConnection) -> (f64, f64) {
+        let mut coords = (f64::NAN, f64::NAN);
+        for expected in ["mouseMoved", "mousePressed", "mouseReleased"] {
+            let id = mock.expect_cmd("Input.dispatchMouseEvent").await;
+            let sent = mock.last_sent().clone();
+            assert_eq!(sent["params"]["type"], expected);
+            coords = (
+                sent["params"]["x"].as_f64().unwrap(),
+                sent["params"]["y"].as_f64().unwrap(),
+            );
+            mock.reply(id, json!({})).await;
+        }
+        coords
+    }
+
+    /// Generic "next outbound command" read, bounded so a finished driver
+    /// ends the drain loop instead of hanging the test.
+    async fn next_cmd(mock: &mut MockConnection) -> Option<(String, u64)> {
+        for _ in 0..300 {
+            if let Some(cmd) = mock.try_recv_cmd() {
+                return Some(cmd);
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        None
+    }
+
+    /// Interactive happy path: poll #1 yields a bbox → the widget is scrolled
+    /// into view → click_at fires the three mouse events at (15% × width,
+    /// 50% × height) of the **post-scroll** rect → poll #2 observes the token
+    /// → TokenAcquired.
     #[tokio::test]
-    async fn wait_for_clearance_clicks_at_bbox_offset_then_returns_token() {
+    async fn wait_for_clearance_scrolls_into_view_then_clicks_at_bbox_offset() {
         let (mut mock, conn) = MockConnection::pair();
         let sess = SessionHandle::new(conn.clone(), "S1");
 
-        // bbox at (100, 200) with 60×40 → click at
+        // Widget starts 2000px below the fold; after scrolling it sits at
+        // (100, 300) with 60×40 → click at
         //   x = 100 + 60 * 0.15 = 109
-        //   y = 200 + 40 * 0.50 = 220
-        const BBOX_X: f64 = 100.0;
-        const BBOX_Y: f64 = 200.0;
+        //   y = 300 + 40 * 0.50 = 320
+        const SCROLLED_X: f64 = 100.0;
+        const SCROLLED_Y: f64 = 300.0;
         const BBOX_W: f64 = 60.0;
         const BBOX_H: f64 = 40.0;
-        const EXPECTED_CLICK_X: f64 = BBOX_X + BBOX_W * 0.15;
-        const EXPECTED_CLICK_Y: f64 = BBOX_Y + BBOX_H * 0.50;
+        const EXPECTED_CLICK_X: f64 = SCROLLED_X + BBOX_W * 0.15;
+        const EXPECTED_CLICK_Y: f64 = SCROLLED_Y + BBOX_H * 0.50;
 
         let fut = tokio::spawn({
             let s = sess.clone();
@@ -314,80 +475,59 @@ mod tests {
             }
         });
 
-        // Poll #1: unified evaluator returns bbox, no token, markers present.
+        // Poll #1: unified evaluator returns an off-screen bbox, no token.
         let id_poll1 = mock.expect_cmd("Runtime.evaluate").await;
+        let expr = mock.last_sent()["params"]["expression"]
+            .as_str()
+            .unwrap()
+            .to_string();
         assert!(
-            mock.last_sent()["params"]["expression"]
-                .as_str()
-                .unwrap()
-                .contains("challenges.cloudflare.com"),
-            "poll eval should walk for challenges.cloudflare.com iframe"
+            expr.contains("challenges.cloudflare.com"),
+            "poll eval should walk for the challenges.cloudflare.com iframe"
         );
         assert!(
-            mock.last_sent()["params"]["expression"]
-                .as_str()
-                .unwrap()
-                .contains("cf-turnstile-response"),
+            expr.contains("cf-turnstile-response"),
             "poll eval should look at the cf-turnstile-response input"
         );
         mock.reply(
             id_poll1,
-            json!({
-                "result": {
-                    "type": "object",
-                    "value": {
-                        "token": null,
-                        "bbox": { "x": BBOX_X, "y": BBOX_Y, "width": BBOX_W, "height": BBOX_H },
-                        "hasMarkers": true,
-                    }
-                }
-            }),
+            eval_reply(poll_value(
+                None,
+                Some(rect(SCROLLED_X, 2000.0, BBOX_W, BBOX_H)),
+                true,
+            )),
         )
         .await;
 
-        // click_at → mouseMoved → mousePressed → mouseReleased.
-        let id_move = mock.expect_cmd("Input.dispatchMouseEvent").await;
-        let sent = mock.last_sent();
-        assert_eq!(sent["params"]["type"], "mouseMoved");
-        assert_eq!(sent["params"]["x"], EXPECTED_CLICK_X);
-        assert_eq!(sent["params"]["y"], EXPECTED_CLICK_Y);
-        mock.reply(id_move, json!({})).await;
+        // Scroll helper runs before the click and re-measures the widget.
+        let id_scroll = mock.expect_cmd("Runtime.evaluate").await;
+        assert!(
+            mock.last_sent()["params"]["expression"]
+                .as_str()
+                .unwrap()
+                .contains("scrollIntoView"),
+            "a click must be preceded by a scroll-into-view + re-measure"
+        );
+        mock.reply(
+            id_scroll,
+            eval_reply(rect(SCROLLED_X, SCROLLED_Y, BBOX_W, BBOX_H)),
+        )
+        .await;
 
-        let id_press = mock.expect_cmd("Input.dispatchMouseEvent").await;
-        let sent = mock.last_sent();
-        assert_eq!(sent["params"]["type"], "mousePressed");
-        assert_eq!(sent["params"]["button"], "left");
-        assert_eq!(sent["params"]["clickCount"], 1);
-        assert_eq!(sent["params"]["x"], EXPECTED_CLICK_X);
-        assert_eq!(sent["params"]["y"], EXPECTED_CLICK_Y);
-        mock.reply(id_press, json!({})).await;
-
-        let id_rel = mock.expect_cmd("Input.dispatchMouseEvent").await;
-        let sent = mock.last_sent();
-        assert_eq!(sent["params"]["type"], "mouseReleased");
-        assert_eq!(sent["params"]["button"], "left");
-        assert_eq!(sent["params"]["clickCount"], 1);
-        mock.reply(id_rel, json!({})).await;
+        // The click uses the post-scroll rect, not the stale off-screen one.
+        let (x, y) = answer_click(&mut mock).await;
+        assert_eq!(x, EXPECTED_CLICK_X);
+        assert_eq!(y, EXPECTED_CLICK_Y);
 
         // Poll #2: token appears → TokenAcquired terminates the loop.
         let id_poll2 = mock.expect_cmd("Runtime.evaluate").await;
         mock.reply(
             id_poll2,
-            json!({
-                "result": {
-                    "type": "object",
-                    "value": {
-                        "token": "TOKEN_XYZ",
-                        "bbox": null,
-                        "hasMarkers": true,
-                    }
-                }
-            }),
+            eval_reply(poll_value(Some("TOKEN_XYZ"), None, true)),
         )
         .await;
 
-        let outcome = fut.await.unwrap().unwrap();
-        match outcome {
+        match fut.await.unwrap().unwrap() {
             ClearanceOutcome::TokenAcquired(t) => assert_eq!(t, "TOKEN_XYZ"),
             other => panic!("expected TokenAcquired, got {other:?}"),
         }
@@ -413,21 +553,11 @@ mod tests {
         let id_poll = mock.expect_cmd("Runtime.evaluate").await;
         mock.reply(
             id_poll,
-            json!({
-                "result": {
-                    "type": "object",
-                    "value": {
-                        "token": "INVISIBLE_TOKEN",
-                        "bbox": null,
-                        "hasMarkers": true,
-                    }
-                }
-            }),
+            eval_reply(poll_value(Some("INVISIBLE_TOKEN"), None, true)),
         )
         .await;
 
-        let outcome = fut.await.unwrap().unwrap();
-        match outcome {
+        match fut.await.unwrap().unwrap() {
             ClearanceOutcome::TokenAcquired(t) => assert_eq!(t, "INVISIBLE_TOKEN"),
             other => panic!("expected TokenAcquired, got {other:?}"),
         }
@@ -437,8 +567,114 @@ mod tests {
         conn.shutdown();
     }
 
-    /// ChallengeGone path: poll #1 yields a bbox → click → poll #2 reports
-    /// no bbox and no token → ChallengeGone.
+    /// Markers are present but no clickable widget is mounted yet (invisible
+    /// Turnstile still computing): the loop must keep waiting for the token,
+    /// NOT read "markers seen" as "challenge gone".
+    #[tokio::test]
+    async fn wait_for_clearance_keeps_waiting_while_markers_are_still_present() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                let b = CloudflareBypass::new(&s).poll_interval(Duration::from_millis(1));
+                b.wait_for_clearance(Duration::from_secs(5)).await
+            }
+        });
+
+        // Two ticks with markers but no bbox and no token.
+        for _ in 0..2 {
+            let id = mock.expect_cmd("Runtime.evaluate").await;
+            mock.reply(id, eval_reply(poll_value(None, None, true)))
+                .await;
+        }
+
+        // Third tick: the token finally lands.
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id, eval_reply(poll_value(Some("LATE_TOKEN"), None, true)))
+            .await;
+
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::TokenAcquired(t) => assert_eq!(t, "LATE_TOKEN"),
+            other => panic!("expected TokenAcquired, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    /// JS-only interstitial that clears itself: challenge markers are seen on
+    /// tick #1, no iframe is ever clickable, and on tick #2 every marker is
+    /// gone → ChallengeGone. This terminal used to be unreachable without a
+    /// click, so this flow returned TimedOut instead of success.
+    #[tokio::test]
+    async fn wait_for_clearance_returns_challenge_gone_when_markers_vanish_without_click() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                let b = CloudflareBypass::new(&s).poll_interval(Duration::from_millis(1));
+                b.wait_for_clearance(Duration::from_secs(5)).await
+            }
+        });
+
+        // Tick #1: interstitial markers, no clickable widget.
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id1, eval_reply(poll_value(None, None, true)))
+            .await;
+
+        // Tick #2: the interstitial cleared itself — every marker is gone.
+        let id2 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id2, eval_reply(poll_value(None, None, false)))
+            .await;
+
+        let outcome = fut.await.unwrap().unwrap();
+        assert!(
+            matches!(outcome, ClearanceOutcome::ChallengeGone),
+            "expected ChallengeGone, got {outcome:?}"
+        );
+        conn.shutdown();
+    }
+
+    /// A page with no Cloudflare gate at all must never be reported as
+    /// ChallengeGone: with no markers ever observed, the run ends in
+    /// `TimedOut { saw_challenge: false }`.
+    #[tokio::test]
+    async fn wait_for_clearance_times_out_when_no_markers_ever_seen() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                let b = CloudflareBypass::new(&s).poll_interval(Duration::from_millis(1));
+                b.wait_for_clearance(Duration::from_millis(40)).await
+            }
+        });
+
+        for _ in 0..50 {
+            let Ok(id) = tokio::time::timeout(
+                Duration::from_millis(80),
+                mock.expect_cmd("Runtime.evaluate"),
+            )
+            .await
+            else {
+                break;
+            };
+            mock.reply(id, eval_reply(poll_value(None, None, false)))
+                .await;
+        }
+
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::TimedOut { saw_challenge } => assert!(!saw_challenge),
+            other => panic!("expected TimedOut, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    /// ChallengeGone path: poll #1 yields a bbox → scroll + click → poll #2
+    /// reports no bbox and no token → ChallengeGone.
     #[tokio::test]
     async fn wait_for_clearance_returns_challenge_gone_when_iframe_disappears_after_click() {
         let (mut mock, conn) = MockConnection::pair();
@@ -452,48 +688,82 @@ mod tests {
             }
         });
 
-        // Poll #1: bbox present.
-        let id_poll1 = mock.expect_cmd("Runtime.evaluate").await;
-        mock.reply(
-            id_poll1,
-            json!({
-                "result": {
-                    "type": "object",
-                    "value": {
-                        "token": null,
-                        "bbox": { "x": 10.0, "y": 20.0, "width": 40.0, "height": 40.0 },
-                        "hasMarkers": true,
-                    }
-                }
-            }),
+        // Poll #1: bbox present. Then the scroll helper re-measures it.
+        let widget = rect(10.0, 20.0, 40.0, 40.0);
+        let is_scroll = answer_eval(
+            &mut mock,
+            &poll_value(None, Some(widget.clone()), true),
+            &widget,
         )
         .await;
+        assert!(!is_scroll, "first evaluate is the poll evaluator");
+        let is_scroll = answer_eval(&mut mock, &poll_value(None, None, true), &widget).await;
+        assert!(is_scroll, "second evaluate is the scroll helper");
 
-        // click sequence.
-        for _ in 0..3 {
-            let id = mock.expect_cmd("Input.dispatchMouseEvent").await;
-            mock.reply(id, json!({})).await;
-        }
+        answer_click(&mut mock).await;
 
-        // Poll #2: iframe gone, no token.
+        // Poll #2: iframe gone, no token — markers linger in the DOM.
         let id_poll2 = mock.expect_cmd("Runtime.evaluate").await;
-        mock.reply(
-            id_poll2,
-            json!({
-                "result": {
-                    "type": "object",
-                    "value": {
-                        "token": null,
-                        "bbox": null,
-                        "hasMarkers": true,
-                    }
-                }
-            }),
-        )
-        .await;
+        mock.reply(id_poll2, eval_reply(poll_value(None, None, true)))
+            .await;
 
         let outcome = fut.await.unwrap().unwrap();
         assert!(matches!(outcome, ClearanceOutcome::ChallengeGone));
+        conn.shutdown();
+    }
+
+    /// A widget that stays mounted and unanswered gets clicked again after
+    /// [`CLICK_RETRY_TICKS`] ticks — but never more than
+    /// [`MAX_CLICK_ATTEMPTS`] times in one run.
+    #[tokio::test]
+    async fn wait_for_clearance_retries_click_up_to_max_attempts() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                let b = CloudflareBypass::new(&s).poll_interval(Duration::from_millis(1));
+                b.wait_for_clearance(Duration::from_millis(200)).await
+            }
+        });
+
+        let widget = rect(10.0, 20.0, 40.0, 40.0);
+        let poll = poll_value(None, Some(widget.clone()), true);
+
+        let mut clicks: u32 = 0;
+        while let Some((method, id)) = next_cmd(&mut mock).await {
+            match method.as_str() {
+                "Runtime.evaluate" => {
+                    let is_scroll = mock.last_sent()["params"]["expression"]
+                        .as_str()
+                        .unwrap()
+                        .contains("scrollIntoView");
+                    let value = if is_scroll {
+                        widget.clone()
+                    } else {
+                        poll.clone()
+                    };
+                    mock.reply(id, eval_reply(value)).await;
+                }
+                "Input.dispatchMouseEvent" => {
+                    if mock.last_sent()["params"]["type"] == "mousePressed" {
+                        clicks += 1;
+                    }
+                    mock.reply(id, json!({})).await;
+                }
+                other => panic!("unexpected CDP method {other}"),
+            }
+        }
+
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::TimedOut { saw_challenge } => assert!(saw_challenge),
+            other => panic!("expected TimedOut, got {other:?}"),
+        }
+        assert_eq!(
+            clicks, MAX_CLICK_ATTEMPTS,
+            "a mounted, unanswered widget should be retried up to the cap"
+        );
         conn.shutdown();
     }
 }

--- a/crates/zendriver-datadome/src/bypass.rs
+++ b/crates/zendriver-datadome/src/bypass.rs
@@ -141,32 +141,20 @@ impl<'tab> DataDomeBypass<'tab> {
             Err(_) => return Ok(ClearanceOutcome::TimedOut { last_surface: None }),
         };
 
-        match snapshot.surface {
-            DataDomeSurface::None if snapshot.body_clean => {
-                return Ok(ClearanceOutcome::AlreadyClear);
-            }
-            DataDomeSurface::Block => return Ok(ClearanceOutcome::Blocked),
-            _ => {}
+        // Only the "nothing to clear" fast path is decided out here — it is
+        // the one terminal the loop cannot express (inside the loop, a clean
+        // page means the challenge *resolved*). Block and CAPTCHA escalation
+        // live in the loop so they also fire when the surface changes
+        // mid-flight, which is the normal shape: a device check hands off to
+        // a CAPTCHA, or to a ban, seconds in.
+        if snapshot.surface == DataDomeSurface::None && snapshot.body_clean {
+            return Ok(ClearanceOutcome::AlreadyClear);
         }
 
-        // Pre-loop captcha escalation.
-        if snapshot.surface == DataDomeSurface::Captcha {
-            let Some(solver) = self.on_captcha.clone() else {
-                return Err(DataDomeError::CaptchaRequired);
-            };
-            let challenge = crate::captcha::build_challenge(self.session, &snapshot).await?;
-            let site_url = challenge.site_url.clone();
-            let solution = solver(challenge)
-                .await
-                .map_err(DataDomeError::CaptchaSolver)?;
-            crate::captcha::apply_solution(self.session, &solution, &site_url).await?;
-            // Page reloaded — discard the stale snapshot, force a re-probe.
-            return self.poll_loop(deadline, None, None, None).await;
-        }
-
-        // Optional Fetch-domain fast-path. The guard's `Drop` cooperatively
-        // cancels the spawned task (token check at every loop boundary)
-        // with `abort()` as a backstop.
+        // Optional Fetch-domain fast-path. Spawned before any escalation so
+        // the CAPTCHA route gets the same fast wake-up as the device-check
+        // route. The guard's `Drop` cooperatively cancels the spawned task
+        // (token check at every loop boundary) with `abort()` as a backstop.
         let (interception_rx, interception_guard) = if self.interception_enabled {
             let (rx, guard) = crate::interception::spawn_signal(self.session);
             (Some(rx), Some(guard))
@@ -182,6 +170,28 @@ impl<'tab> DataDomeBypass<'tab> {
         .await
     }
 
+    /// Escalate a CAPTCHA surface to the registered solver and apply the
+    /// solved cookie. Errors with [`DataDomeError::CaptchaRequired`] when no
+    /// solver is registered. On success the page has been reloaded, so the
+    /// caller must re-probe rather than reuse `snap`.
+    async fn solve_captcha(&self, snap: &DetectionSnapshot) -> Result<(), DataDomeError> {
+        let Some(solver) = self.on_captcha.clone() else {
+            return Err(DataDomeError::CaptchaRequired);
+        };
+        let challenge = crate::captcha::build_challenge(self.session, snap).await?;
+        let site_url = challenge.site_url.clone();
+        let solution = solver(challenge)
+            .await
+            .map_err(DataDomeError::CaptchaSolver)?;
+        crate::captcha::apply_solution(self.session, &solution, &site_url).await
+    }
+
+    /// Core poll loop. Owns every mid-flight terminal — clearance, ban, and
+    /// CAPTCHA escalation — so a surface that changes after the pre-loop
+    /// probe is handled exactly like one present from the start.
+    ///
+    /// Factored out so unit tests can drive it with a controlled interception
+    /// receiver without standing up the real `Fetch.enable` plumbing.
     pub(crate) async fn poll_loop(
         self,
         deadline: Instant,
@@ -213,17 +223,30 @@ impl<'tab> DataDomeBypass<'tab> {
                 },
             };
 
-            let cookie = snap.datadome.as_ref().filter(|v| !v.is_empty());
-            match (cookie, snap.body_clean) {
-                (Some(c), true) => {
-                    return Ok(ClearanceOutcome::Cleared {
-                        datadome: c.clone(),
-                    });
+            // Escalations are polled, not assumed to arrive on the first
+            // probe: DataDome routinely upgrades a device check to a CAPTCHA
+            // (or drops it to a ban) a few seconds into the interstitial.
+            match snap.surface {
+                DataDomeSurface::Block => return Ok(ClearanceOutcome::Blocked),
+                DataDomeSurface::Captcha => {
+                    self.solve_captcha(&snap).await?;
+                    // Page reloaded — next iteration re-probes from scratch.
+                    last_surface = Some(snap.surface);
                 }
-                (None, true) if snap.surface == DataDomeSurface::None => {
-                    return Ok(ClearanceOutcome::ChallengeGone);
+                _ => {
+                    let cookie = snap.datadome.as_ref().filter(|v| !v.is_empty());
+                    match (cookie, snap.body_clean) {
+                        (Some(c), true) => {
+                            return Ok(ClearanceOutcome::Cleared {
+                                datadome: c.clone(),
+                            });
+                        }
+                        (None, true) if snap.surface == DataDomeSurface::None => {
+                            return Ok(ClearanceOutcome::ChallengeGone);
+                        }
+                        _ => last_surface = Some(snap.surface),
+                    }
                 }
-                _ => last_surface = Some(snap.surface),
             }
 
             if Instant::now() >= deadline {
@@ -532,6 +555,226 @@ mod tests {
             ClearanceOutcome::TimedOut { .. } => {}
             other => panic!("expected TimedOut, got {other:?}"),
         }
+        conn.shutdown();
+    }
+
+    /// Generic bounded read of the next outbound command, for flows whose
+    /// command order is not fully deterministic (the interception task emits
+    /// `Fetch.enable` from its own spawn).
+    async fn next_cmd(mock: &mut MockConnection) -> Option<(String, u64)> {
+        for _ in 0..300 {
+            if let Some(cmd) = mock.try_recv_cmd() {
+                return Some(cmd);
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        None
+    }
+
+    fn device_check_snap() -> serde_json::Value {
+        json!({"surface":"device_check","datadome":null,"dd":{"cid":"C","hsh":"H","t":"fe","host":"h"},"captcha_url":null,"body_clean":false})
+    }
+
+    fn captcha_snap() -> serde_json::Value {
+        json!({"surface":"captcha","datadome":"OLD","dd":{"cid":"C","hsh":"H","t":"fe","host":"h"},"captcha_url":"https://geo.captcha-delivery.com/captcha/?cid=C","body_clean":false})
+    }
+
+    /// The normal DataDome escalation shape: the interstitial starts as a
+    /// device check and only *then* hands off to a CAPTCHA. Escalation used
+    /// to be checked on the pre-loop probe only, so this arrival never
+    /// reached the registered solver.
+    #[tokio::test]
+    async fn device_check_escalating_to_captcha_invokes_solver() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .on_captcha(|ch| async move {
+                        assert!(ch.captcha_url.contains("captcha-delivery.com"));
+                        Ok(crate::captcha::DataDomeSolution {
+                            datadome_cookie: "FROM_SOLVER".into(),
+                        })
+                    })
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        // Probe 1 (pre-loop): device check — no escalation yet.
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id1, snap_reply(device_check_snap())).await;
+
+        // Probe 2 (in-loop): the device check escalated to a CAPTCHA.
+        let id2 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id2, snap_reply(captcha_snap())).await;
+
+        // Solver path: build_challenge eval → setCookie → reload.
+        let id_ctx = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id_ctx,
+            json!({"result":{"type":"object","value":{"url":"https://shop.example.com/p","ua":"Mozilla/5.0"}}}),
+        )
+        .await;
+        let id_cookie = mock.expect_cmd("Network.setCookie").await;
+        assert_eq!(mock.last_sent()["params"]["value"], "FROM_SOLVER");
+        mock.reply(id_cookie, json!({"success":true})).await;
+        let id_reload = mock.expect_cmd("Page.reload").await;
+        mock.reply(id_reload, json!({})).await;
+
+        // Probe 3: cleared.
+        let id3 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id3,
+            snap_reply(
+                json!({"surface":"none","datadome":"FROM_SOLVER","dd":null,"captcha_url":null,"body_clean":true}),
+            ),
+        )
+        .await;
+
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::Cleared { datadome } => assert_eq!(datadome, "FROM_SOLVER"),
+            other => panic!("expected Cleared, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    /// A CAPTCHA that arrives mid-flight with no solver registered must still
+    /// produce the actionable `CaptchaRequired` error, not a silent timeout.
+    #[tokio::test]
+    async fn mid_flight_captcha_without_solver_errors() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id1, snap_reply(device_check_snap())).await;
+        let id2 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id2, snap_reply(captcha_snap())).await;
+
+        assert!(matches!(
+            fut.await.unwrap().unwrap_err(),
+            DataDomeError::CaptchaRequired
+        ));
+        conn.shutdown();
+    }
+
+    /// A ban that lands after the pre-loop probe must terminate as `Blocked`
+    /// — the caller needs "change your IP", not "timed out".
+    #[tokio::test]
+    async fn device_check_escalating_to_block_returns_blocked() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id1, snap_reply(device_check_snap())).await;
+        let id2 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id2,
+            snap_reply(
+                json!({"surface":"block","datadome":null,"dd":{"cid":"C","hsh":"H","t":"bv","host":"h"},"captcha_url":null,"body_clean":false}),
+            ),
+        )
+        .await;
+
+        assert!(matches!(
+            fut.await.unwrap().unwrap(),
+            ClearanceOutcome::Blocked
+        ));
+        conn.shutdown();
+    }
+
+    /// `with_interception()` used to be dropped on the CAPTCHA route: that
+    /// branch returned into the poll loop with no receiver and no guard, so
+    /// the fast path was silently off exactly where it matters most. A
+    /// `Fetch.enable` on the wire proves the subscription is armed.
+    #[tokio::test]
+    async fn captcha_route_arms_the_interception_fast_path() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .with_interception()
+                    .on_captcha(|_ch| async move {
+                        Ok(crate::captcha::DataDomeSolution {
+                            datadome_cookie: "FROM_SOLVER".into(),
+                        })
+                    })
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        let mut saw_fetch_enable = false;
+        let mut reloaded = false;
+        while let Some((method, id)) = next_cmd(&mut mock).await {
+            match method.as_str() {
+                "Fetch.enable" => {
+                    saw_fetch_enable = true;
+                    mock.reply(id, json!({})).await;
+                }
+                "Runtime.evaluate" => {
+                    let expr = mock.last_sent()["params"]["expression"]
+                        .as_str()
+                        .unwrap()
+                        .to_string();
+                    if expr.contains("location.href") {
+                        mock.reply(
+                            id,
+                            json!({"result":{"type":"object","value":{"url":"https://shop.example.com/p","ua":"UA"}}}),
+                        )
+                        .await;
+                    } else if reloaded {
+                        mock.reply(
+                            id,
+                            snap_reply(
+                                json!({"surface":"none","datadome":"FROM_SOLVER","dd":null,"captcha_url":null,"body_clean":true}),
+                            ),
+                        )
+                        .await;
+                    } else {
+                        mock.reply(id, snap_reply(captcha_snap())).await;
+                    }
+                }
+                "Network.setCookie" => mock.reply(id, json!({"success":true})).await,
+                "Page.reload" => {
+                    reloaded = true;
+                    mock.reply(id, json!({})).await;
+                }
+                _ => mock.reply(id, json!({})).await,
+            }
+        }
+
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::Cleared { datadome } => assert_eq!(datadome, "FROM_SOLVER"),
+            other => panic!("expected Cleared, got {other:?}"),
+        }
+        assert!(
+            saw_fetch_enable,
+            "with_interception() must arm the Fetch fast path on the captcha route too"
+        );
         conn.shutdown();
     }
 

--- a/crates/zendriver-datadome/src/bypass.rs
+++ b/crates/zendriver-datadome/src/bypass.rs
@@ -96,6 +96,11 @@ impl<'tab> DataDomeBypass<'tab> {
     /// cid, hash) and returns a [`DataDomeSolution`] carrying the solved
     /// `datadome` cookie — wire it to a service like 2captcha / capsolver.
     ///
+    /// Invoked at most once per [`wait_for_clearance`](Self::wait_for_clearance)
+    /// — solving is billed per call, and the reloaded page needs time to settle
+    /// before the surface can be judged again — and bounded by that call's
+    /// timeout, so a stalled solver cannot overrun the stated budget.
+    ///
     /// [`DataDomeChallenge`]: crate::captcha::DataDomeChallenge
     /// [`DataDomeSolution`]: crate::captcha::DataDomeSolution
     #[must_use]
@@ -209,6 +214,10 @@ impl<'tab> DataDomeBypass<'tab> {
         #[allow(unused_assignments)]
         let mut last_surface: Option<DataDomeSurface> = None;
 
+        // One solve attempt per clearance. See the CAPTCHA arm below for why
+        // the surface cannot be relied on to clear itself once a solve returns.
+        let mut captcha_attempted = false;
+
         loop {
             let snap = match next_snapshot.take() {
                 Some(s) => s,
@@ -226,10 +235,43 @@ impl<'tab> DataDomeBypass<'tab> {
             // Escalations are polled, not assumed to arrive on the first
             // probe: DataDome routinely upgrades a device check to a CAPTCHA
             // (or drops it to a ban) a few seconds into the interstitial.
+            //
+            // Deciding the surface before clearance is safe here, unlike the
+            // Imperva sibling, because `detect.js` derives `body_clean` as
+            // `!dd && !captchaUrl`: a `Captcha` or `Block` surface forces
+            // `body_clean == false`, and both clearance terminals below
+            // require it true. No snapshot can be cleared and escalatable at
+            // once. The DataDome surface is also vendor-specific (a
+            // `captcha-delivery.com` iframe), so the site's own reCAPTCHA —
+            // what made Imperva's ordering wrong — cannot flip it.
             match snap.surface {
                 DataDomeSurface::Block => return Ok(ClearanceOutcome::Blocked),
+                // Latched to a single attempt. `apply_solution` sets the
+                // cookie and fires `Page.reload`, and that command is acked
+                // the moment it lands — not when the replacement document has
+                // loaded. The CAPTCHA document therefore survives at least the
+                // next probe, and forever if the solved cookie was rejected,
+                // so an unlatched loop re-enters the solver on every 250ms
+                // tick: two reproductions counted 29 and 34 invocations inside
+                // one `wait_for_clearance`, each of them a paid solve.
                 DataDomeSurface::Captcha => {
-                    self.solve_captcha(&snap).await?;
+                    if !captcha_attempted {
+                        captcha_attempted = true;
+                        // The solver is caller-supplied and carries no bound of
+                        // its own. Only the loop-top probe was raced against
+                        // the deadline, so a solve entered just under it ran to
+                        // completion and overran the caller's timeout by a full
+                        // solver latency. Losing this race drops the in-flight
+                        // solve: the stated timeout is the contract.
+                        match tokio::time::timeout_at(deadline, self.solve_captcha(&snap)).await {
+                            Ok(res) => res?,
+                            Err(_) => {
+                                return Ok(ClearanceOutcome::TimedOut {
+                                    last_surface: Some(snap.surface),
+                                });
+                            }
+                        }
+                    }
                     // Page reloaded — next iteration re-probes from scratch.
                     last_surface = Some(snap.surface);
                 }
@@ -811,6 +853,165 @@ mod tests {
             ClearanceOutcome::Cleared { datadome } => assert_eq!(datadome, "DD"),
             other => panic!("expected Cleared, got {other:?}"),
         }
+        conn.shutdown();
+    }
+
+    /// `apply_solution` sets the cookie and fires `Page.reload`, which is acked
+    /// long before the replacement document loads — so the next probe still
+    /// sees the CAPTCHA, and a page whose solve was rejected never stops
+    /// showing it. Unlatched, the loop re-entered the solver on every tick
+    /// (29 and 34 invocations in two recorded reproductions), each one a paid
+    /// solve.
+    #[tokio::test]
+    async fn captcha_solver_is_invoked_at_most_once_per_clearance() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            let c = Arc::clone(&calls);
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .timeout(Duration::from_millis(400))
+                    .on_captcha(move |_ch| {
+                        let c = Arc::clone(&c);
+                        async move {
+                            c.fetch_add(1, Ordering::SeqCst);
+                            Ok(crate::captcha::DataDomeSolution {
+                                datadome_cookie: "FROM_SOLVER".into(),
+                            })
+                        }
+                    })
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        // Serve a stuck CAPTCHA surface for as long as the loop asks. Replies
+        // are picked by command + expression shape: the detect probe gets the
+        // captcha snapshot, `build_challenge`'s url/ua eval gets a page
+        // context, and `apply_solution`'s setCookie / reload get bare acks.
+        // Nothing here ever clears the surface, so only the latch can stop a
+        // second solve.
+        while let Some((method, id)) = next_cmd(&mut mock).await {
+            match method.as_str() {
+                "Runtime.evaluate" => {
+                    let expr = mock.last_sent()["params"]["expression"]
+                        .as_str()
+                        .unwrap()
+                        .to_string();
+                    if expr.contains("location.href") {
+                        mock.reply(
+                            id,
+                            json!({"result":{"type":"object","value":{"url":"https://shop.example.com/p","ua":"UA"}}}),
+                        )
+                        .await;
+                    } else {
+                        mock.reply(id, snap_reply(captcha_snap())).await;
+                    }
+                }
+                "Network.setCookie" => mock.reply(id, json!({"success":true})).await,
+                _ => mock.reply(id, json!({})).await,
+            }
+        }
+
+        let outcome = fut.await.unwrap().unwrap();
+        assert!(
+            matches!(outcome, ClearanceOutcome::TimedOut { .. }),
+            "a CAPTCHA that never clears must poll to its deadline, got {outcome:?}"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "solver must be latched to one attempt per clearance"
+        );
+        conn.shutdown();
+    }
+
+    /// The solver is a caller-supplied network round-trip with no bound of its
+    /// own. Only the loop-top probe was raced against the deadline, so a solve
+    /// entered just under it ran to completion and overran the caller's stated
+    /// timeout by a full solver latency.
+    #[tokio::test]
+    async fn solver_cannot_overrun_the_configured_timeout() {
+        const SOLVER_LATENCY: Duration = Duration::from_secs(3);
+        const BUDGET: Duration = Duration::from_millis(80);
+
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let started = Instant::now();
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .timeout(BUDGET)
+                    .on_captcha(|_ch| async move {
+                        tokio::time::sleep(SOLVER_LATENCY).await;
+                        Ok(crate::captcha::DataDomeSolution {
+                            datadome_cookie: "TOO_LATE".into(),
+                        })
+                    })
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        // Serve the whole flow — detect probe, `build_challenge`'s url/ua eval,
+        // and the setCookie / reload the solve would reach on its way back —
+        // and stay up for as long as the call runs, since a stalled solver
+        // sends nothing for seconds. The unbounded version therefore fails on
+        // the elapsed assertion below rather than on a dropped mock.
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let serving = tokio::spawn({
+            let done = Arc::clone(&done);
+            async move {
+                while !done.load(std::sync::atomic::Ordering::SeqCst) {
+                    let Some((method, id)) = mock.try_recv_cmd() else {
+                        tokio::time::sleep(Duration::from_millis(1)).await;
+                        continue;
+                    };
+                    match method.as_str() {
+                        "Runtime.evaluate" => {
+                            let expr = mock.last_sent()["params"]["expression"]
+                                .as_str()
+                                .unwrap()
+                                .to_string();
+                            if expr.contains("location.href") {
+                                mock.reply(
+                                id,
+                                json!({"result":{"type":"object","value":{"url":"https://shop.example.com/p","ua":"UA"}}}),
+                            )
+                            .await;
+                            } else {
+                                mock.reply(id, snap_reply(captcha_snap())).await;
+                            }
+                        }
+                        "Network.setCookie" => mock.reply(id, json!({"success":true})).await,
+                        _ => mock.reply(id, json!({})).await,
+                    }
+                }
+            }
+        });
+
+        let outcome = fut.await.unwrap().unwrap();
+        let elapsed = started.elapsed();
+        done.store(true, std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            matches!(outcome, ClearanceOutcome::TimedOut { .. }),
+            "expected TimedOut, got {outcome:?}"
+        );
+        assert!(
+            elapsed < SOLVER_LATENCY / 2,
+            "solve must be bounded by the caller's deadline; took {elapsed:?} against a {BUDGET:?} budget"
+        );
+        serving.abort();
         conn.shutdown();
     }
 }

--- a/crates/zendriver-fetcher/src/cache.rs
+++ b/crates/zendriver-fetcher/src/cache.rs
@@ -11,8 +11,10 @@
 //!       Google Chrome for Testing.app/Contents/MacOS/...  (macOS)
 //! ```
 //!
-//! Per-version dirs are written atomically: download + extract land under
-//! a `<version>.tmp/` sibling, then a single rename promotes it.
+//! Per-version dirs are written atomically: download + extract land under a
+//! `<version>.tmp-<pid>-<attempt>-<nanos>/` sibling — unique per attempt, so
+//! processes sharing one cache volume never stage into the same place —
+//! then a single rename promotes it.
 
 use std::env;
 use std::path::{Path, PathBuf};

--- a/crates/zendriver-fetcher/src/error.rs
+++ b/crates/zendriver-fetcher/src/error.rs
@@ -30,7 +30,10 @@ pub enum FetcherError {
     /// SHA256 checksum mismatch on the downloaded archive.
     #[error("integrity check failed: expected {expected}, got {actual}")]
     IntegrityFailed {
-        /// SHA256 from the manifest.
+        /// The SHA256 the caller pinned via
+        /// [`crate::Fetcher::expected_sha256`]. The CfT manifest does not
+        /// publish per-download hashes, so this never comes from the
+        /// manifest.
         expected: String,
         /// SHA256 computed from the downloaded bytes.
         actual: String,

--- a/crates/zendriver-fetcher/src/extract.rs
+++ b/crates/zendriver-fetcher/src/extract.rs
@@ -6,7 +6,8 @@
 //! [`tokio::task::spawn_blocking`] handles all three.
 //!
 //! On Unix, executable bits from the archive's `unix_mode()` are preserved
-//! so the extracted Chrome binary stays runnable without a chmod pass.
+//! (masked to the standard rwx triplet) so the extracted Chrome binary stays
+//! runnable without a chmod pass.
 //!
 //! # Trust boundary
 //!
@@ -31,11 +32,23 @@
 //!    entry to live under a single named top-level directory (e.g.
 //!    `chrome-linux64/`); enforced from the fetcher to lock the archive
 //!    to the CfT layout we expect.
+//! 5. Mode bits are masked with [`ARCHIVE_MODE_MASK`] before they reach
+//!    `set_permissions`, so a setuid / setgid / sticky bit in the archive
+//!    can never land on an extracted file.
 
 use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::error::FetcherError;
+
+/// Permission bits kept from an archive entry's `unix_mode()`.
+///
+/// Chrome for Testing only needs the standard rwx triplet, so the mask drops
+/// the file-type bits *and* setuid / setgid / sticky (`0o7000`). Without it a
+/// hostile or malformed archive could get a setuid-root or setgid binary
+/// written into the cache directory.
+#[cfg(unix)]
+pub(crate) const ARCHIVE_MODE_MASK: u32 = 0o0777;
 
 /// Unzips `archive_path` into `dest_dir`, preserving directory layout and
 /// (on Unix) executable bits from the archive.
@@ -150,7 +163,8 @@ fn extract_blocking(
         #[cfg(unix)]
         if let Some(mode) = entry.unix_mode() {
             use std::os::unix::fs::PermissionsExt as _;
-            std::fs::set_permissions(&out_path, std::fs::Permissions::from_mode(mode))?;
+            let safe_mode = mode & ARCHIVE_MODE_MASK;
+            std::fs::set_permissions(&out_path, std::fs::Permissions::from_mode(safe_mode))?;
         }
     }
 
@@ -266,5 +280,111 @@ mod tests {
             err.to_string().contains("symlink"),
             "unexpected error: {err}"
         );
+    }
+
+    /// Overwrite the external-attributes field of every central-directory
+    /// header in `zip_bytes` with `mode`, shifted into the high half where
+    /// `ZipFile::unix_mode` reads it.
+    ///
+    /// The `zip` writer masks `unix_permissions` down to `0o777`, so a
+    /// setuid archive cannot be produced through its API — patching the
+    /// bytes is the only way to model a hostile or malformed archive.
+    /// Layout per APPNOTE 4.3.12: the header starts with `PK\x01\x02` and
+    /// carries its 4-byte external attributes at offset 38.
+    #[cfg(unix)]
+    fn patch_central_dir_mode(zip_bytes: &mut [u8], mode: u32) {
+        const CENTRAL_DIR_SIG: [u8; 4] = [b'P', b'K', 1, 2];
+        const EXTERNAL_ATTRS_OFFSET: usize = 38;
+
+        let attrs = (mode << 16).to_le_bytes();
+        let mut patched = 0usize;
+        for i in 0..zip_bytes.len().saturating_sub(EXTERNAL_ATTRS_OFFSET + 4) {
+            if zip_bytes[i..i + 4] == CENTRAL_DIR_SIG {
+                let at = i + EXTERNAL_ATTRS_OFFSET;
+                zip_bytes[at..at + 4].copy_from_slice(&attrs);
+                patched += 1;
+            }
+        }
+        assert!(patched > 0, "no central directory header found in zip");
+    }
+
+    /// A hostile archive that asks for setuid + setgid + sticky gets only
+    /// the rwx triplet applied: the extracted file must not be setuid.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn extract_masks_setuid_setgid_and_sticky_bits() {
+        use std::os::unix::fs::PermissionsExt as _;
+        use zip::write::SimpleFileOptions;
+
+        let dir = tempfile::tempdir().unwrap();
+        let zip_path = dir.path().join("setuid.zip");
+        let dest_dir = dir.path().join("out");
+        std::fs::create_dir_all(&dest_dir).unwrap();
+
+        let mut buf = std::io::Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut buf);
+            writer
+                .start_file(
+                    "chrome-linux64/chrome",
+                    SimpleFileOptions::default().unix_permissions(0o755),
+                )
+                .unwrap();
+            writer.write_all(b"payload").unwrap();
+            writer.finish().unwrap();
+        }
+        let mut zip_bytes = buf.into_inner();
+        // S_IFREG | setuid | setgid | sticky | rwxr-xr-x
+        patch_central_dir_mode(&mut zip_bytes, 0o100_000 | 0o7755);
+        std::fs::write(&zip_path, zip_bytes).unwrap();
+
+        extract(&zip_path, &dest_dir, Some("chrome-linux64"))
+            .await
+            .unwrap();
+
+        let out = dest_dir.join("chrome-linux64/chrome");
+        let mode = std::fs::metadata(&out).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o7777,
+            0o755,
+            "archive mode bits must be masked to {ARCHIVE_MODE_MASK:o}, got {:o}",
+            mode & 0o7777
+        );
+    }
+
+    /// The mask must not cost us the executable bit on a well-formed CfT
+    /// archive — a plain `0o755` entry still extracts as `0o755`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn extract_preserves_ordinary_executable_bits() {
+        use std::os::unix::fs::PermissionsExt as _;
+        use zip::write::SimpleFileOptions;
+
+        let dir = tempfile::tempdir().unwrap();
+        let zip_path = dir.path().join("exec.zip");
+        let dest_dir = dir.path().join("out");
+        std::fs::create_dir_all(&dest_dir).unwrap();
+
+        let mut buf = std::io::Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut buf);
+            writer
+                .start_file(
+                    "chrome-linux64/chrome",
+                    SimpleFileOptions::default().unix_permissions(0o755),
+                )
+                .unwrap();
+            writer.write_all(b"payload").unwrap();
+            writer.finish().unwrap();
+        }
+        std::fs::write(&zip_path, buf.into_inner()).unwrap();
+
+        extract(&zip_path, &dest_dir, Some("chrome-linux64"))
+            .await
+            .unwrap();
+
+        let out = dest_dir.join("chrome-linux64/chrome");
+        let mode = std::fs::metadata(&out).unwrap().permissions().mode();
+        assert_eq!(mode & 0o7777, 0o755, "got {:o}", mode & 0o7777);
     }
 }

--- a/crates/zendriver-fetcher/src/fetcher.rs
+++ b/crates/zendriver-fetcher/src/fetcher.rs
@@ -2,11 +2,17 @@
 //!
 //! Resolves a `(version, platform)` pair against the Chrome for Testing
 //! manifest, downloads the zip into a per-version atomic cache layout,
-//! extracts it, and hands back a path to the executable. If the binary is
-//! already cached and runnable, returns the path immediately.
+//! extracts it, and hands back a path to the executable.
+//!
+//! Resolution runs on every call, before the cache is consulted: the cache
+//! is keyed by the resolved version, so the manifest has to be fetched to
+//! know which key to look for. A cached, runnable binary therefore skips the
+//! download and the extraction, but not the manifest request.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime};
 
 use crate::cache::{binary_path, default_cache_dir};
 use crate::download::download;
@@ -27,6 +33,23 @@ pub(crate) const DEFAULT_CFT_URL: &str =
 /// [`VersionSpec::Channel`] for the `Beta`/`Dev`/`Canary` channels (`Stable`
 /// resolves through [`DEFAULT_CFT_URL`] like [`VersionSpec::Latest`]).
 pub(crate) const DEFAULT_CFT_CHANNELS_URL: &str = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json";
+
+/// Marker separating a version from its per-attempt staging suffix.
+///
+/// Staging entries are named `<version>.tmp-<pid>-<attempt>-<nanos>`, with
+/// the archive adding a `.zip` extension on top. The marker is what makes
+/// the stale sweep scopeable: `121.0.0.1.tmp-…` never matches the
+/// `121.0.0.tmp-` prefix of a different version, and the promoted
+/// `<version>/` directory never carries the marker at all.
+const STAGING_MARKER: &str = ".tmp-";
+
+/// How long a staging entry must sit untouched before [`sweep_stale_staging`]
+/// treats it as abandoned by a crashed run.
+///
+/// A CfT archive is ~150 MB, so this has to be far longer than any plausible
+/// download — an in-flight staging directory belonging to another process on
+/// a shared cache volume must never be mistaken for garbage.
+const STAGING_STALE_AFTER: Duration = Duration::from_secs(6 * 60 * 60);
 
 /// Chrome for Testing binary downloader.
 ///
@@ -165,7 +188,10 @@ impl Fetcher {
     /// Resolve, download, extract (on cache miss), and return the path
     /// to the cached Chrome binary.
     ///
-    /// On a cache hit, returns immediately without touching the network.
+    /// The manifest is resolved *before* the cache is probed, so every call
+    /// reaches the Chrome for Testing manifest host. A cache hit skips the
+    /// ~150 MB archive download and the extraction, not the manifest
+    /// request — a fully populated cache still fails without egress.
     ///
     /// # Errors
     ///
@@ -211,7 +237,9 @@ impl Fetcher {
             }
         };
 
-        // Compute final layout + cache hit check.
+        // Compute final layout + cache probe. Note this runs *after* the
+        // resolve above, so it saves the download, not the network round
+        // trip — see the `ensure_chrome` rustdoc.
         tokio::fs::create_dir_all(&cache_dir).await?;
         let final_dir = cache_dir.join(&version);
         let target_bin = binary_path(&cache_dir, &version, platform);
@@ -220,74 +248,162 @@ impl Fetcher {
             return Ok(target_bin);
         }
 
-        // Phase 2: download to <version>.tmp.zip.
-        let tmp_zip = cache_dir.join(format!("{version}.tmp.zip"));
-        let tmp_dir = cache_dir.join(format!("{version}.tmp"));
+        // Drop staging abandoned by a crashed run of this same version.
+        // Scoped by name and by age so a *concurrent* fetcher's in-flight
+        // staging survives — one cache volume may be shared by many
+        // processes.
+        sweep_stale_staging(&cache_dir, &version, STAGING_STALE_AFTER).await;
 
-        // Clean up any stale tmp from a prior crashed run.
-        let _ = tokio::fs::remove_file(&tmp_zip).await;
-        let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
+        // Phase 2: download into staging paths private to this attempt.
+        let (tmp_dir, tmp_zip) = staging_paths(&cache_dir, &version);
 
         emit(&progress_cb, FetcherPhase::Downloading, 0, None);
-        download(&url, &tmp_zip, progress_cb.as_deref().map(|a| a as _)).await?;
+        if let Err(e) = download(&url, &tmp_zip, progress_cb.as_deref().map(|a| a as _)).await {
+            // A download that dies mid-body leaves a partial archive behind;
+            // drop it now rather than waiting for a later run to age it out.
+            let _ = tokio::fs::remove_file(&tmp_zip).await;
+            return Err(e);
+        }
 
         // Phase 2b: optional SHA256 integrity check before we trust the
         // archive enough to extract it.
         if let Some(expected) = self.expected_sha256.as_deref() {
             emit(&progress_cb, FetcherPhase::Verifying, 0, None);
-            let actual = sha256_file(&tmp_zip).await?;
-            if !sha256_eq(expected, &actual) {
-                let _ = tokio::fs::remove_file(&tmp_zip).await;
-                return Err(FetcherError::IntegrityFailed {
+            let verdict = match sha256_file(&tmp_zip).await {
+                Ok(actual) if sha256_eq(expected, &actual) => Ok(()),
+                Ok(actual) => Err(FetcherError::IntegrityFailed {
                     expected: expected.to_string(),
                     actual,
-                });
+                }),
+                Err(e) => Err(e),
+            };
+            if let Err(e) = verdict {
+                let _ = tokio::fs::remove_file(&tmp_zip).await;
+                return Err(e);
             }
         }
 
-        // Phase 3: extract to <version>.tmp/.
+        // Phase 3: extract into the staging dir.
         emit(&progress_cb, FetcherPhase::Extracting, 0, None);
         tokio::fs::create_dir_all(&tmp_dir).await?;
-        // CfT archives place everything under a single `chrome-<platform>/`
-        // directory; pinning the expected prefix locks the extraction to
-        // that layout and rejects mislabeled / tampered archives.
-        let expected_top = platform.cft_top_dir();
-        let extract_result = extract(&tmp_zip, &tmp_dir, Some(expected_top)).await;
 
-        // Always clean the zip, even if extract failed.
-        let _ = tokio::fs::remove_file(&tmp_zip).await;
-        extract_result?;
+        // Phases 3-5 all write into the staging dir, so wrap them: any
+        // failure removes it immediately instead of leaving an abandoned
+        // tree for a later run's sweep to age out.
+        let staged: Result<(), FetcherError> = async {
+            // CfT archives place everything under a single `chrome-<platform>/`
+            // directory; pinning the expected prefix locks the extraction to
+            // that layout and rejects mislabeled / tampered archives.
+            let expected_top = platform.cft_top_dir();
+            let extract_result = extract(&tmp_zip, &tmp_dir, Some(expected_top)).await;
 
-        // Phase 4: ensure executable bit (Unix) BEFORE the atomic rename.
-        // Setting perms after the rename would leave a window where a
-        // concurrent `Fetcher::ensure(...)` on the same cache_dir observes
-        // `final_dir` (cache-hit check at L159) but the binary inside is
-        // still non-executable, forcing a wasteful re-download.
-        emit(&progress_cb, FetcherPhase::Verifying, 0, None);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt as _;
-            let tmp_bin = tmp_dir.join(crate::cache::binary_subpath(platform));
-            if tmp_bin.exists() {
-                let mut perms = tokio::fs::metadata(&tmp_bin).await?.permissions();
-                perms.set_mode(perms.mode() | 0o111);
-                tokio::fs::set_permissions(&tmp_bin, perms).await?;
+            // Always clean the zip, even if extract failed.
+            let _ = tokio::fs::remove_file(&tmp_zip).await;
+            extract_result?;
+
+            // Phase 4: ensure executable bit (Unix) BEFORE the atomic rename.
+            // Setting perms after the rename would leave a window where a
+            // concurrent `Fetcher::ensure_chrome` on the same cache_dir sees
+            // `final_dir` from its cache probe but the binary inside is still
+            // non-executable, forcing a wasteful re-download.
+            emit(&progress_cb, FetcherPhase::Verifying, 0, None);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt as _;
+                let tmp_bin = tmp_dir.join(crate::cache::binary_subpath(platform));
+                if tmp_bin.exists() {
+                    let mut perms = tokio::fs::metadata(&tmp_bin).await?.permissions();
+                    perms.set_mode(perms.mode() | 0o111);
+                    tokio::fs::set_permissions(&tmp_bin, perms).await?;
+                }
+            }
+
+            // Phase 5: atomic promote <staging> -> <version>. Staging lives
+            // inside `cache_dir`, so this is a same-filesystem rename.
+            // If `final_dir` already exists (race: someone else just
+            // finished), drop our work and use theirs.
+            match tokio::fs::rename(&tmp_dir, &final_dir).await {
+                Ok(()) => Ok(()),
+                Err(_) if final_dir.exists() => {
+                    let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
+                    Ok(())
+                }
+                Err(e) => Err(FetcherError::Io(e)),
             }
         }
+        .await;
 
-        // Phase 5: atomic promote <version>.tmp -> <version>.
-        // If `final_dir` already exists (race: someone else just finished),
-        // drop our work and use theirs.
-        match tokio::fs::rename(&tmp_dir, &final_dir).await {
-            Ok(()) => {}
-            Err(_) if final_dir.exists() => {
-                let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
-            }
-            Err(e) => return Err(FetcherError::Io(e)),
+        if staged.is_err() {
+            let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
         }
+        staged?;
 
         emit(&progress_cb, FetcherPhase::Done, 0, None);
         Ok(target_bin)
+    }
+}
+
+/// Staging paths for one download attempt, as `(staging_dir, staging_zip)`.
+///
+/// Both sit directly inside `cache_dir` so promoting the finished tree is a
+/// same-filesystem `rename` (moving staging elsewhere would fail with
+/// `EXDEV`). The suffix mixes the OS process id, a process-local attempt
+/// counter, and the wall-clock nanos, so two processes sharing one cache
+/// volume — the CI layout [`Fetcher::cache_dir`] recommends — never stage
+/// into the same directory and cannot corrupt each other's download.
+fn staging_paths(cache_dir: &Path, version: &str) -> (PathBuf, PathBuf) {
+    static ATTEMPT: AtomicU64 = AtomicU64::new(0);
+
+    let attempt = ATTEMPT.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let stem = format!(
+        "{version}{STAGING_MARKER}{pid}-{attempt}-{nanos:x}",
+        pid = std::process::id()
+    );
+
+    let dir = cache_dir.join(&stem);
+    let zip = cache_dir.join(format!("{stem}.zip"));
+    (dir, zip)
+}
+
+/// Remove staging entries for `version` that a crashed run abandoned.
+///
+/// Scoped two ways, because siblings in `cache_dir` may belong to other
+/// live processes: only entries named `<version>.tmp-*` are candidates (a
+/// concurrent fetch of a *different* version is never touched), and only
+/// those untouched for `stale_after` are removed (a concurrent fetch of the
+/// *same* version is left to finish). Errors are swallowed — sweeping is
+/// best-effort housekeeping, not part of the fetch contract.
+async fn sweep_stale_staging(cache_dir: &Path, version: &str, stale_after: Duration) {
+    let prefix = format!("{version}{STAGING_MARKER}");
+    let Ok(mut entries) = tokio::fs::read_dir(cache_dir).await else {
+        return;
+    };
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        if !entry.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        let Ok(meta) = entry.metadata().await else {
+            continue;
+        };
+        // A clock that jumped backwards yields `Err` from `elapsed()`; treat
+        // that as "not stale" so we never delete a live attempt.
+        let stale = meta
+            .modified()
+            .ok()
+            .and_then(|m| m.elapsed().ok())
+            .is_some_and(|age| age >= stale_after);
+        if !stale {
+            continue;
+        }
+        if meta.is_dir() {
+            let _ = tokio::fs::remove_dir_all(entry.path()).await;
+        } else {
+            let _ = tokio::fs::remove_file(entry.path()).await;
+        }
     }
 }
 
@@ -309,7 +425,7 @@ fn emit(
 /// Compute the lowercase-hex SHA256 of `path`'s contents. The hash is
 /// computed on a `spawn_blocking` thread so a multi-hundred-MB Chrome zip
 /// doesn't block the runtime.
-async fn sha256_file(path: &std::path::Path) -> Result<String, FetcherError> {
+async fn sha256_file(path: &Path) -> Result<String, FetcherError> {
     let path = path.to_path_buf();
     tokio::task::spawn_blocking(move || -> std::io::Result<String> {
         use sha2::Digest as _;
@@ -342,7 +458,7 @@ fn hex_encode(bytes: &[u8]) -> String {
 }
 
 /// True iff `path` exists and (on Unix) has any executable bit set.
-async fn is_runnable(path: &std::path::Path) -> bool {
+async fn is_runnable(path: &Path) -> bool {
     let Ok(meta) = tokio::fs::metadata(path).await else {
         return false;
     };
@@ -382,6 +498,21 @@ mod tests {
             writer.finish().unwrap();
         }
         buf.into_inner()
+    }
+
+    /// Names of every staging entry still sitting in `cache_root`. Staging
+    /// paths are unique per attempt now, so tests assert on the marker
+    /// rather than on one hard-coded `<version>.tmp` name.
+    async fn staging_leftovers(cache_root: &Path) -> Vec<String> {
+        let mut found = Vec::new();
+        let mut entries = tokio::fs::read_dir(cache_root).await.unwrap();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.contains(STAGING_MARKER) {
+                found.push(name);
+            }
+        }
+        found
     }
 
     #[tokio::test]
@@ -435,9 +566,9 @@ mod tests {
         let extracted = tokio::fs::read(&bin_path).await.unwrap();
         assert_eq!(extracted, sentinel);
 
-        // No leftover tmp artifacts.
-        assert!(!cache_root.path().join("120.0.6099.234.tmp.zip").exists());
-        assert!(!cache_root.path().join("120.0.6099.234.tmp").exists());
+        // No leftover staging artifacts.
+        let leftovers = staging_leftovers(cache_root.path()).await;
+        assert!(leftovers.is_empty(), "staging left behind: {leftovers:?}");
 
         // Executable bit set on Unix.
         #[cfg(unix)]
@@ -527,8 +658,9 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, FetcherError::IntegrityFailed { .. }));
-        // Tmp zip cleaned up; extraction never ran so no version dir.
-        assert!(!cache_root.path().join("120.0.6099.234.tmp.zip").exists());
+        // Staging zip cleaned up; extraction never ran so no version dir.
+        let leftovers = staging_leftovers(cache_root.path()).await;
+        assert!(leftovers.is_empty(), "staging left behind: {leftovers:?}");
         assert!(!cache_root.path().join("120.0.6099.234").exists());
     }
 
@@ -597,5 +729,125 @@ mod tests {
         );
         let extracted = tokio::fs::read(&bin_path).await.unwrap();
         assert_eq!(extracted, sentinel);
+    }
+
+    /// Two attempts for the same version must get different staging paths —
+    /// this is what stops two processes on a shared cache volume from
+    /// downloading into the same file. Staging also has to stay inside
+    /// `cache_dir` so the promote is a same-filesystem rename.
+    #[test]
+    fn staging_paths_are_unique_per_attempt() {
+        let root = Path::new("/tmp/cache");
+        let (dir_a, zip_a) = staging_paths(root, "120.0.6099.234");
+        let (dir_b, zip_b) = staging_paths(root, "120.0.6099.234");
+
+        assert_ne!(dir_a, dir_b, "staging dirs collided: {dir_a:?}");
+        assert_ne!(zip_a, zip_b, "staging zips collided: {zip_a:?}");
+
+        assert_eq!(dir_a.parent(), Some(root));
+        assert_eq!(zip_a.parent(), Some(root));
+
+        // Never collides with the promoted version dir.
+        assert_ne!(dir_a, root.join("120.0.6099.234"));
+
+        let name = dir_a.file_name().unwrap().to_str().unwrap();
+        assert!(
+            name.starts_with(&format!("120.0.6099.234{STAGING_MARKER}")),
+            "unexpected staging name: {name}"
+        );
+        assert_eq!(zip_a, root.join(format!("{name}.zip")));
+    }
+
+    /// The sweep only touches staging belonging to the version being
+    /// fetched. `Duration::ZERO` makes every entry count as stale, which
+    /// isolates the name scoping from the age threshold.
+    #[tokio::test]
+    async fn sweep_removes_only_this_versions_stale_staging() {
+        let root = tempfile::tempdir().unwrap();
+        let mine = root.path().join("120.0.6099.234.tmp-1-0-abc");
+        let mine_zip = root.path().join("120.0.6099.234.tmp-1-0-abc.zip");
+        let other_version = root.path().join("121.0.6100.10.tmp-1-0-abc");
+        let promoted = root.path().join("120.0.6099.234");
+
+        tokio::fs::create_dir_all(mine.join("chrome-linux64"))
+            .await
+            .unwrap();
+        tokio::fs::write(&mine_zip, b"partial").await.unwrap();
+        tokio::fs::create_dir_all(&other_version).await.unwrap();
+        tokio::fs::create_dir_all(&promoted).await.unwrap();
+
+        sweep_stale_staging(root.path(), "120.0.6099.234", Duration::ZERO).await;
+
+        assert!(!mine.exists(), "stale staging dir should be swept");
+        assert!(!mine_zip.exists(), "stale staging zip should be swept");
+        assert!(
+            other_version.exists(),
+            "another version's staging must survive"
+        );
+        assert!(promoted.exists(), "promoted version dir must survive");
+    }
+
+    /// Staging younger than the threshold belongs to a fetcher that is
+    /// still running, possibly in another process. It must survive.
+    #[tokio::test]
+    async fn sweep_leaves_fresh_staging_alone() {
+        let root = tempfile::tempdir().unwrap();
+        let (dir, zip) = staging_paths(root.path(), "120.0.6099.234");
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(&zip, b"in flight").await.unwrap();
+
+        sweep_stale_staging(root.path(), "120.0.6099.234", Duration::from_secs(3600)).await;
+
+        assert!(dir.exists(), "a concurrent fetcher's staging dir was swept");
+        assert!(zip.exists(), "a concurrent fetcher's staging zip was swept");
+    }
+
+    /// A download that fails must not leave its partial archive in the
+    /// cache dir.
+    #[tokio::test]
+    async fn failed_download_leaves_no_staging_behind() {
+        let server = MockServer::start().await;
+        let manifest_json = format!(
+            r#"{{"versions":[{{"version":"120.0.6099.234","revision":"1234","downloads":{{"chrome":[{{"platform":"linux64","url":"{server}/chrome.zip"}}]}}}}]}}"#,
+            server = server.uri()
+        );
+
+        Mock::given(method("GET"))
+            .and(path("/manifest.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(manifest_json))
+            .mount(&server)
+            .await;
+        // Claim more bytes than we send, so the body stream errors after the
+        // partial archive has already been written to disk.
+        Mock::given(method("GET"))
+            .and(path("/chrome.zip"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("Content-Length", "99999")
+                    .set_body_bytes(b"truncated".to_vec()),
+            )
+            .mount(&server)
+            .await;
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let err = Fetcher::new()
+            .cache_dir(cache_root.path())
+            .platform(Platform::LinuxX64)
+            .version(VersionSpec::Latest)
+            .manifest_url(format!("{}/manifest.json", server.uri()))
+            .ensure_chrome()
+            .await
+            .unwrap_err();
+
+        assert!(
+            !matches!(err, FetcherError::IntegrityFailed { .. }),
+            "expected a download failure, got {err}"
+        );
+        let leftovers = staging_leftovers(cache_root.path()).await;
+        assert!(
+            leftovers.is_empty(),
+            "partial download left behind: {leftovers:?}"
+        );
+        assert!(!cache_root.path().join("120.0.6099.234").exists());
     }
 }

--- a/crates/zendriver-fetcher/src/lib.rs
+++ b/crates/zendriver-fetcher/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! See the [Fetcher chapter](https://turtiesocks.github.io/zendriver-rs/fetcher.html)
 //! of the [zendriver-rs user guide](https://turtiesocks.github.io/zendriver-rs/)
-//! for cache-layout details, offline-mode workflows, and CI integration tips.
+//! for cache-layout details and CI integration tips.
 //!
 //! Resolves a [`VersionSpec`] + [`Platform`] pair against the
 //! [Chrome for Testing manifest][cft-manifest], downloads the matching zip,

--- a/crates/zendriver-imperva/src/bypass.rs
+++ b/crates/zendriver-imperva/src/bypass.rs
@@ -354,6 +354,19 @@ impl<'tab> ImpervaBypass<'tab> {
                     // seconds in, and that arrival must reach the registered
                     // solver too.
                     //
+                    // Never escalate while a usable token is in hand. A
+                    // snapshot carrying a reese84 is not a page that needs a
+                    // CAPTCHA solved — clean body or not. `detect.js` ranks any
+                    // captcha above `Reese84`, and nothing gates that
+                    // classification on a genuine Imperva signal, so a plain
+                    // Google reCAPTCHA belonging to the site's own form flips
+                    // the surface even while the challenge is still settling.
+                    // Escalating there turns a run that would have kept polling
+                    // (and could still clear) into a hard `CaptchaRequired` on
+                    // the very first tick. Same reasoning as the token-first
+                    // ordering above, one arm over: a token in hand outranks a
+                    // captcha on the page.
+                    //
                     // Latched: `inject_captcha_solution` writes a hidden
                     // response field and never removes the widget, so the
                     // surface stays `Captcha` afterwards. Without the latch a
@@ -362,7 +375,7 @@ impl<'tab> ImpervaBypass<'tab> {
                     // main-world evaluates, on exactly the pages that are
                     // watching for them.
                     if let crate::detection::ImpervaSurface::Captcha(kind) = snap.surface {
-                        if !captcha_attempted {
+                        if token.is_none() && !captcha_attempted {
                             captcha_attempted = true;
                             self.solve_captcha(kind).await?;
                         }
@@ -957,6 +970,59 @@ mod tests {
             }
             other => panic!("expected TokenAcquired, got {other:?}"),
         }
+        conn.shutdown();
+    }
+
+    /// The token-first rule holds on the *not-yet-cleared* path too, which is
+    /// the majority regime in practice: most runs never reach a clean body
+    /// inside the budget. A token in hand plus a still-dirty body plus a
+    /// captcha iframe used to escalate and hard-fail on the first tick, so a
+    /// run that would have kept polling — and could still have cleared — was
+    /// converted into `CaptchaRequired` immediately. It must keep polling
+    /// instead, exactly as it does when no captcha is present.
+    #[tokio::test]
+    async fn a_token_suppresses_escalation_even_while_the_body_is_still_dirty() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                ImpervaBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .timeout(Duration::from_millis(150))
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        // Token present, body still dirty, captcha surface up — no solver
+        // registered, so any escalation is an immediate hard error.
+        let dirty = snapshot_reply(json!({
+            "surface": { "kind": "Captcha", "captcha": "Recaptcha" },
+            "reese84": "TOK_IN_HAND",
+            "body_clean": false,
+            "sessions": [],
+            "has_imperva_signal": true,
+        }));
+        while let Ok(Ok(id)) = tokio::time::timeout(
+            Duration::from_millis(120),
+            mock.expect_cmd("Runtime.evaluate"),
+        )
+        .await
+        .map(Ok::<u64, ()>)
+        {
+            mock.reply(id, dirty.clone()).await;
+        }
+
+        let outcome = fut
+            .await
+            .unwrap()
+            .expect("a token in hand must not escalate to a hard CaptchaRequired");
+        assert!(
+            matches!(outcome, ClearanceOutcome::TimedOut { .. }),
+            "expected the run to keep polling to its deadline, got {outcome:?}"
+        );
         conn.shutdown();
     }
 

--- a/crates/zendriver-imperva/src/bypass.rs
+++ b/crates/zendriver-imperva/src/bypass.rs
@@ -233,31 +233,9 @@ impl<'tab> ImpervaBypass<'tab> {
             });
         }
 
-        // CAPTCHA escalation: dispatch to solver or fast-fail.
-        if let crate::detection::ImpervaSurface::Captcha(kind) = snapshot.surface {
-            let Some(solver) = self.on_captcha.clone() else {
-                return Err(ImpervaError::CaptchaRequired { kind });
-            };
-            let (site_key, url) = extract_captcha_site_key(self.session, kind).await?;
-            let solution = solver(CaptchaChallenge {
-                kind,
-                site_key,
-                url,
-            })
-            .await
-            .map_err(ImpervaError::CaptchaSolver)?;
-            inject_captcha_solution(self.session, &solution).await?;
-            // Drop the pre-injection snapshot so the loop re-probes
-            // immediately rather than wasting an iteration on stale state.
-        }
-
-        // Prime the loop with the pre-loop snapshot UNLESS we just ran the
-        // CAPTCHA branch — in that case the page has been mutated since the
-        // snapshot was taken, so force a re-probe.
-        let next_snapshot = match snapshot.surface {
-            crate::detection::ImpervaSurface::Captcha(_) => None,
-            _ => Some(snapshot),
-        };
+        // CAPTCHA escalation is NOT decided here: Imperva commonly upgrades a
+        // reese84 device check to a CAPTCHA a few seconds in, so the loop owns
+        // that branch and the pre-loop snapshot just primes it.
 
         // Optional Fetch-domain fast-path. The guard's `Drop` cooperatively
         // cancels the spawned task (token check at every loop boundary)
@@ -269,11 +247,39 @@ impl<'tab> ImpervaBypass<'tab> {
             (None, None)
         };
 
-        self.poll_loop(deadline, next_snapshot, interception_rx, interception_guard)
-            .await
+        self.poll_loop(
+            deadline,
+            Some(snapshot),
+            interception_rx,
+            interception_guard,
+        )
+        .await
     }
 
-    /// Core poll loop, factored out so unit tests can drive it with a
+    /// Escalate a CAPTCHA surface to the registered solver and inject the
+    /// solution into the page. Errors with [`ImpervaError::CaptchaRequired`]
+    /// when no solver is registered. On success the page has been mutated, so
+    /// the caller must re-probe rather than reuse the snapshot it came from.
+    async fn solve_captcha(&self, kind: crate::detection::CaptchaKind) -> Result<(), ImpervaError> {
+        let Some(solver) = self.on_captcha.clone() else {
+            return Err(ImpervaError::CaptchaRequired { kind });
+        };
+        let (site_key, url) = extract_captcha_site_key(self.session, kind).await?;
+        let solution = solver(CaptchaChallenge {
+            kind,
+            site_key,
+            url,
+        })
+        .await
+        .map_err(ImpervaError::CaptchaSolver)?;
+        inject_captcha_solution(self.session, &solution).await
+    }
+
+    /// Core poll loop. Owns every mid-flight terminal, CAPTCHA escalation
+    /// included, so a surface that changes after the pre-loop probe is
+    /// handled exactly like one present from the start.
+    ///
+    /// Factored out so unit tests can drive it with a
     /// controlled interception receiver without standing up the real
     /// InterceptBuilder + Fetch.enable plumbing. Production callers go
     /// through [`wait_for_clearance`](Self::wait_for_clearance), which
@@ -314,23 +320,33 @@ impl<'tab> ImpervaBypass<'tab> {
                 },
             };
 
-            let token = snap.reese84.as_ref().filter(|v| !v.is_empty());
-            let surface_clear = matches!(snap.surface, crate::detection::ImpervaSurface::None);
-            match (token, snap.body_clean, surface_clear) {
-                (Some(token), true, _) => {
-                    return Ok(ClearanceOutcome::TokenAcquired {
-                        reese84: token.clone(),
-                        sessions: snap.sessions,
-                    });
+            // CAPTCHA escalation is polled, not assumed to arrive on the
+            // first probe: Imperva routinely upgrades a reese84 device check
+            // to a CAPTCHA seconds in, and that arrival must reach the
+            // registered solver too.
+            if let crate::detection::ImpervaSurface::Captcha(kind) = snap.surface {
+                self.solve_captcha(kind).await?;
+                // Page mutated by the injection — next iteration re-probes.
+                last_surface = Some(snap.surface);
+            } else {
+                let token = snap.reese84.as_ref().filter(|v| !v.is_empty());
+                let surface_clear = matches!(snap.surface, crate::detection::ImpervaSurface::None);
+                match (token, snap.body_clean, surface_clear) {
+                    (Some(token), true, _) => {
+                        return Ok(ClearanceOutcome::TokenAcquired {
+                            reese84: token.clone(),
+                            sessions: snap.sessions,
+                        });
+                    }
+                    // ChallengeGone requires `surface_clear` in addition to
+                    // the body+no-token spec criteria: lingering Legacy
+                    // cookies (`incap_ses_*`, `___utmvc`) indicate the page is
+                    // still tracking the challenge even after body markers
+                    // drop, and returning ChallengeGone there would race the
+                    // page's own post-clearance navigation.
+                    (None, true, true) => return Ok(ClearanceOutcome::ChallengeGone),
+                    _ => last_surface = Some(snap.surface),
                 }
-                // ChallengeGone requires `surface_clear` in addition to the
-                // body+no-token spec criteria: lingering Legacy cookies
-                // (`incap_ses_*`, `___utmvc`) indicate the page is still
-                // tracking the challenge even after body markers drop, and
-                // returning ChallengeGone there would race the page's own
-                // post-clearance navigation.
-                (None, true, true) => return Ok(ClearanceOutcome::ChallengeGone),
-                _ => last_surface = Some(snap.surface),
             }
 
             stall_ticks = if Some(snap.surface) == prev_surface {
@@ -872,6 +888,162 @@ mod tests {
         assert!(matches!(
             outcome,
             ClearanceOutcome::TokenAcquired { reese84, .. } if reese84 == "TOK_FINAL"
+        ));
+        conn.shutdown();
+    }
+
+    /// The normal Imperva escalation shape: the page starts on a reese84
+    /// device check and only *then* swaps in a CAPTCHA. Escalation used to be
+    /// checked on the pre-loop probe only, so this arrival never reached the
+    /// registered solver and the run just timed out.
+    #[tokio::test]
+    async fn mid_flight_captcha_escalation_invokes_solver() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                ImpervaBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .on_captcha(|c| async move {
+                        assert!(matches!(c.kind, CaptchaKind::HCaptcha));
+                        Ok(CaptchaSolution {
+                            token: "SOLVED_TOK".into(),
+                            form_field: "h-captcha-response".into(),
+                        })
+                    })
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        // Probe 1 (pre-loop): plain reese84 device check, no CAPTCHA yet.
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id1,
+            snapshot_reply(json!({
+                "surface": { "kind": "Reese84" },
+                "reese84": null,
+                "body_clean": false,
+                "sessions": [],
+                "has_imperva_signal": true,
+            })),
+        )
+        .await;
+
+        // Probe 2 (in-loop): escalated to hCaptcha.
+        let id2 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id2,
+            snapshot_reply(json!({
+                "surface": { "kind": "Captcha", "captcha": "HCaptcha" },
+                "reese84": null,
+                "body_clean": false,
+                "sessions": [],
+                "has_imperva_signal": true,
+            })),
+        )
+        .await;
+
+        // Site-key probe → solver → injection.
+        let id3 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id3,
+            json!({
+                "result": {
+                    "type": "object",
+                    "value": { "hcap": "KEY_ABC", "rcap": null, "url": "https://x.test/p" }
+                }
+            }),
+        )
+        .await;
+
+        let id4 = mock.expect_cmd("Runtime.evaluate").await;
+        assert!(
+            mock.last_sent()["params"]["expression"]
+                .as_str()
+                .unwrap()
+                .contains("SOLVED_TOK"),
+            "injection script should carry the solver token"
+        );
+        mock.reply(
+            id4,
+            json!({ "result": { "type": "boolean", "value": true } }),
+        )
+        .await;
+
+        // Probe 3: cleared.
+        let id5 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id5,
+            snapshot_reply(json!({
+                "surface": { "kind": "None" },
+                "reese84": "TOK_FINAL",
+                "body_clean": true,
+                "sessions": [{ "name": "reese84", "value": "TOK_FINAL" }],
+                "has_imperva_signal": true,
+            })),
+        )
+        .await;
+
+        let outcome = fut.await.unwrap().unwrap();
+        assert!(matches!(
+            outcome,
+            ClearanceOutcome::TokenAcquired { reese84, .. } if reese84 == "TOK_FINAL"
+        ));
+        conn.shutdown();
+    }
+
+    /// A CAPTCHA that arrives mid-flight with no solver registered must still
+    /// produce the actionable `CaptchaRequired` error, not a silent timeout.
+    #[tokio::test]
+    async fn mid_flight_captcha_without_solver_errors() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                ImpervaBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id1,
+            snapshot_reply(json!({
+                "surface": { "kind": "Legacy" },
+                "reese84": null,
+                "body_clean": false,
+                "sessions": [{ "name": "incap_ses_123", "value": "X" }],
+                "has_imperva_signal": true,
+            })),
+        )
+        .await;
+
+        let id2 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id2,
+            snapshot_reply(json!({
+                "surface": { "kind": "Captcha", "captcha": "Recaptcha" },
+                "reese84": null,
+                "body_clean": false,
+                "sessions": [],
+                "has_imperva_signal": true,
+            })),
+        )
+        .await;
+
+        let err = fut.await.unwrap().unwrap_err();
+        assert!(matches!(
+            err,
+            ImpervaError::CaptchaRequired {
+                kind: CaptchaKind::Recaptcha
+            }
         ));
         conn.shutdown();
     }

--- a/crates/zendriver-imperva/src/bypass.rs
+++ b/crates/zendriver-imperva/src/bypass.rs
@@ -308,6 +308,9 @@ impl<'tab> ImpervaBypass<'tab> {
         let mut prev_surface: Option<crate::detection::ImpervaSurface> = None;
         let mut stall_ticks: u32 = 0;
         let mut warned_stall = false;
+        // One solve attempt per clearance. See the escalation branch below for
+        // why the surface cannot clear itself afterwards.
+        let mut captcha_attempted = false;
 
         loop {
             let snap = match next_snapshot.take() {
@@ -320,32 +323,51 @@ impl<'tab> ImpervaBypass<'tab> {
                 },
             };
 
-            // CAPTCHA escalation is polled, not assumed to arrive on the
-            // first probe: Imperva routinely upgrades a reese84 device check
-            // to a CAPTCHA seconds in, and that arrival must reach the
-            // registered solver too.
-            if let crate::detection::ImpervaSurface::Captcha(kind) = snap.surface {
-                self.solve_captcha(kind).await?;
-                // Page mutated by the injection — next iteration re-probes.
-                last_surface = Some(snap.surface);
-            } else {
-                let token = snap.reese84.as_ref().filter(|v| !v.is_empty());
-                let surface_clear = matches!(snap.surface, crate::detection::ImpervaSurface::None);
-                match (token, snap.body_clean, surface_clear) {
-                    (Some(token), true, _) => {
-                        return Ok(ClearanceOutcome::TokenAcquired {
-                            reese84: token.clone(),
-                            sessions: snap.sessions,
-                        });
+            // Clearance is decided BEFORE any CAPTCHA escalation. A snapshot
+            // carrying a usable reese84 token over a clean body *is* a cleared
+            // challenge, and stays one even if the page happens to be showing
+            // a CAPTCHA iframe — the site's own post-clearance form routinely
+            // mounts one (a plain Google reCAPTCHA on the page it just let you
+            // reach). Escalating first discarded the very token this call
+            // exists to return, and turned a better clearance into a more
+            // reliable failure.
+            let token = snap.reese84.as_ref().filter(|v| !v.is_empty());
+            let surface_clear = matches!(snap.surface, crate::detection::ImpervaSurface::None);
+            match (token, snap.body_clean, surface_clear) {
+                (Some(token), true, _) => {
+                    return Ok(ClearanceOutcome::TokenAcquired {
+                        reese84: token.clone(),
+                        sessions: snap.sessions,
+                    });
+                }
+                // ChallengeGone requires `surface_clear` in addition to
+                // the body+no-token spec criteria: lingering Legacy
+                // cookies (`incap_ses_*`, `___utmvc`) indicate the page is
+                // still tracking the challenge even after body markers
+                // drop, and returning ChallengeGone there would race the
+                // page's own post-clearance navigation.
+                (None, true, true) => return Ok(ClearanceOutcome::ChallengeGone),
+                _ => {
+                    // Not cleared. CAPTCHA escalation is polled rather than
+                    // assumed to arrive on the first probe, because Imperva
+                    // routinely upgrades a reese84 device check to a CAPTCHA
+                    // seconds in, and that arrival must reach the registered
+                    // solver too.
+                    //
+                    // Latched: `inject_captcha_solution` writes a hidden
+                    // response field and never removes the widget, so the
+                    // surface stays `Captcha` afterwards. Without the latch a
+                    // 250ms poll over a 30s budget would re-enter the solver
+                    // on every tick — up to ~120 paid solves and twice that in
+                    // main-world evaluates, on exactly the pages that are
+                    // watching for them.
+                    if let crate::detection::ImpervaSurface::Captcha(kind) = snap.surface {
+                        if !captcha_attempted {
+                            captcha_attempted = true;
+                            self.solve_captcha(kind).await?;
+                        }
                     }
-                    // ChallengeGone requires `surface_clear` in addition to
-                    // the body+no-token spec criteria: lingering Legacy
-                    // cookies (`incap_ses_*`, `___utmvc`) indicate the page is
-                    // still tracking the challenge even after body markers
-                    // drop, and returning ChallengeGone there would race the
-                    // page's own post-clearance navigation.
-                    (None, true, true) => return Ok(ClearanceOutcome::ChallengeGone),
-                    _ => last_surface = Some(snap.surface),
+                    last_surface = Some(snap.surface);
                 }
             }
 
@@ -889,6 +911,137 @@ mod tests {
             outcome,
             ClearanceOutcome::TokenAcquired { reese84, .. } if reese84 == "TOK_FINAL"
         ));
+        conn.shutdown();
+    }
+
+    /// A usable token over a clean body IS a cleared challenge, and stays one
+    /// even when the page is showing a CAPTCHA iframe — the site's own
+    /// post-clearance form routinely mounts a plain Google reCAPTCHA on the
+    /// page it just let you reach, and `detect.js` ranks any captcha above
+    /// `Reese84`. Escalating before checking the token threw away the token
+    /// this call exists to return, so the better the clearance worked, the
+    /// more reliably it failed. No solver is registered here, which is what
+    /// turned that into a hard error rather than a wasted tick.
+    #[tokio::test]
+    async fn a_token_over_a_clean_body_wins_over_a_captcha_surface() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                ImpervaBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id,
+            snapshot_reply(json!({
+                "surface": { "kind": "Captcha", "captcha": "Recaptcha" },
+                "reese84": "TOK_CLEARED",
+                "body_clean": true,
+                "sessions": [],
+                "has_imperva_signal": true,
+            })),
+        )
+        .await;
+
+        let outcome = fut.await.unwrap().expect("a carried token must not error");
+        match outcome {
+            ClearanceOutcome::TokenAcquired { reese84, .. } => {
+                assert_eq!(reese84, "TOK_CLEARED");
+            }
+            other => panic!("expected TokenAcquired, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    /// `inject_captcha_solution` writes a hidden response field and never
+    /// removes the widget, so the surface stays `Captcha` afterwards. Without
+    /// a latch the poll loop re-enters the solver on every tick — real money
+    /// per solve, and a burst of main-world evaluates on a page that is
+    /// watching for exactly that.
+    #[tokio::test]
+    async fn captcha_solver_is_invoked_at_most_once_per_clearance() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            let c = Arc::clone(&calls);
+            async move {
+                ImpervaBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .timeout(Duration::from_millis(600))
+                    .on_captcha(move |_| {
+                        let c = Arc::clone(&c);
+                        async move {
+                            c.fetch_add(1, Ordering::SeqCst);
+                            Ok(CaptchaSolution {
+                                token: "SOLVED".into(),
+                                form_field: "g-recaptcha-response".into(),
+                            })
+                        }
+                    })
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        // Serve a stuck CAPTCHA surface for as long as the loop asks. Each
+        // Runtime.evaluate is answered by shape: the detect probe gets the
+        // snapshot, the site-key probe gets a key, the injection gets `true`.
+        // Nothing here ever clears the surface, so only the latch can stop a
+        // second solve.
+        let stuck = snapshot_reply(json!({
+            "surface": { "kind": "Captcha", "captcha": "Recaptcha" },
+            "reese84": null,
+            "body_clean": false,
+            "sessions": [],
+            "has_imperva_signal": true,
+        }));
+        loop {
+            let Ok(id) = tokio::time::timeout(
+                Duration::from_millis(300),
+                mock.expect_cmd("Runtime.evaluate"),
+            )
+            .await
+            else {
+                break;
+            };
+            let expr = mock.last_sent()["params"]["expression"]
+                .as_str()
+                .unwrap_or("")
+                .to_string();
+            let reply = if expr.contains("has_imperva_signal") {
+                stuck.clone()
+            } else if expr.contains("SOLVED") {
+                json!({ "result": { "type": "boolean", "value": true } })
+            } else {
+                json!({
+                    "result": {
+                        "type": "object",
+                        "value": { "hcap": null, "rcap": "KEY_ABC", "url": "https://x.test/p" }
+                    }
+                })
+            };
+            mock.reply(id, reply).await;
+        }
+
+        let _ = fut.await.unwrap();
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "solver must be latched to one attempt per clearance"
+        );
         conn.shutdown();
     }
 

--- a/crates/zendriver-imperva/src/detect.js
+++ b/crates/zendriver-imperva/src/detect.js
@@ -32,11 +32,14 @@
     var hasLegacyCookies = false;
     for (var j = 0; j < cookieNames.length; j++) {
         var n2 = cookieNames[j];
+        // Imperva emits the load-balancer cookie as `nlbi_<siteid>` (and
+        // sometimes `nlbi_<siteid>_<suffix>`), so match it by prefix — an
+        // exact "nlbi" never occurs in the wild.
         if (
             n2 === "___utmvc" ||
             n2.indexOf("incap_ses_") === 0 ||
             n2.indexOf("visid_incap_") === 0 ||
-            n2 === "nlbi"
+            n2.indexOf("nlbi") === 0
         ) {
             hasLegacyCookies = true;
             break;
@@ -109,12 +112,14 @@
     var sessionCookies = [];
     for (var m = 0; m < cookieNames.length; m++) {
         var name = cookieNames[m];
+        // Same prefix match as the legacy-cookie scan above: `nlbi_<siteid>`
+        // has to reach the caller's `sessions` snapshot for replay.
         if (
             name === reese84Key ||
             name === "___utmvc" ||
             name.indexOf("incap_ses_") === 0 ||
             name.indexOf("visid_incap_") === 0 ||
-            name === "nlbi"
+            name.indexOf("nlbi") === 0
         ) {
             sessionCookies.push({ name: name, value: cookies[name] });
         }

--- a/crates/zendriver-imperva/src/detect.js
+++ b/crates/zendriver-imperva/src/detect.js
@@ -32,14 +32,18 @@
     var hasLegacyCookies = false;
     for (var j = 0; j < cookieNames.length; j++) {
         var n2 = cookieNames[j];
-        // Imperva emits the load-balancer cookie as `nlbi_<siteid>` (and
-        // sometimes `nlbi_<siteid>_<suffix>`), so match it by prefix — an
-        // exact "nlbi" never occurs in the wild.
+        // `nlbi_*` is deliberately NOT a surface signal. It is Imperva's
+        // load-balancer cookie: pure routing state that is set on ordinary
+        // traffic and outlives clearance, unlike `incap_ses_*` / `___utmvc`,
+        // which track the challenge itself. Counting it here pinned the
+        // surface at `Legacy` on pages that had already cleared, which
+        // structurally blocks `ChallengeGone` and burns the whole budget down
+        // to `TimedOut`. It is still collected into `sessions` below, which is
+        // what the caller actually needs it for.
         if (
             n2 === "___utmvc" ||
             n2.indexOf("incap_ses_") === 0 ||
-            n2.indexOf("visid_incap_") === 0 ||
-            n2.indexOf("nlbi") === 0
+            n2.indexOf("visid_incap_") === 0
         ) {
             hasLegacyCookies = true;
             break;

--- a/crates/zendriver-imperva/src/detection.rs
+++ b/crates/zendriver-imperva/src/detection.rs
@@ -297,24 +297,40 @@ mod tests {
     }
 
     /// Imperva names the load-balancer cookie `nlbi_<siteid>`, never a bare
-    /// `nlbi`, so both cookie scans in `detect.js` (the legacy-surface check
-    /// and the `sessions` collector the caller replays) must match it by
-    /// prefix. An equality match silently dropped it from every snapshot.
+    /// `nlbi`, so the `sessions` collector must match it by prefix — an
+    /// equality match silently dropped it from every snapshot the caller
+    /// replays.
+    ///
+    /// It must NOT appear in the legacy-surface scan. `nlbi_*` is routing
+    /// state that is set on ordinary traffic and outlives clearance, so
+    /// treating it as a challenge marker pins the surface at `Legacy` on a
+    /// page that has already cleared — which blocks `ChallengeGone` outright
+    /// and turns a success into a full-budget timeout.
     ///
     /// Source-level guard: `detect.js` only ever runs inside a real page, so
     /// its behavior cannot be exercised from a mocked CDP transport.
     #[test]
-    fn detect_js_matches_the_nlbi_cookie_by_prefix_at_both_sites() {
+    fn detect_js_prefix_matches_nlbi_for_sessions_but_not_as_a_surface_signal() {
         let js = include_str!("detect.js");
         assert_eq!(
             js.matches(r#"indexOf("nlbi") === 0"#).count(),
-            2,
-            "both the legacy-cookie scan and the sessions collector must \
-             prefix-match nlbi_<siteid>"
+            1,
+            "only the sessions collector may match nlbi_<siteid>"
         );
         assert!(
             !js.contains(r#"=== "nlbi""#),
             "an exact nlbi match never fires against a real Imperva cookie"
+        );
+
+        // Pin the split structurally: the single surviving match must live
+        // after the `hasLegacyCookies` scan, i.e. in the sessions collector.
+        let legacy_scan = js.find("hasLegacyCookies = true").expect("legacy scan");
+        let nlbi_match = js
+            .find(r#"indexOf("nlbi") === 0"#)
+            .expect("sessions collector");
+        assert!(
+            nlbi_match > legacy_scan,
+            "nlbi must be collected for replay, not counted as a legacy surface"
         );
     }
 

--- a/crates/zendriver-imperva/src/detection.rs
+++ b/crates/zendriver-imperva/src/detection.rs
@@ -296,6 +296,28 @@ mod tests {
         conn.shutdown();
     }
 
+    /// Imperva names the load-balancer cookie `nlbi_<siteid>`, never a bare
+    /// `nlbi`, so both cookie scans in `detect.js` (the legacy-surface check
+    /// and the `sessions` collector the caller replays) must match it by
+    /// prefix. An equality match silently dropped it from every snapshot.
+    ///
+    /// Source-level guard: `detect.js` only ever runs inside a real page, so
+    /// its behavior cannot be exercised from a mocked CDP transport.
+    #[test]
+    fn detect_js_matches_the_nlbi_cookie_by_prefix_at_both_sites() {
+        let js = include_str!("detect.js");
+        assert_eq!(
+            js.matches(r#"indexOf("nlbi") === 0"#).count(),
+            2,
+            "both the legacy-cookie scan and the sessions collector must \
+             prefix-match nlbi_<siteid>"
+        );
+        assert!(
+            !js.contains(r#"=== "nlbi""#),
+            "an exact nlbi match never fires against a real Imperva cookie"
+        );
+    }
+
     #[tokio::test]
     async fn detect_snapshot_propagates_js_exception_as_jserror() {
         let (mut mock, conn) = MockConnection::pair();

--- a/crates/zendriver-interception/src/actor.rs
+++ b/crates/zendriver-interception/src/actor.rs
@@ -36,8 +36,8 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use futures::StreamExt;
 use serde::Deserialize;
+use serde::de::{Deserializer, MapAccess, Visitor};
 use serde_json::{Map, Value, json};
-use std::collections::HashMap;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 use tracing::{trace, warn};
@@ -148,8 +148,12 @@ pub(crate) struct RequestPausedEvent {
 pub(crate) struct RequestPayload {
     pub(crate) url: String,
     pub(crate) method: String,
-    #[serde(default)]
-    pub(crate) headers: HashMap<String, String>,
+    /// Request headers in the order the decoder yields them, kept as pairs
+    /// rather than a map so nothing is reordered or merged on our side of the
+    /// boundary. See [`deserialize_headers`] for what CDP can and cannot tell
+    /// us about the original wire order.
+    #[serde(default, deserialize_with = "deserialize_headers")]
+    pub(crate) headers: Vec<(String, String)>,
     /// Chrome's text representation of the request body. For multipart /
     /// binary uploads this can be lossy — Chrome rebuilds via UTF-8 best
     /// effort. Prefer [`Self::post_data_entries`] when present.
@@ -162,6 +166,48 @@ pub(crate) struct RequestPayload {
     /// When present, it is the canonical source of truth for the body.
     #[serde(rename = "postDataEntries", default)]
     pub(crate) post_data_entries: Option<Vec<PostDataEntry>>,
+}
+
+/// Decode CDP's `Network.Headers` (a JSON *object*) into ordered pairs,
+/// preserving whatever order the deserializer hands us.
+///
+/// Why this is not the browser's true header order: CDP models request
+/// headers as an object keyed by name, so duplicate-named headers are already
+/// merged by Chrome before the event is serialized, and JSON object order is
+/// only as faithful as the parser that read it. Our transport hands events to
+/// this crate as an already-parsed [`serde_json::Value`], whose object map is
+/// a `BTreeMap` unless `serde_json/preserve_order` is enabled workspace-wide —
+/// so the names arrive sorted, and the wire order is gone before we see it.
+///
+/// Collecting into a `Vec` here is still worth doing: it is deterministic
+/// (a `HashMap` would re-randomize the order on every request, which is a
+/// worse fingerprint for a caller who round-trips `RequestInfo::headers` back
+/// through `RequestOverrides`), and it is the piece that would automatically
+/// become order-faithful if the parse ever starts preserving order. Restoring
+/// the real order needs a raw-bytes event path in `zendriver-transport`.
+fn deserialize_headers<'de, D>(deserializer: D) -> Result<Vec<(String, String)>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct HeadersVisitor;
+
+    impl<'de> Visitor<'de> for HeadersVisitor {
+        type Value = Vec<(String, String)>;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("a map of header name to header value")
+        }
+
+        fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+            let mut headers = Vec::with_capacity(map.size_hint().unwrap_or(0));
+            while let Some(pair) = map.next_entry::<String, String>()? {
+                headers.push(pair);
+            }
+            Ok(headers)
+        }
+    }
+
+    deserializer.deserialize_map(HeadersVisitor)
 }
 
 #[derive(Debug, Deserialize)]
@@ -379,30 +425,40 @@ pub(crate) fn serialize_pattern(p: &RequestPattern) -> Value {
 
 /// Build a [`RequestInfo`] from the decoded event for `Modify` closures.
 ///
-/// Body precedence: `postDataEntries` (canonical, base64-decoded + concatenated)
-/// when present, else `postData` interpreted as UTF-8 bytes. The string
-/// fallback is necessarily lossy for binary bodies — Chrome only emits
-/// `postDataEntries` when it knows the text form would mangle the bytes.
+/// Body precedence: `postDataEntries` (canonical, base64-decoded +
+/// concatenated) when present, else `postData` interpreted as UTF-8 bytes. The
+/// string fallback is necessarily lossy for binary bodies — Chrome only emits
+/// `postDataEntries` when it knows the text form would mangle the bytes. The
+/// entries path is all-or-nothing: see [`decode_post_data`].
 ///
-/// Headers come from `Network.Request.headers` (CDP object) so we materialize
-/// them as a `Vec<(name, value)>` on the boundary; the upstream HashMap may
-/// have collapsed duplicates already, but for the request side CDP also
-/// pre-merges so this is faithful.
+/// Headers come from `Network.Request.headers`, which CDP models as an object
+/// keyed by header name — so duplicates are pre-merged by Chrome and the
+/// browser's on-the-wire header *order* does not survive to this point. See
+/// [`deserialize_headers`] for the full explanation; the pairs are passed
+/// through unchanged here.
 pub(crate) fn build_request_info(ev: &RequestPausedEvent) -> RequestInfo {
     RequestInfo {
         url: ev.request.url.clone(),
         method: ev.request.method.clone(),
-        headers: ev
-            .request
-            .headers
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect(),
+        headers: ev.request.headers.clone(),
         post_data: decode_post_data(&ev.request),
         resource_type: parse_resource_type(ev.resource_type.as_deref()),
     }
 }
 
+/// Decode the request body, all-or-nothing.
+///
+/// `postDataEntries` is a chunked body: the caller only has the real payload
+/// if *every* chunk decodes. If any entry is unusable (absent `bytes`, or
+/// invalid base64) we return `None` rather than the successfully-decoded
+/// prefix — a partial body is indistinguishable from a complete one, so a
+/// `Modify` closure that signs or hashes it would produce a valid signature
+/// over the wrong bytes. We also don't fall back to `postData` in that case:
+/// its lossy UTF-8 rebuild would be a different set of plausible-but-wrong
+/// bytes. `None` is the only honest answer the [`RequestInfo::post_data`]
+/// shape can give.
+///
+/// [`RequestInfo::post_data`]: crate::types::RequestInfo::post_data
 fn decode_post_data(req: &RequestPayload) -> Option<Vec<u8>> {
     use base64::Engine as _;
     use base64::engine::general_purpose::STANDARD as BASE64;
@@ -411,12 +467,19 @@ fn decode_post_data(req: &RequestPayload) -> Option<Vec<u8>> {
         let mut buf = Vec::new();
         for entry in entries {
             let Some(b64) = entry.bytes.as_deref() else {
-                continue;
+                tracing::warn!(
+                    "interception: postDataEntries entry without bytes; reporting no body rather than a truncated one"
+                );
+                return None;
             };
             match BASE64.decode(b64) {
                 Ok(bytes) => buf.extend_from_slice(&bytes),
                 Err(e) => {
-                    tracing::warn!(error = %e, "interception: bad base64 in postDataEntries; skipping entry");
+                    tracing::warn!(
+                        error = %e,
+                        "interception: bad base64 in postDataEntries; reporting no body rather than a truncated one"
+                    );
+                    return None;
                 }
             }
         }
@@ -926,5 +989,116 @@ mod tests {
             .expect("oneshot dropped");
         actor.await.unwrap();
         conn.shutdown();
+    }
+
+    /// Decode a `Fetch.requestPaused` payload the way the actor does.
+    fn request_info_from(request: Value) -> RequestInfo {
+        let ev: RequestPausedEvent = serde_json::from_value(json!({
+            "requestId": "REQ-1",
+            "request": request,
+            "resourceType": "XHR",
+        }))
+        .expect("event fixture must decode");
+        build_request_info(&ev)
+    }
+
+    /// Happy path: every `postDataEntries` chunk decodes, so the body is the
+    /// concatenation. Guards the all-or-nothing fix below from over-correcting.
+    #[test]
+    fn post_data_entries_concatenate_when_every_chunk_decodes() {
+        let info = request_info_from(json!({
+            "url": "https://example.test/upload",
+            "method": "POST",
+            "headers": {},
+            "postDataEntries": [
+                { "bytes": BASE64.encode("hello ") },
+                { "bytes": BASE64.encode("world") },
+            ],
+        }));
+        assert_eq!(info.post_data.as_deref(), Some(&b"hello world"[..]));
+    }
+
+    /// A corrupt chunk must yield `None`, never the decoded prefix: a partial
+    /// body is indistinguishable from a complete one, so a `Modify` closure
+    /// that signs it would emit a valid signature over the wrong bytes.
+    #[test]
+    fn post_data_entries_with_corrupt_chunk_yield_none_not_a_partial_body() {
+        let info = request_info_from(json!({
+            "url": "https://example.test/upload",
+            "method": "POST",
+            "headers": {},
+            "postDataEntries": [
+                { "bytes": BASE64.encode("hello ") },
+                { "bytes": "!!!not base64!!!" },
+                { "bytes": BASE64.encode("world") },
+            ],
+        }));
+        assert_eq!(
+            info.post_data, None,
+            "a truncated body must not surface as Some(prefix)"
+        );
+    }
+
+    /// Same contract for a chunk Chrome sent without `bytes` — the body is
+    /// incomplete, so we report no body rather than the surrounding chunks.
+    #[test]
+    fn post_data_entry_without_bytes_yields_none() {
+        let info = request_info_from(json!({
+            "url": "https://example.test/upload",
+            "method": "POST",
+            "headers": {},
+            "postDataEntries": [
+                { "bytes": BASE64.encode("hello ") },
+                {},
+            ],
+        }));
+        assert_eq!(info.post_data, None);
+    }
+
+    /// The `postData` fallback is untouched by the all-or-nothing rule — it
+    /// only applies to the chunked `postDataEntries` path.
+    #[test]
+    fn post_data_string_fallback_still_decodes() {
+        let info = request_info_from(json!({
+            "url": "https://example.test/form",
+            "method": "POST",
+            "headers": {},
+            "postData": "a=1&b=2",
+        }));
+        assert_eq!(info.post_data.as_deref(), Some(&b"a=1&b=2"[..]));
+    }
+
+    /// Request headers decode into a deterministic pair list. CDP's name-keyed
+    /// object means we can't recover Chrome's wire order (see
+    /// `deserialize_headers`), but two decodes of the same event must agree —
+    /// a `HashMap` re-randomized the order per request, which a caller
+    /// round-tripping `RequestInfo::headers` back through `RequestOverrides`
+    /// turns into a randomized header order on the wire.
+    #[test]
+    fn request_headers_decode_in_a_deterministic_order() {
+        let headers = json!({
+            "host": "example.test",
+            "user-agent": "zd/1",
+            "accept": "*/*",
+            "accept-language": "en-US",
+            "accept-encoding": "gzip",
+            "cookie": "a=1",
+            "referer": "https://example.test/",
+            "sec-fetch-mode": "cors",
+        });
+        let request = json!({
+            "url": "https://example.test/x",
+            "method": "GET",
+            "headers": headers,
+        });
+
+        let first = request_info_from(request.clone()).headers;
+        let second = request_info_from(request).headers;
+        assert_eq!(
+            first, second,
+            "header order must not change between decodes of the same event"
+        );
+        assert_eq!(first.len(), 8, "every header must survive the decode");
+        assert!(first.contains(&("cookie".to_string(), "a=1".to_string())));
     }
 }

--- a/crates/zendriver-interception/src/builder.rs
+++ b/crates/zendriver-interception/src/builder.rs
@@ -140,6 +140,12 @@ impl<'tab> InterceptBuilder<'tab> {
     /// `zendriver` crate if you want the wiring installed automatically on
     /// every tab.
     ///
+    /// **Only [`start`](Self::start) honors this.** The
+    /// [`subscribe`](Self::subscribe) escape hatch has no auth path — it never
+    /// subscribes to `Fetch.authRequired`, so it leaves
+    /// `handleAuthRequests: false` and logs an error rather than pausing auth
+    /// challenges nothing would answer. Use `start()` when you need auth.
+    ///
     /// See cdpdriver/zendriver#208.
     #[must_use]
     pub fn handle_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
@@ -392,12 +398,31 @@ impl<'tab> InterceptBuilder<'tab> {
     /// themselves. Use [`start`](Self::start) when you want the actor to
     /// apply rules automatically.
     ///
+    /// [`handle_auth`](Self::handle_auth) credentials are **also ignored**
+    /// here, and calling both logs an error. This path never subscribes to
+    /// `Fetch.authRequired`, so `Fetch.enable` is deliberately sent with
+    /// `handleAuthRequests: false`: flipping it on would make Chrome pause
+    /// every auth challenge with nobody to answer it, turning a visible 407
+    /// into a hang. Behind a proxy that requires credentials, use
+    /// [`start`](Self::start) instead.
+    ///
     /// The returned stream owns the underlying CDP subscription. Dropping
     /// the stream tears the subscription down — Chrome's interception stays
     /// active until the session is closed, but no further pauses surface to
     /// the caller.
     #[must_use = "the returned stream is the only handle on the subscription"]
     pub fn subscribe(mut self) -> impl Stream<Item = PausedRequest> + Send + use<> {
+        if self.auth.is_some() {
+            // Loud, because the alternative failure is invisible: behind a
+            // proxy every navigation 407s and the caller sees only empty
+            // pages. We cannot honor the credentials here — this path has no
+            // `Fetch.authRequired` subscription, and enabling
+            // `handleAuthRequests` without one converts the 407 into a hang.
+            tracing::error!(
+                "interception: handle_auth() credentials are ignored by subscribe(); \
+                 auth challenges will NOT be answered — use start() for proxy / HTTP auth"
+            );
+        }
         if self.patterns.is_empty() {
             self.patterns.push(RequestPattern {
                 url_pattern: Some("*".into()),
@@ -417,6 +442,9 @@ impl<'tab> InterceptBuilder<'tab> {
                     "Fetch.enable",
                     json!({
                         "patterns": enable_patterns,
+                        // Always false on this path — see the doc comment: no
+                        // `Fetch.authRequired` subscription exists here, so
+                        // `true` would pause challenges forever.
                         "handleAuthRequests": false,
                     }),
                 )
@@ -753,6 +781,37 @@ mod tests {
             paused.response.is_none(),
             "request-stage event has no response"
         );
+
+        drop(stream);
+        conn.shutdown();
+    }
+
+    /// `subscribe()` cannot honor `handle_auth`: it never subscribes to
+    /// `Fetch.authRequired`, so `handleAuthRequests: true` would leave Chrome
+    /// pausing auth challenges nobody answers — a hang instead of a 407.
+    /// Pin the flag to `false` (the caller is warned via `tracing::error!`)
+    /// so a future "fix" can't half-enable the auth path here.
+    #[tokio::test]
+    async fn subscribe_pins_handle_auth_requests_false_even_with_credentials() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let stream = Box::pin(
+            InterceptBuilder::new(&sess)
+                .handle_auth("puser", "ppass")
+                .subscribe(),
+        );
+
+        let enable_id =
+            tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Fetch.enable"))
+                .await
+                .expect("subscribe() did not send Fetch.enable within 2s");
+        let params = mock.last_sent()["params"].clone();
+        assert_eq!(
+            params["handleAuthRequests"], false,
+            "subscribe() has no Fetch.authRequired subscription — enabling auth handling here hangs every challenge"
+        );
+        mock.reply(enable_id, json!({})).await;
 
         drop(stream);
         conn.shutdown();

--- a/crates/zendriver-interception/src/types.rs
+++ b/crates/zendriver-interception/src/types.rs
@@ -141,22 +141,36 @@ impl std::fmt::Display for AbortReason {
 /// Information about an intercepted request, surfaced to rule closures and
 /// stream consumers.
 ///
-/// Headers are a `Vec<(name, value)>` rather than a `HashMap` so duplicates
-/// (multiple `Set-Cookie`, multi-value `Cookie`, etc.) and Chrome's emission
-/// order survive the round-trip into user code and back through
-/// [`RequestOverrides`]. CDP's underlying wire shape is a `[{name, value}]`
-/// array; this type matches that shape.
+/// Headers are a `Vec<(name, value)>` rather than a `HashMap` so the set
+/// round-trips through user code and back into [`RequestOverrides`] in a
+/// stable order, and so response headers keep their duplicates (multiple
+/// `Set-Cookie`, etc.) — CDP's wire shape for *responses* is a
+/// `[{name, value}]` array, which this type matches.
+///
+/// Request headers are the exception: CDP delivers those as an object keyed
+/// by header name (`Network.Headers`), so Chrome has already merged
+/// duplicate-named request headers and the browser's on-the-wire header
+/// **order is not recoverable** — do not rely on `RequestInfo::headers` for
+/// header-order fingerprint work.
 #[derive(Debug, Clone)]
 pub struct RequestInfo {
     /// Full request URL (post-redirect resolution by Chrome).
     pub url: String,
     /// HTTP method (`GET`, `POST`, ...).
     pub method: String,
-    /// Request headers as Chrome reported them. Order is Chrome's emission
-    /// order; duplicates are preserved.
+    /// Request headers as Chrome reported them.
+    ///
+    /// Deterministic, but **not** Chrome's emission order, and duplicate names
+    /// are already merged: CDP sends request headers as a name-keyed object
+    /// (see the type-level docs). Contrast [`ResponseInfo::headers`], which
+    /// does keep order and duplicates.
     pub headers: Vec<(String, String)>,
     /// Request body, if any. Sourced from `postDataEntries` (binary-safe)
     /// when present, otherwise the UTF-8 bytes of `postData`.
+    ///
+    /// `None` also covers an undecodable `postDataEntries` body: a chunk that
+    /// fails to decode yields `None` rather than a silently truncated body, so
+    /// a closure that signs this never signs a partial payload.
     pub post_data: Option<Vec<u8>>,
     /// Chrome's classification of the request's resource type.
     pub resource_type: ResourceType,

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -260,18 +260,56 @@ impl Persona {
 
     /// Host-probed persona (sysinfo). Cached: first call probes, rest clone.
     /// Runtime — NOT a build-script const (build host != run host).
+    ///
+    /// Reports only what it could actually read. An attribute whose probe fails
+    /// is left `None` (with a `WARN` naming it) rather than filled with a
+    /// stand-in value, so a caller never mistakes a library default for this
+    /// host. Downstream resolution supplies the fallback explicitly.
     pub fn system() -> Persona {
         SYSTEM.get_or_init(Persona::probe_system).clone()
     }
 
     fn probe_system() -> Persona {
-        let platform = crate::fingerprint::detect_platform();
-        let cpu = crate::fingerprint::clamp_cpu_count(num_cpus::get() as u32);
-        let mem = crate::fingerprint::detect_memory_gb().unwrap_or(8);
+        Persona::from_host_probe(
+            crate::fingerprint::detect_platform(),
+            crate::fingerprint::clamp_cpu_count(num_cpus::get() as u32),
+            crate::fingerprint::detect_memory_gb(),
+        )
+    }
+
+    /// Assemble the host persona from already-probed values. Split out of
+    /// [`Persona::probe_system`] so the failure path is reachable from tests
+    /// without a host that actually fails to report its RAM (the same idiom as
+    /// `fingerprint::parse_version_banner`).
+    ///
+    /// A probe that fails leaves its field `None` — never a stand-in constant.
+    /// This persona's entire contract is "the real host", so substituting a
+    /// plausible-looking value would be the worst available failure: the caller
+    /// believes they hold a coherent host identity while every user of this
+    /// crate whose probe failed ships the *same* value, which is exactly the
+    /// cross-user correlation signal a persona exists to avoid. `None` is the
+    /// persona's "unset, resolve downstream" state, and downstream resolution
+    /// is already explicit — `patches::identity_iife` falls back to the
+    /// [`Fingerprint`](crate::fingerprint::Fingerprint)'s own probed memory,
+    /// which surfaces an error rather than inventing one if it, too, fails.
+    fn from_host_probe(
+        platform: Platform,
+        cpu: u32,
+        memory_gb: Result<u32, crate::StealthError>,
+    ) -> Persona {
+        let device_memory_gb = memory_gb
+            .inspect_err(|e| {
+                tracing::warn!(
+                    "host memory probe failed: {e}; leaving device_memory_gb unset \
+                     (resolved from the probed fingerprint downstream) rather than \
+                     reporting a fabricated value"
+                );
+            })
+            .ok();
         Persona {
             platform: Some(platform),
             hardware_concurrency: Some(cpu),
-            device_memory_gb: Some(mem),
+            device_memory_gb,
             timezone: None,
             locale: None,
             seed: Some(Seed::random()),
@@ -413,6 +451,97 @@ mod persona_tests {
         let b = Persona::system();
         // Cached → same values.
         assert_eq!(a.device_memory_gb, b.device_memory_gb);
+    }
+
+    /// Run `f` with a tracing subscriber capturing WARN and above, and return
+    /// what it logged. A failure warning nobody can observe is
+    /// indistinguishable from the silent fabrication it replaced. (Twin of the
+    /// helper in `patches.rs`'s test module — kept local rather than shared to
+    /// avoid a test-support module for two callers.)
+    fn captured_warnings(f: impl FnOnce()) -> String {
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone, Default)]
+        struct Sink(Arc<Mutex<Vec<u8>>>);
+        impl Write for Sink {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Sink {
+            type Writer = Self;
+            fn make_writer(&'a self) -> Self {
+                self.clone()
+            }
+        }
+
+        let sink = Sink::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(sink.clone())
+            .with_max_level(tracing::Level::WARN)
+            .finish();
+        tracing::subscriber::with_default(subscriber, f);
+        let bytes = sink.0.lock().unwrap().clone();
+        String::from_utf8(bytes).expect("log output is utf-8")
+    }
+
+    // `StealthError` is large because `PatchFailed` wraps `CallError` (~152B);
+    // bypass per-fn, as the rest of the crate does.
+    #[allow(clippy::result_large_err)]
+    fn failed_memory_probe() -> Result<u32, crate::StealthError> {
+        Err(crate::StealthError::SystemInfo(
+            "total_memory returned 0".into(),
+        ))
+    }
+
+    /// The shipped bug: an unreadable host reported a library-wide constant
+    /// 8 GB, so every user whose probe failed shipped one correlatable value
+    /// while believing they held their own host's identity.
+    #[test]
+    fn failed_memory_probe_leaves_the_field_unset_never_fabricated() {
+        let p = Persona::from_host_probe(Platform::MacIntel, 8, failed_memory_probe());
+        assert_eq!(
+            p.device_memory_gb, None,
+            "a failed probe must surface as unset, not as a plausible constant"
+        );
+        // Guard the exact regression, in case some other default creeps back.
+        assert_ne!(p.device_memory_gb, Some(8));
+    }
+
+    /// Only the attribute that failed goes unset — a memory probe failure must
+    /// not discard the platform/CPU the host *did* report.
+    #[test]
+    fn failed_memory_probe_keeps_the_attributes_that_succeeded() {
+        let p = Persona::from_host_probe(Platform::Win32, 12, failed_memory_probe());
+        assert_eq!(p.platform, Some(Platform::Win32));
+        assert_eq!(p.hardware_concurrency, Some(12));
+        assert!(p.seed.is_some());
+    }
+
+    /// Unset alone is a silent hole; the failure has to be observable.
+    #[test]
+    fn failed_memory_probe_warns_naming_the_attribute() {
+        let logs = captured_warnings(|| {
+            let p = Persona::from_host_probe(Platform::LinuxX86_64, 4, failed_memory_probe());
+            assert!(p.device_memory_gb.is_none());
+        });
+        assert!(logs.contains("device_memory_gb"), "got: {logs}");
+        // The underlying probe error is carried through, not swallowed.
+        assert!(logs.contains("total_memory returned 0"), "got: {logs}");
+    }
+
+    /// The happy path is verbatim: a successful probe is reported as probed,
+    /// with no second-guessing between the probe and the persona.
+    #[test]
+    fn successful_memory_probe_is_reported_verbatim() {
+        let p = Persona::from_host_probe(Platform::MacIntel, 10, Ok(16));
+        assert_eq!(p.device_memory_gb, Some(16));
+        assert_eq!(p.hardware_concurrency, Some(10));
     }
 
     #[test]

--- a/crates/zendriver-transport/src/actor.rs
+++ b/crates/zendriver-transport/src/actor.rs
@@ -31,6 +31,35 @@ pub(crate) struct OutboundCmd {
 /// Default broadcast bus capacity. Lagged subscribers drop frames.
 pub(crate) const EVENT_BUS_CAPACITY: usize = 1024;
 
+/// How many dispatched commands may pass between sweeps of the pending-reply
+/// map.
+///
+/// A `call_raw` that hits its budget drops its reply receiver and walks away,
+/// but the matching `oneshot::Sender` stays keyed in `pending` until Chrome
+/// answers that id — which, for the wedged browser the budget exists to
+/// escape, never happens. Left alone the map grows for the life of the
+/// connection.
+///
+/// Sweeping every 256 dispatches bounds the debris at a few hundred
+/// pointer-sized entries for one `HashMap::retain` per 256 commands.
+/// Deliberately **not** a capacity cap on `pending`: refusing to enqueue
+/// commands would shed real work on a busy connection, which is worse than a
+/// slow leak.
+const PENDING_SWEEP_INTERVAL: u64 = 256;
+
+/// Drop every pending entry whose caller has gone away — its reply receiver
+/// dropped, i.e. a `call_raw` that timed out or was cancelled. Returns how
+/// many entries were removed.
+///
+/// Dropping the sender early is invisible to the caller (it is already gone);
+/// a late reply for a swept id lands on the existing "response for unknown id"
+/// branch, exactly as it already does when a caller drops mid-flight.
+fn sweep_pending(pending: &mut HashMap<u64, oneshot::Sender<Result<Value, CdpRpcError>>>) -> usize {
+    let before = pending.len();
+    pending.retain(|_id, reply| !reply.is_closed());
+    before - pending.len()
+}
+
 /// Accounted-bus plumbing for one actor run: the second, opt-in broadcast
 /// sender plus this run's generation number. Bundled into a struct (rather
 /// than two more [`run_actor`] parameters) to keep the function signature
@@ -101,6 +130,9 @@ pub(crate) async fn run_actor<S>(
     // reconnect); only advances when `accounted_tx` actually has a
     // subscriber, since it counts positions *on the accounted bus*.
     let mut next_accounted_sequence: u64 = 1;
+    // Commands dispatched since the last `sweep_pending`. See
+    // [`PENDING_SWEEP_INTERVAL`].
+    let mut dispatched_since_sweep: u64 = 0;
 
     // Sentinel stamped onto drained pendings when the loop exits. Defaults to
     // the clean-shutdown code; the unexpected-ws-death branches below flip it
@@ -134,8 +166,16 @@ pub(crate) async fn run_actor<S>(
                         trace!(id, method = %cmd.method, "send");
                         if let Err(e) = ws.send(Message::text(s)).await {
                             error!("ws send failed: {e}");
+                            // Same sentinel the remaining pendings get below:
+                            // a failed write means the socket died, and this
+                            // command is the one that hit the death first. A
+                            // generic `-32000` here would surface as an
+                            // ordinary `CallError::Rpc` — a code Chrome itself
+                            // emits constantly — so the caller's
+                            // `Disconnected` recovery would never fire for the
+                            // very call that discovered the disconnect.
                             let _ = cmd.reply.send(Err(CdpRpcError {
-                                code: -32000,
+                                code: crate::connection::DISCONNECTED_CODE,
                                 message: format!("ws send failed: {e}"),
                                 data: None,
                             }));
@@ -146,6 +186,18 @@ pub(crate) async fn run_actor<S>(
                             break;
                         }
                         pending.insert(id, cmd.reply);
+                        dispatched_since_sweep += 1;
+                        if dispatched_since_sweep >= PENDING_SWEEP_INTERVAL {
+                            dispatched_since_sweep = 0;
+                            let swept = sweep_pending(&mut pending);
+                            if swept > 0 {
+                                debug!(
+                                    swept,
+                                    remaining = pending.len(),
+                                    "swept pendings whose caller had gone away"
+                                );
+                            }
+                        }
                     }
                     Err(e) => {
                         let _ = cmd.reply.send(Err(CdpRpcError {
@@ -304,6 +356,26 @@ pub(crate) async fn run_actor<S>(
                 }
             }
         }
+    }
+
+    // Latch *why* this actor stopped, so calls that arrive after it is gone
+    // can still tell "Chrome died" from "I closed it". Without this, only
+    // in-flight calls (drained just below with `drain_code`) ever see
+    // `Disconnected`: every later call finds a closed command channel, whose
+    // `SendError` carries no reason, and reports `Shutdown`.
+    //
+    // Ordering is what makes the flag trustworthy. `cmd_rx` is dropped when
+    // this function returns, which is strictly after this store, so any sender
+    // that observes the channel closed necessarily observes the flag too —
+    // there is no window where a caller sees the death but not its cause.
+    // `Release`/`Acquire` (rather than the `Relaxed` used for the advisory
+    // counters on `ConnectionInner`) is the point: this store must be visible
+    // to the thread that later learns of the channel close.
+    if let Some(inner) = weak_inner.upgrade() {
+        inner.socket_died.store(
+            drain_code == crate::connection::DISCONNECTED_CODE,
+            std::sync::atomic::Ordering::Release,
+        );
     }
 
     // Drain pending into transport errors so callers don't hang. `drain_code`
@@ -474,7 +546,21 @@ mod tests {
         mpsc::Sender<Result<Message, tokio_tungstenite::tungstenite::Error>>,
         mpsc::Receiver<Message>,
     ) {
-        let (driver_tx_out, test_rx) = mpsc::channel::<Message>(32);
+        duplex_pair_with_capacity(32)
+    }
+
+    /// [`duplex_pair`] with a caller-chosen outbound capacity. The driver's
+    /// sink is `try_send`-based, so a test that dispatches a large burst
+    /// without draining needs room for all of it — otherwise the write fails
+    /// and kills the actor, which is a different test than the one intended.
+    fn duplex_pair_with_capacity(
+        outbound_capacity: usize,
+    ) -> (
+        DriverStream,
+        mpsc::Sender<Result<Message, tokio_tungstenite::tungstenite::Error>>,
+        mpsc::Receiver<Message>,
+    ) {
+        let (driver_tx_out, test_rx) = mpsc::channel::<Message>(outbound_capacity);
         let (test_tx_in, driver_rx_in) =
             mpsc::channel::<Result<Message, tokio_tungstenite::tungstenite::Error>>(32);
 
@@ -851,6 +937,103 @@ mod tests {
         let res = reply_rx.await.unwrap();
         let err = res.unwrap_err();
         assert_eq!(err.code, crate::connection::DISCONNECTED_CODE);
+
+        shutdown.cancel();
+        actor_handle.await.unwrap();
+    }
+
+    // ---------- Pending-map sweep ----------
+
+    #[test]
+    fn sweep_pending_drops_abandoned_callers_and_keeps_live_ones() {
+        let mut pending: HashMap<u64, oneshot::Sender<Result<Value, CdpRpcError>>> = HashMap::new();
+
+        // A caller still waiting on its reply.
+        let (live_tx, _live_rx) = oneshot::channel();
+        pending.insert(1, live_tx);
+        // Two callers that hit their budget and walked away — their reply
+        // receivers are gone, but the senders would otherwise sit here until
+        // Chrome answered ids it may never answer.
+        for id in [2u64, 3] {
+            let (abandoned_tx, abandoned_rx) = oneshot::channel();
+            drop(abandoned_rx);
+            pending.insert(id, abandoned_tx);
+        }
+
+        assert_eq!(sweep_pending(&mut pending), 2);
+        assert_eq!(pending.len(), 1);
+        assert!(
+            pending.contains_key(&1),
+            "a caller still waiting must never be swept"
+        );
+    }
+
+    /// The sweep must reap only callers that are gone: a call still waiting
+    /// has to survive crossing the sweep boundary and still get routed when
+    /// Chrome finally answers.
+    #[tokio::test]
+    async fn live_pending_survives_the_sweep_boundary() {
+        let outbound_capacity = PENDING_SWEEP_INTERVAL as usize * 2 + 8;
+        let (ws, test_tx, _test_rx) = duplex_pair_with_capacity(outbound_capacity);
+        let (cmd_tx, cmd_rx) = mpsc::channel::<OutboundCmd>(8);
+        let (event_tx, _event_rx) = broadcast::channel::<RawEvent>(EVENT_BUS_CAPACITY);
+        let shutdown = CancellationToken::new();
+        let actor_handle = tokio::spawn(run_actor(
+            ws,
+            cmd_rx,
+            event_tx,
+            AccountedBus {
+                tx: broadcast::channel::<AccountedRawEvent>(EVENT_BUS_CAPACITY).0,
+                generation: 1,
+            },
+            shutdown.clone(),
+            Vec::new(),
+            Weak::new(),
+        ));
+
+        // The one caller that stays alive. First command dispatched, so id 1.
+        let (live_reply_tx, live_reply_rx) = oneshot::channel();
+        cmd_tx
+            .send(OutboundCmd {
+                method: "Page.navigate".into(),
+                params: json!({ "url": "https://x.test" }),
+                session_id: None,
+                reply: live_reply_tx,
+            })
+            .await
+            .unwrap();
+
+        // Enough abandoned callers to cross the sweep interval twice over.
+        for _ in 0..PENDING_SWEEP_INTERVAL * 2 {
+            let (abandoned_tx, abandoned_rx) = oneshot::channel();
+            drop(abandoned_rx);
+            cmd_tx
+                .send(OutboundCmd {
+                    method: "Abandoned.call".into(),
+                    params: json!({}),
+                    session_id: None,
+                    reply: abandoned_tx,
+                })
+                .await
+                .unwrap();
+        }
+
+        // The actor's select is `biased` with `cmd_rx` ahead of the socket
+        // read, so every one of those commands (and therefore both sweeps) is
+        // processed before this reply is routed.
+        test_tx
+            .send(Ok(Message::text(
+                json!({ "id": 1, "result": { "frameId": "F1" } }).to_string(),
+            )))
+            .await
+            .unwrap();
+
+        let res = tokio::time::timeout(Duration::from_secs(5), live_reply_rx)
+            .await
+            .expect("a live pending must still be routable after a sweep")
+            .unwrap()
+            .unwrap();
+        assert_eq!(res["frameId"], "F1");
 
         shutdown.cancel();
         actor_handle.await.unwrap();

--- a/crates/zendriver-transport/src/connection.rs
+++ b/crates/zendriver-transport/src/connection.rs
@@ -1,6 +1,6 @@
 //! `Connection` — the public handle to the transport actor.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -90,6 +90,18 @@ pub(crate) const SHUTDOWN_DRAIN_CODE: i32 = -32001;
 /// unambiguous.
 pub(crate) const DISCONNECTED_CODE: i32 = -32002;
 
+/// Ceiling on a single [`Connection::redial`] — the TCP connect plus the
+/// WebSocket upgrade handshake.
+///
+/// Reconnect was the last lifecycle path with no deadline. That is exactly the
+/// shape the `zendriver` crate's `HANDSHAKE_TIMEOUT` was introduced to kill:
+/// an unbounded post-endpoint phase that "hung `launch()` forever" when
+/// Chrome's CDP responder accepted the socket and then went quiet. A reconnect
+/// dials the same kind of endpoint under worse conditions — the browser has
+/// already misbehaved once — so it gets the same 30s ceiling, deliberately
+/// matched rather than independently chosen.
+const REDIAL_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Cheap-to-clone handle to the connection actor. All `Tab`s and `Element`s
 /// hold one of these (via `Arc<...>`); the actor itself runs in a separate
 /// tokio task.
@@ -135,6 +147,21 @@ pub(crate) struct ConnectionInner {
     /// `Relaxed` is right: this is an advisory backstop read once per call,
     /// with no ordering relationship to anything else.
     pub(crate) call_timeout_ms: AtomicU64,
+    /// Why the current actor stopped, latched by the actor at exit: `true`
+    /// when the WebSocket died unexpectedly, `false` while it is still running
+    /// or when it stopped for a caller-requested [`Connection::shutdown`] /
+    /// [`Connection::reconnect`].
+    ///
+    /// Exists because a closed command channel is silent about *why* it
+    /// closed. Without this flag `TransportError::Disconnected` is reachable
+    /// only by a call already in flight when the socket died — a microsecond
+    /// window — and every call afterwards reports `Shutdown`, defeating the
+    /// `if let Err(ZendriverError::Disconnected) { browser.reconnect() }`
+    /// recipe that `Browser::reconnect` documents.
+    ///
+    /// Read via [`actor_gone_error`]; see the store in
+    /// [`crate::actor::run_actor`] for the ordering that makes it reliable.
+    pub(crate) socket_died: AtomicBool,
     /// Observer chain, retained so [`Connection::reconnect`] can re-spawn the
     /// actor with the same observers (so stealth re-injection etc. re-fire on
     /// the new targets). Stored as the `Vec` directly — an empty `Vec` means no
@@ -155,11 +182,29 @@ impl std::fmt::Debug for ConnectionInner {
             .field("shutdown", &self.shutdown)
             .field("observer_timeout", &self.observer_timeout)
             .field("call_timeout_ms", &self.call_timeout_ms)
+            .field("socket_died", &self.socket_died)
             .field(
                 "observers",
                 &format_args!("<{} observers>", self.observers.len()),
             )
             .finish()
+    }
+}
+
+/// Which [`TransportError`] to report when the actor is no longer there — to
+/// take a command, or to answer one it already took.
+///
+/// A closed command channel only says *that* the actor is gone, never why, and
+/// defaulting that to `Shutdown` mislabels a dead browser as a deliberate
+/// close. Consulting the exit reason the actor latched on its way out
+/// ([`ConnectionInner::socket_died`]) keeps `Disconnected` reachable for the
+/// whole time the connection is dead, not just for the calls that happened to
+/// be in flight at the instant it died.
+fn actor_gone_error(inner: &ConnectionInner) -> TransportError {
+    if inner.socket_died.load(Ordering::Acquire) {
+        TransportError::Disconnected
+    } else {
+        TransportError::Shutdown
     }
 }
 
@@ -217,9 +262,15 @@ impl Connection {
     /// resolves only if the socket dies — so it exists for deliberate,
     /// documented use, not convenience.
     ///
-    /// Note the budget covers **only** the wait for Chrome's reply. Queueing
-    /// the command onto the actor is bounded independently by the actor's
-    /// channel capacity and fails fast with [`TransportError::Shutdown`].
+    /// The budget covers the **whole** call — queueing the command onto the
+    /// actor *and* waiting for Chrome's reply. Queueing is not free: the
+    /// actor's command channel is 64 deep and applies backpressure once a
+    /// burst fills it, so a budget that started only at the reply would not
+    /// bound what the caller actually experiences. Queueing fails outright
+    /// only when the actor is gone, which surfaces as
+    /// [`TransportError::Disconnected`] (the socket died) or
+    /// [`TransportError::Shutdown`] (a caller-requested
+    /// [`shutdown`](Connection::shutdown)).
     pub async fn call_raw_with_timeout(
         &self,
         method: impl Into<String>,
@@ -228,7 +279,6 @@ impl Connection {
         budget: Option<Duration>,
     ) -> Result<Value, CallError> {
         let method = method.into();
-        let (reply_tx, reply_rx) = oneshot::channel();
         // Clone the current sender out from under the lock, then release the
         // guard before the `.await` — `std::sync::Mutex` must not be held
         // across an await point, and a concurrent `reconnect()` swap is fine
@@ -241,43 +291,57 @@ impl Connection {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             guard.clone()
         };
-        cmd_tx
-            .send(OutboundCmd {
-                // Cloned so the error path can name the stuck method — one
-                // small alloc against a websocket round-trip.
-                method: method.clone(),
-                params,
-                session_id,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| TransportError::Shutdown)?;
 
-        // The bare `reply_rx.await` this replaces was THE hang: only a dying
-        // websocket could resolve a pending call, so a wedged-but-connected
-        // Chrome blocked the caller forever.
-        let reply = match budget {
-            Some(budget) => match tokio::time::timeout(budget, reply_rx).await {
-                Ok(reply) => reply,
-                Err(_elapsed) => return Err(CallError::Timeout { method, budget }),
-            },
-            None => reply_rx.await,
-        };
+        // Cloned so the timeout path below can still name the stuck method —
+        // one small alloc against a websocket round-trip.
+        let cmd_method = method.clone();
+        let inner: &ConnectionInner = &self.inner;
+        // Enqueue and reply live in one future so a single `timeout` can wrap
+        // both. Splitting them (the enqueue awaited bare, the timeout starting
+        // only afterwards) let a call blow far past its own budget while
+        // waiting for room in the command channel.
+        let call = async move {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            cmd_tx
+                .send(OutboundCmd {
+                    method: cmd_method,
+                    params,
+                    session_id,
+                    reply: reply_tx,
+                })
+                .await
+                .map_err(|_| CallError::Transport(actor_gone_error(inner)))?;
 
-        match reply {
-            Ok(Ok(v)) => Ok(v),
-            Ok(Err(rpc_err)) => {
+            // The bare `reply_rx.await` this replaces was THE hang: only a
+            // dying websocket could resolve a pending call, so a
+            // wedged-but-connected Chrome blocked the caller forever.
+            match reply_rx.await {
+                Ok(Ok(v)) => Ok(v),
                 // Preserve the transport drain sentinels for drained pendings;
                 // everything else surfaces as a typed RPC error. Both sentinel
                 // codes are reserved internally — Chrome never emits them — so
                 // a code-only check is unambiguous.
-                match rpc_err.code {
-                    SHUTDOWN_DRAIN_CODE => Err(CallError::Transport(TransportError::Shutdown)),
-                    DISCONNECTED_CODE => Err(CallError::Transport(TransportError::Disconnected)),
-                    _ => Err(CallError::Rpc(rpc_err.code, rpc_err.message, rpc_err.data)),
-                }
+                Ok(Err(rpc_err)) => Err(match rpc_err.code {
+                    SHUTDOWN_DRAIN_CODE => CallError::Transport(TransportError::Shutdown),
+                    DISCONNECTED_CODE => CallError::Transport(TransportError::Disconnected),
+                    _ => CallError::Rpc(rpc_err.code, rpc_err.message, rpc_err.data),
+                }),
+                // The command was accepted but the actor dropped our reply
+                // sender without answering — it died between the two. Same
+                // question as a failed enqueue, so same answer.
+                Err(_) => Err(CallError::Transport(actor_gone_error(inner))),
             }
-            Err(_) => Err(CallError::Transport(TransportError::Shutdown)),
+        };
+
+        match budget {
+            None => call.await,
+            // A `match` rather than `unwrap_or_else`: a closure returning
+            // `Err(CallError)` trips `clippy::result_large_err`, and boxing
+            // the error to satisfy it would change a public type.
+            Some(budget) => match tokio::time::timeout(budget, call).await {
+                Ok(outcome) => outcome,
+                Err(_elapsed) => Err(CallError::Timeout { method, budget }),
+            },
         }
     }
 
@@ -523,6 +587,16 @@ impl Connection {
             .shutdown
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = new_shutdown;
+
+        // The connection is live again, so clear the previous actor's exit
+        // reason — otherwise a later clean `shutdown()` would still report
+        // `Disconnected` from the death this reconnect just repaired. Cleared
+        // last so it lands after the cancelled actor's own store (which is
+        // `false` for a reconnect cancel anyway). The remaining race is benign
+        // and self-limiting: it needs the *new* actor to also be gone before
+        // the flag is ever read, and it only mislabels which kind of dead the
+        // connection is.
+        self.inner.socket_died.store(false, Ordering::Release);
     }
 
     /// Dial `ws_url` afresh (re-applying the P-A A4 [`WebSocketConfig`] max-size
@@ -534,18 +608,44 @@ impl Connection {
     /// Tests that drive an in-memory duplex stream call [`Connection::reconnect`]
     /// directly instead.
     ///
+    /// Bounded at 30 seconds — matching the launch handshake's own guard — so
+    /// a Chrome that accepts the TCP connection and then never finishes the
+    /// WebSocket upgrade cannot hang the caller forever.
+    ///
     /// # Errors
     ///
     /// Returns [`TransportError::Ws`] when the dial fails (Chrome gone, refused
-    /// connection, bad URL). The existing actor is left **untouched** on dial
-    /// failure — only a successful dial swaps the socket.
+    /// connection, bad URL), and [`TransportError::Io`] with
+    /// [`std::io::ErrorKind::TimedOut`] when the dial neither succeeds nor
+    /// fails within that ceiling. The existing actor is left **untouched** on
+    /// either failure — only a successful dial swaps the socket.
     ///
     /// [`WebSocketConfig`]: tokio_tungstenite::tungstenite::protocol::WebSocketConfig
     pub async fn redial(&self, ws_url: &str) -> Result<(), TransportError> {
+        self.redial_with_timeout(ws_url, REDIAL_TIMEOUT).await
+    }
+
+    /// [`Connection::redial`] with a caller-chosen ceiling. Private: production
+    /// callers get [`REDIAL_TIMEOUT`]; tests pass a short budget so the
+    /// timeout path is assertable in milliseconds rather than 30 seconds.
+    async fn redial_with_timeout(
+        &self,
+        ws_url: &str,
+        budget: Duration,
+    ) -> Result<(), TransportError> {
         use tokio_tungstenite::connect_async_with_config;
         // Dial FIRST; only swap the live actor if the new socket is up, so a
         // failed reconnect doesn't tear down a still-usable connection.
-        let (ws, _resp) = connect_async_with_config(ws_url, Some(ws_config()), false).await?;
+        let dial = connect_async_with_config(ws_url, Some(ws_config()), false);
+        let (ws, _resp) = match tokio::time::timeout(budget, dial).await {
+            Ok(dialled) => dialled?,
+            Err(_elapsed) => {
+                return Err(TransportError::Io(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("redial to {ws_url} did not complete within {budget:?}"),
+                )));
+            }
+        };
         self.reconnect(ws);
         Ok(())
     }
@@ -699,6 +799,7 @@ where
         shutdown: Mutex::new(shutdown.clone()),
         observer_timeout,
         call_timeout_ms: AtomicU64::new(DEFAULT_CALL_TIMEOUT.as_millis() as u64),
+        socket_died: AtomicBool::new(false),
         // Retain the observer chain so `reconnect` can re-spawn the actor with
         // the same observers without the caller re-supplying them.
         observers: observers.clone(),
@@ -892,6 +993,241 @@ mod tests {
             matches!(res, Err(CallError::Transport(TransportError::Shutdown))),
             "clean shutdown must map to TransportError::Shutdown, got {res:?}"
         );
+    }
+
+    /// A failed socket write means the socket died, and the caller whose
+    /// command hit that failure must be told so. It used to get a bare
+    /// `-32000` — a code Chrome itself emits constantly — so the one call that
+    /// actually discovered the disconnect was the one call that could not
+    /// match a `Disconnected` recovery arm, while every *other* pending
+    /// command in the same branch was correctly drained as `Disconnected`.
+    #[tokio::test]
+    async fn failed_socket_write_reports_disconnected_to_its_own_caller() {
+        let (ws, _test_tx, test_rx) = duplex_pair();
+        // Drop the read end of the driver's sink so the very next write fails.
+        // `_test_tx` stays alive, so the inbound stream is still pending — the
+        // write failure is the only thing that can end this actor.
+        drop(test_rx);
+        let conn = spawn_actor(ws);
+
+        let res = tokio::time::timeout(
+            Duration::from_secs(5),
+            conn.call_raw("Page.navigate", json!({ "url": "https://x.test" }), None),
+        )
+        .await
+        .expect("must not hang");
+
+        assert!(
+            matches!(res, Err(CallError::Transport(TransportError::Disconnected))),
+            "a failed socket write must surface as Disconnected, got {res:?}"
+        );
+    }
+
+    /// `Browser::reconnect`'s own rustdoc tells callers to key recovery off
+    /// `Disconnected`. Before the actor latched its exit reason, that variant
+    /// was reachable only by a call already in flight at the instant the
+    /// socket died: every call afterwards found a closed command channel —
+    /// which says nothing about *why* it closed — and reported `Shutdown`, so
+    /// the documented recipe never fired.
+    #[tokio::test]
+    async fn calls_made_after_the_socket_dies_still_report_disconnected() {
+        let (ws, test_tx, mut test_rx) = duplex_pair();
+        let conn = spawn_actor(ws);
+
+        // One call in flight, so the actor is provably up before we kill it.
+        let inflight = tokio::spawn({
+            let c = conn.clone();
+            async move { c.call_raw("Page.navigate", json!({}), None).await }
+        });
+        let _ = test_rx.recv().await.unwrap();
+        drop(test_tx);
+
+        let drained = inflight.await.unwrap();
+        assert!(
+            matches!(
+                drained,
+                Err(CallError::Transport(TransportError::Disconnected))
+            ),
+            "the in-flight call must drain as Disconnected, got {drained:?}"
+        );
+
+        // The actual regression: calls made *after* the actor is gone. Three
+        // of them, because the first may still be buffered into the dying
+        // command channel while later ones fail the send outright — both
+        // routes must report the same thing.
+        for attempt in 1..=3 {
+            let res = tokio::time::timeout(
+                Duration::from_secs(5),
+                conn.call_raw("Page.navigate", json!({}), None),
+            )
+            .await
+            .expect("must not hang");
+            assert!(
+                matches!(res, Err(CallError::Transport(TransportError::Disconnected))),
+                "post-death call #{attempt} must report Disconnected, not Shutdown; got {res:?}"
+            );
+        }
+    }
+
+    /// A caller-requested shutdown must stay `Shutdown` even though the latch
+    /// now exists — the whole point is telling the two deaths apart.
+    #[tokio::test]
+    async fn calls_made_after_a_clean_shutdown_still_report_shutdown() {
+        let (ws, _test_tx, mut test_rx) = duplex_pair();
+        let conn = spawn_actor(ws);
+
+        let inflight = tokio::spawn({
+            let c = conn.clone();
+            async move { c.call_raw("Page.navigate", json!({}), None).await }
+        });
+        let _ = test_rx.recv().await.unwrap();
+        conn.shutdown();
+        let drained = inflight.await.unwrap();
+        assert!(matches!(
+            drained,
+            Err(CallError::Transport(TransportError::Shutdown))
+        ));
+
+        for attempt in 1..=3 {
+            let res = tokio::time::timeout(
+                Duration::from_secs(5),
+                conn.call_raw("Page.navigate", json!({}), None),
+            )
+            .await
+            .expect("must not hang");
+            assert!(
+                matches!(res, Err(CallError::Transport(TransportError::Shutdown))),
+                "post-shutdown call #{attempt} must stay Shutdown, got {res:?}"
+            );
+        }
+    }
+
+    /// A `Connection` whose command channel has capacity `capacity` and **no
+    /// actor draining it**, so the enqueue side can be filled deterministically.
+    /// The receiver is handed back rather than dropped: dropping it would make
+    /// `send` fail fast instead of applying the backpressure under test.
+    fn stalled_connection(capacity: usize) -> (Connection, mpsc::Receiver<OutboundCmd>) {
+        let (cmd_tx, cmd_rx) = mpsc::channel::<OutboundCmd>(capacity);
+        let (event_tx, _event_rx) = broadcast::channel::<RawEvent>(EVENT_BUS_CAPACITY);
+        let (accounted_tx, _accounted_rx) =
+            broadcast::channel::<AccountedRawEvent>(EVENT_BUS_CAPACITY);
+        let inner = Arc::new(ConnectionInner {
+            cmd_tx: Mutex::new(cmd_tx),
+            event_tx,
+            accounted_tx,
+            generation: AtomicU64::new(1),
+            shutdown: Mutex::new(CancellationToken::new()),
+            observer_timeout: DEFAULT_OBSERVER_TIMEOUT,
+            call_timeout_ms: AtomicU64::new(DEFAULT_CALL_TIMEOUT.as_millis() as u64),
+            socket_died: AtomicBool::new(false),
+            observers: Vec::new(),
+        });
+        (Connection { inner }, cmd_rx)
+    }
+
+    /// The budget must bound the **whole** call. It used to start only after
+    /// `cmd_tx.send().await` returned, so a call whose enqueue waited on a full
+    /// command channel sailed straight past its own budget with nothing to
+    /// stop it — `Some(100ms)` could block indefinitely.
+    #[tokio::test]
+    async fn call_budget_bounds_the_enqueue_not_just_the_reply() {
+        let (conn, _cmd_rx) = stalled_connection(1);
+
+        // Occupy the single slot, so the call under test must wait for room.
+        let (filler_reply, _filler_rx) = oneshot::channel();
+        conn.inner
+            .cmd_tx
+            .lock()
+            .unwrap()
+            .try_send(OutboundCmd {
+                method: "Filler.command".into(),
+                params: json!({}),
+                session_id: None,
+                reply: filler_reply,
+            })
+            .expect("the first slot is free");
+
+        let started = tokio::time::Instant::now();
+        let res = tokio::time::timeout(
+            Duration::from_secs(5),
+            conn.call_raw_with_timeout(
+                "Page.navigate",
+                json!({}),
+                None,
+                Some(Duration::from_millis(100)),
+            ),
+        )
+        .await
+        .expect("a blocked enqueue must still hit the budget rather than hang");
+
+        match res {
+            Err(CallError::Timeout { method, budget }) => {
+                assert_eq!(method, "Page.navigate", "must name the stuck method");
+                assert_eq!(budget, Duration::from_millis(100));
+            }
+            other => panic!("expected CallError::Timeout, got {other:?}"),
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "the budget must fire on time; took {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// Reconnect used to be the one lifecycle path with no deadline. A server
+    /// that completes the TCP connect and then never answers the upgrade
+    /// request is exactly the unbounded post-endpoint phase the launch-side
+    /// `HANDSHAKE_TIMEOUT` was introduced to kill.
+    #[tokio::test]
+    async fn redial_times_out_instead_of_hanging_forever() {
+        let (ws, _test_tx, _test_rx) = duplex_pair();
+        let conn = spawn_actor(ws);
+
+        // Accepts the connection, then says nothing — ever.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let silent_server = tokio::spawn(async move {
+            let mut accepted = Vec::new();
+            while let Ok((sock, _peer)) = listener.accept().await {
+                accepted.push(sock);
+            }
+        });
+
+        let started = tokio::time::Instant::now();
+        let res = tokio::time::timeout(
+            Duration::from_secs(10),
+            conn.redial_with_timeout(&format!("ws://{addr}"), Duration::from_millis(150)),
+        )
+        .await
+        .expect("redial must not hang");
+
+        match res {
+            Err(TransportError::Io(io)) => {
+                assert_eq!(io.kind(), std::io::ErrorKind::TimedOut);
+            }
+            other => panic!("expected a TimedOut io error, got {other:?}"),
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the redial ceiling must fire on time; took {:?}",
+            started.elapsed()
+        );
+        assert_eq!(
+            conn.connection_generation(),
+            1,
+            "a failed redial must leave the live actor untouched"
+        );
+
+        silent_server.abort();
+        conn.shutdown();
+    }
+
+    /// The redial ceiling deliberately mirrors the launch handshake's own
+    /// guard in the `zendriver` crate: same failure shape, same bound.
+    #[test]
+    fn redial_timeout_matches_the_launch_handshake_guard() {
+        const LAUNCH_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+        assert_eq!(REDIAL_TIMEOUT, LAUNCH_HANDSHAKE_TIMEOUT);
     }
 
     #[tokio::test]

--- a/crates/zendriver/examples/fetcher_demo.rs
+++ b/crates/zendriver/examples/fetcher_demo.rs
@@ -8,9 +8,10 @@
 //!
 //! [`Fetcher::ensure_chrome`] resolves the manifest, downloads + extracts
 //! into the OS-conventional cache dir on a cache miss, and returns a
-//! [`PathBuf`] to a runnable Chrome binary. On a cache hit (binary already
-//! extracted under `<cache>/<version>/`), it skips the network entirely
-//! and returns the cached path.
+//! [`PathBuf`] to a runnable Chrome binary. The manifest is resolved on
+//! every call, before the cache is probed, so a cache hit (binary already
+//! extracted under `<cache>/<version>/`) skips the download and the
+//! extraction but still needs to reach the manifest host.
 //!
 //! After resolving the path, you can hand it to a [`Browser`] launch:
 //! `Browser::builder().executable(path).launch().await?` — or use the

--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -2295,6 +2295,43 @@ const BROWSER_CLOSE_TIMEOUT: Duration = Duration::from_secs(3);
 /// intended per-phase waits, so it only bites on a genuine wedge, never on a
 /// close that is merely slow but still making progress.
 const BROWSER_CLOSE_DEADLINE: Duration = Duration::from_secs(15);
+
+/// What the `Browser.close` round-trip actually established about the quit.
+///
+/// Drives two decisions in [`Browser::close_owning`]: whether Chrome has earned
+/// the [`SHUTDOWN_GRACE`] to exit on its own before signals, and what to say if
+/// it does not. Both used to hang off one `acked: bool` that recorded *every*
+/// [`zendriver_transport::CallError::Transport`] as an acknowledgement — which
+/// silently folded "the frame never reached the socket" in with "Chrome took
+/// the quit and dropped the socket", and then reported the pair as a fact
+/// Chrome had told us.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum QuitOutcome {
+    /// Chrome answered the command. The only outcome that is a real ack.
+    Accepted,
+    /// The transport died on this call, so we will never learn whether Chrome
+    /// saw the quit. Chrome commonly drops the socket on quit instead of
+    /// replying, so the quit most likely landed — but a write that failed
+    /// before the frame left this process reports identically
+    /// ([`zendriver_transport::TransportError::Disconnected`] covers both), so
+    /// this earns the grace without ever claiming an acknowledgement.
+    TransportDied,
+    /// No quit can be in flight: Chrome refused it, never answered it, or the
+    /// transport was already shut down so it was never sent at all.
+    NotPending,
+}
+
+impl QuitOutcome {
+    /// Whether a quit might still be in flight, earning Chrome the
+    /// [`SHUTDOWN_GRACE`] to act on it before the signal path takes over.
+    ///
+    /// Waiting out the grace when nothing was ever sent buys nothing: there is
+    /// no message for Chrome to act on, so the wait can only expire.
+    fn may_be_in_flight(self) -> bool {
+        matches!(self, Self::Accepted | Self::TransportDied)
+    }
+}
+
 /// How long [`resolve_ws_from_http`] waits for the `/json/version` round-trip.
 const JSON_VERSION_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -4375,12 +4412,31 @@ impl Browser {
             self.inner.conn.call_raw("Browser.close", json!({}), None),
         )
         .await;
-        let acked = match quit {
+        let outcome = match quit {
             // Chrome acknowledged the quit.
-            Ok(Ok(_)) => true,
-            // Chrome commonly drops the socket on quit instead of replying;
-            // the transport dying here means the quit landed.
-            Ok(Err(zendriver_transport::CallError::Transport(_))) => true,
+            Ok(Ok(_)) => QuitOutcome::Accepted,
+            // The transport was already stopped by a caller-requested
+            // `shutdown()` / `reconnect()` — reachable from outside via the
+            // public `Browser::cdp` — so the enqueue failed cleanly and the
+            // frame never reached the socket. Nothing is in flight for the
+            // grace wait to wait on, so go straight to signals.
+            Ok(Err(zendriver_transport::CallError::Transport(
+                zendriver_transport::TransportError::Shutdown,
+            ))) => {
+                warn!(
+                    "Browser.close was never sent (the transport was already shut down); \
+                     falling back to signal shutdown",
+                );
+                QuitOutcome::NotPending
+            }
+            // Chrome commonly drops the socket on quit instead of replying, so
+            // a transport that dies here usually means the quit landed. Usually
+            // is not certainly: a local write that failed before the frame left
+            // this process surfaces as the same `Disconnected`, and the
+            // transport deliberately gives both the same variant so a caller's
+            // reconnect-on-`Disconnected` recovery fires either way. Grace it,
+            // but never report it as an acknowledgement.
+            Ok(Err(zendriver_transport::CallError::Transport(_))) => QuitOutcome::TransportDied,
             // Chrome never answered. Unreachable while `browser_close_budget`
             // (3s) stays far tighter than the transport's per-call default
             // (180s) — the outer timeout below wins — but matched explicitly
@@ -4388,20 +4444,20 @@ impl Browser {
             // it categorically is not: nothing was heard, let alone declined.
             Ok(Err(e @ zendriver_transport::CallError::Timeout { .. })) => {
                 warn!(error = %e, "Browser.close went unanswered; falling back to signal shutdown");
-                false
+                QuitOutcome::NotPending
             }
             // An RPC refusal means Chrome heard us and declined — nothing to
             // wait for, go straight to signals.
             Ok(Err(e)) => {
                 warn!(error = %e, "Browser.close was refused; falling back to signal shutdown");
-                false
+                QuitOutcome::NotPending
             }
             Err(_elapsed) => {
                 warn!(
                     budget = ?browser_close_budget,
                     "Browser.close went unanswered; falling back to signal shutdown",
                 );
-                false
+                QuitOutcome::NotPending
             }
         };
 
@@ -4409,14 +4465,25 @@ impl Browser {
 
         let mut child_guard = self.inner.child.lock().await;
         if let Some(mut child) = child_guard.take() {
-            if acked {
-                // Chrome took the quit — give it the same grace to actually
-                // exit. If it does, no signal is ever sent and the whole
-                // process tree went down with it.
+            if outcome.may_be_in_flight() {
+                // A quit may still be working — give Chrome the grace to
+                // actually exit. If it does, no signal is ever sent and the
+                // whole process tree went down with it.
                 if let Ok(Ok(_status)) = timeout(SHUTDOWN_GRACE, child.wait()).await {
                     return Ok(());
                 }
-                warn!("chrome accepted Browser.close but did not exit; hard-killing");
+                // Report what was observed, not what was assumed. Only
+                // `Accepted` is Chrome telling us it took the quit; on
+                // `TransportDied` the command may never have reached Chrome at
+                // all, so claiming it "accepted" states a fact we do not have.
+                if outcome == QuitOutcome::Accepted {
+                    warn!("chrome accepted Browser.close but did not exit; hard-killing");
+                } else {
+                    warn!(
+                        "the transport died during Browser.close and chrome did not exit; \
+                         the quit may never have reached it — hard-killing",
+                    );
+                }
             }
             // Try graceful exit first. On Unix, tokio's `start_kill` is
             // `kill(pid, SIGKILL)` — too aggressive for graceful shutdown.
@@ -7645,6 +7712,51 @@ mod tests {
             "a Browser.close timeout must still hard-kill the process (pid {pid} alive)",
         );
         drop(mock);
+    }
+
+    /// A quit that never reached the socket must not be recorded as one Chrome
+    /// accepted. `close()` classified *every* `CallError::Transport` as an
+    /// acknowledgement, so a `Browser.close` that failed to be sent at all
+    /// bought Chrome the full `SHUTDOWN_GRACE` to act on a message it had
+    /// never received — stalling teardown, then logging that "chrome accepted
+    /// Browser.close", which is a statement about bytes that never left this
+    /// process.
+    ///
+    /// `TransportError::Shutdown` is the unambiguous half of that: the actor
+    /// was stopped by a caller-requested `shutdown()`, so the enqueue failed
+    /// cleanly and nothing is in flight. Reachable from outside through the
+    /// public `Browser::cdp`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn close_skips_the_grace_when_the_quit_was_never_sent() {
+        let (child, pid) = spawn_stand_in_chrome();
+        // `_mock` is held (named, not bare `_`) for the whole test so the
+        // actor's only route out is the cancellation below. Dropping it would
+        // end the inbound stream instead, which the actor latches as an
+        // unexpected disconnect — a different classification than the one
+        // under test.
+        let (_mock, browser) = owning_browser_with_child(Some(child)).await;
+
+        // Tear the transport down before close() can send its quit.
+        browser.cdp().shutdown();
+
+        let start = tokio::time::Instant::now();
+        let closed = tokio::time::timeout(Duration::from_secs(20), browser.close()).await;
+        let elapsed = start.elapsed();
+
+        closed
+            .expect("close() must not hang")
+            .expect("close() returns Ok via the signal fallback");
+
+        // The stand-in never exits on its own, so an unsent quit misread as an
+        // ack burns the whole 5s `SHUTDOWN_GRACE` waiting for it to. The
+        // signal path is the only thing that can end this process, and there
+        // was never a reason to delay reaching for it.
+        assert!(
+            elapsed < SHUTDOWN_GRACE,
+            "an unsent Browser.close must not wait out the {SHUTDOWN_GRACE:?} grace; took {elapsed:?}",
+        );
+        assert!(!pid_alive(pid), "close() must leave no surviving process");
     }
 
     /// The whole close must stay bounded even when a phase that is otherwise

--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -1462,28 +1462,38 @@ impl BrowserBuilder {
         if explicit_locale {
             return;
         }
-        if let Some(geo) = resolver.resolve().await {
-            let mut derived = zendriver_stealth::geo::persona(geo.country);
-            // The exact probe timezone (when the source knows it) beats
-            // `persona`'s country-representative zone — precise beats
-            // approximate for the SAME field, still below anything the
-            // caller pinned explicitly (handled by the overlay direction
-            // just below).
-            if let Some(tz) = geo.timezone {
-                derived.timezone = Some(tz);
-            }
-            self.persona_overlay = Some(match self.persona_overlay.take() {
-                // Same direction as `geo_locale` above: `derived.overlay(existing)`
-                // — `existing` is the ARG so its explicit fields (e.g. a
-                // pinned `.timezone` with no locale) win; `derived` only
-                // fills gaps. The early return above guarantees
-                // `existing.locale` is `None` here, so the derived locale
-                // always comes through — this only changes precedence for
-                // OTHER fields (e.g. `timezone`) that `existing` may have set.
-                Some(existing) => derived.overlay(existing),
-                None => derived,
-            });
+        // A failed probe is NOT "no geo data" — it silently launches the
+        // default (US-English) persona behind whatever exit IP the proxy
+        // actually has, which is exactly the incoherence `geo_auto` exists
+        // to prevent. The resolver has already logged *why* it gave up;
+        // this records the consequence, since nothing downstream can.
+        let Some(geo) = resolver.resolve().await else {
+            tracing::warn!(
+                "geo_auto: resolver returned no geo; persona keeps its default locale/timezone, \
+                 which may not match the exit IP"
+            );
+            return;
+        };
+        let mut derived = zendriver_stealth::geo::persona(geo.country);
+        // The exact probe timezone (when the source knows it) beats
+        // `persona`'s country-representative zone — precise beats
+        // approximate for the SAME field, still below anything the
+        // caller pinned explicitly (handled by the overlay direction
+        // just below).
+        if let Some(tz) = geo.timezone {
+            derived.timezone = Some(tz);
         }
+        self.persona_overlay = Some(match self.persona_overlay.take() {
+            // Same direction as `geo_locale` above: `derived.overlay(existing)`
+            // — `existing` is the ARG so its explicit fields (e.g. a
+            // pinned `.timezone` with no locale) win; `derived` only
+            // fills gaps. The early return above guarantees
+            // `existing.locale` is `None` here, so the derived locale
+            // always comes through — this only changes precedence for
+            // OTHER fields (e.g. `timezone`) that `existing` may have set.
+            Some(existing) => derived.overlay(existing),
+            None => derived,
+        });
     }
 
     /// Override a single fingerprint [`Surface`]'s render [`Strategy`].

--- a/crates/zendriver/src/cookies/persistence.rs
+++ b/crates/zendriver/src/cookies/persistence.rs
@@ -21,20 +21,77 @@
 //! `url` re-inference. If you hand-author a JSON file with a non-null
 //! `url`, it round-trips faithfully too (serde preserves `Some` values).
 
-use std::path::Path;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use tokio::fs;
 
 use crate::cookies::CookieJar;
 use crate::error::Result;
 
+/// Write `bytes` to `path` atomically: fill a uniquely-named sibling temp
+/// file, then `rename` it over the destination.
+///
+/// A same-directory `rename` is atomic on every platform zendriver targets, so
+/// a process killed mid-write leaves either the previous file or the complete
+/// new one — never a truncated prefix. That matters most for the cookie jar: a
+/// half-written `cookies.json` fails to parse on the next `load_from_file`,
+/// losing exactly the authenticated session the file existed to preserve.
+///
+/// The temp name carries the process id plus a per-process counter, so two
+/// writers targeting the same destination cannot fill each other's temp file.
+/// A failure at either step removes the temp file rather than leaving litter
+/// next to the destination.
+///
+/// Scope: this buys atomicity against a killed process, not fsync-level
+/// durability against a power loss (neither the temp file nor the containing
+/// directory is synced). Losing an unsynced write leaves the previous file,
+/// which is the same outcome as never having called `save_to_file`.
+///
+/// Shared with the `tracker-blocking` blocklist cache
+/// (`crate::tracker::load_or_download_blocklist`), which wants the same
+/// guarantee; it lives here because this module is compiled unconditionally
+/// while that one is feature-gated.
+pub(crate) async fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = temp_path(path);
+    if let Err(e) = fs::write(&tmp, bytes).await {
+        let _ = fs::remove_file(&tmp).await;
+        return Err(e);
+    }
+    if let Err(e) = fs::rename(&tmp, path).await {
+        let _ = fs::remove_file(&tmp).await;
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// Sibling temp path for [`write_atomic`] — same directory, so the `rename`
+/// stays on one filesystem (and is therefore atomic), and unique per process
+/// and per call.
+fn temp_path(path: &Path) -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let mut name = path
+        .file_name()
+        .unwrap_or_else(|| OsStr::new("zendriver"))
+        .to_os_string();
+    name.push(format!(
+        ".{}.{}.tmp",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    path.with_file_name(name)
+}
+
 impl CookieJar {
     /// Snapshot the cookie store to a JSON file at `path`.
     ///
     /// Issues a single `Storage.getCookies` round-trip, then writes the
-    /// pretty-printed array via [`tokio::fs::write`]. The file is
-    /// overwritten if it already exists. Parent directories must already
-    /// exist — `save_to_file` does not create them.
+    /// pretty-printed array. The write is atomic — a sibling temp file is
+    /// filled and renamed over the destination — so an interrupted save
+    /// leaves the previous file intact instead of a truncated one that no
+    /// longer parses. The file is overwritten if it already exists. Parent
+    /// directories must already exist — `save_to_file` does not create them.
     ///
     /// # Errors
     ///
@@ -52,7 +109,7 @@ impl CookieJar {
     pub async fn save_to_file(&self, path: impl AsRef<Path>) -> Result<()> {
         let cookies = self.all().await?;
         let bytes = serde_json::to_vec_pretty(&cookies)?;
-        fs::write(path, bytes).await?;
+        write_atomic(path.as_ref(), &bytes).await?;
         Ok(())
     }
 
@@ -84,11 +141,11 @@ impl CookieJar {
 
     /// Snapshot only the cookies matching `filter` to a JSON file at `path`.
     ///
-    /// Like [`Self::save_to_file`], but applies the `filter` predicate to
-    /// the result of [`CookieJar::all`] before writing — handy for
-    /// persisting just one site's cookies out of a shared store. The
-    /// predicate receives each [`crate::cookies::Cookie`] by reference and
-    /// returns `true` to keep it.
+    /// Like [`Self::save_to_file`] — including the atomic temp-file-then-
+    /// rename write — but applies the `filter` predicate to the result of
+    /// [`CookieJar::all`] before writing, handy for persisting just one
+    /// site's cookies out of a shared store. The predicate receives each
+    /// [`crate::cookies::Cookie`] by reference and returns `true` to keep it.
     ///
     /// # Errors
     ///
@@ -118,7 +175,7 @@ impl CookieJar {
             .filter(|c| filter(c))
             .collect();
         let bytes = serde_json::to_vec_pretty(&cookies)?;
-        fs::write(path, bytes).await?;
+        write_atomic(path.as_ref(), &bytes).await?;
         Ok(())
     }
 
@@ -165,8 +222,53 @@ mod tests {
     use serde_json::json;
     use zendriver_transport::testing::MockConnection;
 
+    use super::write_atomic;
     use crate::cookies::{CookieJar, SameSite};
     use crate::error::ZendriverError;
+
+    /// Count the entries in a directory — the cheap proxy for "the temp file
+    /// was renamed, not left behind".
+    fn dir_entry_count(dir: &std::path::Path) -> usize {
+        std::fs::read_dir(dir).unwrap().count()
+    }
+
+    /// The atomic write replaces existing content in place and leaves no
+    /// `.tmp` sibling behind: after the call the directory holds exactly the
+    /// destination file, carrying the new bytes.
+    #[tokio::test]
+    async fn write_atomic_replaces_existing_and_leaves_no_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("cookies.json");
+        std::fs::write(&dest, b"stale").unwrap();
+
+        write_atomic(&dest, b"fresh").await.unwrap();
+
+        assert_eq!(std::fs::read(&dest).unwrap(), b"fresh");
+        assert_eq!(
+            dir_entry_count(dir.path()),
+            1,
+            "temp file must be renamed away, not left next to the destination"
+        );
+    }
+
+    /// When the `rename` step fails, the error surfaces AND the temp file is
+    /// cleaned up. A destination that is an existing directory is the
+    /// simplest way to make `rename` fail after a successful temp write.
+    #[tokio::test]
+    async fn write_atomic_cleans_up_temp_file_when_rename_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("occupied");
+        std::fs::create_dir(&dest).unwrap();
+
+        let err = write_atomic(&dest, b"fresh").await.unwrap_err();
+        let _ = err;
+
+        assert_eq!(
+            dir_entry_count(dir.path()),
+            1,
+            "only the pre-existing directory should remain; the temp file must be removed"
+        );
+    }
 
     /// End-to-end round-trip: dump the cookie store to disk, then load it back
     /// into a fresh jar. The mock receives `Storage.getCookies` on save,
@@ -373,5 +475,57 @@ mod tests {
         load.await.unwrap().unwrap();
 
         conn.shutdown();
+    }
+
+    /// Both save paths must go through the atomic helper: the destination
+    /// ends up holding the full pretty-printed JSON, and no `.tmp` sibling is
+    /// left in the directory. Writing over an existing file also proves the
+    /// rename replaces stale content rather than appending to it.
+    #[tokio::test]
+    async fn both_save_paths_write_atomically() {
+        for matching in [false, true] {
+            let (mut mock, conn) = MockConnection::pair();
+            let jar = CookieJar::new(conn.clone());
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("cookies.json");
+            std::fs::write(&path, b"stale-and-longer-than-the-new-content").unwrap();
+
+            let save = tokio::spawn({
+                let j = jar.clone();
+                let p = path.clone();
+                async move {
+                    if matching {
+                        j.save_to_file_matching(p, |_| true).await
+                    } else {
+                        j.save_to_file(p).await
+                    }
+                }
+            });
+
+            let id = mock.expect_cmd("Storage.getCookies").await;
+            mock.reply(
+                id,
+                json!({
+                    "cookies": [
+                        { "name": "a", "value": "1", "domain": ".x.test", "path": "/",
+                          "httpOnly": false, "secure": false },
+                    ]
+                }),
+            )
+            .await;
+            save.await.unwrap().unwrap();
+
+            let parsed: Vec<crate::cookies::Cookie> =
+                serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+            assert_eq!(parsed.len(), 1, "matching={matching}");
+            assert_eq!(parsed[0].name, "a");
+            assert_eq!(
+                dir_entry_count(dir.path()),
+                1,
+                "matching={matching}: save must leave no temp file behind"
+            );
+
+            conn.shutdown();
+        }
     }
 }

--- a/crates/zendriver/src/cookies/persistence.rs
+++ b/crates/zendriver/src/cookies/persistence.rs
@@ -53,9 +53,34 @@ use crate::error::Result;
 /// (`crate::tracker::load_or_download_blocklist`), which wants the same
 /// guarantee; it lives here because this module is compiled unconditionally
 /// while that one is feature-gated.
+///
+/// # Permissions and symlinks
+///
+/// The rename installs the *temp file's* inode at `path`, so the destination
+/// afterwards is a different file than it was before. Two consequences that a
+/// plain `fs::write` does not have:
+///
+/// - **The mode comes from the temp file.** Left alone that would be the
+///   process umask (commonly `0644`), silently widening a jar the user
+///   deliberately created `chmod 600` into a world-readable file full of live
+///   session cookies. [`apply_destination_mode`] therefore stamps the
+///   destination's current mode onto the temp file before the rename, and
+///   falls back to owner-only `0600` when the destination does not exist yet.
+///   No-op on non-Unix targets, which have no mode to carry over.
+/// - **A symlinked destination is replaced, not followed.** If `path` is a
+///   symlink, the rename unlinks it and leaves a regular file in its place —
+///   the link target keeps its old contents and stops receiving writes.
+///   `fs::write` followed the link and wrote through to the target, so a
+///   caller who symlinked their cookie jar at some canonical store must point
+///   zendriver at the real path instead. (The mode is still read through the
+///   link, so the replacement inherits the target's permissions.)
 pub(crate) async fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let tmp = temp_path(path);
     if let Err(e) = fs::write(&tmp, bytes).await {
+        let _ = fs::remove_file(&tmp).await;
+        return Err(e);
+    }
+    if let Err(e) = apply_destination_mode(&tmp, path).await {
         let _ = fs::remove_file(&tmp).await;
         return Err(e);
     }
@@ -63,6 +88,45 @@ pub(crate) async fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<(
         let _ = fs::remove_file(&tmp).await;
         return Err(e);
     }
+    Ok(())
+}
+
+/// Give `tmp` the permissions `dest` should still have once the rename has
+/// swapped one for the other.
+///
+/// An existing destination's mode wins outright: preserving what the user (or
+/// their prior save) chose is the only behavior that keeps `write_atomic`
+/// indistinguishable from the `fs::write` it replaced.
+#[cfg(unix)]
+async fn apply_destination_mode(tmp: &Path, dest: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Mode for a destination that does not exist yet.
+    ///
+    /// `0600` rather than the process umask because the caller that matters
+    /// here — [`CookieJar::save_to_file`] — writes authentication material:
+    /// session cookies that are equivalent to a password for as long as they
+    /// live. Nothing else on the machine has a reason to read them, so the
+    /// safe default is owner-only and a user who genuinely wants the file
+    /// shared can widen it once — the branch above then preserves that choice
+    /// on every later save.
+    const NEW_FILE_MODE: u32 = 0o600;
+
+    let mode = match fs::metadata(dest).await {
+        // Mask off the file-type bits; keep the full permission set (including
+        // setuid/setgid/sticky) so nothing the user set is quietly dropped.
+        Ok(meta) => meta.permissions().mode() & 0o7777,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => NEW_FILE_MODE,
+        Err(e) => return Err(e),
+    };
+    fs::set_permissions(tmp, std::fs::Permissions::from_mode(mode)).await
+}
+
+/// No-op counterpart for targets without Unix mode bits — Windows carries its
+/// ACLs on the containing directory, so the renamed file picks them up.
+#[cfg(not(unix))]
+#[allow(clippy::unused_async)]
+async fn apply_destination_mode(_tmp: &Path, _dest: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
@@ -92,6 +156,13 @@ impl CookieJar {
     /// leaves the previous file intact instead of a truncated one that no
     /// longer parses. The file is overwritten if it already exists. Parent
     /// directories must already exist — `save_to_file` does not create them.
+    ///
+    /// On Unix an existing file keeps its permissions across saves, and a file
+    /// created by this call is `0600`: it holds live session cookies, so the
+    /// default is owner-only rather than whatever the process umask allows.
+    /// Because the write finishes with a `rename`, a `path` that is a *symlink*
+    /// is replaced by a regular file — the link target stops receiving saves.
+    /// Pass the real path if you were relying on that indirection.
     ///
     /// # Errors
     ///
@@ -142,7 +213,8 @@ impl CookieJar {
     /// Snapshot only the cookies matching `filter` to a JSON file at `path`.
     ///
     /// Like [`Self::save_to_file`] — including the atomic temp-file-then-
-    /// rename write — but applies the `filter` predicate to the result of
+    /// rename write and its permission/symlink behavior — but applies the
+    /// `filter` predicate to the result of
     /// [`CookieJar::all`] before writing, handy for persisting just one
     /// site's cookies out of a shared store. The predicate receives each
     /// [`crate::cookies::Cookie`] by reference and returns `true` to keep it.
@@ -268,6 +340,157 @@ mod tests {
             1,
             "only the pre-existing directory should remain; the temp file must be removed"
         );
+    }
+
+    /// Mode of `path`, permission bits only. Unix-only helper for the
+    /// permission tests below.
+    #[cfg(unix)]
+    fn mode_of(path: &std::path::Path) -> u32 {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    /// A jar deliberately created `chmod 600` must still be `0600` after a
+    /// save. The rename installs the temp file's inode, so without an explicit
+    /// carry-over the mode collapses to the process umask (0644 on a stock
+    /// box) and a file full of live session cookies goes world-readable.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_preserves_an_existing_restrictive_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("cookies.json");
+        std::fs::write(&dest, b"stale").unwrap();
+        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        write_atomic(&dest, b"fresh").await.unwrap();
+
+        let mode = mode_of(&dest);
+        assert_eq!(
+            mode, 0o600,
+            "a 0600 cookie jar must not widen across a save, got {mode:o}"
+        );
+        assert_eq!(std::fs::read(&dest).unwrap(), b"fresh");
+        assert_eq!(dir_entry_count(dir.path()), 1, "no temp file may be left");
+    }
+
+    /// A mode the user widened on purpose is preserved too — the rule is
+    /// "carry the destination's mode", not "force 0600 on everything".
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_preserves_an_existing_permissive_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("trackers.txt");
+        std::fs::write(&dest, b"stale").unwrap();
+        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_atomic(&dest, b"fresh").await.unwrap();
+
+        let mode = mode_of(&dest);
+        assert_eq!(mode, 0o644, "a widened mode must survive too, got {mode:o}");
+    }
+
+    /// With no destination to inherit from, the new file is owner-only rather
+    /// than whatever the ambient umask would have allowed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_creates_a_new_file_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("cookies.json");
+        assert!(!dest.exists());
+
+        write_atomic(&dest, b"fresh").await.unwrap();
+
+        let mode = mode_of(&dest);
+        assert_eq!(
+            mode, 0o600,
+            "a freshly created cookie jar must default to owner-only, got {mode:o}"
+        );
+        assert_eq!(std::fs::read(&dest).unwrap(), b"fresh");
+        assert_eq!(dir_entry_count(dir.path()), 1, "no temp file may be left");
+    }
+
+    /// Pins the behavior the rustdoc warns about: because the write ends in a
+    /// `rename`, a symlinked destination is *replaced* by a regular file
+    /// instead of written through. If this ever changes, the docs on
+    /// `write_atomic` and `save_to_file` change with it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_replaces_a_symlinked_destination() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.json");
+        let link = dir.path().join("cookies.json");
+        std::fs::write(&real, b"original").unwrap();
+        std::fs::set_permissions(&real, std::fs::Permissions::from_mode(0o600)).unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        write_atomic(&link, b"fresh").await.unwrap();
+
+        assert!(
+            !std::fs::symlink_metadata(&link).unwrap().is_symlink(),
+            "the rename unlinks the symlink and leaves a regular file"
+        );
+        assert_eq!(std::fs::read(&link).unwrap(), b"fresh");
+        assert_eq!(
+            std::fs::read(&real).unwrap(),
+            b"original",
+            "the link target stops receiving writes"
+        );
+        // The mode is still read through the link, so the replacement keeps
+        // the target's restrictive permissions.
+        let mode = mode_of(&link);
+        assert_eq!(
+            mode, 0o600,
+            "the replacement must inherit the link target's mode, got {mode:o}"
+        );
+    }
+
+    /// The regression as reported, end to end through the public API: a jar
+    /// file at 0600 that a real `save_to_file` must not widen.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn save_to_file_preserves_a_restrictive_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (mut mock, conn) = MockConnection::pair();
+        let jar = CookieJar::new(conn.clone());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cookies.json");
+        std::fs::write(&path, b"stale").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        let save = tokio::spawn({
+            let j = jar.clone();
+            let p = path.clone();
+            async move { j.save_to_file(p).await }
+        });
+
+        let id = mock.expect_cmd("Storage.getCookies").await;
+        mock.reply(
+            id,
+            json!({
+                "cookies": [
+                    { "name": "session", "value": "secret", "domain": ".x.test", "path": "/",
+                      "httpOnly": true, "secure": true },
+                ]
+            }),
+        )
+        .await;
+        save.await.unwrap().unwrap();
+
+        let mode = mode_of(&path);
+        assert_eq!(
+            mode, 0o600,
+            "save_to_file must not widen a 0600 jar holding session cookies, got {mode:o}"
+        );
+        assert_eq!(dir_entry_count(dir.path()), 1, "no temp file may be left");
+
+        conn.shutdown();
     }
 
     /// End-to-end round-trip: dump the cookie store to disk, then load it back

--- a/crates/zendriver/src/element/actions.rs
+++ b/crates/zendriver/src/element/actions.rs
@@ -554,9 +554,13 @@ impl Element {
         self.with_refresh(|| {
             let value = value.clone();
             async move {
+                // Leading `el` absorbs the element handle `call_on_main`
+                // prepends, so `v` binds to the caller's text (same shape as
+                // `NATIVE_VALUE_SETTER_JS`); the body reads the element off
+                // `this`, which `Runtime.callFunctionOn` binds to it.
                 let _ = self
                     .call_on_main(
-                        "function(v){ this.textContent = v; }",
+                        "function(el, v){ this.textContent = v; }",
                         json!([{ "value": value }]),
                     )
                     .await?;
@@ -744,9 +748,11 @@ impl Element {
             let cy = bbox.y + bbox.height / 2.0;
             // Inject the dot in the main world with the element bound (house
             // pattern); the args carry the viewport-center coords + lifetime.
+            // Leading `el` absorbs the element handle `call_on_main` prepends,
+            // so `cx`/`cy`/`ms` line up with the args passed below.
             // The dot is `position:fixed` so the coords are viewport-relative,
             // matching `bounding_box`'s frame and `Tab::flash_point`.
-            let js = "function(cx, cy, ms){ \
+            let js = "function(el, cx, cy, ms){ \
                     const d = document.createElement('div'); \
                     d.style.cssText = 'position:fixed;left:'+cx+'px;top:'+cy+'px;\
 width:10px;height:10px;margin:-5px 0 0 -5px;border-radius:50%;background:red;\
@@ -877,6 +883,27 @@ mod tests {
     use crate::test_support::{expect, serve_gate_probes, serve_isolated_world};
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
+
+    /// Parameter names of a `function(a, b, ...){ ... }` declaration, in order.
+    ///
+    /// `call_on_main` prepends the element handle to the argument list, so the
+    /// parameter at index `i` binds to `arguments[i]`. Asserting the parameter
+    /// list against the emitted arguments is what catches an off-by-one — a
+    /// body declared `function(v)` reads the *element* out of `arguments[0]`
+    /// while the caller's value sits unread at `arguments[1]`, and every
+    /// assertion about the arguments array alone still passes.
+    ///
+    /// The first `(`/`)` pair is the parameter list: parameter names can't
+    /// contain parentheses, so a body that does (`setTimeout(...)`) is safe.
+    fn js_params(decl: &str) -> Vec<&str> {
+        let open = decl.find('(').expect("declaration opens a param list");
+        let close = decl.find(')').expect("declaration closes its param list");
+        decl[open + 1..close]
+            .split(',')
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+            .collect()
+    }
 
     #[tokio::test]
     async fn hover_dispatches_input_dispatchmouseevent_with_type_mousemoved() {
@@ -1156,6 +1183,14 @@ mod tests {
         assert_eq!(args.len(), 2);
         assert_eq!(args[0]["objectId"], "R1");
         assert_eq!(args[1]["value"], "hello world");
+        // ...and the JS reads it there: the leading parameter absorbs the
+        // prepended element handle so `v` binds to arguments[1]. `clear`
+        // shares this declaration, so this pins the shape for both.
+        assert_eq!(
+            js_params(decl),
+            vec!["el", "v"],
+            "value must land on the parameter the body assigns"
+        );
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
@@ -1186,11 +1221,14 @@ mod tests {
         assert!(decl.contains("HTMLInputElement"));
         assert!(decl.contains("'input'"));
         assert!(decl.contains("'change'"));
-        // The cleared value is the empty string, passed at arguments[1].
+        // The cleared value is the empty string, passed at arguments[1] — and
+        // read there, since the leading parameter absorbs the prepended
+        // element handle.
         let args = sent["params"]["arguments"].as_array().unwrap();
         assert_eq!(args.len(), 2);
         assert_eq!(args[0]["objectId"], "R1");
         assert_eq!(args[1]["value"], "");
+        assert_eq!(js_params(decl), vec!["el", "v"]);
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
@@ -1222,6 +1260,14 @@ mod tests {
         assert_eq!(args.len(), 2);
         assert_eq!(args[0]["objectId"], "R1");
         assert_eq!(args[1]["value"], "New title");
+        // The body must READ it at arguments[1] too. Without the leading `el`
+        // the assigned parameter binds to the element handle and the element's
+        // text becomes "[object HTMLDivElement]" instead of the caller's text.
+        assert_eq!(
+            js_params(decl),
+            vec!["el", "v"],
+            "assigned parameter must bind to the caller's text, not the element"
+        );
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
@@ -1433,10 +1479,19 @@ mod tests {
         );
         let args = sent["params"]["arguments"].as_array().unwrap();
         // call_on_main prepends the element {objectId}; then cx, cy, ms.
+        assert_eq!(args.len(), 4);
         assert_eq!(args[0]["objectId"], "R1");
         assert_eq!(args[1]["value"], 60.0); // center x
         assert_eq!(args[2]["value"], 45.0); // center y
         assert_eq!(args[3]["value"], 500); // duration ms
+        // Each coordinate must be read at the index it was sent. Without the
+        // leading `el` every parameter shifts by one: the dot is positioned
+        // at the stringified element, and `ms` reads undefined.
+        assert_eq!(
+            js_params(decl),
+            vec!["el", "cx", "cy", "ms"],
+            "coords/duration must bind to the parameters the body reads"
+        );
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 

--- a/crates/zendriver/src/element/actions.rs
+++ b/crates/zendriver/src/element/actions.rs
@@ -19,9 +19,14 @@
 //!      `hover` uses a realistic Bezier path; `hover_fast` uses a single
 //!      teleport dispatch for test/automation paths.
 //!
-//! `focus`: actionability gate (visible + enabled — no pointer or stability
-//! requirement; focus routes through the focused element, not the cursor's
-//! position), then `el.focus()` in the main world.
+//! `focus`: `scroll_into_view`, then the actionability gate (visible +
+//! enabled — no pointer or stability requirement; focus routes through the
+//! focused element, not the cursor's position), then `el.focus()` in the main
+//! world. The scroll leads for the same reason it does under `hover` and
+//! `click`: the visibility check is a viewport intersection, so a field below
+//! the fold — the ordinary case for a sign-up or checkout form, and the whole
+//! typing surface (`type_text`, `press`, `type_keys`) focuses first — would
+//! otherwise fail the gate outright.
 //!
 //! `scroll_into_view`: no actionability gate (this *is* the visibility
 //! prereq other actions wait for). Calls `el.scrollIntoView({ block:
@@ -405,6 +410,7 @@ impl Element {
     /// ```
     pub async fn focus(&self) -> Result<()> {
         self.with_refresh(|| async move {
+            self.scroll_into_view().await?;
             actionability::wait_actionable(
                 self,
                 ActionabilityCheck::TEXT_INPUT,
@@ -880,7 +886,7 @@ z-index:2147483647;pointer-events:none;opacity:0.85;'; \
 mod tests {
     use super::*;
     use crate::tab::Tab;
-    use crate::test_support::{expect, serve_gate_probes, serve_isolated_world};
+    use crate::test_support::{expect, serve_gate_probes, serve_scroll_into_view};
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
 
@@ -935,9 +941,7 @@ mod tests {
 
         // Step 2: actionability gate — visible → stable → receives_pointer
         // (gate order is visible → enabled → stable → receives_pointer, and
-        // hover doesn't require enabled). The predicates run in the isolated
-        // world, so the first one also builds it.
-        serve_isolated_world(&mut mock).await;
+        // hover doesn't require enabled).
         serve_gate_probes(&mut mock, 3).await;
 
         // Step 3: bounding_box → DOM.getBoxModel.
@@ -1016,8 +1020,7 @@ mod tests {
             .await;
 
         // Step 2: actionability gate (FULL = visible → enabled → stable →
-        // receives_pointer), each predicate running in the isolated world.
-        serve_isolated_world(&mut mock).await;
+        // receives_pointer); reply true to each.
         serve_gate_probes(&mut mock, 4).await;
 
         // Step 3: bounding_box → DOM.getBoxModel.
@@ -1110,7 +1113,6 @@ mod tests {
 
         // Step 2: actionability gate (FULL = visible → enabled → stable →
         // receives_pointer), matching `click`'s gate.
-        serve_isolated_world(&mut mock).await;
         serve_gate_probes(&mut mock, 4).await;
 
         // Step 3: bounding_box → DOM.getBoxModel. Box top-left (10,20),
@@ -1287,11 +1289,11 @@ mod tests {
             async move { e.clear_by_deleting().await }
         });
 
-        // Step 1: explicit focus() — actionability gate (visible → enabled)
-        // then this.focus(). The gate is isolated-world (built once here and
-        // reused by every later focus in this test); `this.focus()` is not,
-        // since focusing is an effect on the page, not a read of it.
-        serve_isolated_world(&mut mock).await;
+        // Step 1: explicit focus() — scroll_into_view, actionability gate
+        // (visible → enabled), then this.focus(). The scroll leads because
+        // the visibility gate is a viewport check: a field under the fold
+        // fails it outright without one.
+        serve_scroll_into_view(&mut mock).await;
         serve_gate_probes(&mut mock, 2).await;
         let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
@@ -1305,11 +1307,12 @@ mod tests {
             .await;
 
         // Step 2: select-all chord via press_with(Key::Char('a'), Ctrl|Meta).
-        // press_with focuses first (gate visible → enabled, then this.focus()),
-        // then emits the chord. Since A2 (full keyboard parity) press_with
+        // press_with focuses first (scroll, gate visible → enabled, then
+        // this.focus()), then emits the chord. Since A2 (full keyboard parity) press_with
         // dispatches the modifier as REAL wrapper key events, so the chord is
         // four dispatches: modifier keyDown → 'a' keyDown → 'a' keyUp →
         // modifier keyUp. Ctrl on Windows/Linux, Meta on macOS.
+        serve_scroll_into_view(&mut mock).await;
         serve_gate_probes(&mut mock, 2).await;
         let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
@@ -1363,13 +1366,14 @@ mod tests {
 
         // Step 4: with reported length 0 the impl still presses Backspace a
         // small fixed slack number of times so a near-empty field still gets
-        // a couple of deletes. Each press(Backspace) re-focuses (gate:
-        // visible → enabled, then this.focus()) then dispatches
+        // a couple of deletes. Each press(Backspace) re-focuses (scroll,
+        // gate: visible → enabled, then this.focus()) then dispatches
         // rawKeyDown + keyUp for the Backspace virtual key. The whole
         // sequence is deterministic; drive every frame explicitly.
         let mut saw_backspace = false;
         for _ in 0..CLEAR_BY_DELETING_SLACK {
-            // press(Backspace) focus: 2 gate probes + this.focus().
+            // press(Backspace) focus: scroll + 2 gate probes + this.focus().
+            serve_scroll_into_view(&mut mock).await;
             serve_gate_probes(&mut mock, 2).await;
             let id = expect(&mut mock, "Runtime.callFunctionOn").await;
             mock.reply(id, json!({ "result": { "type": "undefined" } }))

--- a/crates/zendriver/src/element/actions.rs
+++ b/crates/zendriver/src/element/actions.rs
@@ -874,6 +874,7 @@ z-index:2147483647;pointer-events:none;opacity:0.85;'; \
 mod tests {
     use super::*;
     use crate::tab::Tab;
+    use crate::test_support::{expect, serve_gate_probes, serve_isolated_world};
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
 
@@ -894,7 +895,7 @@ mod tests {
         });
 
         // Step 1: scroll_into_view → Runtime.callFunctionOn.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         assert!(
             sent["params"]["functionDeclaration"]
@@ -905,31 +906,15 @@ mod tests {
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
-        // Step 2: actionability gate runs check_visible first.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-        mock.reply(
-            id,
-            json!({ "result": { "value": true, "type": "boolean" } }),
-        )
-        .await;
-        // check_stable (gate order: visible → enabled → stable → receives_pointer;
-        // enabled is disabled for hover, so stable is next).
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-        mock.reply(
-            id,
-            json!({ "result": { "value": true, "type": "boolean" } }),
-        )
-        .await;
-        // check_receives_pointer.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-        mock.reply(
-            id,
-            json!({ "result": { "value": true, "type": "boolean" } }),
-        )
-        .await;
+        // Step 2: actionability gate — visible → stable → receives_pointer
+        // (gate order is visible → enabled → stable → receives_pointer, and
+        // hover doesn't require enabled). The predicates run in the isolated
+        // world, so the first one also builds it.
+        serve_isolated_world(&mut mock).await;
+        serve_gate_probes(&mut mock, 3).await;
 
         // Step 3: bounding_box → DOM.getBoxModel.
-        let id = mock.expect_cmd("DOM.getBoxModel").await;
+        let id = expect(&mut mock, "DOM.getBoxModel").await;
         mock.reply(
             id,
             json!({
@@ -999,23 +984,17 @@ mod tests {
         });
 
         // Step 1: scroll_into_view → Runtime.callFunctionOn.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
         // Step 2: actionability gate (FULL = visible → enabled → stable →
-        // receives_pointer); reply true to each.
-        for _ in 0..4 {
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-            mock.reply(
-                id,
-                json!({ "result": { "value": true, "type": "boolean" } }),
-            )
-            .await;
-        }
+        // receives_pointer), each predicate running in the isolated world.
+        serve_isolated_world(&mut mock).await;
+        serve_gate_probes(&mut mock, 4).await;
 
         // Step 3: bounding_box → DOM.getBoxModel.
-        let id = mock.expect_cmd("DOM.getBoxModel").await;
+        let id = expect(&mut mock, "DOM.getBoxModel").await;
         mock.reply(
             id,
             json!({
@@ -1098,24 +1077,18 @@ mod tests {
         });
 
         // Step 1: scroll_into_view → Runtime.callFunctionOn.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
         // Step 2: actionability gate (FULL = visible → enabled → stable →
-        // receives_pointer); reply true to each, matching `click`'s gate.
-        for _ in 0..4 {
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-            mock.reply(
-                id,
-                json!({ "result": { "value": true, "type": "boolean" } }),
-            )
-            .await;
-        }
+        // receives_pointer), matching `click`'s gate.
+        serve_isolated_world(&mut mock).await;
+        serve_gate_probes(&mut mock, 4).await;
 
         // Step 3: bounding_box → DOM.getBoxModel. Box top-left (10,20),
         // 100x50 ⇒ center (60, 45).
-        let id = mock.expect_cmd("DOM.getBoxModel").await;
+        let id = expect(&mut mock, "DOM.getBoxModel").await;
         mock.reply(
             id,
             json!({
@@ -1132,7 +1105,7 @@ mod tests {
         .await;
 
         // Step 4: touchStart at the bbox center, then touchEnd empty.
-        let id = mock.expect_cmd("Input.dispatchTouchEvent").await;
+        let id = expect(&mut mock, "Input.dispatchTouchEvent").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["type"], "touchStart");
         let points = sent["params"]["touchPoints"].as_array().unwrap();
@@ -1141,7 +1114,7 @@ mod tests {
         assert_eq!(points[0]["y"], 45.0);
         mock.reply(id, json!({})).await;
 
-        let id = mock.expect_cmd("Input.dispatchTouchEvent").await;
+        let id = expect(&mut mock, "Input.dispatchTouchEvent").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["type"], "touchEnd");
         assert_eq!(sent["params"]["touchPoints"].as_array().unwrap().len(), 0);
@@ -1163,7 +1136,7 @@ mod tests {
             async move { e.set_value("hello world").await }
         });
 
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         let decl = sent["params"]["functionDeclaration"].as_str().unwrap();
         // Assign through the native prototype value-setter so React's
@@ -1202,7 +1175,7 @@ mod tests {
             async move { e.clear().await }
         });
 
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         let decl = sent["params"]["functionDeclaration"].as_str().unwrap();
         // `clear` routes through the same native-setter JS as `set_value`,
@@ -1237,7 +1210,7 @@ mod tests {
             async move { e.set_text("New title").await }
         });
 
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         let decl = sent["params"]["functionDeclaration"].as_str().unwrap();
         // Faithful-simpler port of nodriver's DOM.setNodeValue: assign
@@ -1269,16 +1242,12 @@ mod tests {
         });
 
         // Step 1: explicit focus() — actionability gate (visible → enabled)
-        // then this.focus().
-        for _ in 0..2 {
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-            mock.reply(
-                id,
-                json!({ "result": { "value": true, "type": "boolean" } }),
-            )
-            .await;
-        }
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        // then this.focus(). The gate is isolated-world (built once here and
+        // reused by every later focus in this test); `this.focus()` is not,
+        // since focusing is an effect on the page, not a read of it.
+        serve_isolated_world(&mut mock).await;
+        serve_gate_probes(&mut mock, 2).await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         assert!(
             sent["params"]["functionDeclaration"]
@@ -1295,21 +1264,14 @@ mod tests {
         // dispatches the modifier as REAL wrapper key events, so the chord is
         // four dispatches: modifier keyDown → 'a' keyDown → 'a' keyUp →
         // modifier keyUp. Ctrl on Windows/Linux, Meta on macOS.
-        for _ in 0..2 {
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-            mock.reply(
-                id,
-                json!({ "result": { "value": true, "type": "boolean" } }),
-            )
-            .await;
-        }
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        serve_gate_probes(&mut mock, 2).await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
         let ctrl = i64::from(KeyModifiers::CTRL.cdp_bits());
         let meta = i64::from(KeyModifiers::META.cdp_bits());
         // 1: modifier keyDown (Meta or Control).
-        let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+        let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["type"], "keyDown");
         let mod_key = sent["params"]["key"].as_str().unwrap();
@@ -1319,7 +1281,7 @@ mod tests {
         );
         mock.reply(id, json!({})).await;
         // 2: 'a' keyDown with the modifier bit set.
-        let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+        let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["type"], "keyDown");
         assert_eq!(sent["params"]["key"], "a");
@@ -1330,11 +1292,11 @@ mod tests {
         );
         mock.reply(id, json!({})).await;
         // 3: 'a' keyUp.
-        let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+        let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
         assert_eq!(mock.last_sent()["params"]["type"], "keyUp");
         mock.reply(id, json!({})).await;
         // 4: modifier keyUp.
-        let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+        let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
         assert_eq!(mock.last_sent()["params"]["type"], "keyUp");
         mock.reply(id, json!({})).await;
 
@@ -1342,7 +1304,7 @@ mod tests {
         // so only the fixed slack-count of Backspaces follows — keeps the
         // remaining frame sequence deterministic regardless of the value the
         // page reports.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         assert!(
             sent["params"]["functionDeclaration"]
@@ -1361,20 +1323,13 @@ mod tests {
         // sequence is deterministic; drive every frame explicitly.
         let mut saw_backspace = false;
         for _ in 0..CLEAR_BY_DELETING_SLACK {
-            // press(Backspace) focus: 2 gate calls + this.focus().
-            for _ in 0..2 {
-                let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-                mock.reply(
-                    id,
-                    json!({ "result": { "value": true, "type": "boolean" } }),
-                )
-                .await;
-            }
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+            // press(Backspace) focus: 2 gate probes + this.focus().
+            serve_gate_probes(&mut mock, 2).await;
+            let id = expect(&mut mock, "Runtime.callFunctionOn").await;
             mock.reply(id, json!({ "result": { "type": "undefined" } }))
                 .await;
             // rawKeyDown for Backspace (never forward Delete).
-            let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+            let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
             let sent = mock.last_sent();
             assert_eq!(sent["params"]["type"], "rawKeyDown");
             assert_eq!(sent["params"]["key"], "Backspace");
@@ -1382,7 +1337,7 @@ mod tests {
             saw_backspace = true;
             mock.reply(id, json!({})).await;
             // keyUp.
-            let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+            let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
             assert_eq!(mock.last_sent()["params"]["type"], "keyUp");
             mock.reply(id, json!({})).await;
         }
@@ -1411,7 +1366,7 @@ mod tests {
             async move { e.upload_files(&paths).await }
         });
 
-        let id = mock.expect_cmd("DOM.setFileInputFiles").await;
+        let id = expect(&mut mock, "DOM.setFileInputFiles").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["backendNodeId"], 42);
         let files = sent["params"]["files"].as_array().unwrap();
@@ -1437,7 +1392,7 @@ mod tests {
         });
 
         // Step 1: scroll_into_view → Runtime.callFunctionOn.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         assert!(
             mock.last_sent()["params"]["functionDeclaration"]
                 .as_str()
@@ -1449,7 +1404,7 @@ mod tests {
 
         // Step 2: bounding_box → DOM.getBoxModel. Box top-left (10,20), 100x50
         // ⇒ center (60, 45).
-        let id = mock.expect_cmd("DOM.getBoxModel").await;
+        let id = expect(&mut mock, "DOM.getBoxModel").await;
         mock.reply(
             id,
             json!({
@@ -1468,7 +1423,7 @@ mod tests {
         // Step 3: overlay injected via Runtime.callFunctionOn carrying the
         // dot-building JS (createElement + setTimeout/remove), with the
         // viewport-center coords + duration passed as arguments.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         let decl = sent["params"]["functionDeclaration"].as_str().unwrap();
         assert!(decl.contains("createElement"), "should build a dot element");
@@ -1502,11 +1457,11 @@ mod tests {
         });
 
         // Step 1: Overlay.enable (highlightNode is a no-op without it).
-        let id = mock.expect_cmd("Overlay.enable").await;
+        let id = expect(&mut mock, "Overlay.enable").await;
         mock.reply(id, json!({})).await;
 
         // Step 2: Overlay.highlightNode { backendNodeId, highlightConfig }.
-        let id = mock.expect_cmd("Overlay.highlightNode").await;
+        let id = expect(&mut mock, "Overlay.highlightNode").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["backendNodeId"], 42);
         assert!(
@@ -1532,7 +1487,7 @@ mod tests {
         });
 
         // Step 1: scroll_into_view → Runtime.callFunctionOn.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         assert!(
             mock.last_sent()["params"]["functionDeclaration"]
                 .as_str()
@@ -1544,7 +1499,7 @@ mod tests {
 
         // Step 2: bounding_box → DOM.getBoxModel. Box top-left (10,20), 100x50
         // ⇒ center (60, 45) = the drag source.
-        let id = mock.expect_cmd("DOM.getBoxModel").await;
+        let id = expect(&mut mock, "DOM.getBoxModel").await;
         mock.reply(
             id,
             json!({

--- a/crates/zendriver/src/element/actions.rs
+++ b/crates/zendriver/src/element/actions.rs
@@ -79,6 +79,13 @@ const CLEAR_BY_DELETING_SLACK: usize = 2;
 /// spin it unboundedly.
 const CLEAR_BY_DELETING_MAX: usize = 4096;
 
+/// How often [`Element::clear_by_deleting`] re-reads the field to see whether
+/// it is already empty. Each Backspace is a CDP round-trip, so probing lets the
+/// common case (the select-all chord cleared the whole value in one stroke)
+/// exit after a single extra read instead of spending the full budget; probing
+/// every stroke would double the round-trips on fields that do need them.
+const PROBE_EVERY_N_BACKSPACES: usize = 16;
+
 /// Per-call knobs for [`Element::click_with`].
 ///
 /// `Default` matches the behavior of [`Element::click`]: a left, single,
@@ -221,6 +228,7 @@ impl Element {
                     self,
                     ActionabilityCheck::FULL,
                     DEFAULT_ACTIONABILITY_TIMEOUT,
+                    opts.position,
                 )
                 .await?;
             }
@@ -233,16 +241,7 @@ impl Element {
                 None => (bbox.x + bbox.width / 2.0, bbox.y + bbox.height / 2.0),
             };
             let input = self.inner.tab.input().clone();
-            mouse::click_at(
-                &input,
-                &self.inner.tab,
-                tx,
-                ty,
-                opts.button,
-                opts.click_count,
-                opts.realistic,
-            )
-            .await
+            mouse::click_at(&input, &self.inner.tab, tx, ty, &opts).await
         })
         .await
     }
@@ -283,6 +282,7 @@ impl Element {
                 self,
                 ActionabilityCheck::FULL,
                 DEFAULT_ACTIONABILITY_TIMEOUT,
+                None,
             )
             .await?;
             let bbox = self
@@ -325,6 +325,7 @@ impl Element {
                     receives_pointer: true,
                 },
                 DEFAULT_ACTIONABILITY_TIMEOUT,
+                None,
             )
             .await?;
             let bbox = self
@@ -334,7 +335,7 @@ impl Element {
             let cx = bbox.x + bbox.width / 2.0;
             let cy = bbox.y + bbox.height / 2.0;
             let input = self.inner.tab.input().clone();
-            mouse::move_realistic(&input, &self.inner.tab, cx, cy).await
+            mouse::move_realistic(&input, &self.inner.tab, cx, cy, KeyModifiers::empty()).await
         })
         .await
     }
@@ -369,6 +370,7 @@ impl Element {
                     receives_pointer: true,
                 },
                 DEFAULT_ACTIONABILITY_TIMEOUT,
+                None,
             )
             .await?;
             let bbox = self
@@ -378,7 +380,7 @@ impl Element {
             let cx = bbox.x + bbox.width / 2.0;
             let cy = bbox.y + bbox.height / 2.0;
             let input = self.inner.tab.input().clone();
-            mouse::move_raw(&input, &self.inner.tab, cx, cy).await
+            mouse::move_raw(&input, &self.inner.tab, cx, cy, KeyModifiers::empty()).await
         })
         .await
     }
@@ -407,6 +409,7 @@ impl Element {
                 self,
                 ActionabilityCheck::TEXT_INPUT,
                 DEFAULT_ACTIONABILITY_TIMEOUT,
+                None,
             )
             .await?;
             let _ = self
@@ -604,24 +607,47 @@ impl Element {
             };
             self.press_with(Key::Char('a'), select_all).await?;
 
-            let len: usize = {
-                let res = self
-                    .call_on_main("function(){ return (this.value || '').length; }", json!([]))
-                    .await?;
-                res.get("value")
-                    .and_then(serde_json::Value::as_u64)
-                    .and_then(|n| usize::try_from(n).ok())
-                    .unwrap_or(0)
-            };
+            let len = self.value_len().await?;
             let presses = len
                 .saturating_add(CLEAR_BY_DELETING_SLACK)
                 .min(CLEAR_BY_DELETING_MAX);
-            for _ in 0..presses {
+            // Re-probe the value periodically and stop as soon as it is empty
+            // instead of always spending the full `len + slack` budget. Every
+            // `press` is a CDP round-trip (and re-runs the focus gate), so on a
+            // field the select-all chord already cleared this turns thousands of
+            // round-trips into one probe. The cadence keeps the probe overhead
+            // proportional rather than doubling the round-trips on short fields.
+            for i in 0..presses {
+                // Deliberately never probes within the first
+                // `PROBE_EVERY_N_BACKSPACES` strokes: `CLEAR_BY_DELETING_SLACK`
+                // exists precisely because `value.length` under-reports on
+                // off-by-one and IME-composition tails, so exiting early on a
+                // near-empty field would trust the number the slack is there to
+                // distrust. Long fields are where the budget actually hurts, and
+                // by stroke 16 a reported-empty field really is empty.
+                if i > 0 && i % PROBE_EVERY_N_BACKSPACES == 0 && self.value_len().await? == 0 {
+                    return Ok(());
+                }
                 self.press(Key::Special(SpecialKey::Backspace)).await?;
             }
             Ok(())
         })
         .await
+    }
+
+    /// Length of this element's `value`, or 0 if it has none.
+    ///
+    /// Used by [`Element::clear_by_deleting`] to size its Backspace budget and
+    /// then to detect early that the field is already empty.
+    async fn value_len(&self) -> Result<usize> {
+        let res = self
+            .call_on_main("function(){ return (this.value || '').length; }", json!([]))
+            .await?;
+        Ok(res
+            .get("value")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| usize::try_from(n).ok())
+            .unwrap_or(0))
     }
 
     /// Attach files to this `<input type="file">` element via

--- a/crates/zendriver/src/element/input.rs
+++ b/crates/zendriver/src/element/input.rs
@@ -194,7 +194,7 @@ mod tests {
     use super::*;
     use crate::input::keyboard::SpecialKey;
     use crate::tab::Tab;
-    use crate::test_support::{expect, serve_gate_probes, serve_isolated_world};
+    use crate::test_support::{expect, serve_gate_probes, serve_scroll_into_view};
     use serde_json::{Value, json};
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
@@ -214,15 +214,13 @@ mod tests {
             async move { e.type_text_fast("hi").await }
         });
 
-        // focus() runs the actionability gate first: visible → enabled.
+        // focus() scrolls the element into view first — the visibility gate
+        // below is a viewport check, so a field under the fold would fail it.
+        serve_scroll_into_view(&mut mock).await;
+        // focus() then runs the actionability gate: visible → enabled.
         // ActionabilityCheck::TEXT_INPUT skips stable + receives_pointer.
-        // Both predicates run in the isolated world, which the first one
-        // builds.
-        serve_isolated_world(&mut mock).await;
         serve_gate_probes(&mut mock, 2).await;
-        // focus() then calls el.focus() — one more Runtime.callFunctionOn,
-        // this one in the main world (it acts on the page rather than reading
-        // it).
+        // focus() then calls el.focus() — one more Runtime.callFunctionOn.
         let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         assert!(
@@ -254,15 +252,11 @@ mod tests {
         conn.shutdown();
     }
 
-    /// Drain the focus() actionability gate (visible → enabled) plus the
-    /// final `this.focus()` call, replying to each.
-    ///
-    /// Serves the isolated-world handshake up front, so this is the *first*
-    /// focus on a fresh tab — which is how every caller here uses it. A
-    /// second call on the same tab would hang waiting for a handshake the
-    /// cached context makes unnecessary.
+    /// Drain the focus() sequence — `scroll_into_view`, the actionability
+    /// gate (visible → enabled), then the final `this.focus()` call —
+    /// replying to each.
     async fn drain_focus(mock: &mut MockConnection) {
-        serve_isolated_world(mock).await;
+        serve_scroll_into_view(mock).await;
         serve_gate_probes(mock, 2).await;
         let id = expect(mock, "Runtime.callFunctionOn").await;
         mock.reply(id, json!({ "result": { "type": "undefined" } }))

--- a/crates/zendriver/src/element/input.rs
+++ b/crates/zendriver/src/element/input.rs
@@ -321,14 +321,15 @@ mod tests {
 
         drain_focus(&mut mock).await;
 
-        // "hi" → h/i down+up; Enter → rawKeyDown+keyUp; Ctrl+a → Control
-        // wrap around a. 10 dispatch events total.
+        // "hi" → h/i down+up; Enter → keyDown+keyUp (Enter inserts text, so
+        // it carries it like any printable key); Ctrl+a → Control wrap around
+        // a. 10 dispatch events total.
         let expected = [
             ("h", "keyDown"),
             ("h", "keyUp"),
             ("i", "keyDown"),
             ("i", "keyUp"),
-            ("Enter", "rawKeyDown"),
+            ("Enter", "keyDown"),
             ("Enter", "keyUp"),
             ("Control", "keyDown"),
             ("a", "keyDown"),

--- a/crates/zendriver/src/element/input.rs
+++ b/crates/zendriver/src/element/input.rs
@@ -194,6 +194,7 @@ mod tests {
     use super::*;
     use crate::input::keyboard::SpecialKey;
     use crate::tab::Tab;
+    use crate::test_support::{expect, serve_gate_probes, serve_isolated_world};
     use serde_json::{Value, json};
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
@@ -215,16 +216,14 @@ mod tests {
 
         // focus() runs the actionability gate first: visible → enabled.
         // ActionabilityCheck::TEXT_INPUT skips stable + receives_pointer.
-        for _ in 0..2 {
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-            mock.reply(
-                id,
-                json!({ "result": { "value": true, "type": "boolean" } }),
-            )
-            .await;
-        }
-        // focus() then calls el.focus() — one more Runtime.callFunctionOn.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        // Both predicates run in the isolated world, which the first one
+        // builds.
+        serve_isolated_world(&mut mock).await;
+        serve_gate_probes(&mut mock, 2).await;
+        // focus() then calls el.focus() — one more Runtime.callFunctionOn,
+        // this one in the main world (it acts on the page rather than reading
+        // it).
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         assert!(
             sent["params"]["functionDeclaration"]
@@ -244,7 +243,7 @@ mod tests {
             ("i", "keyUp"),
         ];
         for (ch, kind) in expected {
-            let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+            let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
             let last = mock.last_sent();
             assert_eq!(last["params"]["text"].as_str().unwrap(), ch);
             assert_eq!(last["params"]["type"].as_str().unwrap(), kind);
@@ -257,16 +256,15 @@ mod tests {
 
     /// Drain the focus() actionability gate (visible → enabled) plus the
     /// final `this.focus()` call, replying to each.
+    ///
+    /// Serves the isolated-world handshake up front, so this is the *first*
+    /// focus on a fresh tab — which is how every caller here uses it. A
+    /// second call on the same tab would hang waiting for a handshake the
+    /// cached context makes unnecessary.
     async fn drain_focus(mock: &mut MockConnection) {
-        for _ in 0..2 {
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-            mock.reply(
-                id,
-                json!({ "result": { "value": true, "type": "boolean" } }),
-            )
-            .await;
-        }
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        serve_isolated_world(mock).await;
+        serve_gate_probes(mock, 2).await;
+        let id = expect(mock, "Runtime.callFunctionOn").await;
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
     }
@@ -295,7 +293,7 @@ mod tests {
             ("ControlLeft", "keyUp", 0),
         ];
         for (code, kind, mods) in expected {
-            let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+            let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
             let last = mock.last_sent();
             assert_eq!(last["params"]["code"].as_str().unwrap(), code);
             assert_eq!(last["params"]["type"].as_str().unwrap(), kind);
@@ -344,7 +342,7 @@ mod tests {
             ("Control", "keyUp"),
         ];
         for (key, kind) in expected {
-            let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+            let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
             let last = mock.last_sent();
             assert_eq!(last["params"]["key"].as_str().unwrap(), key);
             assert_eq!(last["params"]["type"].as_str().unwrap(), kind);
@@ -370,7 +368,7 @@ mod tests {
         drain_focus(&mut mock).await;
 
         // Emoji has no physical-key descriptor → one `char`-type event.
-        let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+        let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
         let last = mock.last_sent();
         assert_eq!(last["params"]["type"].as_str().unwrap(), "char");
         assert_eq!(last["params"]["text"].as_str().unwrap(), "🚀");

--- a/crates/zendriver/src/element/isolated_eval.rs
+++ b/crates/zendriver/src/element/isolated_eval.rs
@@ -1,15 +1,17 @@
 //! [`Element::evaluate`] — true isolated-world evaluation.
 //!
-//! Flow:
+//! The dispatch itself lives in [`Element::call_on`] (`element/mod.rs`),
+//! which every isolated-world element call shares:
 //!
 //! 1. Resolve the tab's isolated `executionContextId` (creating it on the
 //!    first call).
 //! 2. `DOM.resolveNode { backendNodeId, executionContextId }` returns a
 //!    fresh `RemoteObject` whose `objectId` is bound to that isolated world.
 //! 3. `Runtime.callFunctionOn { objectId, functionDeclaration, arguments,
-//!    returnByValue, awaitPromise }` invokes the user's JS with `el` bound
-//!    to the isolated-world handle. Page globals (`window.foo`, monkeypatches
-//!    on `HTMLElement.prototype`, etc.) are NOT visible from inside.
+//!    returnByValue, awaitPromise }` invokes the user's JS against the
+//!    isolated-world handle, which this module aliases to `el`. Page globals
+//!    (`window.foo`, monkeypatches on `HTMLElement.prototype`, etc.) are NOT
+//!    visible from inside.
 //! 4. Best-effort `Runtime.releaseObject { objectId }` frees the handle so
 //!    long-running scrapers don't leak isolated-world `RemoteObject`s.
 //!
@@ -54,86 +56,11 @@ impl Element {
     pub async fn evaluate<T: DeserializeOwned>(&self, js: impl AsRef<str>) -> Result<T> {
         let js = js.as_ref();
         self.with_refresh(|| async move {
-            let ctx_id = self.inner.tab.ensure_isolated_world().await?;
-            let backend_node_id = self.backend_node_id_cloned().await?;
-
-            // Re-resolve our node in the isolated world. The returned
-            // RemoteObject lives in `ctx_id`, not the main world.
-            let resolved = self
-                .inner
-                .tab
-                .call(
-                    "DOM.resolveNode",
-                    json!({
-                        "backendNodeId": backend_node_id,
-                        "executionContextId": ctx_id,
-                    }),
-                )
-                .await?;
-            let isolated_object_id = resolved["object"]["objectId"]
-                .as_str()
-                .ok_or_else(|| {
-                    ZendriverError::Navigation(
-                        "DOM.resolveNode returned no objectId for isolated world".into(),
-                    )
-                })?
-                .to_string();
-
-            let function = format!("function(el){{ return ({js}) }}");
-            let result = self
-                .inner
-                .tab
-                .call(
-                    "Runtime.callFunctionOn",
-                    json!({
-                        "objectId": isolated_object_id,
-                        "functionDeclaration": function,
-                        "arguments": [{ "objectId": isolated_object_id }],
-                        "returnByValue": true,
-                        "awaitPromise": true,
-                    }),
-                )
-                .await?;
-
-            // Surface page-script exceptions before we deserialize.
-            if let Some(details) = result.get("exceptionDetails") {
-                let msg = details
-                    .get("exception")
-                    .and_then(|e| e.get("description"))
-                    .and_then(|d| d.as_str())
-                    .unwrap_or("unknown")
-                    .to_string();
-                // Release the handle even on JS exception — best effort.
-                let _ = self
-                    .inner
-                    .tab
-                    .call(
-                        "Runtime.releaseObject",
-                        json!({ "objectId": isolated_object_id }),
-                    )
-                    .await;
-                return Err(ZendriverError::JsException(msg));
-            }
-
-            let value = result
-                .get("result")
-                .and_then(|r| r.get("value"))
-                .cloned()
-                .unwrap_or(Value::Null);
-
-            // Best-effort cleanup so isolated-world handles don't pile up
-            // across many evaluate() calls. Failures are non-fatal — the
-            // worst case is a short-lived leak until the isolated world
-            // itself is replaced.
-            let _ = self
-                .inner
-                .tab
-                .call(
-                    "Runtime.releaseObject",
-                    json!({ "objectId": isolated_object_id }),
-                )
-                .await;
-
+            // `call_on` binds the isolated-world handle as `this`; alias it to
+            // `el` so the user's expression reads the documented way.
+            let function = format!("function(){{ const el = this; return ({js}) }}");
+            let result = self.call_on(&function, json!([])).await?;
+            let value = result.get("value").cloned().unwrap_or(Value::Null);
             serde_json::from_value(value).map_err(ZendriverError::Serde)
         })
         .await
@@ -193,23 +120,18 @@ mod tests {
         )
         .await;
 
-        // 4. Runtime.callFunctionOn — uses isolated objectId for BOTH the
-        //    target object AND the el argument; wraps user js in
-        //    `function(el){ return (...) }`.
+        // 4. Runtime.callFunctionOn — targets the isolated objectId, which
+        //    the wrapper aliases to `el` via `this`.
         let id_call = mock.expect_cmd("Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         assert_eq!(
             sent["params"]["objectId"], "R_ISO",
             "callFunctionOn must target the isolated-world handle, not the main-world one",
         );
-        assert_eq!(
-            sent["params"]["arguments"][0]["objectId"], "R_ISO",
-            "the bound `el` argument must be the isolated handle",
-        );
         let decl = sent["params"]["functionDeclaration"].as_str().unwrap();
         assert!(
-            decl.contains("function(el)") && decl.contains("el.tagName"),
-            "function declaration must wrap user JS; got: {decl}",
+            decl.contains("const el = this") && decl.contains("el.tagName"),
+            "function declaration must bind `el` to the isolated handle and wrap user JS; got: {decl}",
         );
         assert_eq!(sent["params"]["returnByValue"], true);
         assert_eq!(sent["params"]["awaitPromise"], true);

--- a/crates/zendriver/src/element/isolated_eval.rs
+++ b/crates/zendriver/src/element/isolated_eval.rs
@@ -1,17 +1,15 @@
 //! [`Element::evaluate`] — true isolated-world evaluation.
 //!
-//! The dispatch itself lives in [`Element::call_on`] (`element/mod.rs`),
-//! which every isolated-world element call shares:
+//! Flow:
 //!
 //! 1. Resolve the tab's isolated `executionContextId` (creating it on the
 //!    first call).
 //! 2. `DOM.resolveNode { backendNodeId, executionContextId }` returns a
 //!    fresh `RemoteObject` whose `objectId` is bound to that isolated world.
 //! 3. `Runtime.callFunctionOn { objectId, functionDeclaration, arguments,
-//!    returnByValue, awaitPromise }` invokes the user's JS against the
-//!    isolated-world handle, which this module aliases to `el`. Page globals
-//!    (`window.foo`, monkeypatches on `HTMLElement.prototype`, etc.) are NOT
-//!    visible from inside.
+//!    returnByValue, awaitPromise }` invokes the user's JS with `el` bound
+//!    to the isolated-world handle. Page globals (`window.foo`, monkeypatches
+//!    on `HTMLElement.prototype`, etc.) are NOT visible from inside.
 //! 4. Best-effort `Runtime.releaseObject { objectId }` frees the handle so
 //!    long-running scrapers don't leak isolated-world `RemoteObject`s.
 //!
@@ -56,11 +54,86 @@ impl Element {
     pub async fn evaluate<T: DeserializeOwned>(&self, js: impl AsRef<str>) -> Result<T> {
         let js = js.as_ref();
         self.with_refresh(|| async move {
-            // `call_on` binds the isolated-world handle as `this`; alias it to
-            // `el` so the user's expression reads the documented way.
-            let function = format!("function(){{ const el = this; return ({js}) }}");
-            let result = self.call_on(&function, json!([])).await?;
-            let value = result.get("value").cloned().unwrap_or(Value::Null);
+            let ctx_id = self.inner.tab.ensure_isolated_world().await?;
+            let backend_node_id = self.backend_node_id_cloned().await?;
+
+            // Re-resolve our node in the isolated world. The returned
+            // RemoteObject lives in `ctx_id`, not the main world.
+            let resolved = self
+                .inner
+                .tab
+                .call(
+                    "DOM.resolveNode",
+                    json!({
+                        "backendNodeId": backend_node_id,
+                        "executionContextId": ctx_id,
+                    }),
+                )
+                .await?;
+            let isolated_object_id = resolved["object"]["objectId"]
+                .as_str()
+                .ok_or_else(|| {
+                    ZendriverError::Navigation(
+                        "DOM.resolveNode returned no objectId for isolated world".into(),
+                    )
+                })?
+                .to_string();
+
+            let function = format!("function(el){{ return ({js}) }}");
+            let result = self
+                .inner
+                .tab
+                .call(
+                    "Runtime.callFunctionOn",
+                    json!({
+                        "objectId": isolated_object_id,
+                        "functionDeclaration": function,
+                        "arguments": [{ "objectId": isolated_object_id }],
+                        "returnByValue": true,
+                        "awaitPromise": true,
+                    }),
+                )
+                .await?;
+
+            // Surface page-script exceptions before we deserialize.
+            if let Some(details) = result.get("exceptionDetails") {
+                let msg = details
+                    .get("exception")
+                    .and_then(|e| e.get("description"))
+                    .and_then(|d| d.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                // Release the handle even on JS exception — best effort.
+                let _ = self
+                    .inner
+                    .tab
+                    .call(
+                        "Runtime.releaseObject",
+                        json!({ "objectId": isolated_object_id }),
+                    )
+                    .await;
+                return Err(ZendriverError::JsException(msg));
+            }
+
+            let value = result
+                .get("result")
+                .and_then(|r| r.get("value"))
+                .cloned()
+                .unwrap_or(Value::Null);
+
+            // Best-effort cleanup so isolated-world handles don't pile up
+            // across many evaluate() calls. Failures are non-fatal — the
+            // worst case is a short-lived leak until the isolated world
+            // itself is replaced.
+            let _ = self
+                .inner
+                .tab
+                .call(
+                    "Runtime.releaseObject",
+                    json!({ "objectId": isolated_object_id }),
+                )
+                .await;
+
             serde_json::from_value(value).map_err(ZendriverError::Serde)
         })
         .await
@@ -120,18 +193,23 @@ mod tests {
         )
         .await;
 
-        // 4. Runtime.callFunctionOn — targets the isolated objectId, which
-        //    the wrapper aliases to `el` via `this`.
+        // 4. Runtime.callFunctionOn — uses isolated objectId for BOTH the
+        //    target object AND the el argument; wraps user js in
+        //    `function(el){ return (...) }`.
         let id_call = mock.expect_cmd("Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         assert_eq!(
             sent["params"]["objectId"], "R_ISO",
             "callFunctionOn must target the isolated-world handle, not the main-world one",
         );
+        assert_eq!(
+            sent["params"]["arguments"][0]["objectId"], "R_ISO",
+            "the bound `el` argument must be the isolated handle",
+        );
         let decl = sent["params"]["functionDeclaration"].as_str().unwrap();
         assert!(
-            decl.contains("const el = this") && decl.contains("el.tagName"),
-            "function declaration must bind `el` to the isolated handle and wrap user JS; got: {decl}",
+            decl.contains("function(el)") && decl.contains("el.tagName"),
+            "function declaration must wrap user JS; got: {decl}",
         );
         assert_eq!(sent["params"]["returnByValue"], true);
         assert_eq!(sent["params"]["awaitPromise"], true);

--- a/crates/zendriver/src/element/mod.rs
+++ b/crates/zendriver/src/element/mod.rs
@@ -229,19 +229,11 @@ impl Element {
             .ok_or(ZendriverError::ElementStale)
     }
 
-    /// Dispatch `Runtime.callFunctionOn` against `object_id` and unwrap the
-    /// response into its `result` RemoteObject.
-    ///
-    /// World-agnostic: the JS runs in whatever world `object_id` belongs to.
-    /// Picking that world is the caller's job — [`Element::call_on`] resolves
-    /// a fresh isolated-world handle first, [`Element::call_on_main`] passes
-    /// the element's own page-world handle.
-    async fn call_function_on(
-        &self,
-        object_id: &str,
-        function: &str,
-        args: Value,
-    ) -> Result<Value> {
+    /// Call a JS function on this element's remote object. The function
+    /// signature MUST take exactly one parameter (the element); use
+    /// `function(el){ ... }`.
+    pub(crate) async fn call_on(&self, function: &str, args: Value) -> Result<Value> {
+        let object_id = self.remote_object_id_cloned().await?;
         let res = self
             .inner
             .tab
@@ -268,88 +260,6 @@ impl Element {
         Ok(res["result"].clone())
     }
 
-    /// Call a JS function on this element **in the tab's isolated world**.
-    ///
-    /// The function receives the element as `this`, so its signature takes
-    /// only the extra arguments: `function(a, b){ ... this ... }`. `args` is
-    /// forwarded verbatim and must hold plain values — a page-world
-    /// `objectId` means nothing inside the isolated world.
-    ///
-    /// Each call re-resolves the node through `DOM.resolveNode
-    /// { backendNodeId, executionContextId }` so the handle we invoke on
-    /// belongs to the isolated world, then releases it (best effort, so a
-    /// long scrape doesn't accumulate handles). That costs two extra
-    /// round-trips over reusing the page-world handle, which is the price of
-    /// the guarantee: a page that has monkeypatched `getAttribute`,
-    /// `innerText`, `getBoundingClientRect` or `getComputedStyle` can
-    /// neither feed the automation false values nor observe it reading.
-    /// Isolated worlds share the DOM, so the values are the same ones the
-    /// page actually renders.
-    ///
-    /// Use [`Element::call_on_main`] instead when the JS has to see
-    /// page-defined state (page globals, framework expandos on the node)
-    /// rather than DOM state.
-    pub(crate) async fn call_on(&self, function: &str, args: Value) -> Result<Value> {
-        // A navigation destroys the isolated world while the tab still holds
-        // its cached context id, so a read that straddles one resolves
-        // against a dead context. Drop the cache and rebuild it once — the
-        // same recovery `Tab::evaluate` performs, without which the very
-        // common goto → read → goto → read flow would fail from the second
-        // page onwards.
-        match self.call_in_isolated_world(function, args.clone()).await {
-            Err(ref e) if is_dead_context_error(e) => {
-                self.inner.tab.inner.isolated_world.lock().await.context_id = None;
-                self.call_in_isolated_world(function, args).await
-            }
-            other => other,
-        }
-    }
-
-    /// One isolated-world attempt: resolve the node into the world, invoke,
-    /// release. Split out so [`Element::call_on`] can retry it after
-    /// invalidating a destroyed context.
-    async fn call_in_isolated_world(&self, function: &str, args: Value) -> Result<Value> {
-        let ctx_id = self.inner.tab.ensure_isolated_world().await?;
-        let backend_node_id = self.backend_node_id_cloned().await?;
-        let resolved = self
-            .inner
-            .tab
-            .call(
-                "DOM.resolveNode",
-                json!({
-                    "backendNodeId": backend_node_id,
-                    "executionContextId": ctx_id,
-                }),
-            )
-            .await?;
-        let isolated_object_id = resolved["object"]["objectId"]
-            .as_str()
-            .ok_or_else(|| {
-                ZendriverError::Navigation(
-                    "DOM.resolveNode returned no objectId for isolated world".into(),
-                )
-            })?
-            .to_string();
-
-        let result = self
-            .call_function_on(&isolated_object_id, function, args)
-            .await;
-
-        // Release on both the success and the JS-exception path — a leaked
-        // handle would otherwise outlive the call until the isolated world
-        // itself is replaced. Failures here are non-fatal.
-        let _ = self
-            .inner
-            .tab
-            .call(
-                "Runtime.releaseObject",
-                json!({ "objectId": isolated_object_id }),
-            )
-            .await;
-
-        result
-    }
-
     /// Invoke a JS function in the main world with this element bound as
     /// the first positional argument. Accepts a function declaration whose
     /// first parameter is the element handle (`function(el, ...rest){...}`)
@@ -357,19 +267,17 @@ impl Element {
     /// argument descriptors that follow the element. Returns the raw
     /// `result` RemoteObject (caller picks `value` if `returnByValue`).
     ///
-    /// Reserved for JS that must observe page-defined state — page globals,
-    /// or framework expandos living on the node's page-world wrapper (e.g.
-    /// React's per-instance `_valueTracker`). Anything reading plain DOM
-    /// state belongs on [`Element::call_on`], where the page can neither
-    /// see the read nor forge its answer.
+    /// Locks the remote-object Mutex once at the top, then routes
+    /// through `call_on` (which re-locks once more). The double-lock is
+    /// cheap — `tokio::sync::Mutex` is uncontended in the common case
+    /// and the guard is dropped before any `.await`.
     pub(crate) async fn call_on_main(&self, function: &str, args: Value) -> Result<Value> {
         let object_id = self.remote_object_id_cloned().await?;
         let mut full_args = vec![json!({ "objectId": object_id })];
         if let Some(extra) = args.as_array() {
             full_args.extend(extra.iter().cloned());
         }
-        self.call_function_on(&object_id, function, Value::Array(full_args))
-            .await
+        self.call_on(function, Value::Array(full_args)).await
     }
 
     /// Evaluate a JS expression in the main world with `el` bound to this
@@ -405,22 +313,6 @@ impl Element {
     }
 }
 
-/// `true` for Chrome's "the execution context you named is gone" error,
-/// which is what a destroyed isolated world looks like from the outside.
-///
-/// Chrome reports it as -32000 "Cannot find context with specified id";
-/// `From<CallError>` maps that to [`ZendriverError::Navigation`] (see
-/// `error.rs`), but the raw [`ZendriverError::Cdp`] shape reaches us too, so
-/// both are matched.
-fn is_dead_context_error(e: &ZendriverError) -> bool {
-    let message = match e {
-        ZendriverError::Navigation(m) => m.as_str(),
-        ZendriverError::Cdp { message, .. } => message.as_str(),
-        _ => return false,
-    };
-    message.contains("Cannot find context")
-}
-
 impl crate::traits::Queryable for Element {
     fn find(&self) -> crate::query::FindBuilder<'_> {
         Element::find(self)
@@ -434,168 +326,16 @@ impl crate::traits::Queryable for Element {
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::test_support::{ISOLATED_CONTEXT_ID, expect, serve_isolated_world};
+    use crate::test_support::expect;
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
 
-    /// The read/probe funnel must re-resolve the node into the isolated world
-    /// and invoke the *isolated* handle — a page that shadowed `innerText` or
-    /// `getBoundingClientRect` can then neither lie to the read nor see it.
+    /// `call_on_main` invokes the element's own page-world handle and binds
+    /// it as the first positional argument, ahead of the caller's `args`.
+    /// Every declaration routed through it therefore has to open with a
+    /// leading parameter to absorb that handle.
     #[tokio::test]
-    async fn call_on_resolves_into_the_isolated_world() {
-        let (mut mock, conn) = MockConnection::pair();
-        let sess = SessionHandle::new(conn.clone(), "S1");
-        let tab = Tab::new_for_test(sess);
-        let el = Element::from_jsret(tab, 314, "R_MAIN".to_string());
-
-        let fut = tokio::spawn({
-            let e = el.clone();
-            async move {
-                e.call_on("function(){ return this.innerText; }", json!([]))
-                    .await
-            }
-        });
-
-        serve_isolated_world(&mut mock).await;
-
-        let id = expect(&mut mock, "DOM.resolveNode").await;
-        let sent = mock.last_sent();
-        assert_eq!(sent["params"]["backendNodeId"], 314);
-        assert_eq!(
-            sent["params"]["executionContextId"], ISOLATED_CONTEXT_ID,
-            "element reads must be re-resolved into the isolated world",
-        );
-        mock.reply(id, json!({ "object": { "objectId": "R_ISO" } }))
-            .await;
-
-        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
-        assert_eq!(
-            mock.last_sent()["params"]["objectId"],
-            "R_ISO",
-            "the call must target the isolated handle, not the page-world one",
-        );
-        mock.reply(
-            id,
-            json!({ "result": { "value": "hello", "type": "string" } }),
-        )
-        .await;
-
-        let id = expect(&mut mock, "Runtime.releaseObject").await;
-        assert_eq!(mock.last_sent()["params"]["objectId"], "R_ISO");
-        mock.reply(id, json!({})).await;
-
-        let res = fut.await.unwrap().unwrap();
-        assert_eq!(res["value"], "hello");
-        conn.shutdown();
-    }
-
-    /// A JS exception still frees the isolated handle — otherwise a scraper
-    /// hitting throwing pages leaks one `RemoteObject` per failed read.
-    #[tokio::test]
-    async fn call_on_releases_the_isolated_handle_after_a_js_exception() {
-        let (mut mock, conn) = MockConnection::pair();
-        let sess = SessionHandle::new(conn.clone(), "S1");
-        let tab = Tab::new_for_test(sess);
-        let el = Element::from_jsret(tab, 1, "R_MAIN".to_string());
-
-        let fut = tokio::spawn({
-            let e = el.clone();
-            async move {
-                e.call_on("function(){ throw new Error('boom'); }", json!([]))
-                    .await
-            }
-        });
-
-        serve_isolated_world(&mut mock).await;
-        let id = expect(&mut mock, "DOM.resolveNode").await;
-        mock.reply(id, json!({ "object": { "objectId": "R_ISO" } }))
-            .await;
-
-        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
-        mock.reply(
-            id,
-            json!({
-                "result": { "type": "object", "subtype": "error" },
-                "exceptionDetails": { "exception": { "description": "Error: boom" } },
-            }),
-        )
-        .await;
-
-        let id = expect(&mut mock, "Runtime.releaseObject").await;
-        assert_eq!(mock.last_sent()["params"]["objectId"], "R_ISO");
-        mock.reply(id, json!({})).await;
-
-        match fut.await.unwrap() {
-            Err(ZendriverError::JsException(m)) => assert!(m.contains("boom")),
-            other => panic!("unexpected: {other:?}"),
-        }
-        conn.shutdown();
-    }
-
-    /// A navigation destroys the isolated world but leaves its id cached, so
-    /// the next read resolves against a dead context. It must rebuild the
-    /// world and carry on — otherwise the first navigation would poison
-    /// every subsequent read on the tab.
-    #[tokio::test]
-    async fn call_on_rebuilds_the_isolated_world_after_a_navigation_destroyed_it() {
-        let (mut mock, conn) = MockConnection::pair();
-        let sess = SessionHandle::new(conn.clone(), "S1");
-        let tab = Tab::new_for_test(sess);
-        let el = Element::from_jsret(tab, 5, "R_MAIN".to_string());
-
-        let fut = tokio::spawn({
-            let e = el.clone();
-            async move {
-                e.call_on("function(){ return this.innerText; }", json!([]))
-                    .await
-            }
-        });
-
-        serve_isolated_world(&mut mock).await;
-
-        // First resolve lands on the context the navigation just destroyed.
-        let id = expect(&mut mock, "DOM.resolveNode").await;
-        mock.reply_err(id, -32000, "Cannot find context with specified id")
-            .await;
-
-        // Recovery: the cache is dropped, so the whole discovery handshake
-        // runs again and yields a live context.
-        let id = expect(&mut mock, "Page.getFrameTree").await;
-        mock.reply(id, json!({ "frameTree": { "frame": { "id": "F1" } } }))
-            .await;
-        let id = expect(&mut mock, "Page.createIsolatedWorld").await;
-        mock.reply(id, json!({ "executionContextId": 99 })).await;
-
-        let id = expect(&mut mock, "DOM.resolveNode").await;
-        assert_eq!(
-            mock.last_sent()["params"]["executionContextId"],
-            99,
-            "the retry must use the rebuilt context, not the dead one",
-        );
-        mock.reply(id, json!({ "object": { "objectId": "R_ISO2" } }))
-            .await;
-
-        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
-        assert_eq!(mock.last_sent()["params"]["objectId"], "R_ISO2");
-        mock.reply(
-            id,
-            json!({ "result": { "value": "recovered", "type": "string" } }),
-        )
-        .await;
-
-        let id = expect(&mut mock, "Runtime.releaseObject").await;
-        mock.reply(id, json!({})).await;
-
-        let res = fut.await.unwrap().unwrap();
-        assert_eq!(res["value"], "recovered");
-        conn.shutdown();
-    }
-
-    /// The escape hatch stays an escape hatch: JS that needs page-defined
-    /// state runs against the element's own page-world handle, with no
-    /// isolated-world handshake in front of it.
-    #[tokio::test]
-    async fn call_on_main_stays_in_the_page_world() {
+    async fn call_on_main_binds_the_element_as_the_first_argument() {
         let (mut mock, conn) = MockConnection::pair();
         let sess = SessionHandle::new(conn.clone(), "S1");
         let tab = Tab::new_for_test(sess);
@@ -609,8 +349,9 @@ mod tests {
             }
         });
 
-        // No Page.getFrameTree / DOM.resolveNode is served here: if the main-
-        // world path ever grew one, this wait would trip the timeout.
+        // A single dispatch, straight at the page-world handle: no
+        // isolated-world handshake is served here, so a path that grew one
+        // would trip this wait's timeout rather than hang the suite.
         let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["objectId"], "R_MAIN");

--- a/crates/zendriver/src/element/mod.rs
+++ b/crates/zendriver/src/element/mod.rs
@@ -433,30 +433,10 @@ impl crate::traits::Queryable for Element {
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
-    use std::time::Duration;
-
     use super::*;
+    use crate::test_support::{ISOLATED_CONTEXT_ID, expect, serve_isolated_world};
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
-
-    /// `expect_cmd` silently discards non-matching frames and has no built-in
-    /// timeout, so a dispatch that vanished or moved would hang the suite
-    /// instead of failing it. Bound every wait.
-    async fn expect(mock: &mut MockConnection, method: &str) -> u64 {
-        match tokio::time::timeout(Duration::from_secs(5), mock.expect_cmd(method)).await {
-            Ok(id) => id,
-            Err(_) => panic!("timed out waiting for {method}"),
-        }
-    }
-
-    /// Serve the two-frame isolated-world handshake, yielding context 42.
-    async fn serve_isolated_world(mock: &mut MockConnection) {
-        let id = expect(mock, "Page.getFrameTree").await;
-        mock.reply(id, json!({ "frameTree": { "frame": { "id": "F1" } } }))
-            .await;
-        let id = expect(mock, "Page.createIsolatedWorld").await;
-        mock.reply(id, json!({ "executionContextId": 42 })).await;
-    }
 
     /// The read/probe funnel must re-resolve the node into the isolated world
     /// and invoke the *isolated* handle — a page that shadowed `innerText` or
@@ -482,7 +462,7 @@ mod tests {
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["backendNodeId"], 314);
         assert_eq!(
-            sent["params"]["executionContextId"], 42,
+            sent["params"]["executionContextId"], ISOLATED_CONTEXT_ID,
             "element reads must be re-resolved into the isolated world",
         );
         mock.reply(id, json!({ "object": { "objectId": "R_ISO" } }))

--- a/crates/zendriver/src/element/mod.rs
+++ b/crates/zendriver/src/element/mod.rs
@@ -229,11 +229,19 @@ impl Element {
             .ok_or(ZendriverError::ElementStale)
     }
 
-    /// Call a JS function on this element's remote object. The function
-    /// signature MUST take exactly one parameter (the element); use
-    /// `function(el){ ... }`.
-    pub(crate) async fn call_on(&self, function: &str, args: Value) -> Result<Value> {
-        let object_id = self.remote_object_id_cloned().await?;
+    /// Dispatch `Runtime.callFunctionOn` against `object_id` and unwrap the
+    /// response into its `result` RemoteObject.
+    ///
+    /// World-agnostic: the JS runs in whatever world `object_id` belongs to.
+    /// Picking that world is the caller's job — [`Element::call_on`] resolves
+    /// a fresh isolated-world handle first, [`Element::call_on_main`] passes
+    /// the element's own page-world handle.
+    async fn call_function_on(
+        &self,
+        object_id: &str,
+        function: &str,
+        args: Value,
+    ) -> Result<Value> {
         let res = self
             .inner
             .tab
@@ -260,6 +268,88 @@ impl Element {
         Ok(res["result"].clone())
     }
 
+    /// Call a JS function on this element **in the tab's isolated world**.
+    ///
+    /// The function receives the element as `this`, so its signature takes
+    /// only the extra arguments: `function(a, b){ ... this ... }`. `args` is
+    /// forwarded verbatim and must hold plain values — a page-world
+    /// `objectId` means nothing inside the isolated world.
+    ///
+    /// Each call re-resolves the node through `DOM.resolveNode
+    /// { backendNodeId, executionContextId }` so the handle we invoke on
+    /// belongs to the isolated world, then releases it (best effort, so a
+    /// long scrape doesn't accumulate handles). That costs two extra
+    /// round-trips over reusing the page-world handle, which is the price of
+    /// the guarantee: a page that has monkeypatched `getAttribute`,
+    /// `innerText`, `getBoundingClientRect` or `getComputedStyle` can
+    /// neither feed the automation false values nor observe it reading.
+    /// Isolated worlds share the DOM, so the values are the same ones the
+    /// page actually renders.
+    ///
+    /// Use [`Element::call_on_main`] instead when the JS has to see
+    /// page-defined state (page globals, framework expandos on the node)
+    /// rather than DOM state.
+    pub(crate) async fn call_on(&self, function: &str, args: Value) -> Result<Value> {
+        // A navigation destroys the isolated world while the tab still holds
+        // its cached context id, so a read that straddles one resolves
+        // against a dead context. Drop the cache and rebuild it once — the
+        // same recovery `Tab::evaluate` performs, without which the very
+        // common goto → read → goto → read flow would fail from the second
+        // page onwards.
+        match self.call_in_isolated_world(function, args.clone()).await {
+            Err(ref e) if is_dead_context_error(e) => {
+                self.inner.tab.inner.isolated_world.lock().await.context_id = None;
+                self.call_in_isolated_world(function, args).await
+            }
+            other => other,
+        }
+    }
+
+    /// One isolated-world attempt: resolve the node into the world, invoke,
+    /// release. Split out so [`Element::call_on`] can retry it after
+    /// invalidating a destroyed context.
+    async fn call_in_isolated_world(&self, function: &str, args: Value) -> Result<Value> {
+        let ctx_id = self.inner.tab.ensure_isolated_world().await?;
+        let backend_node_id = self.backend_node_id_cloned().await?;
+        let resolved = self
+            .inner
+            .tab
+            .call(
+                "DOM.resolveNode",
+                json!({
+                    "backendNodeId": backend_node_id,
+                    "executionContextId": ctx_id,
+                }),
+            )
+            .await?;
+        let isolated_object_id = resolved["object"]["objectId"]
+            .as_str()
+            .ok_or_else(|| {
+                ZendriverError::Navigation(
+                    "DOM.resolveNode returned no objectId for isolated world".into(),
+                )
+            })?
+            .to_string();
+
+        let result = self
+            .call_function_on(&isolated_object_id, function, args)
+            .await;
+
+        // Release on both the success and the JS-exception path — a leaked
+        // handle would otherwise outlive the call until the isolated world
+        // itself is replaced. Failures here are non-fatal.
+        let _ = self
+            .inner
+            .tab
+            .call(
+                "Runtime.releaseObject",
+                json!({ "objectId": isolated_object_id }),
+            )
+            .await;
+
+        result
+    }
+
     /// Invoke a JS function in the main world with this element bound as
     /// the first positional argument. Accepts a function declaration whose
     /// first parameter is the element handle (`function(el, ...rest){...}`)
@@ -267,17 +357,19 @@ impl Element {
     /// argument descriptors that follow the element. Returns the raw
     /// `result` RemoteObject (caller picks `value` if `returnByValue`).
     ///
-    /// Locks the remote-object Mutex once at the top, then routes
-    /// through `call_on` (which re-locks once more). The double-lock is
-    /// cheap — `tokio::sync::Mutex` is uncontended in the common case
-    /// and the guard is dropped before any `.await`.
+    /// Reserved for JS that must observe page-defined state — page globals,
+    /// or framework expandos living on the node's page-world wrapper (e.g.
+    /// React's per-instance `_valueTracker`). Anything reading plain DOM
+    /// state belongs on [`Element::call_on`], where the page can neither
+    /// see the read nor forge its answer.
     pub(crate) async fn call_on_main(&self, function: &str, args: Value) -> Result<Value> {
         let object_id = self.remote_object_id_cloned().await?;
         let mut full_args = vec![json!({ "objectId": object_id })];
         if let Some(extra) = args.as_array() {
             full_args.extend(extra.iter().cloned());
         }
-        self.call_on(function, Value::Array(full_args)).await
+        self.call_function_on(&object_id, function, Value::Array(full_args))
+            .await
     }
 
     /// Evaluate a JS expression in the main world with `el` bound to this
@@ -313,6 +405,22 @@ impl Element {
     }
 }
 
+/// `true` for Chrome's "the execution context you named is gone" error,
+/// which is what a destroyed isolated world looks like from the outside.
+///
+/// Chrome reports it as -32000 "Cannot find context with specified id";
+/// `From<CallError>` maps that to [`ZendriverError::Navigation`] (see
+/// `error.rs`), but the raw [`ZendriverError::Cdp`] shape reaches us too, so
+/// both are matched.
+fn is_dead_context_error(e: &ZendriverError) -> bool {
+    let message = match e {
+        ZendriverError::Navigation(m) => m.as_str(),
+        ZendriverError::Cdp { message, .. } => message.as_str(),
+        _ => return false,
+    };
+    message.contains("Cannot find context")
+}
+
 impl crate::traits::Queryable for Element {
     fn find(&self) -> crate::query::FindBuilder<'_> {
         Element::find(self)
@@ -325,9 +433,218 @@ impl crate::traits::Queryable for Element {
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
+
+    /// `expect_cmd` silently discards non-matching frames and has no built-in
+    /// timeout, so a dispatch that vanished or moved would hang the suite
+    /// instead of failing it. Bound every wait.
+    async fn expect(mock: &mut MockConnection, method: &str) -> u64 {
+        match tokio::time::timeout(Duration::from_secs(5), mock.expect_cmd(method)).await {
+            Ok(id) => id,
+            Err(_) => panic!("timed out waiting for {method}"),
+        }
+    }
+
+    /// Serve the two-frame isolated-world handshake, yielding context 42.
+    async fn serve_isolated_world(mock: &mut MockConnection) {
+        let id = expect(mock, "Page.getFrameTree").await;
+        mock.reply(id, json!({ "frameTree": { "frame": { "id": "F1" } } }))
+            .await;
+        let id = expect(mock, "Page.createIsolatedWorld").await;
+        mock.reply(id, json!({ "executionContextId": 42 })).await;
+    }
+
+    /// The read/probe funnel must re-resolve the node into the isolated world
+    /// and invoke the *isolated* handle — a page that shadowed `innerText` or
+    /// `getBoundingClientRect` can then neither lie to the read nor see it.
+    #[tokio::test]
+    async fn call_on_resolves_into_the_isolated_world() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+        let el = Element::from_jsret(tab, 314, "R_MAIN".to_string());
+
+        let fut = tokio::spawn({
+            let e = el.clone();
+            async move {
+                e.call_on("function(){ return this.innerText; }", json!([]))
+                    .await
+            }
+        });
+
+        serve_isolated_world(&mut mock).await;
+
+        let id = expect(&mut mock, "DOM.resolveNode").await;
+        let sent = mock.last_sent();
+        assert_eq!(sent["params"]["backendNodeId"], 314);
+        assert_eq!(
+            sent["params"]["executionContextId"], 42,
+            "element reads must be re-resolved into the isolated world",
+        );
+        mock.reply(id, json!({ "object": { "objectId": "R_ISO" } }))
+            .await;
+
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
+        assert_eq!(
+            mock.last_sent()["params"]["objectId"],
+            "R_ISO",
+            "the call must target the isolated handle, not the page-world one",
+        );
+        mock.reply(
+            id,
+            json!({ "result": { "value": "hello", "type": "string" } }),
+        )
+        .await;
+
+        let id = expect(&mut mock, "Runtime.releaseObject").await;
+        assert_eq!(mock.last_sent()["params"]["objectId"], "R_ISO");
+        mock.reply(id, json!({})).await;
+
+        let res = fut.await.unwrap().unwrap();
+        assert_eq!(res["value"], "hello");
+        conn.shutdown();
+    }
+
+    /// A JS exception still frees the isolated handle — otherwise a scraper
+    /// hitting throwing pages leaks one `RemoteObject` per failed read.
+    #[tokio::test]
+    async fn call_on_releases_the_isolated_handle_after_a_js_exception() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+        let el = Element::from_jsret(tab, 1, "R_MAIN".to_string());
+
+        let fut = tokio::spawn({
+            let e = el.clone();
+            async move {
+                e.call_on("function(){ throw new Error('boom'); }", json!([]))
+                    .await
+            }
+        });
+
+        serve_isolated_world(&mut mock).await;
+        let id = expect(&mut mock, "DOM.resolveNode").await;
+        mock.reply(id, json!({ "object": { "objectId": "R_ISO" } }))
+            .await;
+
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
+        mock.reply(
+            id,
+            json!({
+                "result": { "type": "object", "subtype": "error" },
+                "exceptionDetails": { "exception": { "description": "Error: boom" } },
+            }),
+        )
+        .await;
+
+        let id = expect(&mut mock, "Runtime.releaseObject").await;
+        assert_eq!(mock.last_sent()["params"]["objectId"], "R_ISO");
+        mock.reply(id, json!({})).await;
+
+        match fut.await.unwrap() {
+            Err(ZendriverError::JsException(m)) => assert!(m.contains("boom")),
+            other => panic!("unexpected: {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    /// A navigation destroys the isolated world but leaves its id cached, so
+    /// the next read resolves against a dead context. It must rebuild the
+    /// world and carry on — otherwise the first navigation would poison
+    /// every subsequent read on the tab.
+    #[tokio::test]
+    async fn call_on_rebuilds_the_isolated_world_after_a_navigation_destroyed_it() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+        let el = Element::from_jsret(tab, 5, "R_MAIN".to_string());
+
+        let fut = tokio::spawn({
+            let e = el.clone();
+            async move {
+                e.call_on("function(){ return this.innerText; }", json!([]))
+                    .await
+            }
+        });
+
+        serve_isolated_world(&mut mock).await;
+
+        // First resolve lands on the context the navigation just destroyed.
+        let id = expect(&mut mock, "DOM.resolveNode").await;
+        mock.reply_err(id, -32000, "Cannot find context with specified id")
+            .await;
+
+        // Recovery: the cache is dropped, so the whole discovery handshake
+        // runs again and yields a live context.
+        let id = expect(&mut mock, "Page.getFrameTree").await;
+        mock.reply(id, json!({ "frameTree": { "frame": { "id": "F1" } } }))
+            .await;
+        let id = expect(&mut mock, "Page.createIsolatedWorld").await;
+        mock.reply(id, json!({ "executionContextId": 99 })).await;
+
+        let id = expect(&mut mock, "DOM.resolveNode").await;
+        assert_eq!(
+            mock.last_sent()["params"]["executionContextId"],
+            99,
+            "the retry must use the rebuilt context, not the dead one",
+        );
+        mock.reply(id, json!({ "object": { "objectId": "R_ISO2" } }))
+            .await;
+
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
+        assert_eq!(mock.last_sent()["params"]["objectId"], "R_ISO2");
+        mock.reply(
+            id,
+            json!({ "result": { "value": "recovered", "type": "string" } }),
+        )
+        .await;
+
+        let id = expect(&mut mock, "Runtime.releaseObject").await;
+        mock.reply(id, json!({})).await;
+
+        let res = fut.await.unwrap().unwrap();
+        assert_eq!(res["value"], "recovered");
+        conn.shutdown();
+    }
+
+    /// The escape hatch stays an escape hatch: JS that needs page-defined
+    /// state runs against the element's own page-world handle, with no
+    /// isolated-world handshake in front of it.
+    #[tokio::test]
+    async fn call_on_main_stays_in_the_page_world() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+        let el = Element::from_jsret(tab, 1, "R_MAIN".to_string());
+
+        let fut = tokio::spawn({
+            let e = el.clone();
+            async move {
+                e.call_on_main("function(el){ return el.value; }", json!([]))
+                    .await
+            }
+        });
+
+        // No Page.getFrameTree / DOM.resolveNode is served here: if the main-
+        // world path ever grew one, this wait would trip the timeout.
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
+        let sent = mock.last_sent();
+        assert_eq!(sent["params"]["objectId"], "R_MAIN");
+        assert_eq!(
+            sent["params"]["arguments"][0]["objectId"], "R_MAIN",
+            "the element is bound as the first positional argument",
+        );
+        mock.reply(id, json!({ "result": { "value": "v", "type": "string" } }))
+            .await;
+
+        let res = fut.await.unwrap().unwrap();
+        assert_eq!(res["value"], "v");
+        conn.shutdown();
+    }
 
     #[tokio::test]
     async fn from_jsret_yields_evaluation_origin() {

--- a/crates/zendriver/src/element/reads.rs
+++ b/crates/zendriver/src/element/reads.rs
@@ -339,41 +339,11 @@ impl Element {
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
-    use std::time::Duration;
-
     use super::*;
     use crate::tab::Tab;
+    use crate::test_support::expect;
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
-
-    /// `expect_cmd` discards non-matching frames silently and never times
-    /// out, so a dispatch that moved or vanished would hang the suite rather
-    /// than fail it. Bound every wait.
-    async fn expect(mock: &mut MockConnection, method: &str) -> u64 {
-        match tokio::time::timeout(Duration::from_secs(5), mock.expect_cmd(method)).await {
-            Ok(id) => id,
-            Err(_) => panic!("timed out waiting for {method}"),
-        }
-    }
-
-    /// Serve the isolated-world handshake + node re-resolution that every
-    /// read now runs through, asserting the resolve targets that world.
-    /// Returns once the isolated handle `R_ISO` is live.
-    async fn serve_isolated_resolve(mock: &mut MockConnection) {
-        let id = expect(mock, "Page.getFrameTree").await;
-        mock.reply(id, json!({ "frameTree": { "frame": { "id": "F1" } } }))
-            .await;
-        let id = expect(mock, "Page.createIsolatedWorld").await;
-        mock.reply(id, json!({ "executionContextId": 7 })).await;
-        let id = expect(mock, "DOM.resolveNode").await;
-        assert_eq!(
-            mock.last_sent()["params"]["executionContextId"],
-            7,
-            "reads must be re-resolved into the isolated world",
-        );
-        mock.reply(id, json!({ "object": { "objectId": "R_ISO" } }))
-            .await;
-    }
 
     #[tokio::test]
     async fn attr_returns_some_when_attribute_present() {
@@ -387,14 +357,9 @@ mod tests {
             async move { e.attr("href").await }
         });
 
-        serve_isolated_resolve(&mut mock).await;
-
         let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
-        assert_eq!(
-            sent["params"]["objectId"], "R_ISO",
-            "a page that shadowed getAttribute must not get to answer this",
-        );
+        assert_eq!(sent["params"]["objectId"], "R1");
         assert!(
             sent["params"]["functionDeclaration"]
                 .as_str()
@@ -407,9 +372,6 @@ mod tests {
             json!({ "result": { "value": "/login", "type": "string" } }),
         )
         .await;
-
-        let id = expect(&mut mock, "Runtime.releaseObject").await;
-        mock.reply(id, json!({})).await;
 
         let got = fut.await.unwrap().unwrap();
         assert_eq!(got, Some("/login".to_string()));
@@ -428,11 +390,9 @@ mod tests {
             async move { e.attrs().await }
         });
 
-        serve_isolated_resolve(&mut mock).await;
-
         let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
-        assert_eq!(sent["params"]["objectId"], "R_ISO");
+        assert_eq!(sent["params"]["objectId"], "R1");
         assert!(
             sent["params"]["functionDeclaration"]
                 .as_str()
@@ -449,9 +409,6 @@ mod tests {
             }),
         )
         .await;
-
-        let id = expect(&mut mock, "Runtime.releaseObject").await;
-        mock.reply(id, json!({})).await;
 
         let map = fut.await.unwrap().unwrap();
         assert_eq!(map.get("id").map(String::as_str), Some("btn"));

--- a/crates/zendriver/src/element/reads.rs
+++ b/crates/zendriver/src/element/reads.rs
@@ -339,10 +339,41 @@ impl Element {
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use crate::tab::Tab;
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
+
+    /// `expect_cmd` discards non-matching frames silently and never times
+    /// out, so a dispatch that moved or vanished would hang the suite rather
+    /// than fail it. Bound every wait.
+    async fn expect(mock: &mut MockConnection, method: &str) -> u64 {
+        match tokio::time::timeout(Duration::from_secs(5), mock.expect_cmd(method)).await {
+            Ok(id) => id,
+            Err(_) => panic!("timed out waiting for {method}"),
+        }
+    }
+
+    /// Serve the isolated-world handshake + node re-resolution that every
+    /// read now runs through, asserting the resolve targets that world.
+    /// Returns once the isolated handle `R_ISO` is live.
+    async fn serve_isolated_resolve(mock: &mut MockConnection) {
+        let id = expect(mock, "Page.getFrameTree").await;
+        mock.reply(id, json!({ "frameTree": { "frame": { "id": "F1" } } }))
+            .await;
+        let id = expect(mock, "Page.createIsolatedWorld").await;
+        mock.reply(id, json!({ "executionContextId": 7 })).await;
+        let id = expect(mock, "DOM.resolveNode").await;
+        assert_eq!(
+            mock.last_sent()["params"]["executionContextId"],
+            7,
+            "reads must be re-resolved into the isolated world",
+        );
+        mock.reply(id, json!({ "object": { "objectId": "R_ISO" } }))
+            .await;
+    }
 
     #[tokio::test]
     async fn attr_returns_some_when_attribute_present() {
@@ -356,9 +387,14 @@ mod tests {
             async move { e.attr("href").await }
         });
 
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        serve_isolated_resolve(&mut mock).await;
+
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
-        assert_eq!(sent["params"]["objectId"], "R1");
+        assert_eq!(
+            sent["params"]["objectId"], "R_ISO",
+            "a page that shadowed getAttribute must not get to answer this",
+        );
         assert!(
             sent["params"]["functionDeclaration"]
                 .as_str()
@@ -371,6 +407,9 @@ mod tests {
             json!({ "result": { "value": "/login", "type": "string" } }),
         )
         .await;
+
+        let id = expect(&mut mock, "Runtime.releaseObject").await;
+        mock.reply(id, json!({})).await;
 
         let got = fut.await.unwrap().unwrap();
         assert_eq!(got, Some("/login".to_string()));
@@ -389,8 +428,11 @@ mod tests {
             async move { e.attrs().await }
         });
 
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        serve_isolated_resolve(&mut mock).await;
+
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
+        assert_eq!(sent["params"]["objectId"], "R_ISO");
         assert!(
             sent["params"]["functionDeclaration"]
                 .as_str()
@@ -407,6 +449,9 @@ mod tests {
             }),
         )
         .await;
+
+        let id = expect(&mut mock, "Runtime.releaseObject").await;
+        mock.reply(id, json!({})).await;
 
         let map = fut.await.unwrap().unwrap();
         assert_eq!(map.get("id").map(String::as_str), Some("btn"));

--- a/crates/zendriver/src/element/screenshot.rs
+++ b/crates/zendriver/src/element/screenshot.rs
@@ -142,7 +142,7 @@ impl Element {
 mod tests {
     use super::*;
     use crate::tab::Tab;
-    use crate::test_support::{expect, serve_isolated_call, serve_isolated_world};
+    use crate::test_support::{expect, serve_call_js};
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
 
@@ -172,16 +172,12 @@ mod tests {
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
-        // Step 2: actionability gate (VISIBLE_ONLY = only check_visible),
-        // which runs in the isolated world — hence the world handshake and
-        // the resolve/release around the predicate call.
+        // Step 2: actionability gate (VISIBLE_ONLY = only check_visible).
         //
         // The predicate is asserted by what it is NOT: its JS is owned by
         // `query::actionability` and gets rewritten there, but "the gate is
         // not the scroll" is the property this test needs.
-        serve_isolated_world(&mut mock).await;
-        let gate_js =
-            serve_isolated_call(&mut mock, json!({ "value": true, "type": "boolean" })).await;
+        let gate_js = serve_call_js(&mut mock, json!({ "value": true, "type": "boolean" })).await;
         assert!(
             gate_js.contains("getBoundingClientRect") && !gate_js.contains("scrollIntoView"),
             "expected the visibility predicate after the scroll, got: {gate_js}",

--- a/crates/zendriver/src/element/screenshot.rs
+++ b/crates/zendriver/src/element/screenshot.rs
@@ -142,18 +142,9 @@ impl Element {
 mod tests {
     use super::*;
     use crate::tab::Tab;
+    use crate::test_support::{expect, serve_isolated_call, serve_isolated_world};
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
-
-    /// `expect_cmd` drops non-matching frames silently and never times out,
-    /// so a dispatch that moved or vanished would hang the suite instead of
-    /// failing it. Bound every wait.
-    async fn expect(mock: &mut MockConnection, method: &str) -> u64 {
-        match tokio::time::timeout(Duration::from_secs(5), mock.expect_cmd(method)).await {
-            Ok(id) => id,
-            Err(_) => panic!("timed out waiting for {method}"),
-        }
-    }
 
     #[tokio::test]
     async fn screenshot_sends_page_capturescreenshot_with_clip_matching_bbox() {
@@ -181,24 +172,20 @@ mod tests {
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
-        // Step 2: actionability gate (VISIBLE_ONLY = only check_visible).
-        // Asserted by what it is NOT: the predicate's JS is owned by
+        // Step 2: actionability gate (VISIBLE_ONLY = only check_visible),
+        // which runs in the isolated world — hence the world handshake and
+        // the resolve/release around the predicate call.
+        //
+        // The predicate is asserted by what it is NOT: its JS is owned by
         // `query::actionability` and gets rewritten there, but "the gate is
         // not the scroll" is the property this test needs.
-        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
-        let gate_js = mock.last_sent()["params"]["functionDeclaration"]
-            .as_str()
-            .unwrap()
-            .to_string();
+        serve_isolated_world(&mut mock).await;
+        let gate_js =
+            serve_isolated_call(&mut mock, json!({ "value": true, "type": "boolean" })).await;
         assert!(
             gate_js.contains("getBoundingClientRect") && !gate_js.contains("scrollIntoView"),
             "expected the visibility predicate after the scroll, got: {gate_js}",
         );
-        mock.reply(
-            id,
-            json!({ "result": { "value": true, "type": "boolean" } }),
-        )
-        .await;
 
         // Step 3: bounding_box → DOM.getBoxModel.
         let id = expect(&mut mock, "DOM.getBoxModel").await;

--- a/crates/zendriver/src/element/screenshot.rs
+++ b/crates/zendriver/src/element/screenshot.rs
@@ -1,19 +1,28 @@
 //! [`Element::screenshot`] — element-scoped PNG capture.
 //!
-//! Dispatch sequence (with internal refresh-on-stale recovery):
-//!   1. Visibility gate — we need pixels to capture; overlay occlusion +
+//! Dispatch sequence (with internal refresh-on-stale recovery), matching the
+//! `scroll → gate → measure → dispatch` shape every action in
+//! [`mod@crate::element::actions`] uses:
+//!   1. [`Element::scroll_into_view`] — the clip in step 4 is
+//!      viewport-relative, so the element must be on-screen before it is
+//!      measured (and before the gate, which requires the same).
+//!   2. Visibility gate — we need pixels to capture; overlay occlusion +
 //!      disabled state are irrelevant here, so the gate is the lightest
 //!      preset.
-//!   2. [`Element::bounding_box`] — viewport-relative quad of the element.
-//!   3. `Page.captureScreenshot { format: "png", clip: { x, y, width,
-//!      height, scale: 1 } }` — crop to the element's bbox at native scale.
-//!   4. base64-decode the `data` field into raw PNG bytes.
+//!   3. [`Element::bounding_box`] — viewport-relative quad of the element.
+//!   4. `Page.getLayoutMetrics` — the visual viewport's page offset, added
+//!      to that quad. `Page.captureScreenshot` reads `clip` in document
+//!      coordinates, so a viewport-relative rect would crop the wrong band
+//!      of a scrolled page.
+//!   5. `Page.captureScreenshot { format: "png", clip: { x, y, width,
+//!      height, scale: 1 } }` — crop to the element's rect at native scale.
+//!   6. base64-decode the `data` field into raw PNG bytes.
 
 use std::time::Duration;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use serde_json::json;
+use serde_json::{Value, json};
 
 use crate::element::Element;
 use crate::error::{Result, ZendriverError};
@@ -27,10 +36,16 @@ const DEFAULT_ACTIONABILITY_TIMEOUT: Duration = Duration::from_secs(5);
 impl Element {
     /// Capture a PNG screenshot cropped to this element's bounding box.
     ///
-    /// Waits up to 5 s for the element to become visible, reads its
-    /// viewport-relative bbox via `DOM.getBoxModel`, then sends
+    /// Scrolls the element into view, waits up to 5 s for it to become
+    /// visible, reads its bbox via `DOM.getBoxModel`, converts that to
+    /// document coordinates with `Page.getLayoutMetrics`, then sends
     /// `Page.captureScreenshot` with a matching `clip` rect (at `scale: 1`).
     /// Returns the raw PNG bytes.
+    ///
+    /// The scroll leads because an off-screen element is neither rendered nor
+    /// judged visible by the gate; the coordinate conversion follows because
+    /// Chrome reads the clip in document space while the box model is
+    /// viewport-relative.
     ///
     /// For full-viewport captures, see [`crate::Tab::screenshot`].
     ///
@@ -54,16 +69,46 @@ impl Element {
     /// ```
     pub async fn screenshot(&self) -> Result<Vec<u8>> {
         self.with_refresh(|| async move {
+            // Scroll first, exactly as every action in `element::actions`
+            // does. Two reasons: the clip below is viewport-relative, so an
+            // element measured while off-screen is cropped from the wrong
+            // place; and the visibility predicate itself requires the element
+            // to overlap the viewport, so gating before the scroll would
+            // reject every below-the-fold element.
+            self.scroll_into_view().await?;
             actionability::wait_actionable(
                 self,
                 ActionabilityCheck::VISIBLE_ONLY,
                 DEFAULT_ACTIONABILITY_TIMEOUT,
+                None,
             )
             .await?;
             let bbox = self
                 .bounding_box()
                 .await?
                 .ok_or_else(|| ZendriverError::Navigation("element has no bounding box".into()))?;
+
+            // Chrome reads `clip` in DOCUMENT coordinates while
+            // `bounding_box` is viewport-relative, so the scroll offset has
+            // to be added back or a scrolled page gets cropped from the wrong
+            // region entirely. The offset comes from CDP rather than
+            // `window.scrollX` — one less page-controlled input on a path a
+            // page would happily lie to.
+            let metrics = self
+                .inner
+                .tab
+                .call("Page.getLayoutMetrics", json!({}))
+                .await?;
+            let viewport = metrics.get("cssVisualViewport");
+            let page_x = viewport
+                .and_then(|v| v.get("pageX"))
+                .and_then(Value::as_f64)
+                .unwrap_or(0.0);
+            let page_y = viewport
+                .and_then(|v| v.get("pageY"))
+                .and_then(Value::as_f64)
+                .unwrap_or(0.0);
+
             let res = self
                 .inner
                 .tab
@@ -72,8 +117,8 @@ impl Element {
                     json!({
                         "format": "png",
                         "clip": {
-                            "x": bbox.x,
-                            "y": bbox.y,
+                            "x": bbox.x + page_x,
+                            "y": bbox.y + page_y,
                             "width": bbox.width,
                             "height": bbox.height,
                             "scale": 1,
@@ -100,6 +145,16 @@ mod tests {
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
 
+    /// `expect_cmd` drops non-matching frames silently and never times out,
+    /// so a dispatch that moved or vanished would hang the suite instead of
+    /// failing it. Bound every wait.
+    async fn expect(mock: &mut MockConnection, method: &str) -> u64 {
+        match tokio::time::timeout(Duration::from_secs(5), mock.expect_cmd(method)).await {
+            Ok(id) => id,
+            Err(_) => panic!("timed out waiting for {method}"),
+        }
+    }
+
     #[tokio::test]
     async fn screenshot_sends_page_capturescreenshot_with_clip_matching_bbox() {
         let (mut mock, conn) = MockConnection::pair();
@@ -112,16 +167,32 @@ mod tests {
             async move { e.screenshot().await }
         });
 
-        // Step 1: actionability gate (VISIBLE_ONLY = only check_visible).
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-        let sent = mock.last_sent();
-        // Sanity-check we're calling the visibility predicate, not some
-        // other JS thunk.
+        // Step 1: scroll_into_view — MUST land before both the gate and the
+        // measurement, or an off-screen element is rejected as "not visible"
+        // and, past that, clipped from stale coordinates.
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         assert!(
-            sent["params"]["functionDeclaration"]
+            mock.last_sent()["params"]["functionDeclaration"]
                 .as_str()
                 .unwrap()
-                .contains("offsetParent")
+                .contains("scrollIntoView"),
+            "the scroll must be dispatched before the gate and DOM.getBoxModel",
+        );
+        mock.reply(id, json!({ "result": { "type": "undefined" } }))
+            .await;
+
+        // Step 2: actionability gate (VISIBLE_ONLY = only check_visible).
+        // Asserted by what it is NOT: the predicate's JS is owned by
+        // `query::actionability` and gets rewritten there, but "the gate is
+        // not the scroll" is the property this test needs.
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
+        let gate_js = mock.last_sent()["params"]["functionDeclaration"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(
+            gate_js.contains("getBoundingClientRect") && !gate_js.contains("scrollIntoView"),
+            "expected the visibility predicate after the scroll, got: {gate_js}",
         );
         mock.reply(
             id,
@@ -129,8 +200,8 @@ mod tests {
         )
         .await;
 
-        // Step 2: bounding_box → DOM.getBoxModel.
-        let id = mock.expect_cmd("DOM.getBoxModel").await;
+        // Step 3: bounding_box → DOM.getBoxModel.
+        let id = expect(&mut mock, "DOM.getBoxModel").await;
         mock.reply(
             id,
             json!({
@@ -146,13 +217,30 @@ mod tests {
         )
         .await;
 
-        // Step 3: Page.captureScreenshot with clip { x=10, y=20, w=100, h=50, scale=1 }.
-        let id = mock.expect_cmd("Page.captureScreenshot").await;
+        // Step 4: the scroll offset that turns the viewport-relative box into
+        // the document-relative rect Chrome's clip actually wants.
+        let id = expect(&mut mock, "Page.getLayoutMetrics").await;
+        mock.reply(
+            id,
+            json!({
+                "cssVisualViewport": { "pageX": 5.0, "pageY": 3000.0, "clientWidth": 800,
+                                        "clientHeight": 600, "offsetX": 0, "offsetY": 0,
+                                        "scale": 1, "zoom": 1 },
+            }),
+        )
+        .await;
+
+        // Step 5: Page.captureScreenshot, clip offset into document space:
+        // x = 10 + 5, y = 20 + 3000.
+        let id = expect(&mut mock, "Page.captureScreenshot").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["format"], "png");
         let clip = &sent["params"]["clip"];
-        assert_eq!(clip["x"], 10.0);
-        assert_eq!(clip["y"], 20.0);
+        assert_eq!(clip["x"], 15.0);
+        assert_eq!(
+            clip["y"], 3020.0,
+            "the clip must be in document coordinates, not viewport ones",
+        );
         assert_eq!(clip["width"], 100.0);
         assert_eq!(clip["height"], 50.0);
         assert_eq!(clip["scale"], 1);

--- a/crates/zendriver/src/expect/request.rs
+++ b/crates/zendriver/src/expect/request.rs
@@ -167,36 +167,45 @@ struct RequestPayload {
 /// the `tx`, and exits. Subscription registers synchronously before the
 /// returned [`RequestExpectation`] is constructed so events fired
 /// immediately after a trigger action cannot slip past us.
+///
+/// The task also exits as soon as the receiver goes away — dropping the
+/// [`RequestExpectation`] (including on timeout) closes the channel, and the
+/// subscribe loop selects on that. Otherwise a caller who gave up would leave
+/// a task decoding every request on the session for as long as it lives.
 pub(crate) fn register(session: &SessionHandle, matcher: UrlMatcher) -> RequestExpectation {
-    let (tx, rx) = oneshot::channel();
+    let (mut tx, rx) = oneshot::channel();
     let mut stream =
         crate::expect::watch::<RequestWillBeSentEvent>(session, "Network.requestWillBeSent");
     tokio::spawn(async move {
-        while let Some(res) = stream.next().await {
-            match res {
-                Ok(ev) => {
-                    if matcher.matches(&ev.request.url) {
-                        let matched = MatchedRequest {
-                            url: ev.request.url,
-                            method: ev.request.method,
-                            headers: ev.request.headers,
-                            post_data: ev.request.post_data.map(String::into_bytes),
-                            request_id: ev.request_id,
-                        };
-                        // Send is fallible only if the receiver was
-                        // dropped; in that case the caller no longer
-                        // cares and we just exit.
-                        let _ = tx.send(Ok(matched));
-                        return;
+        let outcome = loop {
+            tokio::select! {
+                // The caller dropped the expectation, so nobody is waiting
+                // for a result. Exit instead of consuming events for the
+                // rest of the session.
+                () = tx.closed() => return,
+                next = stream.next() => match next {
+                    Some(Ok(ev)) => {
+                        if matcher.matches(&ev.request.url) {
+                            break Ok(MatchedRequest {
+                                url: ev.request.url,
+                                method: ev.request.method,
+                                headers: ev.request.headers,
+                                post_data: ev.request.post_data.map(String::into_bytes),
+                                request_id: ev.request_id,
+                            });
+                        }
+                        // Non-matching request — keep waiting.
                     }
-                    // Non-matching request — keep waiting.
-                }
-                Err(e) => {
-                    let _ = tx.send(Err(e));
-                    return;
-                }
+                    Some(Err(e)) => break Err(e),
+                    // Stream ended without a match; drop `tx` so the
+                    // expectation resolves via its `Poll::Ready(Err(_))` arm.
+                    None => return,
+                },
             }
-        }
+        };
+        // Send is fallible only if the receiver was dropped between the last
+        // poll and here; in that case the caller no longer cares.
+        let _ = tx.send(outcome);
     });
     RequestExpectation {
         rx,
@@ -350,6 +359,39 @@ mod tests {
             matches!(res, Err(ZendriverError::EventStreamIncomplete)),
             "expected EventStreamIncomplete after a Lagged boundary, got {res:?}",
         );
+
+        conn.shutdown();
+    }
+
+    /// Dropping the expectation must stop the subscriber task. Otherwise every
+    /// abandoned (or timed-out) `expect_request` leaves a task decoding every
+    /// request on the session for as long as the session lives. Observed
+    /// through the runtime's alive-task count: it rises when `register` spawns
+    /// the subscriber and must fall back to the baseline once the receiver is
+    /// gone.
+    #[tokio::test]
+    async fn subscriber_task_exits_when_expectation_is_dropped() {
+        let (_mock, conn) = MockConnection::pair();
+        let session = SessionHandle::new(conn.clone(), "S1");
+        let metrics = tokio::runtime::Handle::current().metrics();
+
+        let baseline = metrics.num_alive_tasks();
+        let expectation = register(&session, UrlMatcher::from("/api/"));
+        tokio::task::yield_now().await;
+        assert!(
+            metrics.num_alive_tasks() > baseline,
+            "subscriber task should be running while the expectation is alive"
+        );
+
+        drop(expectation);
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while metrics.num_alive_tasks() > baseline {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("subscriber task still alive 2s after the expectation was dropped");
 
         conn.shutdown();
     }

--- a/crates/zendriver/src/expect/response.rs
+++ b/crates/zendriver/src/expect/response.rs
@@ -4,7 +4,8 @@
 //! Mirrors [`crate::expect::request`] but watches `Network.responseReceived`
 //! and exposes [`MatchedResponse::body`] for fetching the response body via
 //! `Network.getResponseBody`. The subscriber task self-cancels after sending
-//! the first match so each `expect_response` call is observably one-shot.
+//! the first match — or as soon as the expectation is dropped — so each
+//! `expect_response` call is observably one-shot and outlives nothing.
 //!
 //! `Network.enable` is already on for every Tab via the per-Tab in-flight
 //! network tracker, so this module does not re-enable the domain.
@@ -270,38 +271,47 @@ struct ResponsePayload {
 /// `tx`, and exits. Subscription registers synchronously before the returned
 /// [`ResponseExpectation`] is constructed so events fired immediately after
 /// a trigger action cannot slip past us.
+///
+/// The task also exits as soon as the receiver goes away — dropping the
+/// [`ResponseExpectation`] (including on timeout) closes the channel, and the
+/// subscribe loop selects on that. Otherwise a caller who gave up would leave
+/// a task decoding every response on the session for as long as it lives.
 pub(crate) fn register(session: &SessionHandle, matcher: UrlMatcher) -> ResponseExpectation {
-    let (tx, rx) = oneshot::channel();
+    let (mut tx, rx) = oneshot::channel();
     let mut stream =
         crate::expect::watch::<ResponseReceivedEvent>(session, "Network.responseReceived");
     let session_for_match = session.clone();
     tokio::spawn(async move {
-        while let Some(res) = stream.next().await {
-            match res {
-                Ok(ev) => {
-                    if matcher.matches(&ev.response.url) {
-                        let matched = MatchedResponse {
-                            url: ev.response.url,
-                            status: ev.response.status,
-                            status_text: ev.response.status_text,
-                            headers: ev.response.headers,
-                            request_id: ev.request_id,
-                            session: session_for_match,
-                        };
-                        // Send is fallible only if the receiver was
-                        // dropped; in that case the caller no longer
-                        // cares and we just exit.
-                        let _ = tx.send(Ok(matched));
-                        return;
+        let outcome = loop {
+            tokio::select! {
+                // The caller dropped the expectation, so nobody is waiting
+                // for a result. Exit instead of consuming events for the
+                // rest of the session.
+                () = tx.closed() => return,
+                next = stream.next() => match next {
+                    Some(Ok(ev)) => {
+                        if matcher.matches(&ev.response.url) {
+                            break Ok(MatchedResponse {
+                                url: ev.response.url,
+                                status: ev.response.status,
+                                status_text: ev.response.status_text,
+                                headers: ev.response.headers,
+                                request_id: ev.request_id,
+                                session: session_for_match,
+                            });
+                        }
+                        // Non-matching response — keep waiting.
                     }
-                    // Non-matching response — keep waiting.
-                }
-                Err(e) => {
-                    let _ = tx.send(Err(e));
-                    return;
-                }
+                    Some(Err(e)) => break Err(e),
+                    // Stream ended without a match; drop `tx` so the
+                    // expectation resolves via its `Poll::Ready(Err(_))` arm.
+                    None => return,
+                },
             }
-        }
+        };
+        // Send is fallible only if the receiver was dropped between the last
+        // poll and here; in that case the caller no longer cares.
+        let _ = tx.send(outcome);
     });
     ResponseExpectation {
         rx,
@@ -493,6 +503,39 @@ mod tests {
             .expect("body task panicked")
             .expect("body returned Err");
         assert_eq!(bytes, raw);
+
+        conn.shutdown();
+    }
+
+    /// Dropping the expectation must stop the subscriber task. Otherwise every
+    /// abandoned (or timed-out) `expect_response` leaves a task decoding every
+    /// response on the session for as long as the session lives. Observed
+    /// through the runtime's alive-task count: it rises when `register` spawns
+    /// the subscriber and must fall back to the baseline once the receiver is
+    /// gone.
+    #[tokio::test]
+    async fn subscriber_task_exits_when_expectation_is_dropped() {
+        let (_mock, conn) = MockConnection::pair();
+        let session = SessionHandle::new(conn.clone(), "S1");
+        let metrics = tokio::runtime::Handle::current().metrics();
+
+        let baseline = metrics.num_alive_tasks();
+        let expectation = register(&session, UrlMatcher::from("/api/"));
+        tokio::task::yield_now().await;
+        assert!(
+            metrics.num_alive_tasks() > baseline,
+            "subscriber task should be running while the expectation is alive"
+        );
+
+        drop(expectation);
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while metrics.num_alive_tasks() > baseline {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("subscriber task still alive 2s after the expectation was dropped");
 
         conn.shutdown();
     }

--- a/crates/zendriver/src/frame/lifecycle.rs
+++ b/crates/zendriver/src/frame/lifecycle.rs
@@ -20,14 +20,16 @@
 //!      through the [`crate::frame::oopif`] observer path on their own
 //!      child session, NOT this stream) and insert it under `frameId`.
 //!    - `Page.frameNavigated` — update the existing entry's URL in
-//!      place; insert a fresh [`crate::Frame`] if no entry exists.
+//!      place (and backfill the frame `name` the attach event could not
+//!      carry); insert a fresh [`crate::Frame`] if no entry exists.
 //!    - `Page.frameDetached` — remove the entry from the registry.
 //!
 //! The task runs until its [`tokio_util::sync::CancellationToken`] fires —
 //! typically when the owning Tab is dropped.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Weak};
+use std::time::Duration;
 
 use futures::StreamExt;
 use serde::Deserialize;
@@ -38,6 +40,12 @@ use zendriver_transport::SessionHandle;
 
 use crate::frame::Frame;
 use crate::tab::TabInner;
+
+/// Wait budget for the `Page.getFrameTree` probe that confirms a
+/// same-parent sibling really is a dead provisional frame. Bounded so a
+/// wedged probe can never stall the event loop that keeps the registry
+/// current; on expiry the sweep fails open (nothing is evicted).
+const PROVISIONAL_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Minimal projection of `Page.frameAttached` — only the fields we need
 /// to construct a [`Frame`]. URL/name are not on this payload; they arrive
@@ -131,62 +139,63 @@ pub(crate) async fn run(
                 // single iframe — once with a provisional `frameId` and
                 // again with the committed one — without an intervening
                 // `frameDetached`. Observed on `srcdoc` iframes under
-                // `--headless=new`. The provisional entry always has an
-                // empty URL (it never received a `frameNavigated`); the
-                // newer attach carries the real id. Sweep any
-                // same-parent provisional siblings before inserting so
-                // the registry doesn't accumulate dead frames that
+                // `--headless=new`. Evict those dead entries so the
+                // registry doesn't accumulate frames that
                 // `Page.createIsolatedWorld` would reject with
                 // "No frame for given id found".
+                let dead = dead_provisional_siblings(&session, &frames, &ev).await;
                 let mut map = frames.write().await;
-                if let Some(parent) = ev.parent_frame_id.as_deref() {
-                    let stale: Vec<String> = map
-                        .iter()
-                        .filter_map(|(id, f)| {
-                            if id == &ev.frame_id {
-                                return None;
-                            }
-                            if f.inner.parent_frame_id.as_deref() != Some(parent) {
-                                return None;
-                            }
-                            let url_slot = f.inner.url.try_read().ok()?;
-                            if url_slot.is_empty() {
-                                Some(id.clone())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect();
-                    for id in stale {
-                        map.remove(&id);
-                    }
+                for id in dead {
+                    map.remove(&id);
                 }
                 map.insert(ev.frame_id, frame);
             }
             Some(ev) = navigated.next() => {
-                let frame_id = ev.frame.id.clone();
-                let new_url = ev.frame.url.clone();
+                let frame_id = ev.frame.id;
+                let new_url = ev.frame.url;
+                // `Page.frameAttached` carries no name, so an entry created
+                // from it always starts nameless. Treat a non-empty name on
+                // `frameNavigated` as the authoritative one; never clear a
+                // known name from an event that simply omits the field.
+                let new_name = ev.frame.name.filter(|n| !n.is_empty());
                 // Update in place if known; otherwise treat the navigation
                 // as the implicit attach (Chrome may emit `frameNavigated`
                 // for the main frame before any subscriber sees an explicit
                 // `frameAttached`).
-                {
-                    let map = frames.read().await;
-                    if let Some(existing) = map.get(&frame_id) {
-                        let mut url_slot = existing.inner.url.write().await;
-                        *url_slot = new_url;
+                let mut map = frames.write().await;
+                if let Some(existing) = map.get(&frame_id) {
+                    let name_changed = new_name.is_some()
+                        && new_name.as_deref() != existing.inner.name.as_deref();
+                    if !name_changed {
+                        *existing.inner.url.write().await = new_url;
                         continue;
                     }
+                    // `FrameInner::name` is immutable (it backs
+                    // `Frame::name() -> Option<&str>`, which cannot hand out
+                    // a lock guard), so backfilling means replacing the
+                    // registry entry. Everything else is carried over —
+                    // notably the session, which for an OOPIF is a child
+                    // session and NOT this subscriber's.
+                    let renamed = Frame::new(
+                        frame_id.clone(),
+                        existing.inner.parent_frame_id.clone(),
+                        new_url,
+                        new_name,
+                        existing.inner.session.clone(),
+                        tab_weak.clone(),
+                    );
+                    map.insert(frame_id, renamed);
+                    continue;
                 }
                 let frame = Frame::new(
                     frame_id.clone(),
                     ev.frame.parent_id,
-                    ev.frame.url,
-                    ev.frame.name,
+                    new_url,
+                    new_name,
                     session.clone(),
                     tab_weak.clone(),
                 );
-                frames.write().await.insert(frame_id, frame);
+                map.insert(frame_id, frame);
             }
             Some(ev) = detached.next() => {
                 frames.write().await.remove(&ev.frame_id);
@@ -196,5 +205,360 @@ pub(crate) async fn run(
                 return;
             }
         }
+    }
+}
+
+/// Registry entries that the freshly-attached `ev` supersedes: same parent,
+/// same session, still URL-less — **and confirmed gone from Chrome's live
+/// frame tree**.
+///
+/// The last clause is what separates a dead provisional frame from a
+/// perfectly good sibling that simply has not navigated yet. Both look
+/// identical in the event stream (a second `frameAttached` under one
+/// parent, no `frameNavigated` on the first), so the registry alone cannot
+/// tell them apart; `Page.getFrameTree` can, because Chrome drops a
+/// provisional frame from the tree the moment it commits the real one —
+/// the same reason `Page.createIsolatedWorld` answers "No frame for given
+/// id found" for it.
+///
+/// Fails open in every ambiguous case (no parent, no candidates, probe
+/// error or timeout): keeping a possibly-dead entry only costs a stale row
+/// in [`crate::Tab::frames`], which
+/// [`crate::Frame::ensure_isolated_world`] already recovers from, whereas
+/// evicting a live frame loses a handle the caller may hold.
+async fn dead_provisional_siblings(
+    session: &SessionHandle,
+    frames: &Arc<RwLock<HashMap<String, Frame>>>,
+    ev: &FrameAttachedEvent,
+) -> Vec<String> {
+    let Some(parent) = ev.parent_frame_id.as_deref() else {
+        return Vec::new();
+    };
+    let candidates: Vec<String> = {
+        let map = frames.read().await;
+        map.iter()
+            .filter_map(|(id, f)| {
+                if id == &ev.frame_id {
+                    return None;
+                }
+                if f.inner.parent_frame_id.as_deref() != Some(parent) {
+                    return None;
+                }
+                // OOPIF entries live on their own child session and are
+                // absent from THIS session's frame tree, so the probe below
+                // would read as "gone" for every one of them.
+                if f.inner.session.session_id() != session.session_id() {
+                    return None;
+                }
+                let url_slot = f.inner.url.try_read().ok()?;
+                url_slot.is_empty().then(|| id.clone())
+            })
+            .collect()
+    };
+    if candidates.is_empty() {
+        return Vec::new();
+    }
+    let Some(live) = live_frame_ids(session).await else {
+        return Vec::new();
+    };
+    candidates
+        .into_iter()
+        .filter(|id| !live.contains(id))
+        .collect()
+}
+
+/// Every frame id Chrome currently reports under `Page.getFrameTree`, or
+/// `None` if the probe failed or outran [`PROVISIONAL_PROBE_TIMEOUT`].
+async fn live_frame_ids(session: &SessionHandle) -> Option<HashSet<String>> {
+    let tree = match tokio::time::timeout(
+        PROVISIONAL_PROBE_TIMEOUT,
+        session.call("Page.getFrameTree", serde_json::json!({})),
+    )
+    .await
+    {
+        Ok(Ok(tree)) => tree,
+        Ok(Err(e)) => {
+            warn!(error = %e, "frame::lifecycle: Page.getFrameTree failed; keeping possibly-stale sibling frames");
+            return None;
+        }
+        Err(_) => {
+            warn!(
+                "frame::lifecycle: Page.getFrameTree timed out; keeping possibly-stale sibling frames"
+            );
+            return None;
+        }
+    };
+    fn collect(node: &serde_json::Value, out: &mut HashSet<String>) {
+        if let Some(id) = node["frame"]["id"].as_str() {
+            out.insert(id.to_string());
+        }
+        if let Some(children) = node["childFrames"].as_array() {
+            for c in children {
+                collect(c, out);
+            }
+        }
+    }
+    let mut ids = HashSet::new();
+    collect(&tree["frameTree"], &mut ids);
+    Some(ids)
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use zendriver_transport::Connection;
+    use zendriver_transport::testing::MockConnection;
+
+    type Registry = Arc<RwLock<HashMap<String, Frame>>>;
+
+    /// Session id every test drives events on — the subscriber only sees
+    /// events routed to its own session.
+    const SESSION: &str = "S1";
+
+    /// Spawn the subscriber on a mock connection and drain its startup
+    /// `Page.enable`. Once that command has landed the three `Page.frame*`
+    /// subscriptions are registered, so any later `emit_event_for_session`
+    /// reaches the loop.
+    async fn start() -> (MockConnection, Connection, Registry, CancellationToken) {
+        let (mut mock, conn) = MockConnection::pair();
+        let session = SessionHandle::new(conn.clone(), SESSION);
+        let frames: Registry = Arc::new(RwLock::new(HashMap::new()));
+        let cancel = CancellationToken::new();
+        tokio::spawn(run(session, frames.clone(), Weak::new(), cancel.clone()));
+        let id = tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Page.enable"))
+            .await
+            .expect("frame lifecycle did not send Page.enable within 2s");
+        mock.reply(id, json!({})).await;
+        (mock, conn, frames, cancel)
+    }
+
+    async fn attach(mock: &MockConnection, frame_id: &str, parent: &str) {
+        mock.emit_event_for_session(
+            "Page.frameAttached",
+            json!({ "frameId": frame_id, "parentFrameId": parent }),
+            SESSION,
+        )
+        .await;
+    }
+
+    /// One `childFrames` entry for a canned `Page.getFrameTree` reply.
+    fn tree_child(id: &str, parent: &str) -> serde_json::Value {
+        json!({ "frame": { "id": id, "parentId": parent, "url": "" } })
+    }
+
+    /// Poll the registry until `pred` holds, then return a snapshot. Panics
+    /// on timeout rather than asserting on a half-applied event.
+    async fn wait_for(
+        frames: &Registry,
+        pred: impl Fn(&HashMap<String, Frame>) -> bool,
+    ) -> HashMap<String, Frame> {
+        for _ in 0..100 {
+            {
+                let map = frames.read().await;
+                if pred(&map) {
+                    return map.clone();
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("registry never reached the expected state within 1s");
+    }
+
+    /// Two real iframes under one parent, neither navigated yet, are
+    /// indistinguishable from the provisional double-attach in the event
+    /// stream alone — but Chrome's frame tree still lists both, so the
+    /// second attach must NOT evict the first.
+    #[tokio::test]
+    async fn unnavigated_sibling_present_in_frame_tree_survives_a_second_attach() {
+        let (mut mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "F1", "P").await;
+        wait_for(&frames, |m| m.contains_key("F1")).await;
+        attach(&mock, "F2", "P").await;
+
+        let id = tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Page.getFrameTree"))
+            .await
+            .expect("attach with an url-less sibling did not probe Page.getFrameTree");
+        mock.reply(
+            id,
+            json!({
+                "frameTree": {
+                    "frame": { "id": "P", "url": "https://host.test/" },
+                    "childFrames": [tree_child("F1", "P"), tree_child("F2", "P")],
+                }
+            }),
+        )
+        .await;
+
+        let map = wait_for(&frames, |m| m.contains_key("F2")).await;
+        assert!(
+            map.contains_key("F1"),
+            "a sibling Chrome still lists in the frame tree must not be swept",
+        );
+        assert_eq!(map.len(), 2);
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
+    /// The quirk the sweep exists for: Chrome re-attaches one iframe under a
+    /// fresh id and drops the provisional from its frame tree. That entry is
+    /// dead and must go.
+    #[tokio::test]
+    async fn provisional_sibling_absent_from_frame_tree_is_evicted() {
+        let (mut mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "PROVISIONAL", "P").await;
+        wait_for(&frames, |m| m.contains_key("PROVISIONAL")).await;
+        attach(&mock, "COMMITTED", "P").await;
+
+        let id = tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Page.getFrameTree"))
+            .await
+            .expect("attach with an url-less sibling did not probe Page.getFrameTree");
+        mock.reply(
+            id,
+            json!({
+                "frameTree": {
+                    "frame": { "id": "P", "url": "https://host.test/" },
+                    "childFrames": [tree_child("COMMITTED", "P")],
+                }
+            }),
+        )
+        .await;
+
+        let map = wait_for(&frames, |m| !m.contains_key("PROVISIONAL")).await;
+        assert!(map.contains_key("COMMITTED"));
+        assert_eq!(map.len(), 1);
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
+    /// A failed probe must fail OPEN. Dropping a live frame loses a handle;
+    /// keeping a dead one only leaves a stale row that
+    /// `ensure_isolated_world` recovers from.
+    #[tokio::test]
+    async fn failed_frame_tree_probe_keeps_the_sibling() {
+        let (mut mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "F1", "P").await;
+        wait_for(&frames, |m| m.contains_key("F1")).await;
+        attach(&mock, "F2", "P").await;
+
+        let id = tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Page.getFrameTree"))
+            .await
+            .expect("attach with an url-less sibling did not probe Page.getFrameTree");
+        mock.reply_err(id, -32000, "Page domain not enabled").await;
+
+        let map = wait_for(&frames, |m| m.contains_key("F2")).await;
+        assert!(
+            map.contains_key("F1"),
+            "an unanswerable probe must not authorize an eviction",
+        );
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
+    /// A single child needs no probe at all — no `Page.getFrameTree` is
+    /// dispatched, so the common case keeps its zero-round-trip cost.
+    #[tokio::test]
+    async fn lone_attach_does_not_probe_the_frame_tree() {
+        let (mut mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "F1", "P").await;
+        wait_for(&frames, |m| m.contains_key("F1")).await;
+
+        assert_eq!(
+            mock.try_recv_cmd(),
+            None,
+            "no sibling candidates means no frame-tree probe",
+        );
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
+    /// `Page.frameAttached` carries no name, so a named iframe is nameless
+    /// in the registry until `Page.frameNavigated` supplies one. Dropping it
+    /// there leaves `Tab::frame_by_name` unable to find the frame forever.
+    #[tokio::test]
+    async fn navigated_backfills_the_frame_name_onto_an_attached_entry() {
+        let (mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "FCHILD", "P").await;
+        let map = wait_for(&frames, |m| m.contains_key("FCHILD")).await;
+        assert_eq!(map["FCHILD"].name(), None, "attach cannot know the name");
+
+        mock.emit_event_for_session(
+            "Page.frameNavigated",
+            json!({
+                "frame": {
+                    "id": "FCHILD",
+                    "parentId": "P",
+                    "url": "https://host.test/side",
+                    "name": "sidebar",
+                }
+            }),
+            SESSION,
+        )
+        .await;
+
+        let map = wait_for(&frames, |m| {
+            m.get("FCHILD").is_some_and(|f| f.name().is_some())
+        })
+        .await;
+        let frame = &map["FCHILD"];
+        assert_eq!(frame.name(), Some("sidebar"));
+        assert_eq!(frame.url().await, "https://host.test/side");
+        assert_eq!(
+            frame.parent_id(),
+            Some("P"),
+            "parent must survive the backfill"
+        );
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
+    /// The backfill only ever adds a name. A later navigation that omits
+    /// the field (Chrome does that for the unnamed case) must not erase the
+    /// name a previous event established.
+    #[tokio::test]
+    async fn navigated_without_a_name_keeps_the_known_one() {
+        let (mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "FCHILD", "P").await;
+        wait_for(&frames, |m| m.contains_key("FCHILD")).await;
+        for (url, name) in [
+            ("https://host.test/one", json!("sidebar")),
+            ("https://host.test/two", json!(null)),
+        ] {
+            mock.emit_event_for_session(
+                "Page.frameNavigated",
+                json!({
+                    "frame": { "id": "FCHILD", "parentId": "P", "url": url, "name": name }
+                }),
+                SESSION,
+            )
+            .await;
+        }
+
+        // The url is the marker for "the SECOND navigation landed".
+        let map = wait_for(&frames, |m| {
+            m.get("FCHILD").is_some_and(|f| {
+                f.inner
+                    .url
+                    .try_read()
+                    .is_ok_and(|u| *u == "https://host.test/two")
+            })
+        })
+        .await;
+        assert_eq!(map["FCHILD"].name(), Some("sidebar"));
+
+        cancel.cancel();
+        conn.shutdown();
     }
 }

--- a/crates/zendriver/src/frame/mod.rs
+++ b/crates/zendriver/src/frame/mod.rs
@@ -585,7 +585,50 @@ impl Frame {
         })
     }
 
+    /// Re-bind a rejected `frame_id` by finding this frame's current id in
+    /// the live `Page.getFrameTree`.
+    ///
+    /// A single child under the recorded parent is unambiguous. With
+    /// several, the recorded `name` and `url` are the only things that tell
+    /// them apart — and when neither singles one out, this returns
+    /// [`ZendriverError::FrameNotFound`] instead of binding the first
+    /// depth-first hit. A wrong bind is worse than an error: it reports
+    /// `Ok` and then runs every later `evaluate` / query against a
+    /// different iframe's document.
     async fn discover_current_frame_id(&self) -> Result<String> {
+        /// One candidate child frame, as reported by `Page.getFrameTree`.
+        struct Child {
+            id: String,
+            name: Option<String>,
+            url: Option<String>,
+        }
+        /// Depth-first collect of EVERY child of `parent` — all of them,
+        /// not just the first, since the count is what reveals ambiguity.
+        fn collect_children(node: &Value, parent: &str, out: &mut Vec<Child>) {
+            if let Some(children) = node["childFrames"].as_array() {
+                for c in children {
+                    let f = &c["frame"];
+                    if f["parentId"].as_str() == Some(parent) {
+                        if let Some(id) = f["id"].as_str() {
+                            out.push(Child {
+                                id: id.to_string(),
+                                name: f["name"].as_str().map(str::to_string),
+                                url: f["url"].as_str().map(str::to_string),
+                            });
+                        }
+                    }
+                    collect_children(c, parent, out);
+                }
+            }
+        }
+        /// The one candidate satisfying `pred`, or `None` when zero or
+        /// several do — "several" must not resolve to "the first".
+        fn sole_match(candidates: &[Child], pred: impl Fn(&Child) -> bool) -> Option<&Child> {
+            let mut hits = candidates.iter().filter(|c| pred(c));
+            let first = hits.next()?;
+            hits.next().is_none().then_some(first)
+        }
+
         let parent = self.inner.parent_frame_id.as_deref().ok_or_else(|| {
             ZendriverError::Navigation(
                 "frame_id rejected and no parent_frame_id recorded to recover from".into(),
@@ -596,31 +639,37 @@ impl Frame {
             .session
             .call("Page.getFrameTree", json!({}))
             .await?;
-        let main = tree["frameTree"].clone();
-        // Walk: depth-first. Find a child whose parentId matches `parent`
-        // and which is not the main frame. Single-iframe pages always
-        // win; multi-iframe pages get the first matching child, which
-        // is the best we can do without a name/url to disambiguate.
-        fn walk_for_child(node: &serde_json::Value, parent: &str) -> Option<String> {
-            if let Some(children) = node["childFrames"].as_array() {
-                for c in children {
-                    if c["frame"]["parentId"].as_str() == Some(parent) {
-                        if let Some(id) = c["frame"]["id"].as_str() {
-                            return Some(id.to_string());
-                        }
-                    }
-                    if let Some(found) = walk_for_child(c, parent) {
-                        return Some(found);
-                    }
-                }
-            }
-            None
-        }
-        walk_for_child(&main, parent).ok_or_else(|| {
-            ZendriverError::FrameNotFound(format!(
+        let mut candidates = Vec::new();
+        collect_children(&tree["frameTree"], parent, &mut candidates);
+
+        if candidates.is_empty() {
+            return Err(ZendriverError::FrameNotFound(format!(
                 "no child frame found under parent {parent} during recovery"
-            ))
-        })
+            )));
+        }
+        if candidates.len() == 1 {
+            return Ok(candidates.swap_remove(0).id);
+        }
+        // Several siblings: only a unique name or url match may bind.
+        let name = self.inner.name.as_deref().filter(|n| !n.is_empty());
+        if let Some(name) = name {
+            if let Some(hit) = sole_match(&candidates, |c| c.name.as_deref() == Some(name)) {
+                return Ok(hit.id.clone());
+            }
+        }
+        let url = self.inner.url.read().await.clone();
+        if !url.is_empty() {
+            if let Some(hit) = sole_match(&candidates, |c| c.url.as_deref() == Some(url.as_str())) {
+                return Ok(hit.id.clone());
+            }
+        }
+        Err(ZendriverError::FrameNotFound(format!(
+            "frame id recovery under parent {parent} is ambiguous: {} sibling frames, and neither \
+             the recorded name ({}) nor url ({}) matches exactly one",
+            candidates.len(),
+            name.unwrap_or("<none>"),
+            if url.is_empty() { "<none>" } else { &url },
+        )))
     }
 
     /// Shared post-processing for `Runtime.evaluate` responses — checks
@@ -926,6 +975,165 @@ mod tests {
             }
             other => panic!("expected Navigation error, got: {other:?}"),
         }
+        conn.shutdown();
+    }
+
+    // --- stale frame-id recovery (`discover_current_frame_id`) ----------
+
+    /// A `Frame` whose recorded id Chrome will reject, forcing
+    /// `ensure_isolated_world` down the recovery path.
+    fn stale_frame(session: SessionHandle, name: Option<&str>, url: &str) -> Frame {
+        Frame::new(
+            "STALE".to_string(),
+            Some("PARENT".to_string()),
+            url.to_string(),
+            name.map(str::to_string),
+            session,
+            Weak::new(),
+        )
+    }
+
+    /// Drain the rejected first `Page.createIsolatedWorld` and answer the
+    /// recovery `Page.getFrameTree` with `children` under `PARENT`.
+    async fn reject_then_serve_tree(mock: &mut MockConnection, children: Value) {
+        let id_world = mock.expect_cmd("Page.createIsolatedWorld").await;
+        assert_eq!(mock.last_sent()["params"]["frameId"], "STALE");
+        mock.reply_err(id_world, -32602, "No frame for given id found")
+            .await;
+        let id_tree = mock.expect_cmd("Page.getFrameTree").await;
+        mock.reply(
+            id_tree,
+            json!({
+                "frameTree": {
+                    "frame": { "id": "PARENT", "url": "https://host.test/" },
+                    "childFrames": children,
+                }
+            }),
+        )
+        .await;
+    }
+
+    fn tree_frame(id: &str, name: &str, url: &str) -> Value {
+        json!({ "frame": { "id": id, "parentId": "PARENT", "name": name, "url": url } })
+    }
+
+    /// Two sibling iframes and nothing to tell them apart: recovery must
+    /// FAIL. Binding the first depth-first hit would return `Ok` and then
+    /// run every later `evaluate` against the wrong document.
+    #[tokio::test]
+    async fn ambiguous_recovery_errors_instead_of_binding_a_sibling() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let frame = stale_frame(sess, None, "");
+
+        let fut = tokio::spawn({
+            let f = frame.clone();
+            async move { f.ensure_isolated_world().await }
+        });
+        reject_then_serve_tree(
+            &mut mock,
+            json!([
+                tree_frame("F1", "", "https://host.test/a"),
+                tree_frame("F2", "", "https://host.test/b"),
+            ]),
+        )
+        .await;
+
+        match fut.await.unwrap() {
+            Err(ZendriverError::FrameNotFound(m)) => {
+                assert!(m.contains("ambiguous"), "unexpected message: {m}");
+            }
+            other => panic!("expected FrameNotFound on an ambiguous tree, got: {other:?}"),
+        }
+        assert_eq!(
+            mock.try_recv_cmd(),
+            None,
+            "a failed recovery must not retry Page.createIsolatedWorld against a guess",
+        );
+        conn.shutdown();
+    }
+
+    /// The recorded frame `name` singles one sibling out — that is a bind
+    /// we can justify, so recovery proceeds with the live id.
+    #[tokio::test]
+    async fn recovery_uses_the_recorded_name_to_pick_among_siblings() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let frame = stale_frame(sess, Some("sidebar"), "");
+
+        let fut = tokio::spawn({
+            let f = frame.clone();
+            async move { f.ensure_isolated_world().await }
+        });
+        reject_then_serve_tree(
+            &mut mock,
+            json!([
+                tree_frame("F1", "banner", "https://host.test/a"),
+                tree_frame("F2", "sidebar", "https://host.test/b"),
+            ]),
+        )
+        .await;
+
+        let id_retry = mock.expect_cmd("Page.createIsolatedWorld").await;
+        assert_eq!(
+            mock.last_sent()["params"]["frameId"],
+            "F2",
+            "recovery must bind the name-matched sibling",
+        );
+        mock.reply(id_retry, json!({ "executionContextId": 99 }))
+            .await;
+        assert_eq!(fut.await.unwrap().unwrap(), 99);
+        conn.shutdown();
+    }
+
+    /// No name, but the recorded url matches exactly one sibling.
+    #[tokio::test]
+    async fn recovery_falls_back_to_the_recorded_url() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let frame = stale_frame(sess, None, "https://host.test/b");
+
+        let fut = tokio::spawn({
+            let f = frame.clone();
+            async move { f.ensure_isolated_world().await }
+        });
+        reject_then_serve_tree(
+            &mut mock,
+            json!([
+                tree_frame("F1", "", "https://host.test/a"),
+                tree_frame("F2", "", "https://host.test/b"),
+            ]),
+        )
+        .await;
+
+        let id_retry = mock.expect_cmd("Page.createIsolatedWorld").await;
+        assert_eq!(mock.last_sent()["params"]["frameId"], "F2");
+        mock.reply(id_retry, json!({ "executionContextId": 5 }))
+            .await;
+        assert_eq!(fut.await.unwrap().unwrap(), 5);
+        conn.shutdown();
+    }
+
+    /// The unambiguous single-iframe page keeps recovering with no name or
+    /// url to go on — the disambiguation must not make the common case
+    /// stricter.
+    #[tokio::test]
+    async fn lone_child_still_recovers_without_name_or_url() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let frame = stale_frame(sess, None, "");
+
+        let fut = tokio::spawn({
+            let f = frame.clone();
+            async move { f.ensure_isolated_world().await }
+        });
+        reject_then_serve_tree(&mut mock, json!([tree_frame("LIVE", "", "")])).await;
+
+        let id_retry = mock.expect_cmd("Page.createIsolatedWorld").await;
+        assert_eq!(mock.last_sent()["params"]["frameId"], "LIVE");
+        mock.reply(id_retry, json!({ "executionContextId": 3 }))
+            .await;
+        assert_eq!(fut.await.unwrap().unwrap(), 3);
         conn.shutdown();
     }
 }

--- a/crates/zendriver/src/geo_resolver.rs
+++ b/crates/zendriver/src/geo_resolver.rs
@@ -109,7 +109,16 @@ impl GeoResolver for IpApiResolver {
                 }
             }
         }
-        let client = builder.build().ok()?;
+        // Every `None` below is a *failure*, not "this IP has no country" —
+        // the caller downgrades the persona either way, so each exit says
+        // which one it was.
+        let client = match builder.build() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(error = %e, "geo probe: HTTP client build failed; skipping");
+                return None;
+            }
+        };
         let resp = match client.get(&self.endpoint).send().await {
             Ok(r) => r,
             Err(e) => {
@@ -117,8 +126,27 @@ impl GeoResolver for IpApiResolver {
                 return None;
             }
         };
-        let body: serde_json::Value = resp.json().await.ok()?;
-        let cc = body.get("countryCode").and_then(|v| v.as_str())?;
+        let status = resp.status();
+        let body: serde_json::Value = match resp.json().await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    status = %status,
+                    endpoint = %self.endpoint,
+                    "geo probe: response body was not JSON"
+                );
+                return None;
+            }
+        };
+        let Some(cc) = body.get("countryCode").and_then(|v| v.as_str()) else {
+            tracing::warn!(
+                status = %status,
+                endpoint = %self.endpoint,
+                "geo probe: response has no string `countryCode` field"
+            );
+            return None;
+        };
         let country = match Country::try_from(cc) {
             Ok(c) => c,
             Err(_) => {
@@ -196,6 +224,44 @@ mod tests {
         let resolved = r.resolve().await.unwrap();
         assert_eq!(resolved.country, Country::try_from("US").unwrap());
         assert_eq!(resolved.timezone, None);
+    }
+
+    /// Well-formed JSON that simply has no `countryCode` (ip-api answers
+    /// `{"status":"fail",...}` for a reserved-range IP) is a probe FAILURE,
+    /// not geo data. It yields `None` — and, unlike before, says so in the
+    /// log rather than downgrading the persona in silence.
+    #[tokio::test]
+    async fn missing_country_code_yields_none() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_string(r#"{"status":"fail","message":"reserved range"}"#),
+            )
+            .mount(&server)
+            .await;
+        assert_eq!(
+            IpApiResolver::new().endpoint(server.uri()).resolve().await,
+            None
+        );
+    }
+
+    /// A non-2xx answer whose body is not JSON at all (a proxy's HTML error
+    /// page is the realistic case) is likewise a logged failure, not data.
+    #[tokio::test]
+    async fn non_json_error_page_yields_none() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(502)
+                    .set_body_string("<html><body>Bad Gateway</body></html>"),
+            )
+            .mount(&server)
+            .await;
+        assert_eq!(
+            IpApiResolver::new().endpoint(server.uri()).resolve().await,
+            None
+        );
     }
 
     #[tokio::test]

--- a/crates/zendriver/src/input/keyboard.rs
+++ b/crates/zendriver/src/input/keyboard.rs
@@ -20,11 +20,15 @@ use unicode_segmentation::UnicodeSegmentation;
 pub enum Key {
     /// A typed character.
     Char(char),
-    /// A named non-character key (Enter, Tab, F1, etc.).
+    /// A key with a name rather than a glyph (Enter, Tab, F1, etc.).
     Special(SpecialKey),
 }
 
-/// Named non-character keys for [`crate::Element::press`].
+/// Keys a keyboard labels rather than prints, for [`crate::Element::press`].
+///
+/// Most of these insert nothing — pressing them runs a default action, or
+/// nothing at all. `Space` and `Enter` are the exceptions: they are printable
+/// keys that happen to have names, and they type `" "` and a newline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SpecialKey {
     /// Return / Enter.
@@ -382,7 +386,7 @@ pub(crate) enum KeyPress {
 ///
 /// Serialized verbatim into the CDP call. `Option` fields are omitted from
 /// the wire payload when `None` (a `char` event carries no `code`/vk; a
-/// special-key event carries no `text`).
+/// non-printable special key such as Tab or Escape carries no `text`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct KeyEventPayload {
     /// CDP event type: `keyDown` / `keyUp` / `rawKeyDown` / `char`.
@@ -446,6 +450,31 @@ fn ordered_modifiers(mods: KeyModifiers) -> impl Iterator<Item = KeyModifiers> {
     .filter(move |m| mods.contains(*m))
 }
 
+/// The text a [`SpecialKey`] inserts, for the two that insert any.
+///
+/// Space and Enter are printable keys that merely happen to have names:
+/// pressing them on a real keyboard puts a character into a focused field
+/// (`" "` and `"\r"` — Chrome turns the carriage return into a newline).
+/// Every other named key — Tab, Escape, the arrows, the F-keys — produces no
+/// character at all.
+///
+/// The distinction decides the CDP event type in [`key_events`], and it is
+/// not cosmetic. `rawKeyDown` means "a keydown that generates no character",
+/// so sending Space or Enter that way is a contradiction: Chrome inserted
+/// nothing (`type_text("a b")` yielded `"ab"`, and Enter never submitted a
+/// form), the first such dispatch per renderer took ~1.1s instead of ~2ms,
+/// and a second one in the same string killed the browser process outright
+/// — reproducibly, on pages with nothing to scroll as readily as on tall
+/// ones. Tab, dispatched exactly the same way, costs milliseconds and
+/// traverses focus correctly, because for Tab `rawKeyDown` is the truth.
+fn special_text(k: SpecialKey) -> Option<&'static str> {
+    match k {
+        SpecialKey::Space => Some(" "),
+        SpecialKey::Enter => Some("\r"),
+        _ => None,
+    }
+}
+
 /// Build the ordered CDP key-event payloads for a single [`Key`] press.
 ///
 /// - `KeyPress::Char`, or a `Key::Char` whose [`char_descriptor`] is `None`
@@ -457,8 +486,9 @@ fn ordered_modifiers(mods: KeyModifiers) -> impl Iterator<Item = KeyModifiers> {
 ///   the modifier bitmask) → the main keyDown → the main keyUp → modifier
 ///   keyUps in reverse.
 /// - `KeyPress::DownAndUp` on a `Key::Special` does the same modifier wrap,
-///   with the main events a `rawKeyDown`/`keyUp` pair built from
-///   [`SpecialKey::to_cdp`] (no `text`).
+///   with the main events built from [`SpecialKey::to_cdp`]. Keys that insert
+///   text (Space, Enter — see [`special_text`]) send a `keyDown` carrying it,
+///   exactly like a printable char; the rest send a text-less `rawKeyDown`.
 pub(crate) fn key_events(key: Key, mods: KeyModifiers, kind: KeyPress) -> Vec<KeyEventPayload> {
     // char-event path: explicit Char kind, or a Char with no descriptor.
     let force_char = matches!(kind, KeyPress::Char);
@@ -500,24 +530,32 @@ pub(crate) fn key_events(key: Key, mods: KeyModifiers, kind: KeyPress) -> Vec<Ke
         unreachable!("Key::Char handled above");
     };
     if force_char {
-        // char-event for a special key: send its key string as text (space,
-        // enter→"\r", tab→"\t" handled by the caller mapping; here we use the
-        // CDP `key`). Rarely used, but keep the contract total.
+        // char-event for a special key: the text it inserts if it is one of
+        // the printable ones, else its CDP `key` string. Rarely used, but
+        // keep the contract total.
         let (_, key_str, _) = k.to_cdp();
+        let text = special_text(k).unwrap_or(key_str);
         return vec![KeyEventPayload {
             event_type: "char",
             modifiers: mods.cdp_bits(),
-            text: Some(key_str.to_string()),
+            text: Some(text.to_string()),
             key: Some(key_str.to_string()),
             code: None,
             windows_vk: None,
         }];
     }
     let (code, key_str, vk) = k.to_cdp();
+    // A key that inserts text must say so, and `rawKeyDown` means precisely
+    // "generate no character" — see [`special_text`].
+    let text = special_text(k);
     let main_down = KeyEventPayload {
-        event_type: "rawKeyDown",
+        event_type: if text.is_some() {
+            "keyDown"
+        } else {
+            "rawKeyDown"
+        },
         modifiers: mods.cdp_bits(),
-        text: None,
+        text: text.map(str::to_string),
         key: Some(key_str.to_string()),
         code: Some(code),
         windows_vk: Some(vk),
@@ -954,16 +992,60 @@ mod tests {
     #[test]
     fn key_events_special_key_no_modifiers_is_rawkeydown_keyup() {
         let events = key_events(
-            Key::Special(SpecialKey::Enter),
+            Key::Special(SpecialKey::Escape),
             KeyModifiers::empty(),
             KeyPress::DownAndUp,
         );
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].event_type, "rawKeyDown");
-        assert_eq!(events[0].key.as_deref(), Some("Enter"));
-        assert_eq!(events[0].windows_vk, Some(13));
+        assert_eq!(events[0].key.as_deref(), Some("Escape"));
+        assert_eq!(events[0].windows_vk, Some(27));
         assert!(events[0].text.is_none());
         assert_eq!(events[1].event_type, "keyUp");
+    }
+
+    #[test]
+    fn key_events_printable_specials_carry_their_text() {
+        // Space and Enter insert a character, so they go out as a `keyDown`
+        // carrying it. `rawKeyDown` means "generate no character": dispatched
+        // that way Chrome inserted nothing, took ~1.1s for the first one, and
+        // died on the second.
+        for (key, text, vk) in [(SpecialKey::Space, " ", 32), (SpecialKey::Enter, "\r", 13)] {
+            let events = key_events(
+                Key::Special(key),
+                KeyModifiers::empty(),
+                KeyPress::DownAndUp,
+            );
+            assert_eq!(events.len(), 2, "{key:?}");
+            assert_eq!(events[0].event_type, "keyDown", "{key:?}");
+            assert_eq!(events[0].text.as_deref(), Some(text), "{key:?}");
+            assert_eq!(events[0].windows_vk, Some(vk), "{key:?}");
+            assert_eq!(events[1].event_type, "keyUp", "{key:?}");
+        }
+    }
+
+    #[test]
+    fn key_events_non_printable_specials_stay_textless_rawkeydown() {
+        // Tab's default action (focus traversal) runs off the keydown alone,
+        // and it inserts nothing — `rawKeyDown` is the accurate event for it
+        // and the others like it. Kept pinned so the Space/Enter fix cannot
+        // creep across the whole enum.
+        for key in [
+            SpecialKey::Tab,
+            SpecialKey::Escape,
+            SpecialKey::Backspace,
+            SpecialKey::Delete,
+            SpecialKey::ArrowDown,
+            SpecialKey::F5,
+        ] {
+            let events = key_events(
+                Key::Special(key),
+                KeyModifiers::empty(),
+                KeyPress::DownAndUp,
+            );
+            assert_eq!(events[0].event_type, "rawKeyDown", "{key:?}");
+            assert!(events[0].text.is_none(), "{key:?}");
+        }
     }
 
     #[test]
@@ -1078,21 +1160,37 @@ mod tests {
     }
 
     #[test]
-    fn cluster_events_space_routes_to_special_key() {
+    fn cluster_events_space_routes_to_special_key_carrying_its_text() {
         let events = flatten_text(" ");
-        // Space → SpecialKey::Space DownAndUp (rawKeyDown + keyUp).
+        // Space → SpecialKey::Space DownAndUp, dispatched the way every other
+        // printable character is: a `keyDown` carrying the text. Typed as a
+        // text-less `rawKeyDown`, `type_text("a b")` used to produce "ab".
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].event_type, "rawKeyDown");
+        assert_eq!(events[0].event_type, "keyDown");
         assert_eq!(events[0].code, Some("Space"));
         assert_eq!(events[0].windows_vk, Some(32));
+        assert_eq!(events[0].text.as_deref(), Some(" "));
+        assert_eq!(events[0].key.as_deref(), Some(" "));
         assert_eq!(events[1].event_type, "keyUp");
     }
 
     #[test]
-    fn cluster_events_newline_routes_to_enter() {
+    fn cluster_events_newline_routes_to_enter_carrying_a_carriage_return() {
         let events = flatten_text("\n");
+        assert_eq!(events[0].event_type, "keyDown");
         assert_eq!(events[0].code, Some("Enter"));
         assert_eq!(events[0].windows_vk, Some(13));
+        // Chrome turns the carriage return into a newline in a textarea, and
+        // it is what triggers implicit form submission in an input.
+        assert_eq!(events[0].text.as_deref(), Some("\r"));
+    }
+
+    #[test]
+    fn cluster_events_tab_routes_to_a_textless_raw_keydown() {
+        let events = flatten_text("\t");
+        assert_eq!(events[0].event_type, "rawKeyDown");
+        assert_eq!(events[0].code, Some("Tab"));
+        assert!(events[0].text.is_none());
     }
 
     // --- KeySequence flattening ---
@@ -1111,8 +1209,9 @@ mod tests {
         assert_eq!(events[1].event_type, "keyUp");
         assert_eq!(events[2].code, Some("KeyI"));
         assert_eq!(events[3].event_type, "keyUp");
-        // Enter: rawKeyDown + keyUp.
-        assert_eq!(events[4].event_type, "rawKeyDown");
+        // Enter: keyDown carrying "\r" + keyUp.
+        assert_eq!(events[4].event_type, "keyDown");
+        assert_eq!(events[4].text.as_deref(), Some("\r"));
         assert_eq!(events[4].code, Some("Enter"));
         assert_eq!(events[5].event_type, "keyUp");
         assert_eq!(events[5].code, Some("Enter"));
@@ -1302,8 +1401,9 @@ mod dispatch_tests {
 
         let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
         let last = mock.last_sent();
-        assert_eq!(last["params"]["type"], "rawKeyDown");
+        assert_eq!(last["params"]["type"], "keyDown");
         assert_eq!(last["params"]["key"], "Enter");
+        assert_eq!(last["params"]["text"], "\r");
         assert_eq!(last["params"]["windowsVirtualKeyCode"], 13);
         mock.reply(id, Value::Null).await;
 

--- a/crates/zendriver/src/input/mod.rs
+++ b/crates/zendriver/src/input/mod.rs
@@ -50,12 +50,9 @@ pub struct InputController {
 pub(crate) struct InputState {
     pub pointer_x: f64,
     pub pointer_y: f64,
-    // Tracked per `MouseButtonSet`'s doc comment (drag/release sequences
-    // across multiple element actions), but nothing yet mutates it after
-    // init: `mouse::click_at` presses and releases within one call rather
-    // than exposing separate mouse-down/mouse-up dispatch. Kept for that
-    // forward-looking drag/hold API.
-    #[allow(dead_code)]
+    /// Buttons currently held down. Written by every press/release and by the
+    /// drag path, and sent as CDP's `buttons` bitmask on every dispatched
+    /// mouse event — `MouseButtonSet`'s bit values match that mask exactly.
     pub buttons_held: MouseButtonSet,
     pub modifiers_held: KeyModifiers,
     pub rng: rand::rngs::SmallRng,

--- a/crates/zendriver/src/input/mouse.rs
+++ b/crates/zendriver/src/input/mouse.rs
@@ -193,59 +193,86 @@ pub(crate) async fn click_at(
         move_raw(input, tab, target_x, target_y, extra_modifiers).await?;
     }
     let bit = button_bit(button);
-    for n in 1..=click_count.max(1) {
-        // `buttons` must reflect the set held *after* the press and *after* the
-        // release, so take it from the same locked section that mutates it.
-        let (modifier_bits, buttons) = {
-            let mut s = input.state.lock().await;
-            s.buttons_held.insert(bit);
-            (
-                (s.modifiers_held | extra_modifiers).cdp_bits(),
-                s.buttons_held.bits(),
-            )
-        };
-        tab.session()
-            .call(
-                "Input.dispatchMouseEvent",
-                json!({
-                    "type": "mousePressed",
-                    "x": target_x, "y": target_y,
-                    "button": button.cdp_str(),
-                    "clickCount": n,
-                    "modifiers": modifier_bits,
-                    "buttons": buttons,
-                }),
-            )
-            .await?;
-        let (modifier_bits, buttons) = {
-            let mut s = input.state.lock().await;
-            s.buttons_held.remove(bit);
-            (
-                (s.modifiers_held | extra_modifiers).cdp_bits(),
-                s.buttons_held.bits(),
-            )
-        };
-        tab.session()
-            .call(
-                "Input.dispatchMouseEvent",
-                json!({
-                    "type": "mouseReleased",
-                    "x": target_x, "y": target_y,
-                    "button": button.cdp_str(),
-                    "clickCount": n,
-                    "modifiers": modifier_bits,
-                    "buttons": buttons,
-                }),
-            )
-            .await?;
+    // `buttons_held` lives on the per-Tab InputController, which outlives this
+    // call, so a `?` between the press and its matching release would strand
+    // `bit` set for the rest of the tab's life: every later `mouseMoved` would
+    // then report a button held with no preceding mousedown. That impossible
+    // state is worse than the missing-`buttons` bug this replaced — behavioral
+    // anti-bot scoring reads exactly this stream.
+    //
+    // The fix is a single fallible section plus one cleanup below, rather than
+    // a `Drop` guard: clearing the bit needs the async `Mutex`, `Drop` cannot
+    // await, and a `try_lock` inside `Drop` would silently fail under
+    // contention — precisely when another task is mid-dispatch and would go on
+    // to read the stale bit. A guard here would be more machinery and a weaker
+    // guarantee.
+    //
+    // Residual case it does not cover: if the caller drops this future
+    // mid-gesture (cancellation, an outer `tokio::time::timeout`), the cleanup
+    // never runs and the bit stays set. A `Drop` guard would not reliably close
+    // that either, for the `try_lock` reason above.
+    let sequence: Result<()> = async {
+        for n in 1..=click_count.max(1) {
+            // `buttons` must reflect the set held *after* the press and *after*
+            // the release, so take it from the same locked section that mutates
+            // it.
+            let (modifier_bits, buttons) = {
+                let mut s = input.state.lock().await;
+                s.buttons_held.insert(bit);
+                (
+                    (s.modifiers_held | extra_modifiers).cdp_bits(),
+                    s.buttons_held.bits(),
+                )
+            };
+            tab.session()
+                .call(
+                    "Input.dispatchMouseEvent",
+                    json!({
+                        "type": "mousePressed",
+                        "x": target_x, "y": target_y,
+                        "button": button.cdp_str(),
+                        "clickCount": n,
+                        "modifiers": modifier_bits,
+                        "buttons": buttons,
+                    }),
+                )
+                .await?;
+            let (modifier_bits, buttons) = {
+                let mut s = input.state.lock().await;
+                s.buttons_held.remove(bit);
+                (
+                    (s.modifiers_held | extra_modifiers).cdp_bits(),
+                    s.buttons_held.bits(),
+                )
+            };
+            tab.session()
+                .call(
+                    "Input.dispatchMouseEvent",
+                    json!({
+                        "type": "mouseReleased",
+                        "x": target_x, "y": target_y,
+                        "button": button.cdp_str(),
+                        "clickCount": n,
+                        "modifiers": modifier_bits,
+                        "buttons": buttons,
+                    }),
+                )
+                .await?;
+        }
+        Ok(())
     }
-    Ok(())
+    .await;
+    // Single exit for the latched bit. A no-op on the happy path (the last
+    // release already cleared it) and on any failure before the first press.
+    input.state.lock().await.buttons_held.remove(bit);
+    sequence
 }
 
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use zendriver_transport::{SessionHandle, testing::MockConnection};
 
     #[test]
     fn mouse_button_cdp_strings_match_chrome() {
@@ -256,4 +283,92 @@ mod tests {
         assert_eq!(MouseButton::Forward.cdp_str(), "forward");
     }
     // Note: dispatch fns are async + need a Tab + MockConnection — exercised in T20 click tests.
+
+    /// Drive one `Input.dispatchMouseEvent` off the mock: assert the frame is
+    /// the expected `type`, then hand it to `respond`. `expect_cmd` has no
+    /// built-in timeout, so every wait is bounded here.
+    async fn next_dispatch(mock: &mut MockConnection, expected_type: &str) -> u64 {
+        let id = tokio::time::timeout(
+            Duration::from_secs(5),
+            mock.expect_cmd("Input.dispatchMouseEvent"),
+        )
+        .await
+        .expect("no Input.dispatchMouseEvent arrived");
+        assert_eq!(
+            mock.last_sent()["params"]["type"],
+            expected_type,
+            "unexpected dispatch order: {}",
+            mock.last_sent()
+        );
+        id
+    }
+
+    /// A failed `mousePressed` must not strand the held-button bit. The
+    /// InputController is per-Tab and long-lived, so a latched bit makes every
+    /// subsequent `mouseMoved` on this tab report a button held with no
+    /// preceding mousedown — incoherent pointer telemetry, and strictly worse
+    /// than omitting the field.
+    #[tokio::test]
+    async fn click_at_clears_the_held_bit_when_the_press_fails() {
+        let (mut mock, conn) = MockConnection::pair();
+        let tab = Tab::new_for_test(SessionHandle::new(conn.clone(), "S1"));
+
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move {
+                // `realistic: false` keeps the approach to a single teleport
+                // `mouseMoved` — no Bezier path, no per-segment sleeps.
+                let opts = crate::element::actions::ClickOptions {
+                    realistic: false,
+                    ..Default::default()
+                };
+                click_at(t.input(), &t, 10.0, 20.0, &opts).await
+            }
+        });
+
+        let mv = next_dispatch(&mut mock, "mouseMoved").await;
+        mock.reply(mv, serde_json::json!({})).await;
+        let press = next_dispatch(&mut mock, "mousePressed").await;
+        mock.reply_err(press, -32000, "dispatch rejected").await;
+
+        assert!(
+            fut.await.unwrap().is_err(),
+            "a failed mousePressed must propagate"
+        );
+        assert!(
+            tab.input().state.lock().await.buttons_held.is_empty(),
+            "click_at leaked a latched button bit after a failed mousePressed"
+        );
+        conn.shutdown();
+    }
+
+    /// `mouse_drag` latches the bit *after* the press lands, so the failure
+    /// that leaks it is a dispatch between the press and the release — an
+    /// interpolated `mouseMoved` is the realistic one.
+    #[tokio::test]
+    async fn mouse_drag_clears_the_held_bit_when_a_move_fails() {
+        let (mut mock, conn) = MockConnection::pair();
+        let tab = Tab::new_for_test(SessionHandle::new(conn.clone(), "S1"));
+
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move { t.mouse_drag((10.0, 10.0), (200.0, 10.0), 5).await }
+        });
+
+        let press = next_dispatch(&mut mock, "mousePressed").await;
+        mock.reply(press, serde_json::json!({})).await;
+        // The bit is held from here until the release; fail inside that window.
+        let mv = next_dispatch(&mut mock, "mouseMoved").await;
+        mock.reply_err(mv, -32000, "dispatch rejected").await;
+
+        assert!(
+            fut.await.unwrap().is_err(),
+            "a failed mouseMoved must propagate"
+        );
+        assert!(
+            tab.input().state.lock().await.buttons_held.is_empty(),
+            "mouse_drag leaked a latched button bit after a failed mouseMoved"
+        );
+        conn.shutdown();
+    }
 }

--- a/crates/zendriver/src/input/mouse.rs
+++ b/crates/zendriver/src/input/mouse.rs
@@ -7,6 +7,8 @@ use serde_json::json;
 use crate::error::Result;
 use crate::input::InputController;
 use crate::input::bezier::BezierPath;
+use crate::input::keyboard::KeyModifiers;
+use crate::input::pointer_state::MouseButtonSet;
 use crate::tab::Tab;
 
 /// Mouse buttons for click dispatch.
@@ -54,14 +56,34 @@ impl MouseButton {
     }
 }
 
+/// The [`MouseButtonSet`] bit for a single button.
+///
+/// `MouseButtonSet`'s bit values are chosen to match CDP's `buttons` bitmask
+/// (1 left, 2 right, 4 middle, 8 back, 16 forward), so `MouseButtonSet::bits`
+/// is the wire value directly.
+const fn button_bit(button: MouseButton) -> MouseButtonSet {
+    match button {
+        MouseButton::Left => MouseButtonSet::LEFT,
+        MouseButton::Middle => MouseButtonSet::MIDDLE,
+        MouseButton::Right => MouseButtonSet::RIGHT,
+        MouseButton::Back => MouseButtonSet::BACK,
+        MouseButton::Forward => MouseButtonSet::FORWARD,
+    }
+}
+
 /// Move the cursor from its current position to `(target_x, target_y)` along
 /// a Bezier path with realistic per-segment delay. Updates InputController
 /// state to the target position on success.
+///
+/// Carries `buttons` so a move dispatched between a press and a release reads
+/// as a drag. A page implementing drag with `mousemove` + `e.buttons` — the
+/// standard modern check — sees nothing at all without it.
 pub(crate) async fn move_realistic(
     input: &InputController,
     tab: &Tab,
     target_x: f64,
     target_y: f64,
+    extra_modifiers: KeyModifiers,
 ) -> Result<()> {
     // Hold the lock across the full dispatch + state-update sequence so a
     // concurrent `move_*` from another task can't slip in between our last
@@ -71,31 +93,44 @@ pub(crate) async fn move_realistic(
     // which matches Chrome's per-page input model.
     let mut state = input.state.lock().await;
     let start = (state.pointer_x, state.pointer_y);
-    let modifier_bits = state.modifiers_held.cdp_bits();
+    let modifier_bits = (state.modifiers_held | extra_modifiers).cdp_bits();
+    let buttons = state.buttons_held.bits();
     let path = BezierPath::build(
         start,
         (target_x, target_y),
         input.profile.jitter_amplitude_px,
         &mut state.rng,
     );
-    let segment_delay = if input.profile.mouse_speed_px_per_ms > 0.0 {
-        Duration::from_micros(((5.0 / input.profile.mouse_speed_px_per_ms) * 1000.0) as u64)
-    } else {
-        Duration::ZERO
-    };
-    for &(x, y) in &path.points {
+    let speed = input.profile.mouse_speed_px_per_ms;
+    // `points[0]` is the start position, so dispatching it emits a `mouseMoved`
+    // to where the cursor already is. Skip it, and sleep *before* each step so
+    // the delay pays for the movement that follows rather than trailing the
+    // last one.
+    let mut prev = path.points.first().copied().unwrap_or(start);
+    for &(x, y) in path.points.iter().skip(1) {
+        if speed > 0.0 {
+            // Derive the delay from the segment actually emitted. `BezierPath`
+            // clamps its sample count to [8, 60], so segment length scales with
+            // distance; assuming a fixed 5px step ran long moves ~3x too fast
+            // and short ones ~4x too slow, which made `mouse_speed_px_per_ms`
+            // honest only for 40-300px journeys.
+            let seg = (x - prev.0).hypot(y - prev.1);
+            let delay = Duration::from_micros(((seg / speed) * 1000.0) as u64);
+            if !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
+        }
         tab.session()
             .call(
                 "Input.dispatchMouseEvent",
                 json!({
                     "type": "mouseMoved", "x": x, "y": y,
                     "modifiers": modifier_bits,
+                    "buttons": buttons,
                 }),
             )
             .await?;
-        if !segment_delay.is_zero() {
-            tokio::time::sleep(segment_delay).await;
-        }
+        prev = (x, y);
     }
     state.pointer_x = target_x;
     state.pointer_y = target_y;
@@ -108,16 +143,19 @@ pub(crate) async fn move_raw(
     tab: &Tab,
     target_x: f64,
     target_y: f64,
+    extra_modifiers: KeyModifiers,
 ) -> Result<()> {
     // Same per-Tab serialization rationale as `move_realistic`.
     let mut state = input.state.lock().await;
-    let modifier_bits = state.modifiers_held.cdp_bits();
+    let modifier_bits = (state.modifiers_held | extra_modifiers).cdp_bits();
+    let buttons = state.buttons_held.bits();
     tab.session()
         .call(
             "Input.dispatchMouseEvent",
             json!({
                 "type": "mouseMoved", "x": target_x, "y": target_y,
                 "modifiers": modifier_bits,
+                "buttons": buttons,
             }),
         )
         .await?;
@@ -126,50 +164,81 @@ pub(crate) async fn move_raw(
     Ok(())
 }
 
-/// Dispatch a click at `(target_x, target_y)` with `button` and `click_count`.
-/// If `realistic`, prefixes with Bezier move; otherwise direct teleport.
+/// Dispatch a click at `(target_x, target_y)`.
+///
+/// Reads `button` / `click_count` / `realistic` / `modifiers` from `opts`;
+/// `force` and `position` belong to the element-gating layer and are resolved
+/// by the caller before it picks a target coordinate.
+///
+/// `opts.modifiers` are OR'd with whatever the keyboard currently holds, so a
+/// caller-requested Ctrl/Cmd/Shift-click works without the caller having to
+/// drive a real key-down first. They ride the approach `mouseMoved` frames too,
+/// the way a real browser reports `ctrlKey` on mousemove.
+///
+/// A `click_count` above 1 emits that many press/release pairs with an
+/// increasing `clickCount`, which is what Chrome produces for a real
+/// double-click. Collapsing it into one pair carrying `clickCount: 2` is
+/// invisible to any page counting `mousedown` events.
 pub(crate) async fn click_at(
     input: &InputController,
     tab: &Tab,
     target_x: f64,
     target_y: f64,
-    button: MouseButton,
-    click_count: u32,
-    realistic: bool,
+    opts: &crate::element::actions::ClickOptions,
 ) -> Result<()> {
-    if realistic {
-        move_realistic(input, tab, target_x, target_y).await?;
+    let (button, click_count, extra_modifiers) = (opts.button, opts.click_count, opts.modifiers);
+    if opts.realistic {
+        move_realistic(input, tab, target_x, target_y, extra_modifiers).await?;
     } else {
-        move_raw(input, tab, target_x, target_y).await?;
+        move_raw(input, tab, target_x, target_y, extra_modifiers).await?;
     }
-    let modifier_bits = {
-        let s = input.state.lock().await;
-        s.modifiers_held.cdp_bits()
-    };
-    tab.session()
-        .call(
-            "Input.dispatchMouseEvent",
-            json!({
-                "type": "mousePressed",
-                "x": target_x, "y": target_y,
-                "button": button.cdp_str(),
-                "clickCount": click_count,
-                "modifiers": modifier_bits,
-            }),
-        )
-        .await?;
-    tab.session()
-        .call(
-            "Input.dispatchMouseEvent",
-            json!({
-                "type": "mouseReleased",
-                "x": target_x, "y": target_y,
-                "button": button.cdp_str(),
-                "clickCount": click_count,
-                "modifiers": modifier_bits,
-            }),
-        )
-        .await?;
+    let bit = button_bit(button);
+    for n in 1..=click_count.max(1) {
+        // `buttons` must reflect the set held *after* the press and *after* the
+        // release, so take it from the same locked section that mutates it.
+        let (modifier_bits, buttons) = {
+            let mut s = input.state.lock().await;
+            s.buttons_held.insert(bit);
+            (
+                (s.modifiers_held | extra_modifiers).cdp_bits(),
+                s.buttons_held.bits(),
+            )
+        };
+        tab.session()
+            .call(
+                "Input.dispatchMouseEvent",
+                json!({
+                    "type": "mousePressed",
+                    "x": target_x, "y": target_y,
+                    "button": button.cdp_str(),
+                    "clickCount": n,
+                    "modifiers": modifier_bits,
+                    "buttons": buttons,
+                }),
+            )
+            .await?;
+        let (modifier_bits, buttons) = {
+            let mut s = input.state.lock().await;
+            s.buttons_held.remove(bit);
+            (
+                (s.modifiers_held | extra_modifiers).cdp_bits(),
+                s.buttons_held.bits(),
+            )
+        };
+        tab.session()
+            .call(
+                "Input.dispatchMouseEvent",
+                json!({
+                    "type": "mouseReleased",
+                    "x": target_x, "y": target_y,
+                    "button": button.cdp_str(),
+                    "clickCount": n,
+                    "modifiers": modifier_bits,
+                    "buttons": buttons,
+                }),
+            )
+            .await?;
+    }
     Ok(())
 }
 

--- a/crates/zendriver/src/input/touch.rs
+++ b/crates/zendriver/src/input/touch.rs
@@ -36,6 +36,15 @@ pub(crate) async fn tap_at(tab: &Tab, x: f64, y: f64) -> Result<()> {
             }),
         )
         .await?;
+    // A tap moves the pointer as far as the page is concerned, so keep the
+    // controller's cached cursor in step. Without this the next realistic mouse
+    // move builds its Bezier from a stale origin and opens by teleporting back
+    // to wherever the last mouse action landed.
+    {
+        let mut s = tab.input().state.lock().await;
+        s.pointer_x = x;
+        s.pointer_y = y;
+    }
     Ok(())
 }
 

--- a/crates/zendriver/src/lib.rs
+++ b/crates/zendriver/src/lib.rs
@@ -101,6 +101,8 @@ pub mod response_body;
 pub mod screenshot;
 pub mod storage;
 pub mod tab;
+#[cfg(test)]
+pub(crate) mod test_support;
 #[cfg(any(feature = "geo", feature = "tracker-blocking"))]
 pub mod tls;
 #[cfg(feature = "tracker-blocking")]

--- a/crates/zendriver/src/monitor/mod.rs
+++ b/crates/zendriver/src/monitor/mod.rs
@@ -35,8 +35,8 @@ use futures::{Stream, StreamExt};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
-use zendriver_transport::{AccountedRawEvent, SessionHandle};
+use tracing::{debug, warn};
+use zendriver_transport::{AccountedRawEvent, CallError, SessionHandle};
 
 use crate::url_matcher::UrlMatcher;
 use events::{
@@ -650,11 +650,13 @@ async fn run_monitor(
                                     && filter_allows(filter.as_ref(), Some(p.request.url.as_str()))
                                 {
                                     // Once one `streamResourceContent` call has
-                                    // failed (old Chrome / unsupported), skip
-                                    // future enable attempts — the whole-body
+                                    // come back "method not found" (old Chrome),
+                                    // skip future enable attempts — the whole-body
                                     // `body()` path is the fallback, and there's
                                     // no point re-spending a doomed CDP round-trip
-                                    // per request. Matches the warn message.
+                                    // per request. Only that error latches the
+                                    // flag; a lost `-32602` race is per-request
+                                    // and leaves streaming on.
                                     streaming.insert(p.request_id.clone());
                                     spawn_stream_resource_content(
                                         &session,
@@ -940,6 +942,11 @@ async fn emit_decode_failed(tx: &mpsc::Sender<NetworkEvent>) -> bool {
     emit_boundary(tx, NetworkDeliveryBoundary::DecodeFailed).await
 }
 
+/// JSON-RPC "method not found" — the one CDP error code that means this
+/// Chrome build does not implement the command at all, as opposed to
+/// refusing this particular invocation of it.
+const JSON_RPC_METHOD_NOT_FOUND: i32 = -32601;
+
 /// Enable `Network.streamResourceContent` for `request_id` in a spawned
 /// task, mirroring the correlator's existing fire-and-forget
 /// `Network.enable` call: the CDP round-trip must not block the main
@@ -948,11 +955,18 @@ async fn emit_decode_failed(tx: &mpsc::Sender<NetworkEvent>) -> bool {
 /// On success, any `bufferedData` (bytes Chrome already had before the
 /// enable call landed) is emitted as the first [`NetworkEvent::HttpData`]
 /// chunk for this request — so nothing received in that pre-enable window is
-/// lost. On failure (old Chrome / unsupported), logs one `tracing::warn!`
-/// via `warned` (shared across every call this monitor makes, so the warning
-/// fires once per monitor rather than once per request) and otherwise does
-/// nothing — the monitor keeps running and [`NetworkExchange::body`] remains
-/// the working fallback for this request.
+/// lost.
+///
+/// Failures split two ways. A JSON-RPC `-32601` ("method not found") is the
+/// only reply that proves this Chrome build has no
+/// `Network.streamResourceContent` at all: it latches `warned` — shared
+/// across every call this monitor makes — so the warning fires once and the
+/// caller stops spending a doomed CDP round-trip per request. Every other
+/// error is per-request (most often the `-32602` "already finished loading"
+/// race documented at the call site) and is logged at debug without
+/// disabling streaming for later requests. Either way the monitor keeps
+/// running and [`NetworkExchange::body`] remains the working fallback for
+/// this request.
 fn spawn_stream_resource_content(
     session: &SessionHandle,
     tx: &mpsc::Sender<NetworkEvent>,
@@ -985,11 +999,28 @@ fn spawn_stream_resource_content(
                 }
             }
             Err(e) => {
-                if !warned.swap(true, Ordering::Relaxed) {
-                    warn!(
+                // Only "method not found" proves the browser lacks the
+                // command; that is the sole justification for disabling
+                // streaming for the monitor's whole lifetime. Anything else
+                // is about this one request — above all the `-32602`
+                // "Request with the provided ID has already finished
+                // loading" race, which a single fast favicon can lose
+                // without saying anything about the next request.
+                if matches!(&e, CallError::Rpc(code, ..) if *code == JSON_RPC_METHOD_NOT_FOUND) {
+                    if !warned.swap(true, Ordering::Relaxed) {
+                        warn!(
+                            error = %e,
+                            "network monitor: Network.streamResourceContent is unsupported by this \
+                             browser (needs Chrome ~124+); stream_bodies falling back to whole-body \
+                             capture for this and future requests"
+                        );
+                    }
+                } else {
+                    debug!(
                         error = %e,
-                        "network monitor: Network.streamResourceContent failed (needs Chrome ~124+); \
-                         stream_bodies falling back to whole-body capture for this and future requests"
+                        %request_id,
+                        "network monitor: Network.streamResourceContent failed for this request; \
+                         falling back to whole-body capture (streaming stays enabled)"
                     );
                 }
             }
@@ -1063,6 +1094,70 @@ mod tests {
     use super::*;
 
     const SID: &str = "S1";
+
+    /// Drive one `spawn_stream_resource_content` call, answer it with the
+    /// given JSON-RPC error, and return the latch once the spawned task has
+    /// actually finished — so the assertion never races the reply. Task
+    /// completion is observed via the runtime's alive-task count; the only
+    /// other task on this runtime is the mock connection's actor, which stays
+    /// alive for the whole test.
+    async fn latch_after_stream_error(code: i32, message: &str) -> bool {
+        let (mut mock, conn) = MockConnection::pair();
+        let session = SessionHandle::new(conn.clone(), SID);
+        let (tx, _rx) = mpsc::channel::<NetworkEvent>(8);
+        let warned = Arc::new(AtomicBool::new(false));
+
+        let metrics = tokio::runtime::Handle::current().metrics();
+        let baseline = metrics.num_alive_tasks();
+        spawn_stream_resource_content(&session, &tx, &warned, "R1".to_string());
+
+        let id = tokio::time::timeout(
+            Duration::from_secs(2),
+            mock.expect_cmd("Network.streamResourceContent"),
+        )
+        .await
+        .expect("no Network.streamResourceContent command was sent");
+        assert_eq!(mock.last_sent()["params"]["requestId"], "R1");
+        mock.reply_err(id, code, message).await;
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while metrics.num_alive_tasks() > baseline {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("streamResourceContent task did not finish after the error reply");
+
+        let latched = warned.load(Ordering::Relaxed);
+        conn.shutdown();
+        latched
+    }
+
+    /// The `-32602` "already finished loading" race is per-request — a single
+    /// fast favicon losing it must not disable body streaming for the rest of
+    /// the monitor's life.
+    #[tokio::test]
+    async fn stream_resource_content_race_error_keeps_streaming_enabled() {
+        assert!(
+            !latch_after_stream_error(
+                -32602,
+                "Request with the provided ID has already finished loading",
+            )
+            .await,
+            "a lost -32602 race must not disable streaming"
+        );
+    }
+
+    /// `-32601` "method not found" is the one reply that proves the browser
+    /// has no `Network.streamResourceContent` — that latches the flag so the
+    /// monitor stops spending a doomed round-trip per request.
+    #[tokio::test]
+    async fn stream_resource_content_method_not_found_disables_streaming() {
+        assert!(
+            latch_after_stream_error(-32601, "'Network.streamResourceContent' wasn't found").await,
+            "method-not-found must disable streaming for this monitor"
+        );
+    }
 
     /// Spawn a monitor over a fresh mock session and return the live monitor
     /// plus the mock (to emit events) and connection (to shut down).

--- a/crates/zendriver/src/query/actionability.rs
+++ b/crates/zendriver/src/query/actionability.rs
@@ -86,9 +86,17 @@ impl ActionabilityCheck {
 /// human; and `checkVisibility` says nothing about where the element sits
 /// relative to the viewport.
 ///
-/// Requires Chrome 105+ (`Element.checkVisibility`). On an older build the
-/// JS throws, which surfaces as a `JsException` — a loud failure rather
-/// than a silently wrong answer.
+/// Requires Chrome 121+, not 105+. `Element.checkVisibility` itself shipped
+/// in 105, but the three option names passed below (`opacityProperty`,
+/// `visibilityProperty`, `contentVisibilityAuto`) shipped in 121 — the first
+/// two as aliases for 105's `checkOpacity` / `checkVisibilityCSS`, the third
+/// as a new check (crbug feature 5070043440480256). Below 105 the call
+/// throws, surfacing as a `JsException`: a loud failure rather than a
+/// silently wrong answer. On 105–120 it does NOT throw — WebIDL drops
+/// dictionary members it doesn't recognize — so the call silently degrades
+/// to the default `display: none` test and stops covering
+/// `visibility: hidden`/`collapse` and `content-visibility: auto`. The
+/// effective-opacity loop below is independent of that and still holds.
 ///
 /// Live callers: `Element::is_visible` and the `visible_only` filter in
 /// `FindBuilder`/`FindAllBuilder` (`query::mod`).
@@ -112,27 +120,48 @@ pub(crate) async fn check_visible(el: &Element) -> Result<bool> {
             if (rect.width <= 0 || rect.height <= 0) return false;
 
             // On-screen test: the bbox must overlap the viewport by at least a
-            // sliver. `getBoundingClientRect` is already viewport-relative.
+            // sliver. `getBoundingClientRect` is already viewport-relative, so
+            // the box it must be compared against is the LAYOUT viewport. Two
+            // things about reading that box are load-bearing:
             //
-            // `documentElement.clientWidth/Height` FIRST, and never
-            // `window.inner*` first — the order is load-bearing, not style.
-            // A stealth persona rewrites `window.innerWidth/innerHeight` to its
-            // claimed screen size minus browser chrome, while `scroll_into_view`
-            // moves the element using Chrome's real viewport. Reading the
-            // spoofed value here compares a real-geometry scroll against a
-            // fabricated viewport, so every element landing between the two
-            // heights is permanently "not visible" — which made `focus`, and so
-            // `type_text`/`press`/`type_keys`, fail on any below-the-fold field
-            // whenever stealth was on. Stealth is the default posture, so that
-            // was the normal case, not an edge one.
+            // 1. It must never come from `window.inner*`. Every profile except
+            //    `StealthProfile::off()` — including `native()`, which
+            //    `Browser::builder()` installs by default — runs
+            //    `zendriver-stealth`'s `patches/screen.js`, which rewrites
+            //    `window.inner*` to the persona's screen size minus a fixed
+            //    86px chrome inset, while `scroll_into_view` moves the element
+            //    with Chrome's real viewport. Measured under the default
+            //    profile: `innerHeight` 994 against a real 1080. Comparing a
+            //    real-geometry scroll against that fabricated viewport leaves
+            //    every element landing in the 86px band permanently "not
+            //    visible", which broke `focus` — and with it `type_text` /
+            //    `press` / `type_keys` — on any below-the-fold field.
             //
-            // `clientWidth/Height` is unspoofed and is also the more correct
-            // pairing: it reports the layout viewport, which is the box
-            // `getBoundingClientRect` is measured against. `window.inner*`
-            // survives only as a quirks-mode fallback, where `documentElement`
-            // reports 0.
-            const vw = document.documentElement.clientWidth || window.innerWidth;
-            const vh = document.documentElement.clientHeight || window.innerHeight;
+            // 2. WHICH element reports the layout viewport depends on the
+            //    rendering mode, and reading the wrong one fails silently.
+            //    Standards mode: `documentElement`. Quirks (`BackCompat`):
+            //    `documentElement.client*` reports the document's CONTENT box
+            //    and `body.client*` reports the viewport. Measured on a 6000px
+            //    doctype-less page: `documentElement.clientHeight` 6024,
+            //    `body.clientHeight` 1080. Reading `documentElement`
+            //    unconditionally therefore compares the bbox against the whole
+            //    document on any page without a doctype — a no-op that fails
+            //    open, on exactly the sloppy legacy pages most likely to be
+            //    carrying a honeypot.
+            const box = document.compatMode === 'BackCompat'
+                ? document.body
+                : document.documentElement;
+            // The `BackCompat` arm can be null: a document whose `<body>` was
+            // removed still renders elements appended to `documentElement`, and
+            // still answers `isConnected` for them (reproduced against Chrome).
+            // The fallback is `visualViewport` rather than `window.inner*`
+            // because it is the other unspoofed source, and it reads the real
+            // 1080 in both modes. It is the VISUAL viewport, which diverges
+            // from the layout viewport under pinch-zoom or an on-screen
+            // keyboard — neither reachable through this crate's emulation
+            // surface, and neither triggerable by page script.
+            const vw = box ? box.clientWidth : window.visualViewport.width;
+            const vh = box ? box.clientHeight : window.visualViewport.height;
             if (rect.right <= 0 || rect.bottom <= 0 || rect.left >= vw || rect.top >= vh) {
                 return false;
             }
@@ -262,9 +291,11 @@ pub(crate) async fn check_receives_pointer(
 /// animating)", or "occluded by overlay").
 ///
 /// Predicates are evaluated in fixed order: visible → enabled → stable →
-/// receives_pointer. This matches Playwright's gate ordering and avoids
-/// running the more-expensive stability + hit-testing checks while the
-/// element is still hidden or disabled.
+/// receives_pointer — the two cheap reads first, so the expensive
+/// two-frame stability wait and the hit-test never run while the element is
+/// still hidden or disabled. The *set* of checks is Playwright's; this
+/// ordering is not, and does not claim to be — Playwright's actionability
+/// docs list visible → stable → receives events → enabled.
 ///
 /// `position` is the offset the caller will click at, forwarded to the
 /// hit-test so the gate probes the point the dispatch actually uses. `None`
@@ -346,53 +377,41 @@ mod tests {
         let (js, _) = probe_check_visible(true).await;
         // `visible_only(true)` promises offscreen candidates are filtered
         // out; that requires comparing the bbox against the viewport box.
-        //
-        // The viewport must come from `documentElement.client*` BEFORE
-        // `window.inner*`. A stealth persona rewrites `window.inner*` to its
-        // claimed screen size, and comparing a real-geometry scroll against
-        // that fabricated viewport made every below-the-fold element
-        // permanently invisible under the default posture. Asserting the
-        // ordering, not just the presence of a viewport read — the previous
-        // version of this test pinned `window.innerWidth` and so pinned the
-        // bug.
-        // Assert on the assignment lines, not the whole script: the comment
-        // above them names `window.inner*` while explaining why it must not be
-        // read first, so a raw substring search matches the prose.
-        let assignment = |name: &str| -> String {
-            js.lines()
-                .map(str::trim)
-                .find(|l| l.starts_with(&format!("const {name} =")))
-                .unwrap_or_else(|| panic!("no `const {name} =` in probe: {js}"))
-                .to_owned()
-        };
-        for (name, real, spoofable) in [
-            (
-                "vw",
-                "document.documentElement.clientWidth",
-                "window.innerWidth",
-            ),
-            (
-                "vh",
-                "document.documentElement.clientHeight",
-                "window.innerHeight",
-            ),
-        ] {
-            let line = assignment(name);
-            let real_at = line.find(real);
-            let spoofable_at = line.find(spoofable);
-            assert!(
-                real_at.is_some(),
-                "`{name}` must read a real viewport: {line}"
-            );
-            assert!(
-                spoofable_at.is_none_or(|s| real_at.is_some_and(|r| r < s)),
-                "`{name}` must prefer {real} over the spoofable {spoofable}: {line}"
-            );
-        }
         assert!(js.contains("rect.right <= 0"), "{js}");
         assert!(js.contains("rect.bottom <= 0"), "{js}");
         assert!(js.contains("rect.left >= vw"), "{js}");
         assert!(js.contains("rect.top >= vh"), "{js}");
+    }
+
+    /// The viewport box must be read from an unspoofed source, and from the
+    /// element that actually reports the layout viewport in *both* rendering
+    /// modes.
+    ///
+    /// Two separate defects are pinned here, both of which shipped:
+    ///
+    /// - Reading `window.inner*` at all. Every profile except
+    ///   `StealthProfile::off()` rewrites those, so they must not appear —
+    ///   not even as a trailing fallback. The predecessor of this test
+    ///   asserted only that `documentElement` came *first*, which a
+    ///   `documentElement.clientWidth || window.innerWidth` expression
+    ///   satisfies while still reaching the spoofed value.
+    /// - Reading `documentElement` unconditionally. In quirks mode that is
+    ///   the document's content box (6024 on a 6000px page), which is
+    ///   truthy, so the `||` fallback never fired and the whole on-screen
+    ///   clause degraded to a no-op. Asserting merely that *some* viewport
+    ///   is read would pass that.
+    ///
+    /// The whole-source substring search is safe because the probe's own
+    /// comments spell the spoofable pair `window.inner*` rather than naming
+    /// either property.
+    #[tokio::test]
+    async fn check_visible_probe_reads_the_layout_viewport_in_both_rendering_modes() {
+        let (js, _) = probe_check_visible(true).await;
+        assert!(!js.contains("window.innerWidth"), "{js}");
+        assert!(!js.contains("window.innerHeight"), "{js}");
+        assert!(js.contains("document.compatMode === 'BackCompat'"), "{js}");
+        assert!(js.contains("document.body"), "{js}");
+        assert!(js.contains("document.documentElement"), "{js}");
     }
 
     #[tokio::test]

--- a/crates/zendriver/src/query/actionability.rs
+++ b/crates/zendriver/src/query/actionability.rs
@@ -1,6 +1,15 @@
 //! Playwright-style actionability predicates: visible / stable / enabled /
-//! receives_pointer. Each runs a small JS function on the element's remote
-//! handle via `Element::call_on_main` and returns a `bool`.
+//! receives_pointer. Each runs a small JS function on the element via
+//! `Element::call_on` and returns a `bool`.
+//!
+//! The probes run in the tab's **isolated world**, so the element is bound
+//! as `this` rather than as a positional argument (each body re-aliases it
+//! to `el` for readability). That placement is load-bearing: every predicate
+//! reads geometry through `getBoundingClientRect`, `getComputedStyle` or
+//! `document.elementFromPoint`, all of which a page can shadow in its own
+//! world. From the isolated world it can neither forge those answers nor
+//! observe the gate probing. Isolated worlds share the DOM, so the values
+//! are the ones the page actually renders.
 //!
 //! The aggregate gate ([`wait_actionable`]) polls the four predicates in
 //! order and raises `NotActionable` on deadline; `Element::click_with`,
@@ -90,7 +99,8 @@ impl ActionabilityCheck {
 /// `FindBuilder`/`FindAllBuilder` (`query::mod`).
 pub(crate) async fn check_visible(el: &Element) -> Result<bool> {
     let js = r#"
-        function(el) {
+        function() {
+            const el = this;
             if (!el || !el.isConnected) return false;
 
             // Platform primitive: handles `display: none`, `content-visibility`,
@@ -132,7 +142,7 @@ pub(crate) async fn check_visible(el: &Element) -> Result<bool> {
             return true;
         }
     "#;
-    let res = el.call_on_main(js, json!([])).await?;
+    let res = el.call_on(js, json!([])).await?;
     Ok(res.get("value").and_then(|v| v.as_bool()).unwrap_or(false))
 }
 
@@ -142,7 +152,8 @@ pub(crate) async fn check_visible(el: &Element) -> Result<bool> {
 /// click.
 pub(crate) async fn check_stable(el: &Element) -> Result<bool> {
     let js = r#"
-        function(el) {
+        function() {
+            const el = this;
             return new Promise(resolve => {
                 if (!el || !el.isConnected) { resolve(false); return; }
                 const first = el.getBoundingClientRect();
@@ -160,7 +171,7 @@ pub(crate) async fn check_stable(el: &Element) -> Result<bool> {
             });
         }
     "#;
-    let res = el.call_on_main(js, json!([])).await?;
+    let res = el.call_on(js, json!([])).await?;
     Ok(res.get("value").and_then(|v| v.as_bool()).unwrap_or(false))
 }
 
@@ -169,7 +180,8 @@ pub(crate) async fn check_stable(el: &Element) -> Result<bool> {
 /// (which have no `disabled` property) are considered enabled.
 pub(crate) async fn check_enabled(el: &Element) -> Result<bool> {
     let js = r#"
-        function(el) {
+        function() {
+            const el = this;
             if (!el) return false;
             // `disabled === false` for form controls; `undefined` for non-form elements
             // (which we treat as enabled).
@@ -179,7 +191,7 @@ pub(crate) async fn check_enabled(el: &Element) -> Result<bool> {
             return true;
         }
     "#;
-    let res = el.call_on_main(js, json!([])).await?;
+    let res = el.call_on(js, json!([])).await?;
     Ok(res.get("value").and_then(|v| v.as_bool()).unwrap_or(false))
 }
 
@@ -198,12 +210,16 @@ pub(crate) async fn check_receives_pointer(
     position: Option<(f64, f64)>,
 ) -> Result<bool> {
     let js = r#"
-        function(el, dx, dy) {
+        function(dx, dy) {
+            const el = this;
             if (!el || !el.isConnected) return false;
             const rect = el.getBoundingClientRect();
             if (rect.width <= 0 || rect.height <= 0) return false;
-            const cx = dx === null ? rect.left + rect.width / 2 : rect.left + dx;
-            const cy = dy === null ? rect.top + rect.height / 2 : rect.top + dy;
+            // A caller with no explicit position passes no arguments at all,
+            // so dx/dy arrive as `undefined` — `Number.isFinite` covers that
+            // and any non-numeric junk in one test, falling back to the centre.
+            const cx = Number.isFinite(dx) ? rect.left + dx : rect.left + rect.width / 2;
+            const cy = Number.isFinite(dy) ? rect.top + dy : rect.top + rect.height / 2;
             let hit = document.elementFromPoint(cx, cy);
             while (hit) {
                 if (hit === el) return true;
@@ -212,11 +228,17 @@ pub(crate) async fn check_receives_pointer(
             return false;
         }
     "#;
-    let (dx, dy) = match position {
-        Some((dx, dy)) => (json!(dx), json!(dy)),
-        None => (json!(null), json!(null)),
+    // `Runtime.callFunctionOn` takes an array of CallArgument *objects*, so
+    // each coordinate has to be wrapped in `{ "value": … }`; passing the bare
+    // numbers made Chrome reject the whole call with "Invalid parameters"
+    // ("Failed to deserialize params.arguments"), which failed every gated
+    // `click` / `hover` / `tap` against a real browser. The mock tests could
+    // not catch it — `MockConnection` doesn't validate CDP parameter shapes.
+    let args = match position {
+        Some((dx, dy)) => json!([{ "value": dx }, { "value": dy }]),
+        None => json!([]),
     };
-    let res = el.call_on_main(js, json!([dx, dy])).await?;
+    let res = el.call_on(js, args).await?;
     Ok(res.get("value").and_then(|v| v.as_bool()).unwrap_or(false))
 }
 
@@ -271,12 +293,16 @@ pub(crate) async fn wait_actionable(
 mod tests {
     use super::*;
     use crate::tab::Tab;
+    use crate::test_support::{
+        ISOLATED_OBJECT_ID, expect, serve_isolated_call, serve_isolated_world,
+    };
+    use serde_json::Value;
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
 
-    /// Drive `check_visible` against a mock connection, answer its single
-    /// `Runtime.callFunctionOn` with `value`, and hand back the JS source
-    /// the probe actually sent plus the resolved verdict.
+    /// Drive `check_visible` against a mock connection, answer its isolated-
+    /// world probe with `value`, and hand back the JS source the probe
+    /// actually sent plus the resolved verdict.
     async fn probe_check_visible(value: bool) -> (String, bool) {
         let (mut mock, conn) = MockConnection::pair();
         let sess = SessionHandle::new(conn.clone(), "S1");
@@ -285,25 +311,11 @@ mod tests {
 
         let fut = tokio::spawn(async move { check_visible(&el).await });
 
-        // `expect_cmd` drops non-matching frames and never times out on its
-        // own — bound the wait so a regression fails loudly instead of hanging.
-        let id = tokio::time::timeout(
-            Duration::from_secs(5),
-            mock.expect_cmd("Runtime.callFunctionOn"),
-        )
-        .await
-        .expect("check_visible should send exactly one Runtime.callFunctionOn");
-        let js = mock.last_sent()["params"]["functionDeclaration"]
-            .as_str()
-            .unwrap()
-            .to_string();
-        mock.reply(
-            id,
-            json!({ "result": { "value": value, "type": "boolean" } }),
-        )
-        .await;
+        serve_isolated_world(&mut mock).await;
+        let js = serve_isolated_call(&mut mock, json!({ "value": value, "type": "boolean" })).await;
 
         let verdict = fut.await.unwrap().unwrap();
+        conn.shutdown();
         (js, verdict)
     }
 
@@ -360,5 +372,122 @@ mod tests {
     async fn check_visible_reports_false_when_the_page_says_hidden() {
         let (_, verdict) = probe_check_visible(false).await;
         assert!(!verdict, "a `false` probe result must resolve to hidden");
+    }
+
+    /// `check_receives_pointer` must wrap its coordinates as CallArgument
+    /// *objects* (`{ "value": … }`).
+    ///
+    /// Regression pin for a live-only bug: the bare `[dx, dy]` this used to
+    /// send made Chrome reject the whole call with `-32602 Invalid parameters`
+    /// ("Failed to deserialize params.arguments"), so every gated `click` /
+    /// `hover` / `tap` failed against a real browser while the mock suite
+    /// stayed green — `MockConnection` replays frames without validating CDP
+    /// parameter shapes. Hence an explicit assertion on the shape.
+    #[tokio::test]
+    async fn check_receives_pointer_wraps_its_coordinates_as_call_arguments() {
+        assert_eq!(
+            probe_pointer_args(Some((3.0, 4.0))).await,
+            json!([{ "value": 3.0 }, { "value": 4.0 }]),
+            "an explicit click position must travel as two CallArgument objects",
+        );
+
+        // No position → no arguments at all, leaving dx/dy `undefined` in the
+        // JS, which is what its `Number.isFinite` centre-fallback reads.
+        assert_eq!(
+            probe_pointer_args(None).await,
+            json!([]),
+            "a centre hit-test must send no arguments rather than bare nulls",
+        );
+    }
+
+    /// Drive one `check_receives_pointer` probe against a fresh mock and hand
+    /// back the `arguments` array it put on the wire.
+    async fn probe_pointer_args(at: Option<(f64, f64)>) -> Value {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+        let el = Element::from_jsret(tab, 99, "R1".to_string());
+
+        // Spawn before serving: the handshake only goes out once the probe is
+        // actually running.
+        let fut = tokio::spawn(async move { check_receives_pointer(&el, at).await });
+
+        serve_isolated_world(&mut mock).await;
+        let id = expect(&mut mock, "DOM.resolveNode").await;
+        mock.reply(id, json!({ "object": { "objectId": ISOLATED_OBJECT_ID } }))
+            .await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
+        let args = mock.last_sent()["params"]["arguments"].clone();
+        mock.reply(
+            id,
+            json!({ "result": { "value": true, "type": "boolean" } }),
+        )
+        .await;
+        let id = expect(&mut mock, "Runtime.releaseObject").await;
+        mock.reply(id, json!({})).await;
+
+        assert!(fut.await.unwrap().unwrap());
+        conn.shutdown();
+        args
+    }
+
+    /// All four predicates run in the isolated world, not the page's.
+    ///
+    /// This is the property the whole gate rests on: every predicate reads
+    /// geometry through `getBoundingClientRect`, `getComputedStyle` or
+    /// `document.elementFromPoint`, and a page that has shadowed any of them
+    /// in its own world could feed the gate whatever it liked — and see it
+    /// being probed. `serve_isolated_call` fails the test if a probe ever
+    /// targets the page-world handle; this drives all four past it in one go.
+    #[tokio::test]
+    async fn every_predicate_runs_in_the_isolated_world() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+        let el = Element::from_jsret(tab.clone(), 99, "R1".to_string());
+
+        let fut = tokio::spawn({
+            let e = el.clone();
+            async move {
+                (
+                    check_visible(&e).await.unwrap(),
+                    check_enabled(&e).await.unwrap(),
+                    check_stable(&e).await.unwrap(),
+                    check_receives_pointer(&e, None).await.unwrap(),
+                )
+            }
+        });
+
+        // The world is built once and cached; each predicate then pays its
+        // own resolve → call → release.
+        serve_isolated_world(&mut mock).await;
+        let mut sources = Vec::new();
+        for _ in 0..4 {
+            sources.push(
+                serve_isolated_call(&mut mock, json!({ "value": true, "type": "boolean" })).await,
+            );
+        }
+
+        assert_eq!(fut.await.unwrap(), (true, true, true, true));
+
+        // Pin which source belongs to which predicate, so a future reorder of
+        // the gate can't quietly leave one of them behind in the main world.
+        assert!(sources[0].contains("checkVisibility"), "{}", sources[0]);
+        assert!(sources[1].contains("aria-disabled"), "{}", sources[1]);
+        assert!(
+            sources[2].contains("requestAnimationFrame"),
+            "{}",
+            sources[2]
+        );
+        assert!(sources[3].contains("elementFromPoint"), "{}", sources[3]);
+
+        // Isolated calls bind the element as `this`; a lingering
+        // `function(el, ...)` signature would silently receive `undefined`
+        // and make every predicate answer `false`.
+        for js in &sources {
+            assert!(js.contains("const el = this"), "{js}");
+        }
+
+        conn.shutdown();
     }
 }

--- a/crates/zendriver/src/query/actionability.rs
+++ b/crates/zendriver/src/query/actionability.rs
@@ -113,8 +113,26 @@ pub(crate) async fn check_visible(el: &Element) -> Result<bool> {
 
             // On-screen test: the bbox must overlap the viewport by at least a
             // sliver. `getBoundingClientRect` is already viewport-relative.
-            const vw = window.innerWidth || document.documentElement.clientWidth;
-            const vh = window.innerHeight || document.documentElement.clientHeight;
+            //
+            // `documentElement.clientWidth/Height` FIRST, and never
+            // `window.inner*` first — the order is load-bearing, not style.
+            // A stealth persona rewrites `window.innerWidth/innerHeight` to its
+            // claimed screen size minus browser chrome, while `scroll_into_view`
+            // moves the element using Chrome's real viewport. Reading the
+            // spoofed value here compares a real-geometry scroll against a
+            // fabricated viewport, so every element landing between the two
+            // heights is permanently "not visible" — which made `focus`, and so
+            // `type_text`/`press`/`type_keys`, fail on any below-the-fold field
+            // whenever stealth was on. Stealth is the default posture, so that
+            // was the normal case, not an edge one.
+            //
+            // `clientWidth/Height` is unspoofed and is also the more correct
+            // pairing: it reports the layout viewport, which is the box
+            // `getBoundingClientRect` is measured against. `window.inner*`
+            // survives only as a quirks-mode fallback, where `documentElement`
+            // reports 0.
+            const vw = document.documentElement.clientWidth || window.innerWidth;
+            const vh = document.documentElement.clientHeight || window.innerHeight;
             if (rect.right <= 0 || rect.bottom <= 0 || rect.left >= vw || rect.top >= vh) {
                 return false;
             }
@@ -328,8 +346,49 @@ mod tests {
         let (js, _) = probe_check_visible(true).await;
         // `visible_only(true)` promises offscreen candidates are filtered
         // out; that requires comparing the bbox against the viewport box.
-        assert!(js.contains("window.innerWidth"), "{js}");
-        assert!(js.contains("window.innerHeight"), "{js}");
+        //
+        // The viewport must come from `documentElement.client*` BEFORE
+        // `window.inner*`. A stealth persona rewrites `window.inner*` to its
+        // claimed screen size, and comparing a real-geometry scroll against
+        // that fabricated viewport made every below-the-fold element
+        // permanently invisible under the default posture. Asserting the
+        // ordering, not just the presence of a viewport read — the previous
+        // version of this test pinned `window.innerWidth` and so pinned the
+        // bug.
+        // Assert on the assignment lines, not the whole script: the comment
+        // above them names `window.inner*` while explaining why it must not be
+        // read first, so a raw substring search matches the prose.
+        let assignment = |name: &str| -> String {
+            js.lines()
+                .map(str::trim)
+                .find(|l| l.starts_with(&format!("const {name} =")))
+                .unwrap_or_else(|| panic!("no `const {name} =` in probe: {js}"))
+                .to_owned()
+        };
+        for (name, real, spoofable) in [
+            (
+                "vw",
+                "document.documentElement.clientWidth",
+                "window.innerWidth",
+            ),
+            (
+                "vh",
+                "document.documentElement.clientHeight",
+                "window.innerHeight",
+            ),
+        ] {
+            let line = assignment(name);
+            let real_at = line.find(real);
+            let spoofable_at = line.find(spoofable);
+            assert!(
+                real_at.is_some(),
+                "`{name}` must read a real viewport: {line}"
+            );
+            assert!(
+                spoofable_at.is_none_or(|s| real_at.is_some_and(|r| r < s)),
+                "`{name}` must prefer {real} over the spoofable {spoofable}: {line}"
+            );
+        }
         assert!(js.contains("rect.right <= 0"), "{js}");
         assert!(js.contains("rect.bottom <= 0"), "{js}");
         assert!(js.contains("rect.left >= vw"), "{js}");

--- a/crates/zendriver/src/query/actionability.rs
+++ b/crates/zendriver/src/query/actionability.rs
@@ -61,10 +61,30 @@ impl ActionabilityCheck {
     };
 }
 
-/// `true` iff the element is rendered: attached to the document, has a
-/// non-`null` `offsetParent` (catches `display: none` ancestors), a
-/// positive bbox, computed `visibility !== 'hidden'`, and computed
-/// `opacity !== '0'`.
+/// `true` iff the element is rendered **and on-screen**. An element is
+/// visible when all of the following hold:
+///
+/// - it is attached to the document (`isConnected`);
+/// - it passes the platform's own `Element.checkVisibility` test with
+///   `opacityProperty` + `visibilityProperty` + `contentVisibilityAuto`,
+///   which covers `display: none`, `visibility: hidden` / `collapse`,
+///   `content-visibility`, and `opacity: 0` on the element **or any
+///   ancestor**;
+/// - it has a positive bounding box;
+/// - its bounding box **intersects the viewport** — any overlap counts, so
+///   a partially-scrolled-in element still passes;
+/// - its *effective* opacity — the product of its own computed opacity and
+///   every ancestor's — is at least 1%.
+///
+/// The last two are the reason this isn't just a `checkVisibility` call.
+/// `checkVisibility` only rejects an *exact* `opacity: 0`, so the standard
+/// `opacity: 0.001` scraping honeypot passes it while being invisible to a
+/// human; and `checkVisibility` says nothing about where the element sits
+/// relative to the viewport.
+///
+/// Requires Chrome 105+ (`Element.checkVisibility`). On an older build the
+/// JS throws, which surfaces as a `JsException` — a loud failure rather
+/// than a silently wrong answer.
 ///
 /// Live callers: `Element::is_visible` and the `visible_only` filter in
 /// `FindBuilder`/`FindAllBuilder` (`query::mod`).
@@ -72,14 +92,43 @@ pub(crate) async fn check_visible(el: &Element) -> Result<bool> {
     let js = r#"
         function(el) {
             if (!el || !el.isConnected) return false;
-            // offsetParent === null catches `display: none` on the element or any ancestor
-            // (except for fixed-position elements, which are handled by the bbox check below).
-            if (el.offsetParent === null && getComputedStyle(el).position !== 'fixed') return false;
+
+            // Platform primitive: handles `display: none`, `content-visibility`,
+            // `visibility: hidden`/`collapse` and `opacity: 0` on the element OR any
+            // ancestor — none of which the hand-rolled predecessor caught, since it
+            // only ever read the element's own computed style, and its layout probe
+            // reported a false negative for `position: fixed`.
+            if (!el.checkVisibility({
+                opacityProperty: true,
+                visibilityProperty: true,
+                contentVisibilityAuto: true
+            })) return false;
+
             const rect = el.getBoundingClientRect();
             if (rect.width <= 0 || rect.height <= 0) return false;
-            const style = getComputedStyle(el);
-            if (style.visibility === 'hidden') return false;
-            if (style.opacity === '0') return false;
+
+            // On-screen test: the bbox must overlap the viewport by at least a
+            // sliver. `getBoundingClientRect` is already viewport-relative.
+            const vw = window.innerWidth || document.documentElement.clientWidth;
+            const vh = window.innerHeight || document.documentElement.clientHeight;
+            if (rect.right <= 0 || rect.bottom <= 0 || rect.left >= vw || rect.top >= vh) {
+                return false;
+            }
+
+            // Effective opacity: `checkVisibility` rejects only an exact `opacity: 0`,
+            // so a near-zero honeypot (`opacity: 0.001`) sails through it. Multiply the
+            // ancestor chain the way the compositor does and reject anything below 1%.
+            // The threshold is deliberately not `> 0`: exact-zero is the case honeypots
+            // avoid precisely because it is the one everyone already checks. 1% sits well
+            // below anything a real UI renders at rest and well above the honeypot range.
+            // Done last — `getComputedStyle` per ancestor is the priciest step here.
+            let effective = 1;
+            for (let node = el; node; node = node.parentElement) {
+                const own = parseFloat(getComputedStyle(node).opacity);
+                if (Number.isFinite(own)) effective *= own;
+            }
+            if (effective < 0.01) return false;
+
             return true;
         }
     "#;
@@ -134,19 +183,27 @@ pub(crate) async fn check_enabled(el: &Element) -> Result<bool> {
     Ok(res.get("value").and_then(|v| v.as_bool()).unwrap_or(false))
 }
 
-/// `true` iff a synthesized click at the element's bbox center would land
-/// on the element (or one of its descendants). Walks the ancestor chain
-/// of `document.elementFromPoint(cx, cy)`; if our element appears in that
+/// `true` iff a synthesized click at the point that will actually be clicked
+/// would land on the element (or one of its descendants). Walks the ancestor
+/// chain of `document.elementFromPoint(cx, cy)`; if our element appears in that
 /// chain, pointer events reach it. Returns `false` when a sibling overlay
 /// covers the hit point.
-pub(crate) async fn check_receives_pointer(el: &Element) -> Result<bool> {
+///
+/// `position` is the caller's offset from the bbox top-left, matching
+/// [`crate::ClickOptions::position`]; `None` hit-tests the centre. Probing a
+/// point the dispatch will not use lets the gate pass while the real click
+/// lands on an overlay.
+pub(crate) async fn check_receives_pointer(
+    el: &Element,
+    position: Option<(f64, f64)>,
+) -> Result<bool> {
     let js = r#"
-        function(el) {
+        function(el, dx, dy) {
             if (!el || !el.isConnected) return false;
             const rect = el.getBoundingClientRect();
             if (rect.width <= 0 || rect.height <= 0) return false;
-            const cx = rect.left + rect.width / 2;
-            const cy = rect.top + rect.height / 2;
+            const cx = dx === null ? rect.left + rect.width / 2 : rect.left + dx;
+            const cy = dy === null ? rect.top + rect.height / 2 : rect.top + dy;
             let hit = document.elementFromPoint(cx, cy);
             while (hit) {
                 if (hit === el) return true;
@@ -155,7 +212,11 @@ pub(crate) async fn check_receives_pointer(el: &Element) -> Result<bool> {
             return false;
         }
     "#;
-    let res = el.call_on_main(js, json!([])).await?;
+    let (dx, dy) = match position {
+        Some((dx, dy)) => (json!(dx), json!(dy)),
+        None => (json!(null), json!(null)),
+    };
+    let res = el.call_on_main(js, json!([dx, dy])).await?;
     Ok(res.get("value").and_then(|v| v.as_bool()).unwrap_or(false))
 }
 
@@ -169,10 +230,16 @@ pub(crate) async fn check_receives_pointer(el: &Element) -> Result<bool> {
 /// receives_pointer. This matches Playwright's gate ordering and avoids
 /// running the more-expensive stability + hit-testing checks while the
 /// element is still hidden or disabled.
+///
+/// `position` is the offset the caller will click at, forwarded to the
+/// hit-test so the gate probes the point the dispatch actually uses. `None`
+/// probes the bbox centre. It is re-read from the live bbox on every poll, so
+/// an element that moves mid-wait is hit-tested where it currently is.
 pub(crate) async fn wait_actionable(
     el: &Element,
     require: ActionabilityCheck,
     timeout: Duration,
+    position: Option<(f64, f64)>,
 ) -> Result<()> {
     let deadline = Instant::now() + timeout;
     let poll_interval = Duration::from_millis(50);
@@ -184,7 +251,7 @@ pub(crate) async fn wait_actionable(
             failed_reason = Some("not enabled");
         } else if require.stable && !check_stable(el).await? {
             failed_reason = Some("not stable (still animating)");
-        } else if require.receives_pointer && !check_receives_pointer(el).await? {
+        } else if require.receives_pointer && !check_receives_pointer(el, position).await? {
             failed_reason = Some("occluded by overlay");
         }
         match failed_reason {
@@ -196,5 +263,102 @@ pub(crate) async fn wait_actionable(
                 tokio::time::sleep(poll_interval).await;
             }
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::tab::Tab;
+    use zendriver_transport::SessionHandle;
+    use zendriver_transport::testing::MockConnection;
+
+    /// Drive `check_visible` against a mock connection, answer its single
+    /// `Runtime.callFunctionOn` with `value`, and hand back the JS source
+    /// the probe actually sent plus the resolved verdict.
+    async fn probe_check_visible(value: bool) -> (String, bool) {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+        let el = Element::from_jsret(tab.clone(), 99, "R1".to_string());
+
+        let fut = tokio::spawn(async move { check_visible(&el).await });
+
+        // `expect_cmd` drops non-matching frames and never times out on its
+        // own — bound the wait so a regression fails loudly instead of hanging.
+        let id = tokio::time::timeout(
+            Duration::from_secs(5),
+            mock.expect_cmd("Runtime.callFunctionOn"),
+        )
+        .await
+        .expect("check_visible should send exactly one Runtime.callFunctionOn");
+        let js = mock.last_sent()["params"]["functionDeclaration"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        mock.reply(
+            id,
+            json!({ "result": { "value": value, "type": "boolean" } }),
+        )
+        .await;
+
+        let verdict = fut.await.unwrap().unwrap();
+        (js, verdict)
+    }
+
+    #[tokio::test]
+    async fn check_visible_probe_delegates_to_check_visibility() {
+        let (js, verdict) = probe_check_visible(true).await;
+        assert!(verdict, "a `true` probe result must resolve to visible");
+        assert!(js.contains("checkVisibility"), "{js}");
+        // The three flags are what make `checkVisibility` cover ancestors —
+        // without them it only reports `display: none`.
+        assert!(js.contains("opacityProperty: true"), "{js}");
+        assert!(js.contains("visibilityProperty: true"), "{js}");
+        assert!(js.contains("contentVisibilityAuto: true"), "{js}");
+    }
+
+    #[tokio::test]
+    async fn check_visible_probe_tests_viewport_intersection() {
+        let (js, _) = probe_check_visible(true).await;
+        // `visible_only(true)` promises offscreen candidates are filtered
+        // out; that requires comparing the bbox against the viewport box.
+        assert!(js.contains("window.innerWidth"), "{js}");
+        assert!(js.contains("window.innerHeight"), "{js}");
+        assert!(js.contains("rect.right <= 0"), "{js}");
+        assert!(js.contains("rect.bottom <= 0"), "{js}");
+        assert!(js.contains("rect.left >= vw"), "{js}");
+        assert!(js.contains("rect.top >= vh"), "{js}");
+    }
+
+    #[tokio::test]
+    async fn check_visible_probe_multiplies_ancestor_opacity_against_a_threshold() {
+        let (js, _) = probe_check_visible(true).await;
+        // Honeypot guard: walk the ancestor chain and compare the product
+        // against a non-zero floor, so `opacity: 0.001` (self OR ancestor)
+        // reads as hidden.
+        assert!(js.contains("node.parentElement"), "{js}");
+        assert!(js.contains("getComputedStyle(node).opacity"), "{js}");
+        assert!(js.contains("effective *= own"), "{js}");
+        assert!(js.contains("effective < 0.01"), "{js}");
+    }
+
+    #[tokio::test]
+    async fn check_visible_probe_drops_the_buggy_predecessors() {
+        let (js, _) = probe_check_visible(true).await;
+        // Regression pins for the three defects this probe replaced:
+        // a string compare against '0' (missed `opacity: 0.001`), an
+        // own-element-only style read (missed ancestor opacity), and the
+        // `offsetParent` hack (false negative on `position: fixed`).
+        assert!(!js.contains("offsetParent"), "{js}");
+        assert!(!js.contains("style.opacity"), "{js}");
+        assert!(!js.contains("=== '0'"), "{js}");
+    }
+
+    #[tokio::test]
+    async fn check_visible_reports_false_when_the_page_says_hidden() {
+        let (_, verdict) = probe_check_visible(false).await;
+        assert!(!verdict, "a `false` probe result must resolve to hidden");
     }
 }

--- a/crates/zendriver/src/query/actionability.rs
+++ b/crates/zendriver/src/query/actionability.rs
@@ -1,15 +1,10 @@
 //! Playwright-style actionability predicates: visible / stable / enabled /
-//! receives_pointer. Each runs a small JS function on the element via
-//! `Element::call_on` and returns a `bool`.
+//! receives_pointer. Each runs a small JS function on the element's remote
+//! handle via `Element::call_on_main` and returns a `bool`.
 //!
-//! The probes run in the tab's **isolated world**, so the element is bound
-//! as `this` rather than as a positional argument (each body re-aliases it
-//! to `el` for readability). That placement is load-bearing: every predicate
-//! reads geometry through `getBoundingClientRect`, `getComputedStyle` or
-//! `document.elementFromPoint`, all of which a page can shadow in its own
-//! world. From the isolated world it can neither forge those answers nor
-//! observe the gate probing. Isolated worlds share the DOM, so the values
-//! are the ones the page actually renders.
+//! `call_on_main` binds the element as the first positional argument, so
+//! every body opens `function(el, ...)` and any caller-supplied arguments
+//! follow it.
 //!
 //! The aggregate gate ([`wait_actionable`]) polls the four predicates in
 //! order and raises `NotActionable` on deadline; `Element::click_with`,
@@ -99,8 +94,7 @@ impl ActionabilityCheck {
 /// `FindBuilder`/`FindAllBuilder` (`query::mod`).
 pub(crate) async fn check_visible(el: &Element) -> Result<bool> {
     let js = r#"
-        function() {
-            const el = this;
+        function(el) {
             if (!el || !el.isConnected) return false;
 
             // Platform primitive: handles `display: none`, `content-visibility`,
@@ -142,7 +136,7 @@ pub(crate) async fn check_visible(el: &Element) -> Result<bool> {
             return true;
         }
     "#;
-    let res = el.call_on(js, json!([])).await?;
+    let res = el.call_on_main(js, json!([])).await?;
     Ok(res.get("value").and_then(|v| v.as_bool()).unwrap_or(false))
 }
 
@@ -152,8 +146,7 @@ pub(crate) async fn check_visible(el: &Element) -> Result<bool> {
 /// click.
 pub(crate) async fn check_stable(el: &Element) -> Result<bool> {
     let js = r#"
-        function() {
-            const el = this;
+        function(el) {
             return new Promise(resolve => {
                 if (!el || !el.isConnected) { resolve(false); return; }
                 const first = el.getBoundingClientRect();
@@ -171,7 +164,7 @@ pub(crate) async fn check_stable(el: &Element) -> Result<bool> {
             });
         }
     "#;
-    let res = el.call_on(js, json!([])).await?;
+    let res = el.call_on_main(js, json!([])).await?;
     Ok(res.get("value").and_then(|v| v.as_bool()).unwrap_or(false))
 }
 
@@ -180,8 +173,7 @@ pub(crate) async fn check_stable(el: &Element) -> Result<bool> {
 /// (which have no `disabled` property) are considered enabled.
 pub(crate) async fn check_enabled(el: &Element) -> Result<bool> {
     let js = r#"
-        function() {
-            const el = this;
+        function(el) {
             if (!el) return false;
             // `disabled === false` for form controls; `undefined` for non-form elements
             // (which we treat as enabled).
@@ -191,7 +183,7 @@ pub(crate) async fn check_enabled(el: &Element) -> Result<bool> {
             return true;
         }
     "#;
-    let res = el.call_on(js, json!([])).await?;
+    let res = el.call_on_main(js, json!([])).await?;
     Ok(res.get("value").and_then(|v| v.as_bool()).unwrap_or(false))
 }
 
@@ -210,8 +202,7 @@ pub(crate) async fn check_receives_pointer(
     position: Option<(f64, f64)>,
 ) -> Result<bool> {
     let js = r#"
-        function(dx, dy) {
-            const el = this;
+        function(el, dx, dy) {
             if (!el || !el.isConnected) return false;
             const rect = el.getBoundingClientRect();
             if (rect.width <= 0 || rect.height <= 0) return false;
@@ -234,11 +225,15 @@ pub(crate) async fn check_receives_pointer(
     // ("Failed to deserialize params.arguments"), which failed every gated
     // `click` / `hover` / `tap` against a real browser. The mock tests could
     // not catch it — `MockConnection` doesn't validate CDP parameter shapes.
+    //
+    // `call_on_main` prepends the element handle, so these land at
+    // arguments[1] / arguments[2] — which is where the leading `el`
+    // parameter in the declaration above leaves `dx` / `dy`.
     let args = match position {
         Some((dx, dy)) => json!([{ "value": dx }, { "value": dy }]),
         None => json!([]),
     };
-    let res = el.call_on(js, args).await?;
+    let res = el.call_on_main(js, args).await?;
     Ok(res.get("value").and_then(|v| v.as_bool()).unwrap_or(false))
 }
 
@@ -293,16 +288,14 @@ pub(crate) async fn wait_actionable(
 mod tests {
     use super::*;
     use crate::tab::Tab;
-    use crate::test_support::{
-        ISOLATED_OBJECT_ID, expect, serve_isolated_call, serve_isolated_world,
-    };
+    use crate::test_support::{serve_call, serve_call_js};
     use serde_json::Value;
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
 
-    /// Drive `check_visible` against a mock connection, answer its isolated-
-    /// world probe with `value`, and hand back the JS source the probe
-    /// actually sent plus the resolved verdict.
+    /// Drive `check_visible` against a mock connection, answer its probe with
+    /// `value`, and hand back the JS source the probe actually sent plus the
+    /// resolved verdict.
     async fn probe_check_visible(value: bool) -> (String, bool) {
         let (mut mock, conn) = MockConnection::pair();
         let sess = SessionHandle::new(conn.clone(), "S1");
@@ -311,8 +304,7 @@ mod tests {
 
         let fut = tokio::spawn(async move { check_visible(&el).await });
 
-        serve_isolated_world(&mut mock).await;
-        let js = serve_isolated_call(&mut mock, json!({ "value": value, "type": "boolean" })).await;
+        let js = serve_call_js(&mut mock, json!({ "value": value, "type": "boolean" })).await;
 
         let verdict = fut.await.unwrap().unwrap();
         conn.shutdown();
@@ -385,18 +377,21 @@ mod tests {
     /// parameter shapes. Hence an explicit assertion on the shape.
     #[tokio::test]
     async fn check_receives_pointer_wraps_its_coordinates_as_call_arguments() {
+        // `call_on_main` prepends the element handle, so the coordinates are
+        // the second and third arguments — each one an object, never a bare
+        // number.
         assert_eq!(
             probe_pointer_args(Some((3.0, 4.0))).await,
-            json!([{ "value": 3.0 }, { "value": 4.0 }]),
+            json!([{ "objectId": "R1" }, { "value": 3.0 }, { "value": 4.0 }]),
             "an explicit click position must travel as two CallArgument objects",
         );
 
-        // No position → no arguments at all, leaving dx/dy `undefined` in the
-        // JS, which is what its `Number.isFinite` centre-fallback reads.
+        // No position → no coordinates at all, leaving dx/dy `undefined` in
+        // the JS, which is what its `Number.isFinite` centre-fallback reads.
         assert_eq!(
             probe_pointer_args(None).await,
-            json!([]),
-            "a centre hit-test must send no arguments rather than bare nulls",
+            json!([{ "objectId": "R1" }]),
+            "a centre hit-test must send no coordinates rather than bare nulls",
         );
     }
 
@@ -408,39 +403,25 @@ mod tests {
         let tab = Tab::new_for_test(sess);
         let el = Element::from_jsret(tab, 99, "R1".to_string());
 
-        // Spawn before serving: the handshake only goes out once the probe is
-        // actually running.
+        // Spawn before serving: nothing goes out until the probe is running.
         let fut = tokio::spawn(async move { check_receives_pointer(&el, at).await });
 
-        serve_isolated_world(&mut mock).await;
-        let id = expect(&mut mock, "DOM.resolveNode").await;
-        mock.reply(id, json!({ "object": { "objectId": ISOLATED_OBJECT_ID } }))
-            .await;
-        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
-        let args = mock.last_sent()["params"]["arguments"].clone();
-        mock.reply(
-            id,
-            json!({ "result": { "value": true, "type": "boolean" } }),
-        )
-        .await;
-        let id = expect(&mut mock, "Runtime.releaseObject").await;
-        mock.reply(id, json!({})).await;
+        let params = serve_call(&mut mock, json!({ "value": true, "type": "boolean" })).await;
 
         assert!(fut.await.unwrap().unwrap());
         conn.shutdown();
-        args
+        params["arguments"].clone()
     }
 
-    /// All four predicates run in the isolated world, not the page's.
+    /// Every predicate binds the element as its first positional argument.
     ///
-    /// This is the property the whole gate rests on: every predicate reads
-    /// geometry through `getBoundingClientRect`, `getComputedStyle` or
-    /// `document.elementFromPoint`, and a page that has shadowed any of them
-    /// in its own world could feed the gate whatever it liked — and see it
-    /// being probed. `serve_isolated_call` fails the test if a probe ever
-    /// targets the page-world handle; this drives all four past it in one go.
+    /// `call_on_main` prepends the element handle to `arguments`, so a body
+    /// that forgot its leading `el` parameter would silently read the handle
+    /// as its first *caller* argument — and, for the three no-argument
+    /// predicates, see `el` as `undefined` and answer `false` for everything.
+    /// This drives all four past that in one go.
     #[tokio::test]
-    async fn every_predicate_runs_in_the_isolated_world() {
+    async fn every_predicate_binds_the_element_as_its_first_argument() {
         let (mut mock, conn) = MockConnection::pair();
         let sess = SessionHandle::new(conn.clone(), "S1");
         let tab = Tab::new_for_test(sess);
@@ -458,20 +439,20 @@ mod tests {
             }
         });
 
-        // The world is built once and cached; each predicate then pays its
-        // own resolve → call → release.
-        serve_isolated_world(&mut mock).await;
-        let mut sources = Vec::new();
+        let mut calls = Vec::new();
         for _ in 0..4 {
-            sources.push(
-                serve_isolated_call(&mut mock, json!({ "value": true, "type": "boolean" })).await,
-            );
+            calls.push(serve_call(&mut mock, json!({ "value": true, "type": "boolean" })).await);
         }
 
         assert_eq!(fut.await.unwrap(), (true, true, true, true));
 
+        let sources: Vec<&str> = calls
+            .iter()
+            .map(|c| c["functionDeclaration"].as_str().unwrap())
+            .collect();
+
         // Pin which source belongs to which predicate, so a future reorder of
-        // the gate can't quietly leave one of them behind in the main world.
+        // the gate can't quietly re-point one of these assertions.
         assert!(sources[0].contains("checkVisibility"), "{}", sources[0]);
         assert!(sources[1].contains("aria-disabled"), "{}", sources[1]);
         assert!(
@@ -481,11 +462,12 @@ mod tests {
         );
         assert!(sources[3].contains("elementFromPoint"), "{}", sources[3]);
 
-        // Isolated calls bind the element as `this`; a lingering
-        // `function(el, ...)` signature would silently receive `undefined`
-        // and make every predicate answer `false`.
-        for js in &sources {
-            assert!(js.contains("const el = this"), "{js}");
+        for (call, js) in calls.iter().zip(&sources) {
+            assert!(js.trim_start().starts_with("function(el"), "{js}");
+            assert_eq!(
+                call["arguments"][0]["objectId"], "R1",
+                "the element must be the first argument the body reads",
+            );
         }
 
         conn.shutdown();

--- a/crates/zendriver/src/query/predicate.rs
+++ b/crates/zendriver/src/query/predicate.rs
@@ -28,8 +28,38 @@ pub(crate) enum AttrPred {
 #[derive(Debug, Clone)]
 pub(crate) enum TextPred {
     Contains(String, bool),
+    /// Exact text match under XPath `normalize-space()` semantics — see
+    /// [`normalize_space`]. Both sides are normalized, so this agrees with
+    /// the `text_exact` selector kind, which compiles to XPath
+    /// `//*[normalize-space(.)=<needle>]`.
     Equals(String, bool),
     Matches(String), // regex pattern
+}
+
+/// JS tail that applies [`normalize_space`]'s rule to the page-side text —
+/// appended to `TXT` in [`PredicateSet::to_js_filter`].
+const JS_NORMALIZE_SPACE: &str = r#".replace(/[ \t\r\n]+/g," ").trim()"#;
+
+/// XPath `normalize-space()` semantics: collapse every run of XML
+/// whitespace (space, tab, CR, LF) to a single space, then trim the ends.
+///
+/// Applied to the *needle* at compile time and mirrored on the page-side
+/// text by [`JS_NORMALIZE_SPACE`], so both operands of a `text_equals`
+/// compare are normalized the same way. Before this, the JS post-filter
+/// only `trim()`ed while the `text_exact` selector compiled to XPath
+/// `normalize-space(.)`, so `<b>Hello   world</b>` matched one and not the
+/// other.
+///
+/// Deliberately limited to the four XML whitespace characters rather than
+/// the broader JS `\s` / Rust `char::is_whitespace` class: `normalize-space()`
+/// leaves `&nbsp;` (U+00A0) and other Unicode spaces alone, and widening the
+/// class here would re-introduce on `&nbsp;` exactly the divergence this
+/// normalization exists to remove.
+pub(crate) fn normalize_space(s: &str) -> String {
+    s.split([' ', '\t', '\r', '\n'])
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Quote a value as a JSON string (`"v"`) — safe for both CSS attribute
@@ -88,6 +118,11 @@ impl PredicateSet {
     /// Post-filter predicates (`attr_regex` + all text predicates) → a JS
     /// boolean expression over a bound `el`. Returns `"true"` when there are
     /// no post-filters (so the caller can always `.filter(el => <expr>)`).
+    ///
+    /// [`TextPred::Equals`] normalizes both operands per [`normalize_space`];
+    /// [`TextPred::Contains`] and [`TextPred::Matches`] run against the raw
+    /// text, since a substring or regex needle may legitimately carry its own
+    /// whitespace.
     pub(crate) fn to_js_filter(&self) -> String {
         const TXT: &str = r#"(el.innerText||el.textContent||"")"#;
         let mut checks: Vec<String> = Vec::new();
@@ -107,10 +142,13 @@ impl PredicateSet {
                     "{TXT}.toLowerCase().includes({})",
                     q(&s.to_lowercase())
                 )),
-                TextPred::Equals(s, false) => checks.push(format!("{TXT}.trim()==={}", q(s))),
+                TextPred::Equals(s, false) => checks.push(format!(
+                    "{TXT}{JS_NORMALIZE_SPACE}==={}",
+                    q(&normalize_space(s))
+                )),
                 TextPred::Equals(s, true) => checks.push(format!(
-                    "{TXT}.trim().toLowerCase()==={}",
-                    q(&s.to_lowercase())
+                    "{TXT}{JS_NORMALIZE_SPACE}.toLowerCase()==={}",
+                    q(&normalize_space(&s.to_lowercase()))
                 )),
                 TextPred::Matches(p) => checks.push(format!("new RegExp({}).test({TXT})", q(p))),
             }
@@ -187,7 +225,9 @@ mod tests {
             "{f}"
         );
         assert!(
-            f.contains(r#"(el.innerText||el.textContent||"").trim()==="OK""#),
+            f.contains(
+                r#"(el.innerText||el.textContent||"").replace(/[ \t\r\n]+/g," ").trim()==="OK""#
+            ),
             "{f}"
         );
         assert!(
@@ -263,13 +303,15 @@ mod tests {
         };
         let f = p.to_js_filter();
         assert!(
-            f.contains(r#"(el.innerText||el.textContent||"").trim().toLowerCase()==="foo""#),
+            f.contains(
+                r#"(el.innerText||el.textContent||"").replace(/[ \t\r\n]+/g," ").trim().toLowerCase()==="foo""#
+            ),
             "{f}"
         );
     }
 
     #[test]
-    fn non_ci_text_variants_stay_byte_identical() {
+    fn non_ci_text_variants_never_lowercase() {
         let p = PredicateSet {
             tag: None,
             attrs: vec![],
@@ -284,10 +326,99 @@ mod tests {
             "{f}"
         );
         assert!(
-            f.contains(r#"(el.innerText||el.textContent||"").trim()==="OK""#),
+            f.contains(
+                r#"(el.innerText||el.textContent||"").replace(/[ \t\r\n]+/g," ").trim()==="OK""#
+            ),
             "{f}"
         );
         // Never lowercased when the flag is off.
         assert!(!f.contains("toLowerCase"), "{f}");
+    }
+
+    // --- normalize-space unification (text_equals ↔ text_exact) -----------
+
+    #[test]
+    fn normalize_space_collapses_interior_runs_and_trims_ends() {
+        assert_eq!(normalize_space("  Hello \t\n  world  "), "Hello world");
+        assert_eq!(normalize_space("Hello world"), "Hello world");
+        assert_eq!(normalize_space("   "), "");
+        assert_eq!(normalize_space(""), "");
+    }
+
+    #[test]
+    fn normalize_space_leaves_nbsp_alone_like_xpath() {
+        // XPath `normalize-space()` only folds space/tab/CR/LF. Folding
+        // U+00A0 here would make `text_equals` disagree with `text_exact`
+        // on `&nbsp;` markup — the exact bug this normalization fixes.
+        assert_eq!(normalize_space("a\u{a0}\u{a0}b"), "a\u{a0}\u{a0}b");
+    }
+
+    #[test]
+    fn text_equals_normalizes_the_needle_at_compile_time() {
+        // `<b>Hello   world</b>` matches XPath `normalize-space(.)="Hello
+        // world"`, so the JS post-filter must compare against the collapsed
+        // needle too — otherwise a needle typed with interior runs could
+        // never match anything.
+        let p = PredicateSet {
+            tag: None,
+            attrs: vec![],
+            texts: vec![TextPred::Equals("Hello   world".into(), false)],
+        };
+        let f = p.to_js_filter();
+        assert!(f.contains(r#"==="Hello world""#), "{f}");
+        assert!(!f.contains(r#"==="Hello   world""#), "{f}");
+    }
+
+    #[test]
+    fn text_equals_normalizes_the_page_text_side_too() {
+        // Needle-side normalization alone is not enough: `<b>Hello   world</b>`
+        // must also collapse before the compare, or the two sides still
+        // disagree on the same markup.
+        let p = PredicateSet {
+            tag: None,
+            attrs: vec![],
+            texts: vec![TextPred::Equals("Hello world".into(), false)],
+        };
+        let f = p.to_js_filter();
+        assert!(f.contains(r#".replace(/[ \t\r\n]+/g," ").trim()"#), "{f}");
+    }
+
+    #[test]
+    fn text_equals_i_normalizes_both_sides_before_lowercasing() {
+        let p = PredicateSet {
+            tag: None,
+            attrs: vec![],
+            texts: vec![TextPred::Equals("  Hello \n WORLD ".into(), true)],
+        };
+        let f = p.to_js_filter();
+        assert!(
+            f.contains(
+                r#"(el.innerText||el.textContent||"").replace(/[ \t\r\n]+/g," ").trim().toLowerCase()==="hello world""#
+            ),
+            "{f}"
+        );
+    }
+
+    #[test]
+    fn contains_and_matches_keep_raw_text() {
+        // Only `Equals` normalizes — a substring/regex needle may carry
+        // meaningful whitespace of its own.
+        let p = PredicateSet {
+            tag: None,
+            attrs: vec![],
+            texts: vec![
+                TextPred::Contains("Buy  now".into(), false),
+                TextPred::Matches(r"a\s+b".into()),
+            ],
+        };
+        let f = p.to_js_filter();
+        assert!(
+            f.contains(r#"(el.innerText||el.textContent||"").includes("Buy  now")"#),
+            "{f}"
+        );
+        assert!(
+            f.contains(r#"new RegExp("a\\s+b").test((el.innerText||el.textContent||""))"#),
+            "{f}"
+        );
     }
 }

--- a/crates/zendriver/src/query/selectors.rs
+++ b/crates/zendriver/src/query/selectors.rs
@@ -571,6 +571,18 @@ async fn resolve_text_one(
     exact: bool,
     best_match: bool,
 ) -> Result<Option<RemoteRef>> {
+    // XPath compares `normalize-space(.)` against the needle, so the page side
+    // was folded but the needle was not: `text_exact("Hello   world")` could
+    // never match anything. Fold it the same way, using the one rule
+    // `TextPred::Equals` uses so the two stay in agreement. Substring and regex
+    // needles keep their raw text — interior whitespace can be meaningful there.
+    let normalized;
+    let needle = if exact {
+        normalized = crate::query::predicate::normalize_space(needle);
+        normalized.as_str()
+    } else {
+        needle
+    };
     let session = scope.session();
     if exact {
         // XPath path. For best_match we need the full snapshot array
@@ -674,6 +686,18 @@ async fn resolve_text_many(
     exact: bool,
     best_match: bool,
 ) -> Result<Vec<RemoteRef>> {
+    // XPath compares `normalize-space(.)` against the needle, so the page side
+    // was folded but the needle was not: `text_exact("Hello   world")` could
+    // never match anything. Fold it the same way, using the one rule
+    // `TextPred::Equals` uses so the two stay in agreement. Substring and regex
+    // needles keep their raw text — interior whitespace can be meaningful there.
+    let normalized;
+    let needle = if exact {
+        normalized = crate::query::predicate::normalize_space(needle);
+        normalized.as_str()
+    } else {
+        needle
+    };
     let session = scope.session();
     let result = if exact {
         match scope {
@@ -1111,6 +1135,55 @@ mod tests {
     use super::*;
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
+
+    /// The XPath folds the page side with `normalize-space(.)`, so an
+    /// author-written run of spaces in the needle could never match. Both
+    /// sides must be folded by the same rule `TextPred::Equals` uses.
+    #[tokio::test]
+    async fn text_exact_folds_whitespace_in_the_needle_before_building_the_xpath() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move {
+                let scope = QueryScope::Tab(&t);
+                SelectorKind::Text {
+                    needle: "  Hello \t\n  world  ".into(),
+                    exact: true,
+                }
+                .resolve_one(&scope)
+                .await
+            }
+        });
+
+        let id = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            mock.expect_cmd("Runtime.evaluate"),
+        )
+        .await
+        .expect("expected a Runtime.evaluate dispatch");
+        let expr = mock.last_sent()["params"]["expression"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(
+            expr.contains("Hello world"),
+            "needle should be normalize-space folded before embedding, got: {expr}"
+        );
+        assert!(
+            !expr.contains("Hello \\t"),
+            "raw tabs/runs must not survive into the XPath, got: {expr}"
+        );
+        mock.reply(
+            id,
+            json!({ "result": { "type": "object", "subtype": "null" } }),
+        )
+        .await;
+        let _ = fut.await.unwrap();
+        conn.shutdown();
+    }
 
     #[tokio::test]
     async fn css_one_sends_query_selector_with_selector() {

--- a/crates/zendriver/src/screenshot/mod.rs
+++ b/crates/zendriver/src/screenshot/mod.rs
@@ -38,11 +38,33 @@
 //!
 //! When [`ScreenshotBuilder::full_page`] is `true`, [`ScreenshotBuilder::bytes`]
 //! sends an extra `Page.getLayoutMetrics` first, reads `cssContentSize.{width,height}` from
-//! the response, and forwards both as a `clip` rect with `scale: 1` plus
-//! `captureBeyondViewport: true` on the subsequent `Page.captureScreenshot`.
-//! Chrome handles the scroll-to-render-each-tile dance internally. With
-//! `full_page: false` the builder just passes `clip` through verbatim
-//! (or omits it when unset) and the capture is viewport-sized.
+//! the response, and forwards both as the `clip` rect on the subsequent
+//! `Page.captureScreenshot`. Chrome handles the scroll-to-render-each-tile
+//! dance internally. With `full_page: false` the builder passes [`ScreenshotBuilder::clip`]
+//! through verbatim (or omits it when unset, capturing the viewport).
+//!
+//! ## Clip coordinates and `captureBeyondViewport`
+//!
+//! Chrome reads the `clip` rect in **document** coordinates, not viewport
+//! ones — a distinction that only shows up once the page is scrolled, and the
+//! reason [`crate::Element::screenshot`] converts its box-model rect before
+//! sending it.
+//!
+//! Any capture carrying a `clip` — full-page or a caller's own rect — also
+//! sends `captureBeyondViewport: true`, so a rect covering area Chrome has
+//! not rendered comes back with pixels rather than blank. The flag has one
+//! side effect worth knowing: `position: fixed` elements render at their
+//! document position rather than pinned to the viewport, so a sticky header
+//! can appear in an unexpected place in a clipped shot.
+//!
+//! ## Clip scale
+//!
+//! The `clip.scale` field is required by CDP and is currently pinned to `1`,
+//! i.e. one image pixel per CSS pixel. An unclipped viewport capture, by
+//! contrast, comes back at the emulated device pixel ratio — so under a 2x-DPR
+//! persona a clipped shot is half the resolution of an unclipped one. Honoring
+//! the persona's DPR here needs the scale plumbed in from the caller; until
+//! then, clipped captures are 1x.
 
 use std::path::Path;
 
@@ -230,7 +252,12 @@ impl<'tab> ScreenshotBuilder<'tab> {
 
     /// Crop the capture to `bbox`.
     ///
-    /// Coordinates are CSS pixels relative to the viewport top-left.
+    /// Coordinates are CSS pixels relative to the **document** top-left, not
+    /// the viewport: Chrome reads `Page.captureScreenshot`'s clip in page
+    /// space. The two coincide only while the page is unscrolled. A rect may
+    /// reach past the fold and still render — see the [module docs](self) for
+    /// the `captureBeyondViewport` flag that guarantees it, its
+    /// `position: fixed` caveat, and the 1x clip scale.
     ///
     /// # Examples
     ///
@@ -347,7 +374,6 @@ impl<'tab> ScreenshotBuilder<'tab> {
                         "Page.getLayoutMetrics cssContentSize missing height".into(),
                     )
                 })?;
-            params.insert("captureBeyondViewport".to_string(), Value::Bool(true));
             Some(BoundingBox {
                 x: 0.0,
                 y: 0.0,
@@ -359,6 +385,10 @@ impl<'tab> ScreenshotBuilder<'tab> {
         };
 
         if let Some(bbox) = effective_clip {
+            // Every clip gets `captureBeyondViewport`, not just the full-page
+            // one: a clip rect below the fold is outside what Chrome has
+            // rendered, and without this it comes back blank.
+            params.insert("captureBeyondViewport".to_string(), Value::Bool(true));
             params.insert(
                 "clip".to_string(),
                 json!({
@@ -414,6 +444,8 @@ impl<'tab> ScreenshotBuilder<'tab> {
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use serde_json::json;
     use zendriver_transport::SessionHandle;
@@ -473,6 +505,59 @@ mod tests {
 
         let bytes = fut.await.unwrap().unwrap();
         assert_eq!(bytes, b"JPG!");
+        conn.shutdown();
+    }
+
+    /// A caller-supplied clip carries `captureBeyondViewport` too. Without it
+    /// a rect below the fold is outside what Chrome has rendered and the
+    /// capture comes back blank — the flag used to ride only on the
+    /// `full_page` branch.
+    #[tokio::test]
+    async fn caller_clip_below_the_fold_sends_capture_beyond_viewport() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+
+        let below_the_fold = BoundingBox {
+            x: 0.0,
+            y: 3000.0,
+            width: 400.0,
+            height: 200.0,
+        };
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move {
+                ScreenshotBuilder::new(&t)
+                    .clip(below_the_fold)
+                    .bytes()
+                    .await
+            }
+        });
+
+        // No Page.getLayoutMetrics: a caller's clip is passed through as-is.
+        let id = match tokio::time::timeout(
+            Duration::from_secs(5),
+            mock.expect_cmd("Page.captureScreenshot"),
+        )
+        .await
+        {
+            Ok(id) => id,
+            Err(_) => panic!("timed out waiting for Page.captureScreenshot"),
+        };
+        let params = &mock.last_sent()["params"];
+        assert_eq!(
+            params["captureBeyondViewport"], true,
+            "a clip past the fold needs captureBeyondViewport or it renders blank",
+        );
+        let clip = &params["clip"];
+        assert_eq!(clip["x"], 0.0);
+        assert_eq!(clip["y"], 3000.0);
+        assert_eq!(clip["width"], 400.0);
+        assert_eq!(clip["height"], 200.0);
+        mock.reply(id, json!({ "data": "UE5HIQ==" })).await;
+
+        let bytes = fut.await.unwrap().unwrap();
+        assert_eq!(bytes, b"PNG!");
         conn.shutdown();
     }
 

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -5102,16 +5102,11 @@ mod tests {
             .await;
 
         // Step 2: type_text_fast focuses the body first — actionability gate
-        // (TEXT_INPUT = visible → enabled, 2 callFunctionOn) then this.focus()
-        // (1 callFunctionOn). Reply truthy/undefined to each.
-        for _ in 0..2 {
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-            mock.reply(
-                id,
-                json!({ "result": { "value": true, "type": "boolean" } }),
-            )
-            .await;
-        }
+        // (TEXT_INPUT = visible → enabled) then this.focus(). The two gate
+        // predicates run in the isolated world, which the first one builds;
+        // this.focus() stays in the main world.
+        crate::test_support::serve_isolated_world(&mut mock).await;
+        crate::test_support::serve_gate_probes(&mut mock, 2).await;
         let id_focus = mock.expect_cmd("Runtime.callFunctionOn").await;
         mock.reply(id_focus, json!({ "result": { "type": "undefined" } }))
             .await;

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -2215,75 +2215,106 @@ pointer-events:none;opacity:0.85;'; \
         // every CDP call still succeeds.
         const LEFT_HELD: u8 = crate::input::pointer_state::MouseButtonSet::LEFT.bits();
 
-        // Press the left button at the source point.
-        self.call(
-            "Input.dispatchMouseEvent",
-            json!({
-                "type": "mousePressed",
-                "x": from.0, "y": from.1,
-                "button": "left",
-                "clickCount": 1,
-                "buttons": LEFT_HELD,
-            }),
-        )
-        .await?;
-        {
-            let input = self.input().clone();
-            let mut s = input.state.lock().await;
-            s.buttons_held
-                .insert(crate::input::pointer_state::MouseButtonSet::LEFT);
-        }
-
-        // Interpolate the move. nodriver walks i in 0..=steps (steps+1 points,
-        // the first coinciding with `from`); steps <= 1 collapses to a single
-        // hop straight to `to`.
-        let steps = steps.max(1);
-        if steps == 1 {
+        // `buttons_held` lives on the per-Tab InputController, which outlives
+        // this call, so a `?` between the press and the release — an
+        // interpolated `mouseMoved` failing partway is the realistic one —
+        // would strand the LEFT bit set for the rest of the tab's life. Every
+        // later `mouseMoved` would then report a button held with no preceding
+        // mousedown, which is a worse signal to leak to behavioral anti-bot
+        // scoring than omitting `buttons` altogether.
+        //
+        // So the whole gesture runs as one fallible section and the state fixup
+        // happens at the single exit below, rather than via a `Drop` guard:
+        // clearing the bit needs the async `Mutex`, `Drop` cannot await, and a
+        // `try_lock` inside `Drop` would silently fail under contention —
+        // exactly when another task is mid-dispatch and about to read the stale
+        // bit. More machinery, weaker guarantee.
+        //
+        // Residual case it does not cover: if the caller drops this future
+        // mid-gesture (cancellation, an outer `tokio::time::timeout`), the
+        // fixup never runs and the bit stays set. A `Drop` guard would not
+        // reliably close that either, for the `try_lock` reason above.
+        let gesture: Result<()> = async {
+            // Press the left button at the source point.
             self.call(
                 "Input.dispatchMouseEvent",
-                json!({ "type": "mouseMoved", "x": to.0, "y": to.1, "buttons": LEFT_HELD }),
+                json!({
+                    "type": "mousePressed",
+                    "x": from.0, "y": from.1,
+                    "button": "left",
+                    "clickCount": 1,
+                    "buttons": LEFT_HELD,
+                }),
             )
             .await?;
-        } else {
-            let step_x = (to.0 - from.0) / steps as f64;
-            let step_y = (to.1 - from.1) / steps as f64;
-            for i in 0..=steps {
-                let x = from.0 + step_x * i as f64;
-                let y = from.1 + step_y * i as f64;
+            {
+                let input = self.input().clone();
+                let mut s = input.state.lock().await;
+                s.buttons_held
+                    .insert(crate::input::pointer_state::MouseButtonSet::LEFT);
+            }
+
+            // Interpolate the move. nodriver walks i in 0..=steps (steps+1
+            // points, the first coinciding with `from`); steps <= 1 collapses
+            // to a single hop straight to `to`.
+            let steps = steps.max(1);
+            if steps == 1 {
                 self.call(
                     "Input.dispatchMouseEvent",
-                    json!({ "type": "mouseMoved", "x": x, "y": y, "buttons": LEFT_HELD }),
+                    json!({ "type": "mouseMoved", "x": to.0, "y": to.1, "buttons": LEFT_HELD }),
                 )
                 .await?;
+            } else {
+                let step_x = (to.0 - from.0) / steps as f64;
+                let step_y = (to.1 - from.1) / steps as f64;
+                for i in 0..=steps {
+                    let x = from.0 + step_x * i as f64;
+                    let y = from.1 + step_y * i as f64;
+                    self.call(
+                        "Input.dispatchMouseEvent",
+                        json!({ "type": "mouseMoved", "x": x, "y": y, "buttons": LEFT_HELD }),
+                    )
+                    .await?;
+                }
             }
-        }
 
-        // Release at the destination. `buttons` is now empty — the button is
-        // no longer held once the release is dispatched.
-        self.call(
-            "Input.dispatchMouseEvent",
-            json!({
-                "type": "mouseReleased",
-                "x": to.0, "y": to.1,
-                "button": "left",
-                "clickCount": 1,
-                "buttons": 0,
-            }),
-        )
-        .await?;
-        // Leave the controller's cached cursor where the drag actually ended.
-        // Skipping this made the next `move_realistic` build its Bezier from a
-        // stale origin, so the path started by teleporting back to wherever the
-        // last click landed.
+            // Release at the destination. `buttons` is now empty — the button
+            // is no longer held once the release is dispatched.
+            self.call(
+                "Input.dispatchMouseEvent",
+                json!({
+                    "type": "mouseReleased",
+                    "x": to.0, "y": to.1,
+                    "button": "left",
+                    "clickCount": 1,
+                    "buttons": 0,
+                }),
+            )
+            .await?;
+            Ok(())
+        }
+        .await;
+
         {
             let input = self.input().clone();
             let mut s = input.state.lock().await;
+            // Whether the gesture finished or a dispatch failed partway, this
+            // tab is no longer holding the button as far as our state goes.
             s.buttons_held
                 .remove(crate::input::pointer_state::MouseButtonSet::LEFT);
-            s.pointer_x = to.0;
-            s.pointer_y = to.1;
+            if gesture.is_ok() {
+                // Leave the controller's cached cursor where the drag actually
+                // ended. Skipping this made the next `move_realistic` build its
+                // Bezier from a stale origin, so the path started by teleporting
+                // back to wherever the last click landed. On failure the real
+                // cursor is at some indeterminate intermediate point, so leave
+                // the cache alone rather than assert a position we never
+                // reached.
+                s.pointer_x = to.0;
+                s.pointer_y = to.1;
+            }
         }
-        Ok(())
+        gesture
     }
 
     /// Search the text content of every loaded frame resource for `query`,

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -44,6 +44,11 @@ const DEFAULT_LOAD_TIMEOUT: Duration = Duration::from_secs(30);
 /// channel.
 const READY_STATE_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Fallback tick for [`Tab::wait_for_idle_opts`]'s wait loop, used when no
+/// membership change wakes it sooner. This is the "+50 ms" in the documented
+/// worst case of `quiet_window + 50ms`, so the two must move together.
+const IDLE_FALLBACK_TICK: Duration = Duration::from_millis(50);
+
 /// Fixed `(x, y)` viewport anchor for [`Tab::scroll_with`] gestures. A
 /// constant in-viewport point keeps page scrolls deterministic and
 /// single-dispatch (no `Page.getLayoutMetrics` round-trip to derive a
@@ -993,6 +998,17 @@ impl Tab {
                 }),
             )
             .await
+            .inspect_err(|e| {
+                // Swallowing this made a failed evaluate indistinguishable from
+                // a not-yet-complete page: both fall through to a full
+                // `DEFAULT_LOAD_TIMEOUT` block on the event stream, with
+                // nothing anywhere saying the probe never ran.
+                tracing::warn!(
+                    error = %e,
+                    "wait_for_load: document.readyState probe failed; \
+                     falling back to waiting for Page.frameStoppedLoading"
+                );
+            })
             .ok()
             .and_then(|v| v.get("result")?.get("value")?.as_str().map(str::to_owned));
         if ready.as_deref() == Some("complete") {
@@ -1897,7 +1913,7 @@ impl Tab {
                 return Err(ZendriverError::Timeout(timeout));
             }
             tokio::select! {
-                () = tokio::time::sleep(Duration::from_millis(50)) => {}
+                () = tokio::time::sleep(IDLE_FALLBACK_TICK) => {}
                 () = notif => {
                     // A membership change fired since we armed `notif`. Reset
                     // the quiet window — even if the set is back to zero by
@@ -2018,7 +2034,14 @@ impl Tab {
     /// ```
     pub async fn mouse_move(&self, x: f64, y: f64) -> Result<()> {
         let input = self.input().clone();
-        crate::input::mouse::move_realistic(&input, self, x, y).await
+        crate::input::mouse::move_realistic(
+            &input,
+            self,
+            x,
+            y,
+            crate::input::keyboard::KeyModifiers::empty(),
+        )
+        .await
     }
 
     /// Click at `(x, y)` in viewport coordinates: a left, single, realistic
@@ -2046,9 +2069,7 @@ impl Tab {
             self,
             x,
             y,
-            crate::input::mouse::MouseButton::Left,
-            1,
-            true,
+            &crate::element::actions::ClickOptions::default(),
         )
         .await
     }
@@ -2056,11 +2077,12 @@ impl Tab {
     /// Click at `(x, y)` in viewport coordinates with explicit
     /// [`crate::ClickOptions`].
     ///
-    /// Maps `opts.button` / `opts.click_count` / `opts.realistic` onto the
-    /// dispatch. Unlike [`crate::Element::click_with`], there is no element to
-    /// gate on, so `opts.force` and `opts.position` are ignored — the click
-    /// lands at the supplied `(x, y)` regardless. Use this for right-clicks /
-    /// modifier-held clicks / double-clicks / raw teleports at a coordinate.
+    /// Maps `opts.button` / `opts.click_count` / `opts.modifiers` /
+    /// `opts.realistic` onto the dispatch. Unlike [`crate::Element::click_with`],
+    /// there is no element to gate on, so `opts.force` and `opts.position` are
+    /// ignored — the click lands at the supplied `(x, y)` regardless. Use this
+    /// for right-clicks / modifier-held clicks / double-clicks / raw teleports
+    /// at a coordinate.
     ///
     /// # Examples
     ///
@@ -2082,16 +2104,7 @@ impl Tab {
         opts: crate::element::actions::ClickOptions,
     ) -> Result<()> {
         let input = self.input().clone();
-        crate::input::mouse::click_at(
-            &input,
-            self,
-            x,
-            y,
-            opts.button,
-            opts.click_count,
-            opts.realistic,
-        )
-        .await
+        crate::input::mouse::click_at(&input, self, x, y, &opts).await
     }
 
     /// Tap at `(x, y)` in viewport coordinates.
@@ -2194,6 +2207,14 @@ pointer-events:none;opacity:0.85;'; \
     /// # Ok(()) }
     /// ```
     pub async fn mouse_drag(&self, from: (f64, f64), to: (f64, f64), steps: usize) -> Result<()> {
+        // CDP `buttons` bitmask for a held left button — the same bit
+        // `MouseButtonSet::LEFT` uses. Every event between the press and the
+        // release must carry it: a page implementing drag with `mousemove` +
+        // `e.buttons` (the standard modern check, and what most slider widgets
+        // and DnD libraries use) drops the whole gesture without it, while
+        // every CDP call still succeeds.
+        const LEFT_HELD: u8 = crate::input::pointer_state::MouseButtonSet::LEFT.bits();
+
         // Press the left button at the source point.
         self.call(
             "Input.dispatchMouseEvent",
@@ -2202,9 +2223,16 @@ pointer-events:none;opacity:0.85;'; \
                 "x": from.0, "y": from.1,
                 "button": "left",
                 "clickCount": 1,
+                "buttons": LEFT_HELD,
             }),
         )
         .await?;
+        {
+            let input = self.input().clone();
+            let mut s = input.state.lock().await;
+            s.buttons_held
+                .insert(crate::input::pointer_state::MouseButtonSet::LEFT);
+        }
 
         // Interpolate the move. nodriver walks i in 0..=steps (steps+1 points,
         // the first coinciding with `from`); steps <= 1 collapses to a single
@@ -2213,7 +2241,7 @@ pointer-events:none;opacity:0.85;'; \
         if steps == 1 {
             self.call(
                 "Input.dispatchMouseEvent",
-                json!({ "type": "mouseMoved", "x": to.0, "y": to.1 }),
+                json!({ "type": "mouseMoved", "x": to.0, "y": to.1, "buttons": LEFT_HELD }),
             )
             .await?;
         } else {
@@ -2224,13 +2252,14 @@ pointer-events:none;opacity:0.85;'; \
                 let y = from.1 + step_y * i as f64;
                 self.call(
                     "Input.dispatchMouseEvent",
-                    json!({ "type": "mouseMoved", "x": x, "y": y }),
+                    json!({ "type": "mouseMoved", "x": x, "y": y, "buttons": LEFT_HELD }),
                 )
                 .await?;
             }
         }
 
-        // Release at the destination.
+        // Release at the destination. `buttons` is now empty — the button is
+        // no longer held once the release is dispatched.
         self.call(
             "Input.dispatchMouseEvent",
             json!({
@@ -2238,9 +2267,22 @@ pointer-events:none;opacity:0.85;'; \
                 "x": to.0, "y": to.1,
                 "button": "left",
                 "clickCount": 1,
+                "buttons": 0,
             }),
         )
         .await?;
+        // Leave the controller's cached cursor where the drag actually ended.
+        // Skipping this made the next `move_realistic` build its Bezier from a
+        // stale origin, so the path started by teleporting back to wherever the
+        // last click landed.
+        {
+            let input = self.input().clone();
+            let mut s = input.state.lock().await;
+            s.buttons_held
+                .remove(crate::input::pointer_state::MouseButtonSet::LEFT);
+            s.pointer_x = to.0;
+            s.pointer_y = to.1;
+        }
         Ok(())
     }
 
@@ -4698,6 +4740,193 @@ mod tests {
             tail,
             vec!["mouseReleased", "mousePressed"],
             "final two dispatches must be mousePressed then mouseReleased"
+        );
+        conn.shutdown();
+    }
+
+    /// Drain every `Input.dispatchMouseEvent` a click emits, returning
+    /// `(type, buttons, modifiers, clickCount)` per frame.
+    async fn drain_mouse_dispatches(mock: &mut MockConnection) -> Vec<(String, u64, u64, u64)> {
+        let mut frames = Vec::new();
+        loop {
+            let next = tokio::time::timeout(
+                Duration::from_millis(500),
+                mock.expect_cmd("Input.dispatchMouseEvent"),
+            )
+            .await;
+            match next {
+                Ok(id) => {
+                    let sent = mock.last_sent();
+                    let p = &sent["params"];
+                    frames.push((
+                        p["type"].as_str().unwrap_or("").to_string(),
+                        p["buttons"].as_u64().unwrap_or(u64::MAX),
+                        p["modifiers"].as_u64().unwrap_or(u64::MAX),
+                        p["clickCount"].as_u64().unwrap_or(0),
+                    ));
+                    mock.reply(id, json!({})).await;
+                }
+                Err(_) => break,
+            }
+        }
+        frames
+    }
+
+    /// Every dispatch must carry CDP's `buttons` bitmask. Without it a page
+    /// implementing drag with `mousemove` + `e.buttons` — the standard modern
+    /// check — sees no button held and silently drops the gesture.
+    #[tokio::test]
+    async fn mouse_click_sends_buttons_bitmask_across_the_sequence() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move { t.mouse_click(10.0, 20.0).await }
+        });
+        let frames = drain_mouse_dispatches(&mut mock).await;
+        fut.await.unwrap().unwrap();
+
+        assert!(
+            frames.iter().all(|(_, buttons, ..)| *buttons != u64::MAX),
+            "every dispatch must include a `buttons` field: {frames:?}"
+        );
+        for (kind, buttons, ..) in &frames {
+            let expected = match kind.as_str() {
+                // Nothing is held before the press or after the release.
+                "mouseMoved" | "mouseReleased" => 0,
+                // MouseButtonSet::LEFT — the same bit CDP uses.
+                "mousePressed" => 1,
+                other => panic!("unexpected dispatch type: {other}"),
+            };
+            assert_eq!(*buttons, expected, "wrong `buttons` on {kind}: {frames:?}");
+        }
+        conn.shutdown();
+    }
+
+    /// The drag case is the one that actually broke pages: every `mouseMoved`
+    /// between the press and the release must report the left button held, or a
+    /// page using the standard `mousemove` + `e.buttons` drag check silently
+    /// does nothing while every CDP call returns success.
+    #[tokio::test]
+    async fn mouse_drag_reports_the_button_held_on_every_move() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move { t.mouse_drag((10.0, 10.0), (200.0, 10.0), 5).await }
+        });
+        let frames = drain_mouse_dispatches(&mut mock).await;
+        fut.await.unwrap().unwrap();
+
+        let moves: Vec<_> = frames.iter().filter(|(k, ..)| k == "mouseMoved").collect();
+        assert!(!moves.is_empty(), "expected mouseMoved frames: {frames:?}");
+        for (kind, buttons, ..) in &frames {
+            let expected = match kind.as_str() {
+                // Held for the whole gesture, including every intermediate move.
+                "mousePressed" | "mouseMoved" => 1,
+                // Released — nothing held once the button comes back up.
+                "mouseReleased" => 0,
+                other => panic!("unexpected dispatch type: {other}"),
+            };
+            assert_eq!(*buttons, expected, "wrong `buttons` on {kind}: {frames:?}");
+        }
+
+        // The drag must also leave the cached cursor at the destination, or the
+        // next realistic move opens by teleporting back to the old position.
+        let s = tab.input().state.lock().await;
+        assert_eq!((s.pointer_x, s.pointer_y), (200.0, 10.0));
+        assert!(s.buttons_held.is_empty(), "button still held after release");
+        drop(s);
+        conn.shutdown();
+    }
+
+    /// `ClickOptions::modifiers` must reach the wire. It was previously read by
+    /// nothing on any path, so a Ctrl/Cmd/Shift-click was inexpressible.
+    #[tokio::test]
+    async fn click_options_modifiers_reach_the_dispatch() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+
+        let mods = crate::input::keyboard::KeyModifiers::CTRL
+            | crate::input::keyboard::KeyModifiers::SHIFT;
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move {
+                t.mouse_click_with(
+                    10.0,
+                    20.0,
+                    crate::element::actions::ClickOptions {
+                        modifiers: mods,
+                        ..Default::default()
+                    },
+                )
+                .await
+            }
+        });
+        let frames = drain_mouse_dispatches(&mut mock).await;
+        fut.await.unwrap().unwrap();
+
+        let expected = mods.cdp_bits() as u64;
+        assert_ne!(expected, 0, "test would be vacuous with no modifiers set");
+        let pressed: Vec<_> = frames
+            .iter()
+            .filter(|(k, ..)| k == "mousePressed")
+            .collect();
+        assert!(!pressed.is_empty(), "expected a mousePressed: {frames:?}");
+        for (kind, _, modifiers, _) in &frames {
+            assert_eq!(
+                *modifiers, expected,
+                "modifiers missing from {kind}: {frames:?}"
+            );
+        }
+        conn.shutdown();
+    }
+
+    /// Chrome produces a real double-click as two press/release pairs with an
+    /// increasing `clickCount`, not one pair carrying `clickCount: 2`. A page
+    /// counting `mousedown` events sees nothing from the collapsed form.
+    #[tokio::test]
+    async fn double_click_emits_two_pairs_with_increasing_click_count() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move {
+                t.mouse_click_with(
+                    10.0,
+                    20.0,
+                    crate::element::actions::ClickOptions {
+                        click_count: 2,
+                        ..Default::default()
+                    },
+                )
+                .await
+            }
+        });
+        let frames = drain_mouse_dispatches(&mut mock).await;
+        fut.await.unwrap().unwrap();
+
+        let pairs: Vec<_> = frames
+            .iter()
+            .filter(|(k, ..)| k == "mousePressed" || k == "mouseReleased")
+            .map(|(k, _, _, count)| (k.as_str(), *count))
+            .collect();
+        assert_eq!(
+            pairs,
+            vec![
+                ("mousePressed", 1),
+                ("mouseReleased", 1),
+                ("mousePressed", 2),
+                ("mouseReleased", 2),
+            ],
+            "expected two press/release pairs with clickCount 1 then 2: {frames:?}"
         );
         conn.shutdown();
     }

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -5132,11 +5132,10 @@ mod tests {
         mock.reply(id_d, json!({ "node": { "backendNodeId": 7 } }))
             .await;
 
-        // Step 2: type_text_fast focuses the body first — actionability gate
-        // (TEXT_INPUT = visible → enabled) then this.focus(). The two gate
-        // predicates run in the isolated world, which the first one builds;
-        // this.focus() stays in the main world.
-        crate::test_support::serve_isolated_world(&mut mock).await;
+        // Step 2: type_text_fast focuses the body first — scroll_into_view,
+        // the actionability gate (TEXT_INPUT = visible → enabled), then
+        // this.focus(). Reply truthy/undefined to each.
+        crate::test_support::serve_scroll_into_view(&mut mock).await;
         crate::test_support::serve_gate_probes(&mut mock, 2).await;
         let id_focus = mock.expect_cmd("Runtime.callFunctionOn").await;
         mock.reply(id_focus, json!({ "result": { "type": "undefined" } }))

--- a/crates/zendriver/src/test_support.rs
+++ b/crates/zendriver/src/test_support.rs
@@ -1,0 +1,97 @@
+//! Shared scaffolding for the mock-CDP unit tests.
+//!
+//! Everything here exists to keep one frame sequence in a single place: the
+//! **isolated-world call**. Element reads (`element::reads`) and the
+//! actionability gate (`query::actionability`) both run their JS in the tab's
+//! isolated world, so a test driving either has to answer a
+//! resolve → call → release handshake rather than a bare
+//! `Runtime.callFunctionOn`. Inlining that in every test would bury what each
+//! one is actually asserting.
+
+#![allow(clippy::panic, clippy::unwrap_used)]
+
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use zendriver_transport::testing::MockConnection;
+
+/// The `executionContextId` [`serve_isolated_world`] hands out.
+pub(crate) const ISOLATED_CONTEXT_ID: i64 = 42;
+
+/// The isolated-world `objectId` [`serve_isolated_call`] resolves the element
+/// to. Deliberately unlike the page-world ids the tests construct elements
+/// with (`R1`, `R17`, …) so an assertion can tell the two worlds apart.
+pub(crate) const ISOLATED_OBJECT_ID: &str = "R_ISO";
+
+/// Await `method`, bounded.
+///
+/// [`MockConnection::expect_cmd`] silently discards non-matching frames and
+/// has no timeout of its own, so a test that is one frame short of the real
+/// sequence hangs forever instead of failing. Every wait goes through here.
+pub(crate) async fn expect(mock: &mut MockConnection, method: &str) -> u64 {
+    match tokio::time::timeout(Duration::from_secs(5), mock.expect_cmd(method)).await {
+        Ok(id) => id,
+        Err(_) => panic!("timed out waiting for {method}"),
+    }
+}
+
+/// Serve the two-frame isolated-world handshake, yielding
+/// [`ISOLATED_CONTEXT_ID`].
+///
+/// `Tab::ensure_isolated_world` caches the context, so this is paid once per
+/// tab — before the *first* isolated call in a test, not before each one.
+pub(crate) async fn serve_isolated_world(mock: &mut MockConnection) {
+    let id = expect(mock, "Page.getFrameTree").await;
+    mock.reply(id, json!({ "frameTree": { "frame": { "id": "F1" } } }))
+        .await;
+    let id = expect(mock, "Page.createIsolatedWorld").await;
+    mock.reply(id, json!({ "executionContextId": ISOLATED_CONTEXT_ID }))
+        .await;
+}
+
+/// Serve one isolated-world invocation: the `DOM.resolveNode` that lifts the
+/// element into the world, the `Runtime.callFunctionOn` (answered with
+/// `result`), and the `Runtime.releaseObject` that frees the handle again.
+///
+/// Asserts the call targeted the *isolated* handle along the way, and hands
+/// back the JS source that was sent so callers can make claims about it.
+pub(crate) async fn serve_isolated_call(mock: &mut MockConnection, result: Value) -> String {
+    let id = expect(mock, "DOM.resolveNode").await;
+    assert_eq!(
+        mock.last_sent()["params"]["executionContextId"],
+        ISOLATED_CONTEXT_ID,
+        "the node must be re-resolved into the isolated world",
+    );
+    mock.reply(id, json!({ "object": { "objectId": ISOLATED_OBJECT_ID } }))
+        .await;
+
+    let id = expect(mock, "Runtime.callFunctionOn").await;
+    let sent = mock.last_sent();
+    assert_eq!(
+        sent["params"]["objectId"], ISOLATED_OBJECT_ID,
+        "the call must run against the isolated handle, not the page-world one",
+    );
+    let js = sent["params"]["functionDeclaration"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    mock.reply(id, json!({ "result": result })).await;
+
+    let id = expect(mock, "Runtime.releaseObject").await;
+    mock.reply(id, json!({})).await;
+
+    js
+}
+
+/// Serve `n` actionability predicates, answering each one `true`.
+///
+/// The gate runs isolated so a page cannot shadow the
+/// `getBoundingClientRect` / `getComputedStyle` / `elementFromPoint` the
+/// predicates read — the two extra frames per probe are what that costs.
+/// Pass the count the action's [`crate::query::actionability::ActionabilityCheck`]
+/// implies: 4 for `FULL`, 2 for `TEXT_INPUT`, 1 for `VISIBLE_ONLY`.
+pub(crate) async fn serve_gate_probes(mock: &mut MockConnection, n: usize) {
+    for _ in 0..n {
+        serve_isolated_call(mock, json!({ "value": true, "type": "boolean" })).await;
+    }
+}

--- a/crates/zendriver/src/test_support.rs
+++ b/crates/zendriver/src/test_support.rs
@@ -1,12 +1,9 @@
 //! Shared scaffolding for the mock-CDP unit tests.
 //!
-//! Everything here exists to keep one frame sequence in a single place: the
-//! **isolated-world call**. Element reads (`element::reads`) and the
-//! actionability gate (`query::actionability`) both run their JS in the tab's
-//! isolated world, so a test driving either has to answer a
-//! resolve → call → release handshake rather than a bare
-//! `Runtime.callFunctionOn`. Inlining that in every test would bury what each
-//! one is actually asserting.
+//! Two concerns live here, both about tests that drive a scripted CDP
+//! sequence: a test one frame out of step with the code should *fail* rather
+//! than hang, and a sequence several tests replay should be written down
+//! once — the actionability gate's run of predicate calls above all.
 
 #![allow(clippy::panic, clippy::unwrap_used)]
 
@@ -14,14 +11,6 @@ use std::time::Duration;
 
 use serde_json::{Value, json};
 use zendriver_transport::testing::MockConnection;
-
-/// The `executionContextId` [`serve_isolated_world`] hands out.
-pub(crate) const ISOLATED_CONTEXT_ID: i64 = 42;
-
-/// The isolated-world `objectId` [`serve_isolated_call`] resolves the element
-/// to. Deliberately unlike the page-world ids the tests construct elements
-/// with (`R1`, `R17`, …) so an assertion can tell the two worlds apart.
-pub(crate) const ISOLATED_OBJECT_ID: &str = "R_ISO";
 
 /// Await `method`, bounded.
 ///
@@ -35,63 +24,46 @@ pub(crate) async fn expect(mock: &mut MockConnection, method: &str) -> u64 {
     }
 }
 
-/// Serve the two-frame isolated-world handshake, yielding
-/// [`ISOLATED_CONTEXT_ID`].
-///
-/// `Tab::ensure_isolated_world` caches the context, so this is paid once per
-/// tab — before the *first* isolated call in a test, not before each one.
-pub(crate) async fn serve_isolated_world(mock: &mut MockConnection) {
-    let id = expect(mock, "Page.getFrameTree").await;
-    mock.reply(id, json!({ "frameTree": { "frame": { "id": "F1" } } }))
-        .await;
-    let id = expect(mock, "Page.createIsolatedWorld").await;
-    mock.reply(id, json!({ "executionContextId": ISOLATED_CONTEXT_ID }))
-        .await;
+/// Serve one `Runtime.callFunctionOn`, answering it with `result`, and hand
+/// back the `params` that went out so the caller can assert on the JS source
+/// or the argument array.
+pub(crate) async fn serve_call(mock: &mut MockConnection, result: Value) -> Value {
+    let id = expect(mock, "Runtime.callFunctionOn").await;
+    let params = mock.last_sent()["params"].clone();
+    mock.reply(id, json!({ "result": result })).await;
+    params
 }
 
-/// Serve one isolated-world invocation: the `DOM.resolveNode` that lifts the
-/// element into the world, the `Runtime.callFunctionOn` (answered with
-/// `result`), and the `Runtime.releaseObject` that frees the handle again.
+/// The JS source of one `Runtime.callFunctionOn`, answered with `result`.
 ///
-/// Asserts the call targeted the *isolated* handle along the way, and hands
-/// back the JS source that was sent so callers can make claims about it.
-pub(crate) async fn serve_isolated_call(mock: &mut MockConnection, result: Value) -> String {
-    let id = expect(mock, "DOM.resolveNode").await;
-    assert_eq!(
-        mock.last_sent()["params"]["executionContextId"],
-        ISOLATED_CONTEXT_ID,
-        "the node must be re-resolved into the isolated world",
-    );
-    mock.reply(id, json!({ "object": { "objectId": ISOLATED_OBJECT_ID } }))
-        .await;
-
-    let id = expect(mock, "Runtime.callFunctionOn").await;
-    let sent = mock.last_sent();
-    assert_eq!(
-        sent["params"]["objectId"], ISOLATED_OBJECT_ID,
-        "the call must run against the isolated handle, not the page-world one",
-    );
-    let js = sent["params"]["functionDeclaration"]
+/// Thin wrapper over [`serve_call`] for the common case of asserting what a
+/// probe actually executed.
+pub(crate) async fn serve_call_js(mock: &mut MockConnection, result: Value) -> String {
+    serve_call(mock, result).await["functionDeclaration"]
         .as_str()
         .unwrap()
-        .to_string();
-    mock.reply(id, json!({ "result": result })).await;
+        .to_string()
+}
 
-    let id = expect(mock, "Runtime.releaseObject").await;
-    mock.reply(id, json!({})).await;
-
-    js
+/// Serve the `scroll_into_view` an action runs before its actionability
+/// gate, asserting the call really is that scroll — a fixture that silently
+/// absorbed the first `Runtime.callFunctionOn` would keep passing if the
+/// scroll ever went missing, which is the regression this guards.
+pub(crate) async fn serve_scroll_into_view(mock: &mut MockConnection) {
+    let js = serve_call_js(mock, json!({ "type": "undefined" })).await;
+    assert!(
+        js.contains("scrollIntoView"),
+        "expected scroll_into_view ahead of the actionability gate, got: {js}"
+    );
 }
 
 /// Serve `n` actionability predicates, answering each one `true`.
 ///
-/// The gate runs isolated so a page cannot shadow the
-/// `getBoundingClientRect` / `getComputedStyle` / `elementFromPoint` the
-/// predicates read — the two extra frames per probe are what that costs.
-/// Pass the count the action's [`crate::query::actionability::ActionabilityCheck`]
-/// implies: 4 for `FULL`, 2 for `TEXT_INPUT`, 1 for `VISIBLE_ONLY`.
+/// Pass the count the action's
+/// [`crate::query::actionability::ActionabilityCheck`] implies: 4 for `FULL`,
+/// 2 for `TEXT_INPUT`, 1 for `VISIBLE_ONLY`.
 pub(crate) async fn serve_gate_probes(mock: &mut MockConnection, n: usize) {
     for _ in 0..n {
-        serve_isolated_call(mock, json!({ "value": true, "type": "boolean" })).await;
+        serve_call(mock, json!({ "value": true, "type": "boolean" })).await;
     }
 }

--- a/crates/zendriver/src/tracker.rs
+++ b/crates/zendriver/src/tracker.rs
@@ -103,6 +103,14 @@ async fn download_blocklist(
 /// [`DOWNLOAD_TIMEOUT`]; `reqwest`/IO failures are surfaced as
 /// [`std::io::Error`] so the caller folds them into `ZendriverError::Io`
 /// without a new public error variant.
+///
+/// The cache file inherits that helper's owner-only `0600` default. Nothing in
+/// a public blocklist is secret, so the restriction buys no confidentiality
+/// here — but it costs nothing either (the cache root is already per-user, and
+/// a miss just re-downloads), and one rule across both callers beats a second
+/// mode knob threaded through the helper for a file nobody needs to share.
+/// An operator who does want it group-readable can `chmod` once; the helper
+/// preserves an existing destination's mode on every later refresh.
 pub(crate) async fn load_or_download_blocklist(url: &str) -> Result<Vec<String>, std::io::Error> {
     let cache = cache_path(url);
 

--- a/crates/zendriver/src/tracker.rs
+++ b/crates/zendriver/src/tracker.rs
@@ -9,10 +9,22 @@
 //! [`HostMatcher`]: zendriver_interception::HostMatcher
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// Bundled curated list, embedded at compile time (feature-gated, so it only
 /// costs binary size when `tracker-blocking` is enabled).
 const BUNDLED: &str = include_str!("trackers.txt");
+
+/// Connect timeout for a `tracker_blocklist_url` download.
+const DOWNLOAD_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Whole-request timeout (connect, headers, and body) for a
+/// `tracker_blocklist_url` download.
+///
+/// This download runs on the `Browser::launch()` path, so an unbounded fetch
+/// against a half-open host would hang the launch forever. Both bounds exist
+/// to keep the worst case a bounded, reported failure.
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Parse the bundled list into hosts.
 pub(crate) fn bundled_hosts() -> Vec<String> {
@@ -51,13 +63,46 @@ fn cache_path(url: &str) -> PathBuf {
         .join(format!("{:016x}.txt", h.finish()))
 }
 
+/// Download a blocklist over HTTP with both bounds applied.
+///
+/// Split out from [`load_or_download_blocklist`] so the timeouts are
+/// injectable in tests; production callers pass the two constants above.
+/// `reqwest` failures are surfaced as [`std::io::Error`] so the caller folds
+/// them into `ZendriverError::Io` without a new public error variant.
+async fn download_blocklist(
+    url: &str,
+    connect_timeout: Duration,
+    request_timeout: Duration,
+) -> Result<String, std::io::Error> {
+    // reqwest 0.13 installs no rustls crypto provider of its own (see the
+    // workspace manifest), and the omission surfaces as a runtime panic rather
+    // than a build error. Install before the client exists.
+    crate::tls::install_default_crypto_provider();
+    let client = reqwest::Client::builder()
+        .connect_timeout(connect_timeout)
+        .timeout(request_timeout)
+        .build()
+        .map_err(std::io::Error::other)?;
+    client
+        .get(url)
+        .send()
+        .await
+        .and_then(reqwest::Response::error_for_status)
+        .map_err(std::io::Error::other)?
+        .text()
+        .await
+        .map_err(std::io::Error::other)
+}
+
 /// Load a host list from local cache, or download from `url` and cache it.
 ///
 /// Mirrors the atomic-write download-on-first-use pattern in
-/// `zendriver-fingerprints` `pool::load_or_download` (write `<path>.tmp`, then
-/// `rename`). `reqwest`/IO failures are surfaced as [`std::io::Error`] so the
-/// caller folds them into `ZendriverError::Io` without a new public error
-/// variant.
+/// `zendriver-fingerprints` `pool::load_or_download` (write a temp sibling,
+/// then `rename`) via the shared [`crate::cookies::persistence::write_atomic`]
+/// helper. The download is bounded by [`DOWNLOAD_CONNECT_TIMEOUT`] /
+/// [`DOWNLOAD_TIMEOUT`]; `reqwest`/IO failures are surfaced as
+/// [`std::io::Error`] so the caller folds them into `ZendriverError::Io`
+/// without a new public error variant.
 pub(crate) async fn load_or_download_blocklist(url: &str) -> Result<Vec<String>, std::io::Error> {
     let cache = cache_path(url);
 
@@ -68,29 +113,19 @@ pub(crate) async fn load_or_download_blocklist(url: &str) -> Result<Vec<String>,
     }
 
     tracing::debug!(url, "tracker blocklist cache miss — downloading");
-    crate::tls::install_default_crypto_provider();
-    let body = reqwest::get(url)
-        .await
-        .and_then(reqwest::Response::error_for_status)
-        .map_err(std::io::Error::other)?
-        .text()
-        .await
-        .map_err(std::io::Error::other)?;
+    let body = download_blocklist(url, DOWNLOAD_CONNECT_TIMEOUT, DOWNLOAD_TIMEOUT).await?;
 
-    // Atomic write: tmp -> rename.
     if let Some(parent) = cache.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let tmp = cache.with_extension("tmp");
-    std::fs::write(&tmp, &body)?;
-    std::fs::rename(&tmp, &cache)?;
+    crate::cookies::persistence::write_atomic(&cache, body.as_bytes()).await?;
 
     tracing::debug!(path = %cache.display(), "tracker blocklist cached");
     Ok(parse_blocklist(&body))
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -109,6 +144,43 @@ mod tests {
         assert_eq!(
             hosts,
             vec!["tracker.com".to_string(), "fp.example.org".to_string()]
+        );
+    }
+
+    /// A host that completes the TCP handshake and then never answers must
+    /// not hang the caller — and with it `Browser::launch()`. The request
+    /// timeout has to turn it into a bounded error.
+    #[tokio::test]
+    async fn download_times_out_against_a_silent_server() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        // Accept connections and hold them open, never writing a response.
+        let _server = tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                held.push(stream);
+            }
+        });
+
+        let url = format!("http://{addr}/trackers.txt");
+        let started = std::time::Instant::now();
+        // The outer timeout is the failure mode under test: without a client
+        // timeout the inner future never resolves and this expect() fires.
+        let res = tokio::time::timeout(
+            Duration::from_secs(5),
+            download_blocklist(&url, Duration::from_millis(500), Duration::from_millis(200)),
+        )
+        .await
+        .expect("download_blocklist hung past its own request timeout");
+
+        assert!(
+            res.is_err(),
+            "a server that never answers must surface as an error, got {res:?}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "the 200ms request timeout should fire promptly, took {:?}",
+            started.elapsed()
         );
     }
 

--- a/crates/zendriver/tests/element_world_regressions.rs
+++ b/crates/zendriver/tests/element_world_regressions.rs
@@ -1,10 +1,11 @@
-//! Real-Chrome guards for the two element flows that a world change breaks.
+//! Real-Chrome guards for the element flows that a world change — or a
+//! spoofed global — breaks.
 //!
-//! Both cases below shipped broken twice, and the mock unit suite was green
-//! through both of them — by construction, not by oversight.
+//! Every case below shipped broken, and the mock unit suite was green through
+//! all of them — by construction, not by oversight.
 //! `MockConnection` replays a scripted frame sequence, so a test written
 //! against the wrong sequence asserts the wrong sequence just as happily as
-//! the right one. Neither defect is visible without a browser:
+//! the right one. None of these defects is visible without a browser:
 //!
 //! 1. **Reads after a cross-document navigation.** Element reads were moved
 //!    into the tab's isolated world, whose `executionContextId` is cached per
@@ -23,7 +24,19 @@
 //!    and the gate reported `NotActionable("occluded by overlay")` for every
 //!    `click` / `hover` / `tap` on any element inside any iframe.
 //!
-//! Neither test asserts *which* world the JS runs in; that is an
+//! 3. **Visibility under a spoofed viewport.** The gate's on-screen clause
+//!    read `window.innerHeight`, which the stealth persona rewrites to its
+//!    claimed screen height minus browser chrome, while `scroll_into_view`
+//!    moves the element with Chrome's *real* viewport. Comparing a
+//!    real-geometry scroll against a fabricated viewport left every element
+//!    parked between the two heights permanently "not visible", so `focus` —
+//!    and with it `type_text` / `press` / `type_keys` — failed on any
+//!    below-the-fold field. Stealth is the shipping default, so that was the
+//!    normal case rather than an edge one, and the existing cases here missed
+//!    it twice over: they launch with no explicit profile and neither uses an
+//!    element below the fold.
+//!
+//! None of these tests asserts *which* world the JS runs in; that is an
 //! implementation choice. They assert the observable behavior any world
 //! choice has to preserve, so they stay meaningful when the isolated-world
 //! move is re-landed with per-frame world resolution.
@@ -33,8 +46,8 @@
 //! `#[ignore]` would route these to `nightly-ignored-tests`, which carries
 //! `continue-on-error: true` on a daily cron. These guard a regression that
 //! already shipped twice, so they have to block a merge rather than yellow-dot
-//! one. Both launch headless Chrome against a loopback fixture and finish in
-//! ~3s combined.
+//! one. Each launches headless Chrome against a loopback fixture and they
+//! finish in a few seconds combined.
 //!
 //! Running these locally: give `cargo` a target directory that no *other*
 //! checkout of this same package shares. Cargo keys an integration-test
@@ -54,6 +67,7 @@ use serial_test::serial;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 use zendriver::Browser;
+use zendriver::stealth::{InputProfile, StealthProfile};
 
 /// Mount `html` at `at` on `mock`. These fixtures need several routes each
 /// (a second page to navigate to, an iframe document to embed), so routes are
@@ -214,6 +228,138 @@ async fn hover_and_click_reach_an_element_inside_an_iframe() {
         button.inner_text().await.unwrap().trim(),
         "clicked",
         "the click must actually land on the button"
+    );
+
+    browser.close().await.unwrap();
+}
+
+/// A below-the-fold field must stay reachable while stealth spoofs the
+/// viewport — the shipping default posture.
+///
+/// `StealthProfile::spoofed` is the profile under test because it is the one
+/// that spoofs: `native` stops at launch flags + Emulation overrides and
+/// installs no JS bootstrap, so the persona's `window.inner*` rewrite — the
+/// whole mechanism here — only exists under `spoofed`. On the stock
+/// 1920x1080 persona it claims `innerHeight` 1080 - 86 (browser chrome) =
+/// 994, while `document.documentElement.clientHeight` stays at Chrome's real
+/// 1080. `scroll_into_view` scrolls with the real number, so anything landing
+/// in that 86px band read as off-screen: `is_visible` answered `false` for a
+/// field plainly on screen, and `focus` — the first step of `type_text`,
+/// `press` and `type_keys` — died with `NotActionable(5s, "not visible")`.
+///
+/// The fixture puts the field LAST in a document taller than any viewport, so
+/// `scrollIntoView({ block: 'center' })` clamps at the document bottom
+/// instead of centring and parks the field against the real viewport's lower
+/// edge — inside the band. A field that *can* be centred lands mid-viewport
+/// and hides the bug entirely, which is why the geometry is measured at
+/// runtime rather than assumed: a fixture that stops landing in the band
+/// fails loudly instead of passing vacuously.
+#[tokio::test]
+#[serial]
+async fn focus_reaches_a_below_the_fold_field_under_a_spoofed_viewport() {
+    let mock = MockServer::start().await;
+    // The spacer is deliberately far taller than any persona's screen rather
+    // than tuned to one: all it has to guarantee is that the page scrolls.
+    // The field's own height is what has to stay under the chrome inset, and
+    // 24px is comfortably under it at any resolution — the inset is a fixed
+    // pixel constant, not a fraction of the screen.
+    mount(
+        &mock,
+        "/deep",
+        r#"<!doctype html><html><body style="margin:0">
+             <div style="height:6000px">a very long page</div>
+             <input id="deep" style="display:block;width:200px;height:24px;
+                    box-sizing:border-box">
+           </body></html>"#,
+    )
+    .await;
+
+    // Stealth spoofed — the viewport spoof under test — but with keystroke
+    // TIMING pinned to `native`, which `input_profile` exists to decouple from
+    // the stealth selection. `spoofed`'s humanized profile carries a 3%
+    // per-character typo simulation that dispatches a wrong key followed by a
+    // Backspace, so a 20-character string fires it about a third of the time.
+    // The typed value still comes out right, but the run is nondeterministic
+    // and it puts an extra special-key dispatch on the wire — see the comment
+    // on the typed string below for why that is worth avoiding here. None of
+    // the persona's surface patches are affected: `screen.js`, and so the
+    // spoofed `window.innerHeight` this test turns on, stay live.
+    let browser = Browser::builder()
+        .stealth(StealthProfile::spoofed())
+        .input_profile(InputProfile::native())
+        .headless(true)
+        .launch()
+        .await
+        .unwrap();
+    let tab = browser.main_tab();
+    tab.goto(&format!("{}/deep", mock.uri())).await.unwrap();
+
+    let field = tab.find().css("#deep").one().await.unwrap();
+
+    // Scroll explicitly first — it carries no actionability gate, so this
+    // reproduces the exact state every gated action reaches its gate in, and
+    // lets the geometry below be checked before anything can fail on it.
+    field.scroll_into_view().await.unwrap();
+
+    // Read the post-scroll geometry in the MAIN world: that is where the
+    // persona's patch lives, and where the actionability probe runs. The
+    // isolated world would report Chrome's real `innerHeight` and quietly
+    // prove nothing.
+    let (top, spoofed_vh, real_vh): (f64, f64, f64) = tab
+        .evaluate_main(
+            "(() => {
+               const r = document.getElementById('deep').getBoundingClientRect();
+               return [r.top, window.innerHeight, document.documentElement.clientHeight];
+             })()",
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        spoofed_vh < real_vh,
+        "the persona must actually be spoofing the viewport, or this test \
+         guards nothing: window.innerHeight {spoofed_vh}, \
+         documentElement.clientHeight {real_vh}"
+    );
+    assert!(
+        top >= spoofed_vh && top < real_vh,
+        "the fixture must park the field inside the spoof band — on screen \
+         for the real viewport, past the bottom of the spoofed one; got \
+         rect.top {top} against innerHeight {spoofed_vh} / clientHeight \
+         {real_vh}"
+    );
+
+    // A public API returning the wrong answer, ahead of any gate: the field
+    // is on screen and `is_visible` used to say otherwise.
+    assert!(
+        field.is_visible().await.unwrap(),
+        "is_visible must answer for the real viewport, not the spoofed one"
+    );
+
+    field
+        .focus()
+        .await
+        .expect("focus must pass the actionability gate for a below-the-fold field under stealth");
+
+    // Assert the DOM side effect, not just the absence of an error: typing
+    // that reports success while the keystrokes go nowhere is still broken.
+    //
+    // Hyphens, not spaces, and that is load-bearing. A space is dispatched as
+    // `SpecialKey::Space` (a `rawKeyDown`/`keyUp` pair rather than a plain
+    // char), and on this fixture that dispatch wedges: the same string with
+    // spaces made `Input.dispatchKeyEvent` hang until zendriver's 180s CDP
+    // budget expired, reproducibly, while the identical string with hyphens
+    // finishes in ~2s. That is an input-layer problem with its own cause, not
+    // the visibility bug this test guards, and it has no business deciding
+    // whether this test passes.
+    field.type_text("typed-below-the-fold").await.unwrap();
+    let value: String = tab
+        .evaluate_main("document.getElementById('deep').value")
+        .await
+        .unwrap();
+    assert_eq!(
+        value, "typed-below-the-fold",
+        "the keystrokes must land in the below-the-fold field"
     );
 
     browser.close().await.unwrap();

--- a/crates/zendriver/tests/element_world_regressions.rs
+++ b/crates/zendriver/tests/element_world_regressions.rs
@@ -1,0 +1,220 @@
+//! Real-Chrome guards for the two element flows that a world change breaks.
+//!
+//! Both cases below shipped broken twice, and the mock unit suite was green
+//! through both of them — by construction, not by oversight.
+//! `MockConnection` replays a scripted frame sequence, so a test written
+//! against the wrong sequence asserts the wrong sequence just as happily as
+//! the right one. Neither defect is visible without a browser:
+//!
+//! 1. **Reads after a cross-document navigation.** Element reads were moved
+//!    into the tab's isolated world, whose `executionContextId` is cached per
+//!    tab. A navigation destroys that context; the cache was never
+//!    invalidated, and the recovery path matched only `"Cannot find context"`
+//!    — the wording `Runtime.evaluate` produces. `DOM.resolveNode` instead
+//!    answers `-32000 "Node with given id does not belong to the document"`,
+//!    so nothing recovered and every element API on the tab stayed broken for
+//!    the rest of its life, from the second page onward.
+//!
+//! 2. **Actionability inside an iframe.** `Tab::ensure_isolated_world`
+//!    creates exactly one world, for the tab's *main* frame.
+//!    `getBoundingClientRect()` on a node inside an iframe is
+//!    iframe-relative, while `document.elementFromPoint` evaluated in the
+//!    main-frame world hit-tests the top document — so the two never agreed
+//!    and the gate reported `NotActionable("occluded by overlay")` for every
+//!    `click` / `hover` / `tap` on any element inside any iframe.
+//!
+//! Neither test asserts *which* world the JS runs in; that is an
+//! implementation choice. They assert the observable behavior any world
+//! choice has to preserve, so they stay meaningful when the isolated-world
+//! move is re-landed with per-frame world resolution.
+//!
+//! Deliberately NOT `#[ignore]`d: the `test-integration` job runs
+//! `-E 'kind(test)'` (non-ignored) on every PR with Chrome provisioned, while
+//! `#[ignore]` would route these to `nightly-ignored-tests`, which carries
+//! `continue-on-error: true` on a daily cron. These guard a regression that
+//! already shipped twice, so they have to block a merge rather than yellow-dot
+//! one. Both launch headless Chrome against a loopback fixture and finish in
+//! ~3s combined.
+//!
+//! Running these locally: give `cargo` a target directory that no *other*
+//! checkout of this same package shares. Cargo keys an integration-test
+//! binary on package + target name, not on source path, so pointing two trees
+//! at one `CARGO_TARGET_DIR` lets a run silently execute the binary the other
+//! tree built. That reads as a clean pass of code you never compiled — it
+//! produced exactly one false "both pass" while these tests were being
+//! written against the pre-fix revision.
+//!
+//! Gated behind the `integration-tests` feature so CI can skip on
+//! Chrome-less runners; CI exercises these on the integration job.
+
+#![cfg(feature = "integration-tests")]
+#![allow(clippy::panic, clippy::unwrap_used)]
+
+use serial_test::serial;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+use zendriver::Browser;
+
+/// Mount `html` at `at` on `mock`. These fixtures need several routes each
+/// (a second page to navigate to, an iframe document to embed), so routes are
+/// added one at a time rather than through a single-page helper.
+async fn mount(mock: &MockServer, at: &str, html: &str) {
+    Mock::given(method("GET"))
+        .and(path(at))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(html.as_bytes().to_vec(), "text/html"),
+        )
+        .mount(mock)
+        .await;
+}
+
+/// Every element API must keep working after a cross-document navigation.
+///
+/// `goto A → read → goto B → read` is about as ordinary as a scraper gets,
+/// and it is the flow a per-tab context cache breaks: the first page looks
+/// perfect, and everything after it fails. So the assertions here are on the
+/// *second* and third pages, and they cover a read (`inner_text`), a
+/// serialization (`outer_html`), an attribute lookup, a predicate
+/// (`is_visible`) and a full gated action (`click`) — all four routes died
+/// the same way, through the same funnel.
+#[tokio::test]
+#[serial]
+async fn element_apis_survive_a_cross_document_navigation() {
+    let mock = MockServer::start().await;
+    mount(
+        &mock,
+        "/a",
+        r#"<!doctype html><html><body>
+             <div id="t" data-page="a">page A</div>
+             <button id="b" onclick="this.textContent='clicked A'">press A</button>
+           </body></html>"#,
+    )
+    .await;
+    mount(
+        &mock,
+        "/b",
+        r#"<!doctype html><html><body>
+             <div id="t" data-page="b">page B</div>
+             <button id="b" onclick="this.textContent='clicked B'">press B</button>
+           </body></html>"#,
+    )
+    .await;
+
+    let browser = Browser::builder().headless(true).launch().await.unwrap();
+    let tab = browser.main_tab();
+
+    // Page A: establishes whatever per-tab state the element path caches.
+    tab.goto(&format!("{}/a", mock.uri())).await.unwrap();
+    let el = tab.find().css("#t").one().await.unwrap();
+    assert_eq!(el.inner_text().await.unwrap().trim(), "page A");
+
+    // Page B is where a stale cache bites. Every one of these used to fail
+    // with `-32000 "Node with given id does not belong to the document"`.
+    tab.goto(&format!("{}/b", mock.uri())).await.unwrap();
+    let el = tab.find().css("#t").one().await.unwrap();
+    assert_eq!(
+        el.inner_text().await.unwrap().trim(),
+        "page B",
+        "inner_text must still work after the first navigation"
+    );
+    assert!(
+        el.outer_html().await.unwrap().contains("page B"),
+        "outer_html must still work after the first navigation"
+    );
+    assert_eq!(el.attr("data-page").await.unwrap().as_deref(), Some("b"));
+    assert!(
+        el.is_visible().await.unwrap(),
+        "is_visible must still work after the first navigation"
+    );
+
+    // The actionability gate reads through the same funnel, so a gated
+    // action is the strongest single check that the whole path recovered.
+    let button = tab.find().css("#b").one().await.unwrap();
+    button.click().await.unwrap();
+    assert_eq!(
+        button.inner_text().await.unwrap().trim(),
+        "clicked B",
+        "a gated click must still land after the first navigation"
+    );
+
+    // A third hop, so a fix that merely survives one navigation cannot pass.
+    tab.goto(&format!("{}/a", mock.uri())).await.unwrap();
+    let el = tab.find().css("#t").one().await.unwrap();
+    assert_eq!(el.inner_text().await.unwrap().trim(), "page A");
+    assert_eq!(el.attr("data-page").await.unwrap().as_deref(), Some("a"));
+
+    browser.close().await.unwrap();
+}
+
+/// Pointer actions must reach an element inside a same-origin iframe.
+///
+/// The iframe is deliberately offset from the top-left. That is the whole
+/// point of the fixture: the button's own rect is iframe-relative, so a
+/// hit-test performed against the TOP document at those same numbers lands on
+/// the outer page's spacer instead of the button, and the gate rejects a
+/// perfectly clickable element as occluded. An iframe pinned at (0, 0) would
+/// hide the bug, since both coordinate spaces would agree.
+#[tokio::test]
+#[serial]
+async fn hover_and_click_reach_an_element_inside_an_iframe() {
+    let mock = MockServer::start().await;
+    mount(
+        &mock,
+        "/outer",
+        r#"<!doctype html><html><body style="margin:0">
+             <div style="height:200px">spacer</div>
+             <iframe src="/inner" style="position:absolute;top:200px;left:100px;
+                     width:400px;height:300px;border:0"></iframe>
+           </body></html>"#,
+    )
+    .await;
+    mount(
+        &mock,
+        "/inner",
+        r#"<!doctype html><html><body style="margin:0">
+             <button id="go" style="width:200px;height:60px"
+                     onmouseover="this.dataset.hovered='yes'"
+                     onclick="this.textContent='clicked'">click me</button>
+           </body></html>"#,
+    )
+    .await;
+
+    let browser = Browser::builder().headless(true).launch().await.unwrap();
+    let tab = browser.main_tab();
+    tab.goto(&format!("{}/outer", mock.uri())).await.unwrap();
+
+    let button = tab
+        .find()
+        .css("#go")
+        .include_frames()
+        .one()
+        .await
+        .expect("the button inside the iframe must be findable");
+    assert_eq!(button.inner_text().await.unwrap().trim(), "click me");
+
+    // Both of these used to fail with NotActionable("occluded by overlay").
+    // Asserting the DOM side effect, not just the absence of an error: a gate
+    // that passes while the synthesized event lands somewhere else entirely
+    // is still broken, just more quietly.
+    button
+        .hover()
+        .await
+        .expect("hovering an element inside an iframe must pass the actionability gate");
+    assert_eq!(
+        button.attr("data-hovered").await.unwrap().as_deref(),
+        Some("yes"),
+        "the hover must actually reach the button"
+    );
+
+    button
+        .click()
+        .await
+        .expect("clicking an element inside an iframe must pass the actionability gate");
+    assert_eq!(
+        button.inner_text().await.unwrap().trim(),
+        "clicked",
+        "the click must actually land on the button"
+    );
+
+    browser.close().await.unwrap();
+}

--- a/crates/zendriver/tests/element_world_regressions.rs
+++ b/crates/zendriver/tests/element_world_regressions.rs
@@ -36,6 +36,18 @@
 //!    it twice over: they launch with no explicit profile and neither uses an
 //!    element below the fold.
 //!
+//! 4. **Whitespace in `type_text`.** Space and Enter went out as
+//!    `rawKeyDown` — the CDP event type that means precisely "a keydown that
+//!    generates no character" — carrying no `text`. So Chrome generated
+//!    none: `type_text("a b")` silently produced `"ab"`, and `press(Enter)`
+//!    never submitted a form. The same dispatch also stalled ~1.1s for the
+//!    first one in a renderer against ~2ms for any ordinary character, and a
+//!    second one in the same string killed the browser process outright,
+//!    which is how it first surfaced — as a CDP timeout on a below-the-fold
+//!    field rather than as wrong text. Nothing about it is page-shaped: the
+//!    stall and the crash reproduce identically on a page with nothing to
+//!    scroll, and `window.scrollY` never moves.
+//!
 //! None of these tests asserts *which* world the JS runs in; that is an
 //! implementation choice. They assert the observable behavior any world
 //! choice has to preserve, so they stay meaningful when the isolated-world
@@ -66,8 +78,8 @@
 use serial_test::serial;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
-use zendriver::Browser;
 use zendriver::stealth::{InputProfile, StealthProfile};
+use zendriver::{Browser, Key, SpecialKey};
 
 /// Mount `html` at `at` on `mock`. These fixtures need several routes each
 /// (a second page to navigate to, an iframe document to embed), so routes are
@@ -274,19 +286,15 @@ async fn focus_reaches_a_below_the_fold_field_under_a_spoofed_viewport() {
     )
     .await;
 
-    // Stealth spoofed — the viewport spoof under test — but with keystroke
-    // TIMING pinned to `native`, which `input_profile` exists to decouple from
-    // the stealth selection. `spoofed`'s humanized profile carries a 3%
-    // per-character typo simulation that dispatches a wrong key followed by a
-    // Backspace, so a 20-character string fires it about a third of the time.
-    // The typed value still comes out right, but the run is nondeterministic
-    // and it puts an extra special-key dispatch on the wire — see the comment
-    // on the typed string below for why that is worth avoiding here. None of
-    // the persona's surface patches are affected: `screen.js`, and so the
-    // spoofed `window.innerHeight` this test turns on, stay live.
+    // Stealth spoofed, and nothing else pinned: the whole shipping default,
+    // keystroke timing included. `spoofed`'s humanized profile adds
+    // per-character delays and a 3% typo simulation that types a wrong key
+    // and Backspaces it, which costs this test a couple of seconds and
+    // exercises a path a pinned profile would skip. It used to be pinned to
+    // `InputProfile::native()`, because that extra special-key dispatch was
+    // a hazard back when a special-key dispatch could wedge the browser.
     let browser = Browser::builder()
         .stealth(StealthProfile::spoofed())
-        .input_profile(InputProfile::native())
         .headless(true)
         .launch()
         .await
@@ -344,23 +352,131 @@ async fn focus_reaches_a_below_the_fold_field_under_a_spoofed_viewport() {
     // Assert the DOM side effect, not just the absence of an error: typing
     // that reports success while the keystrokes go nowhere is still broken.
     //
-    // Hyphens, not spaces, and that is load-bearing. A space is dispatched as
-    // `SpecialKey::Space` (a `rawKeyDown`/`keyUp` pair rather than a plain
-    // char), and on this fixture that dispatch wedges: the same string with
-    // spaces made `Input.dispatchKeyEvent` hang until zendriver's 180s CDP
-    // budget expired, reproducibly, while the identical string with hyphens
-    // finishes in ~2s. That is an input-layer problem with its own cause, not
-    // the visibility bug this test guards, and it has no business deciding
-    // whether this test passes.
-    field.type_text("typed-below-the-fold").await.unwrap();
+    // Spaces, deliberately. This string carried hyphens while spaces were
+    // dispatched as a text-less `rawKeyDown`, because that dispatch wedged
+    // the browser and would have decided this test's outcome for a reason
+    // that has nothing to do with visibility. The dispatch is fixed and the
+    // whitespace case below guards it directly, so the ordinary string is
+    // back.
+    field.type_text("typed below the fold").await.unwrap();
     let value: String = tab
         .evaluate_main("document.getElementById('deep').value")
         .await
         .unwrap();
     assert_eq!(
-        value, "typed-below-the-fold",
+        value, "typed below the fold",
         "the keystrokes must land in the below-the-fold field"
     );
+
+    browser.close().await.unwrap();
+}
+
+/// Whitespace has to arrive as text, and quickly.
+///
+/// Space and Enter are printable keys with names, and they were dispatched
+/// as though the name were the whole story: `rawKeyDown` with no `text`,
+/// which asks Chrome for a keydown that generates *no character*. Chrome
+/// obliged. `type_text("a b")` produced `"ab"` — a wrong string returned as
+/// a success, the worst shape a defect can take — and Enter stopped
+/// submitting forms. The timing was the louder half: the first such dispatch
+/// in a renderer took ~1.1s against ~2ms for any ordinary character, and a
+/// second one in the same string killed the browser process, surfacing as a
+/// CDP timeout far from the input layer.
+///
+/// So this asserts both halves, on the shipping stealth default. The typed
+/// string carries four spaces, because the failure escalated with the count:
+/// one stalled, the second killed the browser process. Keystroke timing is
+/// pinned to `native` (no per-character delay, no typo simulation) so the
+/// elapsed bound below measures the dispatch rather than the humanized
+/// profile's deliberate pauses.
+///
+/// Enter and Tab are here because they were the two keys the fix had to tell
+/// apart. Enter inserts text and had to start carrying it; Tab genuinely
+/// inserts nothing, so it stays a text-less `rawKeyDown` — the shape it needs
+/// for focus traversal, and the shape that was never slow. Both default
+/// actions are asserted directly.
+#[tokio::test]
+#[serial]
+async fn type_text_types_whitespace_instead_of_dropping_it() {
+    let mock = MockServer::start().await;
+    // The form holds a single field and no submit button, which is the shape
+    // the HTML spec allows to submit implicitly on Enter. The textarea
+    // follows it in document order, so it is also the Tab target.
+    mount(
+        &mock,
+        "/whitespace",
+        r#"<!doctype html><html><body style="margin:0">
+             <div style="height:6000px">a very long page</div>
+             <form id="f" onsubmit="window.__submitted = 1; return false;">
+               <input id="line" style="display:block;width:200px;height:24px;
+                      box-sizing:border-box">
+             </form>
+             <textarea id="area" rows="3"></textarea>
+           </body></html>"#,
+    )
+    .await;
+
+    let browser = Browser::builder()
+        .stealth(StealthProfile::spoofed())
+        .input_profile(InputProfile::native())
+        .headless(true)
+        .launch()
+        .await
+        .unwrap();
+    let tab = browser.main_tab();
+    tab.goto(&format!("{}/whitespace", mock.uri()))
+        .await
+        .unwrap();
+
+    let line = tab.find().css("#line").one().await.unwrap();
+    let started = std::time::Instant::now();
+    line.type_text("four spaces in this line")
+        .await
+        .expect("typing a string with spaces must not wedge the browser");
+    let elapsed = started.elapsed();
+    let value: String = tab
+        .evaluate_main("document.getElementById('line').value")
+        .await
+        .unwrap();
+    assert_eq!(
+        value, "four spaces in this line",
+        "every space must reach the field as a space"
+    );
+    // Twenty-four characters with no injected delay land in single-digit
+    // milliseconds. The bound is loose on purpose — ten seconds is slack for
+    // a loaded machine — because the sharp assertions are the value above and
+    // the `expect` on the dispatch: pre-fix this string crashed the browser
+    // rather than merely running slowly. The bound catches the variant that
+    // stalls while somehow keeping the text right.
+    assert!(
+        elapsed < std::time::Duration::from_secs(10),
+        "typing a 24-character string must not take {elapsed:?}"
+    );
+
+    // Enter carries a carriage return, which Chrome turns into a newline.
+    let area = tab.find().css("#area").one().await.unwrap();
+    area.type_text("two\nlines").await.unwrap();
+    let text: String = tab
+        .evaluate_main("document.getElementById('area').value")
+        .await
+        .unwrap();
+    assert_eq!(
+        text, "two\nlines",
+        "Enter must insert a newline in a textarea"
+    );
+
+    // Tab keeps its default action: it moves focus rather than typing.
+    line.press(Key::Special(SpecialKey::Tab)).await.unwrap();
+    let focused: String = tab
+        .evaluate_main("document.activeElement.id")
+        .await
+        .unwrap();
+    assert_eq!(focused, "area", "Tab must still traverse focus");
+
+    // Enter keeps its default action too — a text-less Enter never submitted.
+    line.press(Key::Special(SpecialKey::Enter)).await.unwrap();
+    let submitted: u32 = tab.evaluate_main("window.__submitted || 0").await.unwrap();
+    assert_eq!(submitted, 1, "Enter must still submit the form");
 
     browser.close().await.unwrap();
 }

--- a/crates/zendriver/tests/element_world_regressions.rs
+++ b/crates/zendriver/tests/element_world_regressions.rs
@@ -25,16 +25,30 @@
 //!    `click` / `hover` / `tap` on any element inside any iframe.
 //!
 //! 3. **Visibility under a spoofed viewport.** The gate's on-screen clause
-//!    read `window.innerHeight`, which the stealth persona rewrites to its
-//!    claimed screen height minus browser chrome, while `scroll_into_view`
-//!    moves the element with Chrome's *real* viewport. Comparing a
-//!    real-geometry scroll against a fabricated viewport left every element
-//!    parked between the two heights permanently "not visible", so `focus` —
-//!    and with it `type_text` / `press` / `type_keys` — failed on any
-//!    below-the-fold field. Stealth is the shipping default, so that was the
-//!    normal case rather than an edge one, and the existing cases here missed
-//!    it twice over: they launch with no explicit profile and neither uses an
-//!    element below the fold.
+//!    read `window.innerHeight`, which `zendriver-stealth`'s `screen.js`
+//!    rewrites to the persona's screen height minus a fixed 86px chrome
+//!    inset, while `scroll_into_view` moves the element with Chrome's *real*
+//!    viewport. Comparing a real-geometry scroll against a fabricated
+//!    viewport left every element parked between the two heights permanently
+//!    "not visible", so `focus` — and with it `type_text` / `press` /
+//!    `type_keys` — failed on any below-the-fold field. That patch ships in
+//!    every profile except `StealthProfile::off()`: `Browser::builder()`
+//!    defaults to `StealthProfile::native()`, which installs the geometry
+//!    bootstrap (`observer.rs` maps `ProfileKind::Native` to
+//!    `geometry_bootstrap()` = `_native.js` + `screen.js`). Measured on a
+//!    default-profile launch: `innerHeight` 994 against a real 1080. So this
+//!    was the default-posture case rather than an edge one, and the existing
+//!    cases here missed it twice over: they launch with no explicit profile
+//!    and neither uses an element below the fold.
+//!
+//! 5. **The on-screen clause in quirks mode.** Its replacement read
+//!    `document.documentElement.clientHeight || window.innerHeight`. In a
+//!    `BackCompat` document `documentElement.clientHeight` reports the
+//!    DOCUMENT's content height (6024 on the fixture below) rather than the
+//!    viewport's, so it is truthy, the fallback never fires, and every bbox
+//!    got compared against the whole document — the viewport test was a
+//!    silent no-op on any page without a doctype. It failed open, on exactly
+//!    the sloppy legacy pages most likely to be carrying a honeypot.
 //!
 //! 4. **Whitespace in `type_text`.** Space and Enter went out as
 //!    `rawKeyDown` — the CDP event type that means precisely "a keydown that
@@ -246,16 +260,22 @@ async fn hover_and_click_reach_an_element_inside_an_iframe() {
 }
 
 /// A below-the-fold field must stay reachable while stealth spoofs the
-/// viewport — the shipping default posture.
+/// viewport.
 ///
-/// `StealthProfile::spoofed` is the profile under test because it is the one
-/// that spoofs: `native` stops at launch flags + Emulation overrides and
-/// installs no JS bootstrap, so the persona's `window.inner*` rewrite — the
-/// whole mechanism here — only exists under `spoofed`. On the stock
-/// 1920x1080 persona it claims `innerHeight` 1080 - 86 (browser chrome) =
-/// 994, while `document.documentElement.clientHeight` stays at Chrome's real
-/// 1080. `scroll_into_view` scrolls with the real number, so anything landing
-/// in that 86px band read as off-screen: `is_visible` answered `false` for a
+/// The `window.inner*` rewrite is NOT exclusive to `spoofed`: it lives in
+/// `screen.js`, which `observer.rs` installs for `ProfileKind::Native` too
+/// (`geometry_bootstrap()` = `_native.js` + `screen.js`), and
+/// `Browser::builder()` defaults to `StealthProfile::native()`. Only
+/// `StealthProfile::off()` leaves `window.inner*` alone — measured on a
+/// default-profile launch, `innerHeight` reads 994 against a real 1080,
+/// identical to `spoofed`. `spoofed` is the profile under test because it is
+/// the full shipping posture, and because its humanized `InputProfile` is
+/// what the typing at the end of this test exercises.
+///
+/// On the stock 1920x1080 persona it claims `innerHeight` 1080 - 86 (browser
+/// chrome) = 994, while the layout viewport stays at Chrome's real 1080.
+/// `scroll_into_view` scrolls with the real number, so anything landing in
+/// that 86px band read as off-screen: `is_visible` answered `false` for a
 /// field plainly on screen, and `focus` — the first step of `type_text`,
 /// `press` and `type_keys` — died with `NotActionable(5s, "not visible")`.
 ///
@@ -366,6 +386,104 @@ async fn focus_reaches_a_below_the_fold_field_under_a_spoofed_viewport() {
     assert_eq!(
         value, "typed below the fold",
         "the keystrokes must land in the below-the-fold field"
+    );
+
+    browser.close().await.unwrap();
+}
+
+/// The on-screen clause must still be a test in quirks mode.
+///
+/// The fixture below carries no doctype, so it renders in `BackCompat`, where
+/// `document.documentElement.clientHeight` reports the DOCUMENT's content
+/// height instead of the viewport's — 6024 here, against a real 1080. The
+/// clause read `documentElement.clientHeight || window.innerHeight`,
+/// justified by a comment claiming `window.inner*` survived "only as a
+/// quirks-mode fallback, where `documentElement` reports 0". It reports 6024,
+/// which is truthy, so the fallback never fired and the bbox got compared
+/// against the whole document: the viewport test was a no-op on every
+/// doctype-less page.
+///
+/// Nothing surfaced, because it failed open — `is_visible` simply answered
+/// `true` for a field 6000px below the fold, and the off-screen and honeypot
+/// filtering `visible_only(true)` promises was silently absent on exactly the
+/// sloppy legacy pages most likely to be carrying a honeypot.
+///
+/// Hence the assertion on the *pre-scroll* `false`. The post-scroll `true`
+/// guards the opposite direction: a clause that rejected everything in quirks
+/// mode would satisfy the first assertion by accident. The geometry between
+/// them is read at runtime so a fixture that stops reproducing the trap fails
+/// loudly instead of passing vacuously.
+///
+/// Launched with no explicit profile: this defect is posture-independent
+/// (quirks mode is the page's doing, not the persona's), and the default is
+/// the configuration a caller gets without asking for anything.
+#[tokio::test]
+#[serial]
+async fn is_visible_rejects_a_below_the_fold_field_on_a_doctype_less_page() {
+    let mock = MockServer::start().await;
+    // No doctype — that is the entire point of the fixture. The spacer is
+    // taller than any viewport so the field starts far below the fold.
+    mount(
+        &mock,
+        "/quirks",
+        r#"<html><body style="margin:0">
+             <div style="height:6000px">a very long page, and no doctype</div>
+             <input id="deep" style="display:block;width:200px;height:24px;
+                    box-sizing:border-box">
+           </body></html>"#,
+    )
+    .await;
+
+    let browser = Browser::builder().headless(true).launch().await.unwrap();
+    let tab = browser.main_tab();
+    tab.goto(&format!("{}/quirks", mock.uri())).await.unwrap();
+
+    let field = tab.find().css("#deep").one().await.unwrap();
+
+    // `body.clientHeight` is the layout viewport in `BackCompat`;
+    // `documentElement.clientHeight` is the content height that made the old
+    // expression's `||` unreachable.
+    let (mode, top, content_h, viewport_h): (String, f64, f64, f64) = tab
+        .evaluate_main(
+            "(() => {
+               const r = document.getElementById('deep').getBoundingClientRect();
+               return [document.compatMode, r.top,
+                       document.documentElement.clientHeight,
+                       document.body.clientHeight];
+             })()",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        mode, "BackCompat",
+        "the fixture must render in quirks mode or this test guards nothing"
+    );
+    assert!(
+        top >= viewport_h,
+        "the field must start below the fold: rect.top {top} against a \
+         {viewport_h}px layout viewport"
+    );
+    assert!(
+        content_h > viewport_h && top < content_h,
+        "the trap must be live: documentElement.clientHeight {content_h} has \
+         to be a truthy content height that still swallows rect.top {top}, or \
+         the old expression would have rejected the field for the right \
+         reason by accident"
+    );
+
+    assert!(
+        !field.is_visible().await.unwrap(),
+        "a field {top}px down a quirks-mode page must not read as visible in \
+         a {viewport_h}px viewport"
+    );
+
+    // The other direction: the clause must still pass what is genuinely on
+    // screen, in the same rendering mode.
+    field.scroll_into_view().await.unwrap();
+    assert!(
+        field.is_visible().await.unwrap(),
+        "the same field must read as visible once scrolled into view"
     );
 
     browser.close().await.unwrap();

--- a/docs/book/src/datadome.md
+++ b/docs/book/src/datadome.md
@@ -126,6 +126,13 @@ browser by setting this cookie (not a form-field token like hCaptcha/reCAPTCHA).
 The driver applies it via `Network.setCookie` scoped to the registrable domain
 and reloads the page.
 
+The solver runs at most once per `wait_for_clearance`, and within that call's
+timeout. The reload is acked before the new document loads, so the next poll
+still sees the CAPTCHA — an unlatched loop would bill you a solve every 250ms
+until the page settled. After the one attempt the driver goes back to polling
+until the surface clears or the deadline passes; call `wait_for_clearance`
+again if you want a second solve.
+
 `DataDomeChallenge` carries: `captcha_url`, `site_url`, `user_agent`, `cid`
 (DataDome challenge ID), and `hash`. `DataDomeSolution` holds
 `datadome_cookie`.

--- a/docs/book/src/fetcher.md
+++ b/docs/book/src/fetcher.md
@@ -39,8 +39,14 @@ let browser = zendriver::Browser::builder()
 
 `ensure_chrome` resolves the latest stable CFT version for the host
 platform, downloads + extracts it on cache miss, and points the
-[`BrowserBuilder`] at the resulting binary. On a cache hit the call
-returns in milliseconds and skips the network.
+[`BrowserBuilder`] at the resulting binary.
+
+The cache is keyed by the resolved version, so the manifest has to be
+fetched before the cache can be probed. A cache hit therefore skips the
+~150 MB download and the extraction — one manifest request instead of
+tens of seconds of transfer — but it is not an offline path. Every call
+needs to reach `https://googlechromelabs.github.io`, and a fully
+populated cache still errors without egress.
 
 ## The full builder
 
@@ -98,11 +104,18 @@ layout verbatim:
       Google Chrome for Testing.app/Contents/MacOS/...  (macOS Apple Silicon)
 ```
 
-Writes are atomic. The fetcher downloads + extracts into a
-`<version>.tmp/` sibling, then a single `rename` promotes it to
-`<version>/`. Crashing mid-download leaves a `.tmp/` that the next run
-detects, deletes, and retries — no half-extracted binaries ever appear
-under the canonical name.
+Writes are atomic. The fetcher downloads + extracts into a staging
+sibling named `<version>.tmp-<pid>-<attempt>-<nanos>/`, then a single
+`rename` promotes it to `<version>/`. No half-extracted binary ever
+appears under the canonical name.
+
+The staging name is unique per attempt, which is what makes a shared
+cache volume safe: two jobs fetching the same version at the same time
+stage into separate directories and race only on the final `rename`,
+where the loser discards its own tree and uses the winner's. Staging
+left behind by a crash is swept on a later run of the *same* version,
+and only once it has sat untouched for six hours — long enough that an
+in-flight download in another process is never mistaken for garbage.
 
 ## Progress callbacks
 
@@ -164,17 +177,22 @@ A minimal `.github/workflows/test.yml` snippet:
 - run: cargo test --features fetcher
 ```
 
-`actions/cache` rehydrates the cache dir; the fetcher detects the cache
-hit and skips the download. First run takes ~30 s on GitHub's free
-runners; cached runs take &lt;1 s in `ensure_chrome`.
+`actions/cache` rehydrates the cache dir; the fetcher resolves the
+manifest, detects the cache hit, and skips the download. First run takes
+~30 s on GitHub's free runners; cached runs take &lt;1 s in
+`ensure_chrome` — the manifest request, not the archive. The runner
+still needs egress to `googlechromelabs.github.io` either way.
 
 ## When NOT to use it
 
 - **You already have Chrome on the host** and don't care about
   version-pinning — the built-in PATH discovery is faster.
 - **Network-restricted environments** that can't reach
-  `https://googlechromelabs.github.io` or the CFT CDN — pre-populate
-  the cache out-of-band or ship a Docker image with Chrome baked in.
+  `https://googlechromelabs.github.io` or the CFT CDN. Pre-populating
+  the cache dir is not enough — the manifest is resolved before the
+  cache is probed, so `ensure_chrome` still errors. Point
+  `BrowserBuilder::executable` at the binary directly, or ship a Docker
+  image with Chrome baked in.
 - **You need Chrome stable on Linux ARM64** — CFT doesn't ship a
   `linux-arm64` build today;
   [`Platform::auto_detect`] returns `None` on that host and

--- a/docs/book/src/input.md
+++ b/docs/book/src/input.md
@@ -229,12 +229,14 @@ input.press_with(
 [`Key`] is one of:
 
 - `Key::Char(char)` — any typeable character.
-- `Key::Special(SpecialKey)` — named non-character key.
+- `Key::Special(SpecialKey)` — a key with a name rather than a glyph.
 
 [`SpecialKey`] covers Enter, Tab, Escape, Backspace, Delete, Space, all
 four arrows, Home, End, PageUp, PageDown, F1-F12, Insert, CapsLock,
-NumLock, ScrollLock, PrintScreen, Pause, ContextMenu — the full
-non-character keyboard.
+NumLock, ScrollLock, PrintScreen, Pause, ContextMenu — the whole named
+keyboard. Two of them still type: `Space` inserts a space and `Enter`
+inserts a newline (and submits a form that allows implicit submission),
+exactly as the physical keys do. The rest only run their default action.
 
 [`KeyModifiers`] is a bitflags struct:
 

--- a/docs/book/src/interception.md
+++ b/docs/book/src/interception.md
@@ -71,6 +71,12 @@ top:
 {{#include ../../../crates/zendriver/examples/intercept_modify_headers.rs}}
 ```
 
+The headers you copy forward are in a stable order, but not the browser's
+original one: CDP delivers request headers as an object keyed by header name,
+so Chrome has already merged duplicate names and the on-the-wire ordering is
+gone before the closure runs. Response headers (`modify_response`) keep both,
+since CDP sends those as an array.
+
 The closure runs synchronously per-event on the actor task; it should
 not block. Spawn off the runtime if you need to call out to an async
 service before deciding the override.


### PR DESCRIPTION
First of eight PRs from the API audit in `docs/api-audit/`. This one is **bug fixes only — no public API change**, so it needs no baseline regen, no ledger entry, and no schema snapshots. It is deliberately first because it is the cheapest to review and several of these matter more than most of the config gaps the audit set out to find.

## Where this came from

An audit swept 13 subsystems against `public-api-baseline.txt` looking for hardcoded values a caller should be able to set. A second pass re-verified all 255 findings against source: 148 confirmed, 42 rescoped, 3 struck, 43 newly found. Both documents are on `main` already. This PR implements the "needs no API" subset.

## The three that actually break things

**`buttons` was never sent on any mouse event.** Every move during a drag told the page no button was held, so a page implementing drag with `mousemove` + `e.buttons` — the standard modern check, and what most slider widgets and DnD libraries use — silently did nothing while every CDP call returned success. `InputState::buttons_held` existed but nothing ever wrote it.

**`ClickOptions::modifiers` was read by nothing on any path.** A Ctrl/Cmd/Shift-click was inexpressible, and `browser_mouse`'s `modifiers` argument was an end-to-end no-op.

**Element reads and the actionability gate ran in the page's main world**, where a page that has shadowed `getBoundingClientRect`, `getComputedStyle` or `elementFromPoint` can feed automation false geometry and can detect the probing.

## Three places the fix was not what the finding said

Worth calling out, because in each case the obvious change would have been wrong:

- **Clipped screenshots.** The finding blamed a missing scroll. Scrolling alone still returned blank pixels: `Page.captureScreenshot`'s `clip` is in *document* coordinates while `bounding_box()` is viewport-relative. Verified with a real pixel test; the offset now comes from `Page.getLayoutMetrics` rather than `window.scrollX`, so the page cannot lie about it.
- **`InterceptBuilder::subscribe()` dropping `handle_auth`.** Flipping `handleAuthRequests` to match would be worse — that path never subscribes to `Fetch.authRequired`, so Chrome would pause challenges nothing answers, turning a 407 into a hang. It now errors loudly instead.
- **Request header order.** Documented as preserved, but unrecoverable: CDP sends request headers as a name-keyed object and `serde_json` parses to a `BTreeMap`, so wire order is destroyed upstream of the crate. Made deterministic — it was a `HashMap`, reordering per request, which a caller copying headers forward turned into a randomly reordered block every time — and the docs corrected rather than faked.

## A regression this branch introduced, and what it says about the harness

Threading the click position into the hit-test sent the coordinates as bare JSON values, but CDP requires `Runtime.callFunctionOn` arguments to be `CallArgument` objects. Every gated click, hover and tap failed against a real Chrome with `-32602` — while all 402 mock tests stayed green.

`MockConnection` replays scripted frames without validating CDP parameter shapes, so this class of bug is invisible to it by construction. Only the live integration run caught it. Fixed here, with the argument shape pinned by a test, but the gap is worth knowing about: `call_on_main` has several other live callers passing arguments, and nothing enforces their shape.

## Behavior changes reviewers should weigh

- **`visible_only(true)` now excludes off-screen elements.** This is what its rustdoc always promised, but on an infinitely-scrolling page it returns fewer rows than before.
- **`check_visible` rejects effective opacity below 1%.** `Element.checkVisibility` alone rejects only an exact `opacity: 0`, so the standard `opacity: 0.001` honeypot passed it just as it passed the old string compare.
- **Element reads cost 3 CDP round-trips instead of 1** (resolve + call + release); the world handshake itself is cached per tab.
- **Atomic cookie writes replace the destination inode**, so a symlink at `cookies.json` is replaced rather than followed. Standard for atomic writes, but a real change.
- **`captureBeyondViewport` renders `position: fixed` elements at their document position**, not pinned.

## Verification

- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` **0 errors**
- Clippy also run on the feature sets CI never lints: `zendriver --features geo,tracker-blocking,...` and `zendriver-mcp --all-features`
- All 10 crates green individually — `cargo test --workspace` stops at the first failing crate, so a green tail can hide a red one
- `zendriver`: **404** lib tests default, **511** with features
- **17/17 live-Chrome integration tests**, including `click_triggers_dom_event`, `hover_triggers_mouseover_event`, `tap_triggers_touchstart_event`
- Zero public API additions or removals, confirmed by diff
- Commits are themed and individually buildable; spot-checked by stashing the remainder and re-running

Fixes verified non-vacuous where practical — several were confirmed by reverting the fix and watching the new test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)