### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.4.12"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.16.8"
+version = "0.16.9"
 dependencies = [
  "async-trait",
  "axum",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.11.6"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.4.12", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.5.0", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.4" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.11.6" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.12.0" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.12" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.15" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.15" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.8" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.9" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.1" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.18" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.14" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.15" }
 
 # MCP server
 # Pinned exactly, matching proxybroker-rs: rmcp's macro and transport surface moves across

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.15] - 2026-08-05
+
+
 ## [0.3.14] - 2026-07-31
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.3.14"
+version = "0.3.15"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.16.9] - 2026-08-05
+
+
 ## [0.16.8] - 2026-07-31
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.16.8"
+version = "0.16.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.12.0] - 2026-08-05
+
+### Added
+
+- Present a capture's MEASURED screen insets, not derived constants **(BREAKING)**
+
+
 ## [0.11.6] - 2026-07-31
 
 ### Fixed

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.11.6"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-05
+
+### Added
+
+- Present a capture's MEASURED screen insets, not derived constants **(BREAKING)**
+
+
 ## [0.4.12] - 2026-07-31
 
 ### Fixed

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.4.12"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.11.6 -> 0.12.0 (⚠ API breaking changes)
* `zendriver`: 0.4.12 -> 0.5.0 (✓ API compatible changes)
* `zendriver-fingerprints`: 0.3.14 -> 0.3.15
* `zendriver-mcp`: 0.16.8 -> 0.16.9

### ⚠ `zendriver-stealth` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ScreenSpec.avail_width in /tmp/.tmpFPG8ni/zendriver-rs/crates/zendriver-stealth/src/persona/specs.rs:129
  field ScreenSpec.avail_height in /tmp/.tmpFPG8ni/zendriver-rs/crates/zendriver-stealth/src/persona/specs.rs:142
  field ScreenSpec.inner_height in /tmp/.tmpFPG8ni/zendriver-rs/crates/zendriver-stealth/src/persona/specs.rs:148
  field ScreenSpec.avail_width in /tmp/.tmpFPG8ni/zendriver-rs/crates/zendriver-stealth/src/persona/specs.rs:129
  field ScreenSpec.avail_height in /tmp/.tmpFPG8ni/zendriver-rs/crates/zendriver-stealth/src/persona/specs.rs:142
  field ScreenSpec.inner_height in /tmp/.tmpFPG8ni/zendriver-rs/crates/zendriver-stealth/src/persona/specs.rs:148
  field ScreenSpec.avail_width in /tmp/.tmpFPG8ni/zendriver-rs/crates/zendriver-stealth/src/persona/specs.rs:129
  field ScreenSpec.avail_height in /tmp/.tmpFPG8ni/zendriver-rs/crates/zendriver-stealth/src/persona/specs.rs:142
  field ScreenSpec.inner_height in /tmp/.tmpFPG8ni/zendriver-rs/crates/zendriver-stealth/src/persona/specs.rs:148
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-stealth`

<blockquote>

## [0.12.0] - 2026-08-05

### Added

- Present a capture's MEASURED screen insets, not derived constants **(BREAKING)**
</blockquote>

## `zendriver`

<blockquote>

## [0.5.0] - 2026-08-05

### Added

- Present a capture's MEASURED screen insets, not derived constants **(BREAKING)**
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).