### PR TITLE
feat(stealth)!: present a capture's measured screen insets, not derived constants

### DIFF
--- a/crates/zendriver-stealth/src/observer.rs
+++ b/crates/zendriver-stealth/src/observer.rs
@@ -11,7 +11,7 @@
 use serde_json::json;
 use zendriver_transport::{CallError, ObserverError, PausedSession, TargetObserver};
 
-use crate::patches::{bootstrap_script, bootstrap_script_native_webgl, geometry_bootstrap};
+use crate::patches::{bootstrap_script, bootstrap_script_native_webgl, geometry_bootstrap_with};
 use crate::persona::GeoPos;
 use crate::persona::specs::{ScreenSpec, UaMetadata};
 use crate::{Fingerprint, Persona, ProfileKind, StealthProfile};
@@ -81,7 +81,12 @@ impl StealthObserver {
             // its own window) and `availHeight === height` (no taskbar inset). Those are
             // artifacts this library introduces, not properties of the host, so repairing
             // them keeps `Native` native rather than spoofing anything.
-            ProfileKind::Native => geometry_bootstrap(),
+            // The persona's screen still reaches this arm even in `Native`: it
+            // carries no identity, only the geometry CDP cannot set. A profile
+            // captured on real hardware brings its own insets, and presenting
+            // the derived defaults instead would describe a machine that does
+            // not exist. `None` is byte-identical to the old call.
+            ProfileKind::Native => geometry_bootstrap_with(persona.screen.as_ref()),
             ProfileKind::Off => String::new(),
         };
         let geolocation = persona.geolocation;
@@ -824,11 +829,7 @@ mod tests {
                 }),
                 ..Default::default()
             }),
-            screen: Some(crate::persona::specs::ScreenSpec {
-                width: 1536,
-                height: 864,
-                device_pixel_ratio: 1.25,
-            }),
+            screen: Some(crate::persona::specs::ScreenSpec::new(1536, 864, 1.25)),
             ..crate::Persona::default()
         };
         let profile = StealthProfile::spoofed();

--- a/crates/zendriver-stealth/src/patches.rs
+++ b/crates/zendriver-stealth/src/patches.rs
@@ -108,11 +108,34 @@ pub fn bootstrap_script_native_webgl(persona: &Persona, identity: &Fingerprint) 
 /// identity-neutral by construction: it reads no persona and no fingerprint, and
 /// repairs an artifact rather than spoofing a device characteristic, so it does not
 /// make `Native` any less native.
+/// Substitute `screen.js`'s inset tokens from a caller's [`ScreenSpec`].
+///
+/// `None` — or no screen at all — emits `null` for each, which the patch reads
+/// as "derive it". That is what keeps every existing caller byte-identical:
+/// the defaults only apply when nobody measured anything.
+fn screen_patch(screen: Option<&crate::persona::specs::ScreenSpec>) -> String {
+    let tok = |v: Option<u32>| v.map_or_else(|| "null".to_string(), |n| n.to_string());
+    SCREEN
+        .replace("ZD_AVAIL_WIDTH", &tok(screen.and_then(|s| s.avail_width)))
+        .replace("ZD_AVAIL_HEIGHT", &tok(screen.and_then(|s| s.avail_height)))
+        .replace("ZD_INNER_HEIGHT", &tok(screen.and_then(|s| s.inner_height)))
+}
+
 #[must_use]
 pub fn geometry_bootstrap() -> String {
+    geometry_bootstrap_with(None)
+}
+
+/// [`geometry_bootstrap`], replaying a caller's MEASURED insets.
+///
+/// A profile captured on real hardware carries its own `availHeight` /
+/// `innerHeight`; presenting the derived defaults instead would describe a
+/// machine that does not exist. `None` is exactly [`geometry_bootstrap`].
+#[must_use]
+pub fn geometry_bootstrap_with(screen: Option<&crate::persona::specs::ScreenSpec>) -> String {
     let mut body = String::from(NATIVE);
     body.push('\n');
-    body.push_str(SCREEN);
+    body.push_str(&screen_patch(screen));
     // Same single outer IIFE `bootstrap_script_impl` uses, and for the same two reasons:
     // `_native.js` is written as a fragment that runs inside it, and `screen.js` reaches
     // `__zdGetter` as a closure-local of that scope. Emitting the fragments bare leaves the
@@ -144,7 +167,7 @@ fn bootstrap_script_impl(persona: &Persona, identity: &Fingerprint, spoof_webgl:
     // Geometry coherence runs unconditionally (no persona spec) — it repairs the
     // outer*/avail* props that the CDP metrics override cannot reach.
     body.push('\n');
-    body.push_str(SCREEN);
+    body.push_str(&screen_patch(persona.screen.as_ref()));
     // Synthetic pointer entropy, also unconditional.
     body.push('\n');
     body.push_str(MOUSE);
@@ -2129,6 +2152,69 @@ mod tests {
 
 #[cfg(test)]
 mod geometry_bootstrap_tests {
+    use crate::persona::specs::ScreenSpec;
+
+    /// The safety property of the whole change: a caller that measured nothing
+    /// gets exactly what it got before.
+    ///
+    /// Every shipped zeus profile was captured THROUGH the metrics override, so
+    /// all of them already carry `height - 48`. If `None` drifted from the
+    /// derived default, the geometry that took auth's imperva-15 rate from 25%
+    /// to 0/80 would move underneath them silently.
+    #[test]
+    fn no_measured_insets_emits_the_derived_defaults() {
+        let derived = geometry_bootstrap();
+        assert_eq!(
+            derived,
+            geometry_bootstrap_with(None),
+            "an absent screen must be byte-identical to the no-arg form"
+        );
+        assert_eq!(
+            derived,
+            geometry_bootstrap_with(Some(&ScreenSpec::new(1920, 1080, 1.0))),
+            "a screen with no measured insets must ALSO derive them"
+        );
+        assert!(
+            derived.contains("null"),
+            "the tokens must resolve to null: {derived:.0}"
+        );
+        assert!(
+            !derived.contains("ZD_AVAIL_HEIGHT"),
+            "no token may survive substitution"
+        );
+    }
+
+    /// A capture from real hardware is presented as captured — this is what
+    /// makes a profile taken on someone else's machine usable at all.
+    #[test]
+    fn measured_insets_are_presented_verbatim() {
+        // A real macOS: menu bar 25px, dock showing, so neither inset is the
+        // -48 / -86 the derivation would invent.
+        let mac = ScreenSpec::new(1920, 1080, 2.0)
+            .with_avail(1920, 1030)
+            .with_inner_height(974);
+        let js = geometry_bootstrap_with(Some(&mac));
+        assert!(
+            js.contains("1030"),
+            "the measured availHeight must reach the page"
+        );
+        assert!(
+            js.contains("974"),
+            "the measured innerHeight must reach the page"
+        );
+        assert!(
+            !js.contains("ZD_AVAIL_HEIGHT") && !js.contains("ZD_INNER_HEIGHT"),
+            "no token may survive substitution"
+        );
+        // The derivation constants stay in the file as the fallback arm; what
+        // must not happen is the PAGE seeing a derived value when one was given.
+        assert_ne!(
+            js,
+            geometry_bootstrap(),
+            "measured must differ from derived"
+        );
+    }
+
     use super::*;
 
     /// `Native` must ship the geometry repair. It receives

--- a/crates/zendriver-stealth/src/patches/screen.js
+++ b/crates/zendriver-stealth/src/patches/screen.js
@@ -10,8 +10,10 @@
 // screen geometry in one pass; both are cheap, deterministic, high-weight bot
 // tells.
 //
-// This patch REPAIRS those two gaps. It does not choose a resolution: the size
-// comes from whatever `setDeviceMetricsOverride` already established, so a caller
+// This patch REPAIRS those two gaps. It does not choose a resolution OR the
+// insets: the size comes from whatever `setDeviceMetricsOverride` already
+// established, and the insets come from the caller when it has measured them.
+// A caller
 // that configures 1366x768 gets a coherent 1366x768 and not a silent 1920x1080.
 // Earlier versions hardcoded 1920x1080 here, which overrode the caller's own
 // metrics — invisible while every caller happened to use 1920x1080, and wrong the
@@ -23,10 +25,19 @@
   const W = window.screen.width || window.innerWidth || 1920;
   const H = window.screen.height || window.innerHeight || 1080;
 
-  // Chrome inset (title + tabs + bookmarks + omnibox) and the OS taskbar/menu-bar
-  // inset. Both are shape constants, not resolution: they keep `inner < outer` and
-  // `availHeight < height` true at any size. They stay approximate on purpose —
-  // the tells are the RELATIONSHIPS, not the exact pixel counts.
+  // Insets. The caller substitutes these when it is REPLAYING a measured device;
+  // `null` falls back to the derived defaults below.
+  //
+  // The defaults are a plausible fiction and nothing more: they exist so a caller
+  // who supplies no capture still gets `inner < outer` and `availHeight < height`,
+  // which is where the tell lives. They CANNOT describe a real machine — a real
+  // macOS reports `height - 25` minus the dock, a real Windows `- 40/48/72`
+  // depending on DPI scaling, or `- 0` with the taskbar auto-hidden. A capture
+  // taken on someone else's hardware is presentable only because these are now
+  // parameters.
+  const AVAIL_W = ZD_AVAIL_WIDTH;
+  const AVAIL_H = ZD_AVAIL_HEIGHT;
+  const INNER_H = ZD_INNER_HEIGHT;
   const CHROME_H = 86;
   const TASKBAR_H = 48;
 
@@ -36,8 +47,8 @@
   // screen.* — a real monitor has a work area smaller than the panel. width/height
   // are deliberately NOT re-set: CDP owns them, and rewriting them here is what
   // overrode the caller.
-  set(window.screen, 'availWidth', W);
-  set(window.screen, 'availHeight', Math.max(1, H - TASKBAR_H));
+  set(window.screen, 'availWidth', AVAIL_W === null ? W : AVAIL_W);
+  set(window.screen, 'availHeight', Math.max(1, AVAIL_H === null ? H - TASKBAR_H : AVAIL_H));
   set(window.screen, 'availLeft', 0);
   set(window.screen, 'availTop', 0);
 
@@ -47,7 +58,7 @@
   set(window, 'outerWidth', W);
   set(window, 'outerHeight', H);
   set(window, 'innerWidth', W);
-  set(window, 'innerHeight', Math.max(1, H - CHROME_H));
+  set(window, 'innerHeight', Math.max(1, INNER_H === null ? H - CHROME_H : INNER_H));
   set(window, 'screenX', 0);
   set(window, 'screenY', 0);
   set(window, 'screenLeft', 0);

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -632,11 +632,7 @@ mod persona_tests {
                 }),
                 ..Default::default()
             }),
-            screen: Some(ScreenSpec {
-                width: 1536,
-                height: 864,
-                device_pixel_ratio: 1.25,
-            }),
+            screen: Some(ScreenSpec::new(1536, 864, 1.25)),
             ..Persona::default()
         };
         let s = serde_json::to_string(&p).unwrap();
@@ -649,52 +645,23 @@ mod persona_tests {
                 .as_deref(),
             Some("arm")
         );
-        assert_eq!(
-            back.screen,
-            Some(ScreenSpec {
-                width: 1536,
-                height: 864,
-                device_pixel_ratio: 1.25
-            })
-        );
+        assert_eq!(back.screen, Some(ScreenSpec::new(1536, 864, 1.25)));
     }
 
     #[test]
     fn overlay_screen_some_wins_none_inherits() {
         let base = Persona {
-            screen: Some(ScreenSpec {
-                width: 1920,
-                height: 1080,
-                device_pixel_ratio: 1.0,
-            }),
+            screen: Some(ScreenSpec::new(1920, 1080, 1.0)),
             ..Persona::default()
         };
         let over = Persona {
-            screen: Some(ScreenSpec {
-                width: 1536,
-                height: 864,
-                device_pixel_ratio: 1.25,
-            }),
+            screen: Some(ScreenSpec::new(1536, 864, 1.25)),
             ..Persona::default()
         };
         let merged = base.clone().overlay(over);
-        assert_eq!(
-            merged.screen,
-            Some(ScreenSpec {
-                width: 1536,
-                height: 864,
-                device_pixel_ratio: 1.25
-            })
-        ); // some wins
+        assert_eq!(merged.screen, Some(ScreenSpec::new(1536, 864, 1.25))); // some wins
         let merged2 = base.overlay(Persona::default());
-        assert_eq!(
-            merged2.screen,
-            Some(ScreenSpec {
-                width: 1920,
-                height: 1080,
-                device_pixel_ratio: 1.0
-            })
-        ); // none inherits
+        assert_eq!(merged2.screen, Some(ScreenSpec::new(1920, 1080, 1.0))); // none inherits
     }
 
     #[test]

--- a/crates/zendriver-stealth/src/persona/specs.rs
+++ b/crates/zendriver-stealth/src/persona/specs.rs
@@ -123,6 +123,64 @@ pub struct ScreenSpec {
     pub width: u32,
     pub height: u32,
     pub device_pixel_ratio: f64,
+    /// Work-area width, i.e. `screen.availWidth`. `None` keeps the derived
+    /// default (the full width — no vertical dock or side panel).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub avail_width: Option<u32>,
+    /// Work-area height, i.e. `screen.availHeight` — `height` minus whatever
+    /// the OS reserves (Windows taskbar, macOS menu bar plus dock).
+    ///
+    /// `None` keeps the derived default of `height - 48`. That constant is a
+    /// plausible Windows taskbar and nothing more: it exists so a caller who
+    /// supplies no capture still gets `availHeight < height`, which is the
+    /// relationship the tell lives in. A caller REPLAYING a real device should
+    /// pass the value it measured — a real macOS reports `height - 25` minus
+    /// the dock, a real Windows `- 40/48/72` depending on DPI scaling, or
+    /// `- 0` with the taskbar auto-hidden, and none of those can be expressed
+    /// by a constant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub avail_height: Option<u32>,
+    /// Viewport height, i.e. `window.innerHeight`. `None` keeps the derived
+    /// default of `height - 86` (a plausible tab strip + omnibox + bookmarks
+    /// bar). Same reasoning as [`Self::avail_height`]: the browser chrome's
+    /// real height varies with the user's toolbars and zoom.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inner_height: Option<u32>,
+}
+
+impl ScreenSpec {
+    /// A screen of `width x height` at `device_pixel_ratio`, with every inset
+    /// left to the patch's own derivation.
+    ///
+    /// Use the `with_*` setters to replay a MEASURED device instead. They are
+    /// separate because the derived defaults are a plausible fiction and a
+    /// measurement is not: a caller should have to say which one it means.
+    #[must_use]
+    pub fn new(width: u32, height: u32, device_pixel_ratio: f64) -> Self {
+        Self {
+            width,
+            height,
+            device_pixel_ratio,
+            avail_width: None,
+            avail_height: None,
+            inner_height: None,
+        }
+    }
+
+    /// Replay a measured `screen.availWidth` / `screen.availHeight`.
+    #[must_use]
+    pub fn with_avail(mut self, width: u32, height: u32) -> Self {
+        self.avail_width = Some(width);
+        self.avail_height = Some(height);
+        self
+    }
+
+    /// Replay a measured `window.innerHeight`.
+    #[must_use]
+    pub fn with_inner_height(mut self, height: u32) -> Self {
+        self.inner_height = Some(height);
+        self
+    }
 }
 
 /// WebGL value substitution.
@@ -447,11 +505,7 @@ mod tests {
 
     #[test]
     fn screen_spec_round_trips_json() {
-        let s = ScreenSpec {
-            width: 1536,
-            height: 864,
-            device_pixel_ratio: 1.25,
-        };
+        let s = ScreenSpec::new(1536, 864, 1.25);
         let json = serde_json::to_string(&s).unwrap();
         let back: ScreenSpec = serde_json::from_str(&json).unwrap();
         assert_eq!(s, back);

--- a/crates/zendriver-stealth/src/profile.rs
+++ b/crates/zendriver-stealth/src/profile.rs
@@ -865,11 +865,7 @@ mod profile_tests {
 
     #[test]
     fn custom_screen_resolves_onto_fingerprint_when_supplied() {
-        let screen = ScreenSpec {
-            width: 1536,
-            height: 864,
-            device_pixel_ratio: 1.25,
-        };
+        let screen = ScreenSpec::new(1536, 864, 1.25);
         let profile = StealthProfile::native()
             .fingerprint(bare_fp())
             .screen(screen);

--- a/crates/zendriver/examples/screen_geometry.rs
+++ b/crates/zendriver/examples/screen_geometry.rs
@@ -14,11 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .headless(true)
         .stealth(StealthProfile::native())
         .persona_overlay(Persona {
-            screen: Some(ScreenSpec {
-                width: w,
-                height: h,
-                device_pixel_ratio: 1.0,
-            }),
+            screen: Some(ScreenSpec::new(w, h, 1.0)),
             ..Persona::default()
         })
         .launch()


### PR DESCRIPTION
## The problem

`patches/screen.js` hardcoded `CHROME_H = 86` / `TASKBAR_H = 48` and derived `availHeight` / `innerHeight` from them.

Those constants are a plausible fiction — they exist so a caller who supplies no capture still gets `availHeight < height` and `inner < outer`, which is where the tell lives. But they cannot describe a real machine:

| host | real `availHeight` |
|---|---|
| macOS | `height - 25` (menu bar), minus the dock |
| Windows | `height - 40/48/72`, by DPI scaling |
| Windows, taskbar auto-hidden | `height - 0` |

So a profile captured on real hardware could be **recorded but never presented** — the page always saw the constants. A consumer that gates on *"does the capture match what we can present"* therefore had to refuse every genuine capture. That is the blocker for replaying a device profile taken on a machine you don't control.

## The change

- `ScreenSpec` carries optional `avail_width` / `avail_height` / `inner_height`.
- `screen.js` takes them as substituted tokens, falling back to the derivation when absent.
- `geometry_bootstrap_with(Option<&ScreenSpec>)` is the replaying entry point; `geometry_bootstrap()` delegates with `None`.
- The `Native` arm in `observer.rs` passes the persona's screen. It carries no identity — only the geometry CDP can't reach — so `Native` stays native.

## Safety property

**`None` reproduces the old output byte-for-byte**, asserted rather than assumed. `no_measured_insets_emits_the_derived_defaults` checks that the no-arg form, an absent screen, and a screen with no measured insets all produce identical script.

This matters downstream: profiles captured *through* the metrics override all carry `height - 48` already, so they take the unchanged path.

## Breaking

`ScreenSpec` gained three fields, so struct literals no longer compile.

```rust
// before
ScreenSpec { width: 1920, height: 1080, device_pixel_ratio: 1.0 }
// after
ScreenSpec::new(1920, 1080, 1.0)
// replaying a measured device
ScreenSpec::new(1920, 1080, 2.0).with_avail(1920, 1030).with_inner_height(974)
```

The setters are separate from `new` deliberately: the derived defaults are a fiction and a measurement is not, so a caller should have to say which one it means. All nine internal construction sites migrated.

`zendriver-stealth` 308/308.