### PR TITLE
fix(stealth): UA string must carry the reduced version, not the build number

### DIFF
--- a/crates/zendriver-stealth/src/fingerprint.rs
+++ b/crates/zendriver-stealth/src/fingerprint.rs
@@ -753,7 +753,27 @@ mod fingerprint_tests {
         };
         fp.recompose();
         assert!(fp.ua_string.contains("Windows NT 10.0"));
-        assert!(fp.ua_string.contains("Chrome/120.0.6099.234"));
+        // The UA string carries the REDUCED version and the full build number
+        // never reaches it — Chrome froze the minor/build/patch at `0.0.0` in
+        // v110. This assertion used to demand the opposite.
+        assert!(
+            fp.ua_string.contains("Chrome/120.0.0.0"),
+            "recompose must reduce the UA version: {}",
+            fp.ua_string
+        );
+        assert!(
+            !fp.ua_string.contains("120.0.6099.234"),
+            "the full build number must not reach the UA string: {}",
+            fp.ua_string
+        );
+        // ...while UA-CH keeps it, which is the asymmetry a real Chrome shows.
+        assert!(
+            fp.ua_metadata
+                .full_version_list
+                .iter()
+                .any(|b| b.version == "120.0.6099.234"),
+            "fullVersionList must still carry the complete version"
+        );
     }
 
     #[test]

--- a/crates/zendriver-stealth/src/snapshots/zendriver_stealth__ua__tests__ua_linux_chrome_120.snap
+++ b/crates/zendriver-stealth/src/snapshots/zendriver_stealth__ua__tests__ua_linux_chrome_120.snap
@@ -2,4 +2,4 @@
 source: crates/zendriver-stealth/src/ua.rs
 expression: ua
 ---
-Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.234 Safari/537.36
+Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36

--- a/crates/zendriver-stealth/src/snapshots/zendriver_stealth__ua__tests__ua_macintel_chrome_120.snap
+++ b/crates/zendriver-stealth/src/snapshots/zendriver_stealth__ua__tests__ua_macintel_chrome_120.snap
@@ -2,4 +2,4 @@
 source: crates/zendriver-stealth/src/ua.rs
 expression: ua
 ---
-Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.234 Safari/537.36
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36

--- a/crates/zendriver-stealth/src/snapshots/zendriver_stealth__ua__tests__ua_win32_chrome_120.snap
+++ b/crates/zendriver-stealth/src/snapshots/zendriver_stealth__ua__tests__ua_win32_chrome_120.snap
@@ -2,4 +2,4 @@
 source: crates/zendriver-stealth/src/ua.rs
 expression: ua
 ---
-Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.234 Safari/537.36
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36

--- a/crates/zendriver-stealth/src/ua.rs
+++ b/crates/zendriver-stealth/src/ua.rs
@@ -4,11 +4,32 @@ use crate::Platform;
 
 /// Build a Chrome desktop UA string for the given platform + version.
 ///
-/// Format: `Mozilla/5.0 ({platform-token}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/{full-version} Safari/537.36`
+/// Format: `Mozilla/5.0 ({platform-token}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/{major}.0.0.0 Safari/537.36`
+///
+/// `chrome_full` is the full version (e.g. `"120.0.6099.234"`); only its MAJOR
+/// reaches the string. Chrome has frozen the UA's minor/build/patch at `0.0.0`
+/// since User-Agent reduction completed in Chrome 110, so a real desktop Chrome
+/// sends `Chrome/120.0.0.0` and never `Chrome/120.0.6099.234`. Emitting the full
+/// version is a one-line fingerprint tell: it is checkable against a static
+/// pattern with no device knowledge at all, and no real browser matches it.
+///
+/// The full version still belongs in high-entropy UA-CH — `fullVersionList` and
+/// `uaFullVersion` — which is where [`UaMetadata`](crate::UaMetadata) puts it.
+/// That asymmetry IS the real shape: reduced in the UA string, complete in UA-CH.
+///
+/// A `chrome_full` with no leading integer is passed through verbatim rather than
+/// being turned into `0.0.0`, so a caller that hands over an already-composed or
+/// non-standard version is not silently rewritten into a worse one.
 #[must_use]
 pub fn compose_ua_string(platform: Platform, chrome_full: &str) -> String {
+    let reduced = match chrome_full.split('.').next().map(str::trim) {
+        Some(major) if !major.is_empty() && major.bytes().all(|b| b.is_ascii_digit()) => {
+            format!("{major}.0.0.0")
+        }
+        _ => chrome_full.to_string(),
+    };
     format!(
-        "Mozilla/5.0 ({platform_token}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/{chrome_full} Safari/537.36",
+        "Mozilla/5.0 ({platform_token}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/{reduced} Safari/537.36",
         platform_token = platform.ua_token(),
     )
 }
@@ -22,6 +43,36 @@ mod tests {
     fn compose_macintel_chrome_120_matches_snapshot() {
         let ua = compose_ua_string(Platform::MacIntel, "120.0.6099.234");
         insta::assert_snapshot!("ua_macintel_chrome_120", ua);
+    }
+
+    /// The regression this module exists to prevent. Every real desktop Chrome
+    /// since v110 sends `Chrome/<major>.0.0.0`; the full build number appears
+    /// only in UA-CH. Asserting the exact token rather than a snapshot, because
+    /// a snapshot silently re-blesses whatever it is shown.
+    #[test]
+    fn ua_carries_only_the_reduced_version_never_the_build() {
+        for (full, want) in [
+            ("120.0.6099.234", "Chrome/120.0.0.0"),
+            ("146.0.7680.153", "Chrome/146.0.0.0"),
+            ("151.0.7922.76", "Chrome/151.0.0.0"),
+            ("120.0.0.0", "Chrome/120.0.0.0"),
+            ("120", "Chrome/120.0.0.0"),
+        ] {
+            let ua = compose_ua_string(Platform::MacIntel, full);
+            assert!(ua.contains(want), "{full} should compose {want}, got: {ua}");
+            assert!(
+                !ua.contains(&format!("Chrome/{full} ")) || full == "120.0.0.0",
+                "the full build number must not reach the UA string: {ua}"
+            );
+        }
+    }
+
+    /// A version we cannot parse is passed through rather than mangled into
+    /// `0.0.0`, which would be a worse string than the one the caller supplied.
+    #[test]
+    fn an_unparseable_version_is_left_alone() {
+        let ua = compose_ua_string(Platform::Win32, "not-a-version");
+        assert!(ua.contains("Chrome/not-a-version "), "{ua}");
     }
 
     #[test]


### PR DESCRIPTION
## The problem

`compose_ua_string` interpolates the **full** Chrome version into the User-Agent string, so a composed identity sends:

```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.234 Safari/537.36
```

Every real desktop Chrome since User-Agent reduction completed in v110 sends the minor/build/patch frozen at `0.0.0`:

```
… Chrome/120.0.0.0 Safari/537.36
```

The full build number belongs in high-entropy UA-CH (`fullVersionList` / `uaFullVersion`), which is already where `UserAgentMetadata::realistic` puts it. **That asymmetry is the real shape** — reduced in the UA string, complete in UA-CH. Emitting the build number in both is a tell that can be checked against a static pattern with no device knowledge at all, and no real browser matches it.

## Evidence

Measured against 11 browser captures from 9 machines, spanning Chrome 146/150/151 across macOS, Windows and Linux (Apple M1 / M2 Pro ×2 / M4 Pro / M5 Pro, RTX 4090, Intel HD 520, Iris Pro 580, and a GPU-less VM):

| what | reports |
|---|---|
| all 11 real browsers, `navigator.userAgent` | `Chrome/<major>.0.0.0` |
| a `compose_ua_string` identity | `Chrome/<major>.<minor>.<build>.<patch>` |

Not one real capture carries a build number in the UA string.

## The fix

Only the major reaches the string. The public signature is unchanged — this crate is published and the fix is a one-line semantic correction, not an API change, so callers still pass the full version.

A `chrome_full` with no leading integer is passed through verbatim rather than mangled into `0.0.0`, so a caller supplying something non-standard doesn't get a worse string than it handed over.

## Why it survived this long

The three `ua_*_chrome_120` snapshots pinned `Chrome/120.0.6099.234`, and `fingerprint_recompose_updates_ua_and_uam` asserted it outright:

```rust
assert!(fp.ua_string.contains("Chrome/120.0.6099.234"));
```

A snapshot re-blesses whatever it is shown, so updating the `.snap` files alone would have hidden the same bug again. The replacement asserts the invariant explicitly across five version shapes (`120.0.6099.234`, `146.0.7680.153`, `151.0.7922.76`, an already-reduced `120.0.0.0`, and a bare `120`), plus a case for the unparseable input, plus a check that `fullVersionList` still carries the complete version.

## Verification

```
cargo test --workspace --no-fail-fast   EXIT=0, 75 suites, 0 failures
cargo clippy --workspace --all-targets -- -D warnings   clean
cargo fmt --all   applied
```

## Scope

Touches `zendriver-stealth` only. Independent of #145, which does not touch UA composition.