### PR TITLE
fix(interception): stop losing auth config and truncated bodies silently

### DIFF
--- a/crates/zendriver-interception/src/actor.rs
+++ b/crates/zendriver-interception/src/actor.rs
@@ -36,8 +36,8 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use futures::StreamExt;
 use serde::Deserialize;
+use serde::de::{Deserializer, MapAccess, Visitor};
 use serde_json::{Map, Value, json};
-use std::collections::HashMap;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 use tracing::{trace, warn};
@@ -148,8 +148,12 @@ pub(crate) struct RequestPausedEvent {
 pub(crate) struct RequestPayload {
     pub(crate) url: String,
     pub(crate) method: String,
-    #[serde(default)]
-    pub(crate) headers: HashMap<String, String>,
+    /// Request headers in the order the decoder yields them, kept as pairs
+    /// rather than a map so nothing is reordered or merged on our side of the
+    /// boundary. See [`deserialize_headers`] for what CDP can and cannot tell
+    /// us about the original wire order.
+    #[serde(default, deserialize_with = "deserialize_headers")]
+    pub(crate) headers: Vec<(String, String)>,
     /// Chrome's text representation of the request body. For multipart /
     /// binary uploads this can be lossy — Chrome rebuilds via UTF-8 best
     /// effort. Prefer [`Self::post_data_entries`] when present.
@@ -162,6 +166,48 @@ pub(crate) struct RequestPayload {
     /// When present, it is the canonical source of truth for the body.
     #[serde(rename = "postDataEntries", default)]
     pub(crate) post_data_entries: Option<Vec<PostDataEntry>>,
+}
+
+/// Decode CDP's `Network.Headers` (a JSON *object*) into ordered pairs,
+/// preserving whatever order the deserializer hands us.
+///
+/// Why this is not the browser's true header order: CDP models request
+/// headers as an object keyed by name, so duplicate-named headers are already
+/// merged by Chrome before the event is serialized, and JSON object order is
+/// only as faithful as the parser that read it. Our transport hands events to
+/// this crate as an already-parsed [`serde_json::Value`], whose object map is
+/// a `BTreeMap` unless `serde_json/preserve_order` is enabled workspace-wide —
+/// so the names arrive sorted, and the wire order is gone before we see it.
+///
+/// Collecting into a `Vec` here is still worth doing: it is deterministic
+/// (a `HashMap` would re-randomize the order on every request, which is a
+/// worse fingerprint for a caller who round-trips `RequestInfo::headers` back
+/// through `RequestOverrides`), and it is the piece that would automatically
+/// become order-faithful if the parse ever starts preserving order. Restoring
+/// the real order needs a raw-bytes event path in `zendriver-transport`.
+fn deserialize_headers<'de, D>(deserializer: D) -> Result<Vec<(String, String)>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct HeadersVisitor;
+
+    impl<'de> Visitor<'de> for HeadersVisitor {
+        type Value = Vec<(String, String)>;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("a map of header name to header value")
+        }
+
+        fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+            let mut headers = Vec::with_capacity(map.size_hint().unwrap_or(0));
+            while let Some(pair) = map.next_entry::<String, String>()? {
+                headers.push(pair);
+            }
+            Ok(headers)
+        }
+    }
+
+    deserializer.deserialize_map(HeadersVisitor)
 }
 
 #[derive(Debug, Deserialize)]
@@ -379,30 +425,40 @@ pub(crate) fn serialize_pattern(p: &RequestPattern) -> Value {
 
 /// Build a [`RequestInfo`] from the decoded event for `Modify` closures.
 ///
-/// Body precedence: `postDataEntries` (canonical, base64-decoded + concatenated)
-/// when present, else `postData` interpreted as UTF-8 bytes. The string
-/// fallback is necessarily lossy for binary bodies — Chrome only emits
-/// `postDataEntries` when it knows the text form would mangle the bytes.
+/// Body precedence: `postDataEntries` (canonical, base64-decoded +
+/// concatenated) when present, else `postData` interpreted as UTF-8 bytes. The
+/// string fallback is necessarily lossy for binary bodies — Chrome only emits
+/// `postDataEntries` when it knows the text form would mangle the bytes. The
+/// entries path is all-or-nothing: see [`decode_post_data`].
 ///
-/// Headers come from `Network.Request.headers` (CDP object) so we materialize
-/// them as a `Vec<(name, value)>` on the boundary; the upstream HashMap may
-/// have collapsed duplicates already, but for the request side CDP also
-/// pre-merges so this is faithful.
+/// Headers come from `Network.Request.headers`, which CDP models as an object
+/// keyed by header name — so duplicates are pre-merged by Chrome and the
+/// browser's on-the-wire header *order* does not survive to this point. See
+/// [`deserialize_headers`] for the full explanation; the pairs are passed
+/// through unchanged here.
 pub(crate) fn build_request_info(ev: &RequestPausedEvent) -> RequestInfo {
     RequestInfo {
         url: ev.request.url.clone(),
         method: ev.request.method.clone(),
-        headers: ev
-            .request
-            .headers
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect(),
+        headers: ev.request.headers.clone(),
         post_data: decode_post_data(&ev.request),
         resource_type: parse_resource_type(ev.resource_type.as_deref()),
     }
 }
 
+/// Decode the request body, all-or-nothing.
+///
+/// `postDataEntries` is a chunked body: the caller only has the real payload
+/// if *every* chunk decodes. If any entry is unusable (absent `bytes`, or
+/// invalid base64) we return `None` rather than the successfully-decoded
+/// prefix — a partial body is indistinguishable from a complete one, so a
+/// `Modify` closure that signs or hashes it would produce a valid signature
+/// over the wrong bytes. We also don't fall back to `postData` in that case:
+/// its lossy UTF-8 rebuild would be a different set of plausible-but-wrong
+/// bytes. `None` is the only honest answer the [`RequestInfo::post_data`]
+/// shape can give.
+///
+/// [`RequestInfo::post_data`]: crate::types::RequestInfo::post_data
 fn decode_post_data(req: &RequestPayload) -> Option<Vec<u8>> {
     use base64::Engine as _;
     use base64::engine::general_purpose::STANDARD as BASE64;
@@ -411,12 +467,19 @@ fn decode_post_data(req: &RequestPayload) -> Option<Vec<u8>> {
         let mut buf = Vec::new();
         for entry in entries {
             let Some(b64) = entry.bytes.as_deref() else {
-                continue;
+                tracing::warn!(
+                    "interception: postDataEntries entry without bytes; reporting no body rather than a truncated one"
+                );
+                return None;
             };
             match BASE64.decode(b64) {
                 Ok(bytes) => buf.extend_from_slice(&bytes),
                 Err(e) => {
-                    tracing::warn!(error = %e, "interception: bad base64 in postDataEntries; skipping entry");
+                    tracing::warn!(
+                        error = %e,
+                        "interception: bad base64 in postDataEntries; reporting no body rather than a truncated one"
+                    );
+                    return None;
                 }
             }
         }
@@ -926,5 +989,116 @@ mod tests {
             .expect("oneshot dropped");
         actor.await.unwrap();
         conn.shutdown();
+    }
+
+    /// Decode a `Fetch.requestPaused` payload the way the actor does.
+    fn request_info_from(request: Value) -> RequestInfo {
+        let ev: RequestPausedEvent = serde_json::from_value(json!({
+            "requestId": "REQ-1",
+            "request": request,
+            "resourceType": "XHR",
+        }))
+        .expect("event fixture must decode");
+        build_request_info(&ev)
+    }
+
+    /// Happy path: every `postDataEntries` chunk decodes, so the body is the
+    /// concatenation. Guards the all-or-nothing fix below from over-correcting.
+    #[test]
+    fn post_data_entries_concatenate_when_every_chunk_decodes() {
+        let info = request_info_from(json!({
+            "url": "https://example.test/upload",
+            "method": "POST",
+            "headers": {},
+            "postDataEntries": [
+                { "bytes": BASE64.encode("hello ") },
+                { "bytes": BASE64.encode("world") },
+            ],
+        }));
+        assert_eq!(info.post_data.as_deref(), Some(&b"hello world"[..]));
+    }
+
+    /// A corrupt chunk must yield `None`, never the decoded prefix: a partial
+    /// body is indistinguishable from a complete one, so a `Modify` closure
+    /// that signs it would emit a valid signature over the wrong bytes.
+    #[test]
+    fn post_data_entries_with_corrupt_chunk_yield_none_not_a_partial_body() {
+        let info = request_info_from(json!({
+            "url": "https://example.test/upload",
+            "method": "POST",
+            "headers": {},
+            "postDataEntries": [
+                { "bytes": BASE64.encode("hello ") },
+                { "bytes": "!!!not base64!!!" },
+                { "bytes": BASE64.encode("world") },
+            ],
+        }));
+        assert_eq!(
+            info.post_data, None,
+            "a truncated body must not surface as Some(prefix)"
+        );
+    }
+
+    /// Same contract for a chunk Chrome sent without `bytes` — the body is
+    /// incomplete, so we report no body rather than the surrounding chunks.
+    #[test]
+    fn post_data_entry_without_bytes_yields_none() {
+        let info = request_info_from(json!({
+            "url": "https://example.test/upload",
+            "method": "POST",
+            "headers": {},
+            "postDataEntries": [
+                { "bytes": BASE64.encode("hello ") },
+                {},
+            ],
+        }));
+        assert_eq!(info.post_data, None);
+    }
+
+    /// The `postData` fallback is untouched by the all-or-nothing rule — it
+    /// only applies to the chunked `postDataEntries` path.
+    #[test]
+    fn post_data_string_fallback_still_decodes() {
+        let info = request_info_from(json!({
+            "url": "https://example.test/form",
+            "method": "POST",
+            "headers": {},
+            "postData": "a=1&b=2",
+        }));
+        assert_eq!(info.post_data.as_deref(), Some(&b"a=1&b=2"[..]));
+    }
+
+    /// Request headers decode into a deterministic pair list. CDP's name-keyed
+    /// object means we can't recover Chrome's wire order (see
+    /// `deserialize_headers`), but two decodes of the same event must agree —
+    /// a `HashMap` re-randomized the order per request, which a caller
+    /// round-tripping `RequestInfo::headers` back through `RequestOverrides`
+    /// turns into a randomized header order on the wire.
+    #[test]
+    fn request_headers_decode_in_a_deterministic_order() {
+        let headers = json!({
+            "host": "example.test",
+            "user-agent": "zd/1",
+            "accept": "*/*",
+            "accept-language": "en-US",
+            "accept-encoding": "gzip",
+            "cookie": "a=1",
+            "referer": "https://example.test/",
+            "sec-fetch-mode": "cors",
+        });
+        let request = json!({
+            "url": "https://example.test/x",
+            "method": "GET",
+            "headers": headers,
+        });
+
+        let first = request_info_from(request.clone()).headers;
+        let second = request_info_from(request).headers;
+        assert_eq!(
+            first, second,
+            "header order must not change between decodes of the same event"
+        );
+        assert_eq!(first.len(), 8, "every header must survive the decode");
+        assert!(first.contains(&("cookie".to_string(), "a=1".to_string())));
     }
 }

--- a/crates/zendriver-interception/src/builder.rs
+++ b/crates/zendriver-interception/src/builder.rs
@@ -140,6 +140,12 @@ impl<'tab> InterceptBuilder<'tab> {
     /// `zendriver` crate if you want the wiring installed automatically on
     /// every tab.
     ///
+    /// **Only [`start`](Self::start) honors this.** The
+    /// [`subscribe`](Self::subscribe) escape hatch has no auth path — it never
+    /// subscribes to `Fetch.authRequired`, so it leaves
+    /// `handleAuthRequests: false` and logs an error rather than pausing auth
+    /// challenges nothing would answer. Use `start()` when you need auth.
+    ///
     /// See cdpdriver/zendriver#208.
     #[must_use]
     pub fn handle_auth(mut self, user: impl Into<String>, pass: impl Into<String>) -> Self {
@@ -392,12 +398,31 @@ impl<'tab> InterceptBuilder<'tab> {
     /// themselves. Use [`start`](Self::start) when you want the actor to
     /// apply rules automatically.
     ///
+    /// [`handle_auth`](Self::handle_auth) credentials are **also ignored**
+    /// here, and calling both logs an error. This path never subscribes to
+    /// `Fetch.authRequired`, so `Fetch.enable` is deliberately sent with
+    /// `handleAuthRequests: false`: flipping it on would make Chrome pause
+    /// every auth challenge with nobody to answer it, turning a visible 407
+    /// into a hang. Behind a proxy that requires credentials, use
+    /// [`start`](Self::start) instead.
+    ///
     /// The returned stream owns the underlying CDP subscription. Dropping
     /// the stream tears the subscription down — Chrome's interception stays
     /// active until the session is closed, but no further pauses surface to
     /// the caller.
     #[must_use = "the returned stream is the only handle on the subscription"]
     pub fn subscribe(mut self) -> impl Stream<Item = PausedRequest> + Send + use<> {
+        if self.auth.is_some() {
+            // Loud, because the alternative failure is invisible: behind a
+            // proxy every navigation 407s and the caller sees only empty
+            // pages. We cannot honor the credentials here — this path has no
+            // `Fetch.authRequired` subscription, and enabling
+            // `handleAuthRequests` without one converts the 407 into a hang.
+            tracing::error!(
+                "interception: handle_auth() credentials are ignored by subscribe(); \
+                 auth challenges will NOT be answered — use start() for proxy / HTTP auth"
+            );
+        }
         if self.patterns.is_empty() {
             self.patterns.push(RequestPattern {
                 url_pattern: Some("*".into()),
@@ -417,6 +442,9 @@ impl<'tab> InterceptBuilder<'tab> {
                     "Fetch.enable",
                     json!({
                         "patterns": enable_patterns,
+                        // Always false on this path — see the doc comment: no
+                        // `Fetch.authRequired` subscription exists here, so
+                        // `true` would pause challenges forever.
                         "handleAuthRequests": false,
                     }),
                 )
@@ -753,6 +781,37 @@ mod tests {
             paused.response.is_none(),
             "request-stage event has no response"
         );
+
+        drop(stream);
+        conn.shutdown();
+    }
+
+    /// `subscribe()` cannot honor `handle_auth`: it never subscribes to
+    /// `Fetch.authRequired`, so `handleAuthRequests: true` would leave Chrome
+    /// pausing auth challenges nobody answers — a hang instead of a 407.
+    /// Pin the flag to `false` (the caller is warned via `tracing::error!`)
+    /// so a future "fix" can't half-enable the auth path here.
+    #[tokio::test]
+    async fn subscribe_pins_handle_auth_requests_false_even_with_credentials() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let stream = Box::pin(
+            InterceptBuilder::new(&sess)
+                .handle_auth("puser", "ppass")
+                .subscribe(),
+        );
+
+        let enable_id =
+            tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Fetch.enable"))
+                .await
+                .expect("subscribe() did not send Fetch.enable within 2s");
+        let params = mock.last_sent()["params"].clone();
+        assert_eq!(
+            params["handleAuthRequests"], false,
+            "subscribe() has no Fetch.authRequired subscription — enabling auth handling here hangs every challenge"
+        );
+        mock.reply(enable_id, json!({})).await;
 
         drop(stream);
         conn.shutdown();

--- a/crates/zendriver-interception/src/types.rs
+++ b/crates/zendriver-interception/src/types.rs
@@ -141,22 +141,36 @@ impl std::fmt::Display for AbortReason {
 /// Information about an intercepted request, surfaced to rule closures and
 /// stream consumers.
 ///
-/// Headers are a `Vec<(name, value)>` rather than a `HashMap` so duplicates
-/// (multiple `Set-Cookie`, multi-value `Cookie`, etc.) and Chrome's emission
-/// order survive the round-trip into user code and back through
-/// [`RequestOverrides`]. CDP's underlying wire shape is a `[{name, value}]`
-/// array; this type matches that shape.
+/// Headers are a `Vec<(name, value)>` rather than a `HashMap` so the set
+/// round-trips through user code and back into [`RequestOverrides`] in a
+/// stable order, and so response headers keep their duplicates (multiple
+/// `Set-Cookie`, etc.) — CDP's wire shape for *responses* is a
+/// `[{name, value}]` array, which this type matches.
+///
+/// Request headers are the exception: CDP delivers those as an object keyed
+/// by header name (`Network.Headers`), so Chrome has already merged
+/// duplicate-named request headers and the browser's on-the-wire header
+/// **order is not recoverable** — do not rely on `RequestInfo::headers` for
+/// header-order fingerprint work.
 #[derive(Debug, Clone)]
 pub struct RequestInfo {
     /// Full request URL (post-redirect resolution by Chrome).
     pub url: String,
     /// HTTP method (`GET`, `POST`, ...).
     pub method: String,
-    /// Request headers as Chrome reported them. Order is Chrome's emission
-    /// order; duplicates are preserved.
+    /// Request headers as Chrome reported them.
+    ///
+    /// Deterministic, but **not** Chrome's emission order, and duplicate names
+    /// are already merged: CDP sends request headers as a name-keyed object
+    /// (see the type-level docs). Contrast [`ResponseInfo::headers`], which
+    /// does keep order and duplicates.
     pub headers: Vec<(String, String)>,
     /// Request body, if any. Sourced from `postDataEntries` (binary-safe)
     /// when present, otherwise the UTF-8 bytes of `postData`.
+    ///
+    /// `None` also covers an undecodable `postDataEntries` body: a chunk that
+    /// fails to decode yields `None` rather than a silently truncated body, so
+    /// a closure that signs this never signs a partial payload.
     pub post_data: Option<Vec<u8>>,
     /// Chrome's classification of the request's resource type.
     pub resource_type: ResourceType,

--- a/docs/book/src/interception.md
+++ b/docs/book/src/interception.md
@@ -71,6 +71,12 @@ top:
 {{#include ../../../crates/zendriver/examples/intercept_modify_headers.rs}}
 ```
 
+The headers you copy forward are in a stable order, but not the browser's
+original one: CDP delivers request headers as an object keyed by header name,
+so Chrome has already merged duplicate names and the on-the-wire ordering is
+gone before the closure runs. Response headers (`modify_response`) keep both,
+since CDP sends those as an array.
+
 The closure runs synchronously per-event on the actor task; it should
 not block. Spawn off the runtime if you need to call out to an async
 service before deciding the override.


### PR DESCRIPTION
- `subscribe()` dropped a configured `handle_auth`, so behind a proxy every navigation 407s while the builder read as configured. Note the *obvious* fix is wrong — that path never subscribes to `Fetch.authRequired`, so flipping the flag would make Chrome pause challenges nothing answers. It errors loudly instead.
- `decode_post_data` returned a decoded prefix on partial failure, indistinguishable from a complete body — a `Modify` closure that signs the payload signed the wrong bytes.
- Request header order is documented as preserved but is unrecoverable (CDP sends a name-keyed object, `serde_json` parses to a BTreeMap). The decode is at least deterministic now; it was a `HashMap` reordering per request. Docs corrected rather than faked.

**279 insertions.** Self-contained; merges in any order.

---
Split out of #145, which grew to 24 commits and became hard to merge with confidence. Every finding here was surfaced by consumer review and verified by execution; that history lives on #145.

Gates: `fmt --all --check` clean, `clippy --workspace --all-targets -- -D warnings` **0 errors**, all 9 crates green individually. No public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)