### PR TITLE
fix(solvers): reach terminals that were structurally unreachable

### DIFF
--- a/crates/zendriver-cloudflare/src/bypass.rs
+++ b/crates/zendriver-cloudflare/src/bypass.rs
@@ -24,9 +24,11 @@
 //!    `CLICK_RETRY_TICKS` ticks apart, so a swallowed first click is not
 //!    the end of the run.
 //! 4. Resolves to [`ClearanceOutcome::ChallengeGone`] when the challenge
-//!    disappears without yielding a token — either the iframe we clicked is
-//!    gone, or every challenge marker observed on an earlier tick has
-//!    vanished (the JS-only interstitial that clears itself).
+//!    stops being actionable without yielding a token — either the iframe we
+//!    clicked is no longer a valid click target, or every challenge marker
+//!    observed on an earlier tick has vanished (the JS-only interstitial
+//!    that clears itself). The first of those is weaker than it sounds; see
+//!    the variant's own docs before treating it as clearance.
 //! 5. Resolves to [`ClearanceOutcome::TimedOut`] on deadline, carrying
 //!    `saw_challenge` — `true` when challenge markers were seen but never
 //!    resolved, `false` when the entire timeout window elapsed without
@@ -48,9 +50,18 @@ use crate::error::CloudflareError;
 pub enum ClearanceOutcome {
     /// Turnstile produced a token (value of `cf-turnstile-response`).
     TokenAcquired(String),
-    /// The challenge disappeared without yielding a token — the iframe we
-    /// clicked was torn down, or all challenge markers seen earlier in the
-    /// run have vanished (a JS-only interstitial that cleared itself).
+    /// The challenge stopped being actionable without yielding a token — the
+    /// iframe we clicked is no longer a valid click target, or all challenge
+    /// markers seen earlier in the run have vanished (a JS-only interstitial
+    /// that cleared itself). Usually the clearance-cookie shortcut.
+    ///
+    /// **Not proof the gate was passed.** "No longer a valid click target"
+    /// is `clickableRect` returning null, which it also does for a widget
+    /// that is still mounted but zero-size, `visibility: hidden`,
+    /// `display: none` or `opacity: 0`. So once a click has landed, a tick
+    /// where the widget is merely between states reaches this terminal too.
+    /// Confirm the page is actually through the gate before treating what
+    /// you scrape next as clean.
     ChallengeGone,
     /// Deadline elapsed without a terminal clearance state. `saw_challenge`
     /// is `true` if any challenge marker (container, hidden input, or live
@@ -113,10 +124,12 @@ impl<'a> CloudflareBypass<'a> {
     ///   `cf-turnstile-response` input picked up a non-empty value, either
     ///   after we clicked the interactive iframe or because the page uses
     ///   invisible Turnstile.
-    /// - `Ok(ClearanceOutcome::ChallengeGone)` — the challenge went away
-    ///   without yielding a token (e.g. a clearance-cookie shortcut): either
-    ///   an iframe we clicked was torn down, or challenge markers observed on
-    ///   an earlier tick are all gone.
+    /// - `Ok(ClearanceOutcome::ChallengeGone)` — the challenge stopped being
+    ///   actionable without yielding a token (e.g. a clearance-cookie
+    ///   shortcut): either an iframe we clicked is no longer a valid click
+    ///   target, or challenge markers observed on an earlier tick are all
+    ///   gone. Read [`ClearanceOutcome::ChallengeGone`] before treating this
+    ///   as proof the gate was passed.
     /// - `Ok(ClearanceOutcome::TimedOut { saw_challenge })` — `timeout`
     ///   elapsed without a terminal clearance state. `saw_challenge` is
     ///   `true` if challenge markers were observed (markers present but
@@ -189,10 +202,19 @@ impl<'a> CloudflareBypass<'a> {
                         clicked = true;
                     }
                 }
-                // The challenge went away without a token: either the iframe
-                // we clicked was torn down, or markers seen on an earlier tick
-                // are all gone (a JS-only interstitial clearing itself). Both
-                // are the clearance-cookie shortcut.
+                // The challenge stopped being actionable without a token:
+                // either the iframe we clicked is no longer a valid click
+                // target, or markers seen on an earlier tick are all gone (a
+                // JS-only interstitial clearing itself). Both are usually the
+                // clearance-cookie shortcut.
+                //
+                // OPEN QUESTION: `bbox` is `None` for a widget that is merely
+                // hidden or zero-size, so after the first landed click any
+                // unclickable tick hits this *success* terminal. Prescribed
+                // fix: return `iframePresent` alongside `bbox` from `POLL_JS`
+                // and key the `clicks > 0` disjunct off presence, not
+                // clickability. Not applied here — changing which runs report
+                // clearance is a call for a human, not a doc fix.
                 None if clicks > 0 || (seen_markers_before && !state.has_markers) => {
                     return Ok(ClearanceOutcome::ChallengeGone);
                 }
@@ -281,13 +303,33 @@ struct PollState {
 /// # JavaScript style
 /// Injected scripts in this crate declare with `var` and iterate with
 /// indexed loops, never `for...of` — `detect.js` included. `for...of` over a
-/// `NodeList` goes through `NodeList.prototype[Symbol.iterator]`, which the
-/// page can redefine to watch someone walk its DOM; an indexed loop reads
-/// `length` and integer keys, which a page cannot instrument without
-/// breaking its own scripts. In a crate whose job is to be unobservable that
-/// is worth the plainer syntax. This is a rule about declarations and
-/// iteration only — modern methods with no such hook, `String.includes`
-/// among them, are used freely.
+/// `NodeList` enters through `NodeList.prototype[Symbol.iterator]`, a
+/// writable, configurable property the page can redefine to watch someone
+/// walk its DOM. That one is worth declining: it is a single chokepoint,
+/// entered once per loop and then driven by one `next()` per element, and a
+/// handler installed there can read `new Error().stack` and filter the
+/// page's own iteration out of what it collects. An indexed loop never
+/// reaches it.
+///
+/// It buys that one signal and no more. Indexed access is *not*
+/// unobservable: `NodeList.prototype.length` is a WebIDL accessor with
+/// `configurable: true`, so a page can wrap the getter, delegate to the
+/// original, and count every read with nothing of its own broken. The rest
+/// of the walk is louder. Each tick calls `root.querySelectorAll("iframe")`
+/// and then `root.querySelectorAll("*")`, both ordinary writable methods on
+/// `Document` / `Element` / `DocumentFragment`, and the iframe test below
+/// calls `String.prototype.includes` — equally patchable — with the literal
+/// `"challenges.cloudflare.com"`. A hook there is handed the hostname the
+/// walker is hunting for, which is a sharper tell than the iterator hook
+/// this convention avoids.
+///
+/// Measured on Chrome 151 with all four wrapped: the walk still returns the
+/// right iframe, while the page observes both `querySelectorAll` selectors,
+/// every `length` read and that hostname, against zero `Symbol.iterator`
+/// calls. So the convention removes one signal from a loop that stays
+/// observable to a page that looks for it; it is not cover. This is a rule
+/// about declarations and iteration only — modern methods are used freely,
+/// since declining them would buy nothing either.
 const WALKER_JS: &str = r#"
 function findChallengeIframe(root) {
     var iframes = root.querySelectorAll ? root.querySelectorAll("iframe") : [];
@@ -469,15 +511,21 @@ mod tests {
         coords
     }
 
-    /// Names of every *named* `function` declaration in `src` that sits at
-    /// `{}` depth 0. An anonymous `function (` — the IIFE wrapper itself — is
-    /// a function expression and binds nothing, so it is not counted.
+    /// Names every declaration in `src` at `{}` depth 0 that a classic
+    /// script publishes on the page's global object: `var` and *named*
+    /// `function`. Both become enumerable `window` properties (verified on
+    /// Chrome 151); `let` / `const` / `class` are script-scoped and never
+    /// do, so they are not leaks and are not counted. An anonymous
+    /// `function (` — the IIFE wrapper itself — is an expression and binds
+    /// nothing.
     ///
     /// Brace counting is only sound because no injected source puts a brace
     /// inside a string literal. Keep it that way; the alternative is a JS
-    /// parser for a cookie-name-sized job.
-    fn top_level_function_declarations(src: &str) -> Vec<String> {
-        const KEYWORD: &str = "function";
+    /// parser for a cookie-name-sized job. Comment text is scanned like any
+    /// other, which can only ever produce a loud false positive, never a
+    /// silent pass.
+    fn top_level_page_globals(src: &str) -> Vec<String> {
+        let is_ident = |c: char| c.is_alphanumeric() || c == '_' || c == '$';
         let mut found = Vec::new();
         let mut depth = 0i32;
         for (i, ch) in src.char_indices() {
@@ -486,17 +534,33 @@ mod tests {
                 '}' => depth -= 1,
                 _ => {}
             }
-            if !src[i..].starts_with(KEYWORD) {
+            if depth != 0 {
                 continue;
             }
-            let rest = src[i + KEYWORD.len()..].trim_start();
-            let name: String = rest
-                .chars()
-                .take_while(|c| c.is_alphanumeric() || *c == '_' || *c == '$')
-                .collect();
-            // A name means a declaration; `function (` is an expression.
-            if depth == 0 && !name.is_empty() {
-                found.push(name);
+            // A keyword that is really the tail of a longer identifier
+            // declares nothing: `myvar`, `refunction`.
+            if src[..i].chars().next_back().is_some_and(is_ident) {
+                continue;
+            }
+            for keyword in ["function", "var"] {
+                let Some(rest) = src[i..].strip_prefix(keyword) else {
+                    continue;
+                };
+                // `var` needs a separator to be a declaration. `function`
+                // does not: `function(` is an expression, and the empty-name
+                // check below is what rejects it.
+                if keyword == "var" && !rest.starts_with(char::is_whitespace) {
+                    break;
+                }
+                let name: String = rest
+                    .trim_start()
+                    .chars()
+                    .take_while(|c| is_ident(*c))
+                    .collect();
+                if !name.is_empty() {
+                    found.push(name);
+                }
+                break;
             }
         }
         found
@@ -504,28 +568,43 @@ mod tests {
 
     /// The leak guard has to be able to fail. Fed the pre-fix shape — the
     /// walker evaluated beside the IIFE rather than inside it — it must name
-    /// the declaration; fed the shipped shape it must stay quiet.
+    /// the declaration; fed the shipped shape it must stay quiet. The `var`
+    /// case is here because the scan is named for page globals, and a
+    /// top-level `var` is one just as much as a `function` is.
     #[test]
-    fn top_level_function_scan_catches_a_leaked_declaration() {
+    fn top_level_scan_catches_every_leaked_page_global() {
         assert_eq!(
-            top_level_function_declarations(
+            top_level_page_globals(
                 "function findChallengeIframe(root) { return null; }\n(function(){ return 1; })()"
             ),
             vec!["findChallengeIframe".to_string()],
         );
+        assert_eq!(
+            top_level_page_globals("var iframes = document.querySelectorAll('iframe');"),
+            vec!["iframes".to_string()],
+            "a top-level `var` is a `window` property too"
+        );
         assert!(
-            top_level_function_declarations("(function(){ function nested(){} return 1; })()")
+            top_level_page_globals("(function(){ function nested(){} var local = 1; })()")
                 .is_empty(),
             "a declaration inside the wrapper is a local, not a global"
+        );
+        // Script-scoped forms never reach `window`, so flagging them would
+        // be a false positive, and a keyword inside a longer identifier is
+        // not a keyword at all.
+        assert!(
+            top_level_page_globals("let a = 1; const b = 2; class C {}\nvarnish.myvar = 3;")
+                .is_empty(),
         );
     }
 
     /// `Runtime.evaluate` with no `contextId` runs a classic script in the
-    /// page's main world, where a top-level `function foo() {}` becomes
-    /// `window.foo`. Publishing `findChallengeIframe` / `clickableRect` there
-    /// hands the challenge script — same realm, actively looking — a pair of
-    /// names belonging to an automation library, on every poll tick. Every
-    /// source this crate injects keeps its helpers inside a function scope.
+    /// page's main world, where a top-level `function foo() {}` or `var bar`
+    /// becomes `window.foo` / `window.bar`. Publishing `findChallengeIframe`
+    /// / `clickableRect` there hands the challenge script — same realm,
+    /// actively looking — a pair of names belonging to an automation
+    /// library, on every poll tick. Every source this crate injects keeps
+    /// its helpers and its locals inside a function scope.
     #[test]
     fn injected_sources_declare_no_page_globals() {
         for (name, src) in [
@@ -533,7 +612,7 @@ mod tests {
             ("scroll evaluator", main_world_expr(SCROLL_JS)),
             ("detect.js", include_str!("detect.js").to_string()),
         ] {
-            let leaked = top_level_function_declarations(&src);
+            let leaked = top_level_page_globals(&src);
             assert!(
                 leaked.is_empty(),
                 "{name} publishes {leaked:?} onto the page's global object"

--- a/crates/zendriver-cloudflare/src/bypass.rs
+++ b/crates/zendriver-cloudflare/src/bypass.rs
@@ -36,12 +36,11 @@
 use std::time::Duration;
 
 use serde::Deserialize;
-use serde_json::{Value, json};
 use tokio::time::Instant;
 use zendriver_transport::SessionHandle;
 
 use crate::click::click_at;
-use crate::detection::BoundingBox;
+use crate::detection::{BoundingBox, eval_main_world};
 use crate::error::CloudflareError;
 
 /// Result of a clearance attempt.
@@ -167,9 +166,15 @@ impl<'a> CloudflareBypass<'a> {
                 return Ok(ClearanceOutcome::TokenAcquired(token));
             }
 
+            // Click cadence: the first clickable tick clicks straight away,
+            // every later attempt waits `CLICK_RETRY_TICKS` ticks after the
+            // click that landed, and a run spends at most
+            // `MAX_CLICK_ATTEMPTS` clicks. So at the default interval the
+            // second click lands on tick 5, not tick 4.
             let may_click = clicks < MAX_CLICK_ATTEMPTS
                 && (clicks == 0 || ticks_since_click >= CLICK_RETRY_TICKS);
 
+            let mut clicked = false;
             match state.bbox {
                 Some(_) if may_click => {
                     // Raw `Input.dispatchMouseEvent` coordinates are viewport
@@ -181,6 +186,7 @@ impl<'a> CloudflareBypass<'a> {
                         click_at(self.session, click_x, click_y).await?;
                         clicks += 1;
                         ticks_since_click = 0;
+                        clicked = true;
                     }
                 }
                 // The challenge went away without a token: either the iframe
@@ -190,19 +196,36 @@ impl<'a> CloudflareBypass<'a> {
                 None if clicks > 0 || (seen_markers_before && !state.has_markers) => {
                     return Ok(ClearanceOutcome::ChallengeGone);
                 }
-                _ => {
-                    stall_ticks += 1;
-                    if stall_ticks == 10 && !warned_stall {
-                        tracing::warn!(
-                            poll_interval_ms = self.poll_interval.as_millis() as u64,
-                            "cloudflare clearance stalled — is BrowserBuilder::stealth enabled?"
-                        );
-                        warned_stall = true;
-                    }
+                _ => {}
+            }
+
+            // Every tick that did not land a click is a tick with no progress,
+            // the scroll-returned-`None` path included. That path used to skip
+            // the counter, so a widget that stayed mounted but stopped being
+            // measurable — the run this hint exists to explain — was the one
+            // run that could never produce it.
+            if clicked {
+                stall_ticks = 0;
+            } else {
+                stall_ticks += 1;
+                if stall_ticks == 10 && !warned_stall {
+                    tracing::warn!(
+                        poll_interval_ms = self.poll_interval.as_millis() as u64,
+                        "cloudflare clearance stalled — is BrowserBuilder::stealth enabled?"
+                    );
+                    // `stall_ticks` resets on a landed click, so `== 10` is
+                    // reachable more than once per run; the latch is what
+                    // keeps the hint to a single line.
+                    warned_stall = true;
                 }
             }
 
-            ticks_since_click = ticks_since_click.saturating_add(1);
+            // Only meaningful once something has been clicked — unguarded, it
+            // counted ticks before the first click, which the `clicks == 0`
+            // arm of `may_click` then had to ignore.
+            if clicks > 0 {
+                ticks_since_click = ticks_since_click.saturating_add(1);
+            }
 
             if Instant::now() >= deadline {
                 return Ok(ClearanceOutcome::TimedOut {
@@ -251,6 +274,20 @@ struct PollState {
 ///   `opacity`. A zero-size or hidden iframe is not a target — invisible
 ///   Turnstile mounts a 0×0 iframe whose token is populated with no click,
 ///   and clicking it would dispatch mouse events at a meaningless point.
+///
+/// Never evaluated on its own — [`main_world_expr`] wraps it, so nothing here
+/// reaches the page's global object. See that function for why.
+///
+/// # JavaScript style
+/// Injected scripts in this crate declare with `var` and iterate with
+/// indexed loops, never `for...of` — `detect.js` included. `for...of` over a
+/// `NodeList` goes through `NodeList.prototype[Symbol.iterator]`, which the
+/// page can redefine to watch someone walk its DOM; an indexed loop reads
+/// `length` and integer keys, which a page cannot instrument without
+/// breaking its own scripts. In a crate whose job is to be unobservable that
+/// is worth the plainer syntax. This is a rule about declarations and
+/// iteration only — modern methods with no such hook, `String.includes`
+/// among them, are used freely.
 const WALKER_JS: &str = r#"
 function findChallengeIframe(root) {
     var iframes = root.querySelectorAll ? root.querySelectorAll("iframe") : [];
@@ -280,7 +317,8 @@ function clickableRect(el) {
 }
 "#;
 
-/// Unified poll evaluator (appended to [`WALKER_JS`]). Returns:
+/// Body of the unified poll evaluator — statements only, run inside
+/// [`main_world_expr`]'s wrapper alongside [`WALKER_JS`]. Returns:
 /// - `token` — non-empty `cf-turnstile-response` (or legacy
 ///   `cf_challenge_response`) input value, else null.
 /// - `bbox` — the challenge iframe's rect when it is a valid click target,
@@ -291,7 +329,6 @@ function clickableRect(el) {
 /// The token input is in light DOM by design (page JS reads it to submit
 /// forms), so `document.querySelector` is sufficient there.
 const POLL_JS: &str = r#"
-(function () {
     var iframe = findChallengeIframe(document);
     var bbox = clickableRect(iframe);
     var input =
@@ -301,15 +338,20 @@ const POLL_JS: &str = r#"
     var hasContainer = !!document.querySelector('.cf-turnstile, .turnstile, [data-sitekey]');
     var hasMarkers = hasContainer || !!input || !!iframe;
     return { token: token, bbox: bbox, hasMarkers: hasMarkers };
-})()
 "#;
 
-/// Scroll-into-view evaluator (appended to [`WALKER_JS`]). Brings the
+/// Body of the scroll-into-view evaluator — statements only, run inside
+/// [`main_world_expr`]'s wrapper alongside [`WALKER_JS`]. Brings the
 /// challenge iframe fully into the viewport when it isn't already, then
 /// returns its *post-scroll* rect — or null if the widget vanished or is not
 /// a valid click target.
+///
+/// `behavior: "instant"` is load-bearing: the default `"auto"` resolves to
+/// the element's computed `scroll-behavior`, so on a page setting
+/// `html { scroll-behavior: smooth }` the scroll animates and the
+/// `clickableRect` call on the next synchronous line reads the *pre*-scroll
+/// rect — the one thing this round-trip exists to avoid.
 const SCROLL_JS: &str = r#"
-(function () {
     var iframe = findChallengeIframe(document);
     if (!iframe) return null;
     var r = iframe.getBoundingClientRect();
@@ -317,46 +359,30 @@ const SCROLL_JS: &str = r#"
     var vh = window.innerHeight || document.documentElement.clientHeight;
     var fullyVisible = r.top >= 0 && r.left >= 0 && r.bottom <= vh && r.right <= vw;
     if (!fullyVisible && iframe.scrollIntoView) {
-        iframe.scrollIntoView({ block: "center", inline: "center" });
+        iframe.scrollIntoView({ block: "center", inline: "center", behavior: "instant" });
     }
     return clickableRect(iframe);
-})()
 "#;
 
-/// Evaluate `WALKER_JS` + `body` in `session`'s main world and return the
-/// result value (`Value::Null` when the script produced nothing).
-async fn eval_main_world(session: &SessionHandle, body: &str) -> Result<Value, CloudflareError> {
-    let res = session
-        .call(
-            "Runtime.evaluate",
-            json!({
-                "expression": format!("{WALKER_JS}{body}"),
-                "returnByValue": true,
-                "awaitPromise": true,
-            }),
-        )
-        .await?;
-
-    if let Some(details) = res.get("exceptionDetails") {
-        let msg = details
-            .get("exception")
-            .and_then(|e| e.get("description"))
-            .and_then(|d| d.as_str())
-            .unwrap_or("unknown")
-            .to_string();
-        return Err(CloudflareError::JsError(msg));
-    }
-
-    Ok(res
-        .get("result")
-        .and_then(|r| r.get("value"))
-        .cloned()
-        .unwrap_or(Value::Null))
+/// Compose the in-page source for `body`: [`WALKER_JS`] and `body` together
+/// inside a single IIFE, whose completion value is whatever `body` returns.
+///
+/// The wrapper is a stealth requirement, not formatting. `Runtime.evaluate`
+/// with no `contextId` runs a *classic script* in the page's main world,
+/// where a top-level `function foo() {}` becomes a property of the global
+/// object. Evaluating `WALKER_JS` unwrapped therefore published
+/// `window.findChallengeIframe` and `window.clickableRect` to the page on
+/// every poll tick — names belonging to an automation library, sitting in
+/// the same realm as the challenge script, for anything enumerating `window`
+/// to find. Inside the IIFE they are ordinary locals and the page's globals
+/// are untouched.
+fn main_world_expr(body: &str) -> String {
+    format!("(function(){{{WALKER_JS}{body}}})()")
 }
 
 /// Run [`POLL_JS`] against `session`'s main world and decode the result.
 async fn poll_state(session: &SessionHandle) -> Result<PollState, CloudflareError> {
-    let value = eval_main_world(session, POLL_JS).await?;
+    let value = eval_main_world(session, &main_world_expr(POLL_JS)).await?;
     serde_json::from_value(value)
         .map_err(|e| CloudflareError::JsError(format!("invalid poll payload: {e}")))
 }
@@ -365,7 +391,7 @@ async fn poll_state(session: &SessionHandle) -> Result<PollState, CloudflareErro
 /// iframe into view if needed and return the rect to click, or `None` when
 /// the widget is gone or not clickable.
 async fn scroll_into_view(session: &SessionHandle) -> Result<Option<BoundingBox>, CloudflareError> {
-    let value = eval_main_world(session, SCROLL_JS).await?;
+    let value = eval_main_world(session, &main_world_expr(SCROLL_JS)).await?;
     if value.is_null() {
         return Ok(None);
     }
@@ -377,8 +403,16 @@ async fn scroll_into_view(session: &SessionHandle) -> Result<Option<BoundingBox>
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
+    use serde_json::{Value, json};
+
     use super::*;
-    use zendriver_transport::testing::MockConnection;
+    use zendriver_transport::testing::{LogCapture, MockConnection};
+
+    /// How long a drain loop waits for the driver's next command before
+    /// deciding the run is over. Long enough to cover a poll interval plus
+    /// scheduling jitter, short enough that a finished driver ends the loop
+    /// promptly instead of hanging the test.
+    const DRAIN_BUDGET: Duration = Duration::from_millis(300);
 
     /// Wrap an evaluator result value in the CDP `Runtime.evaluate` envelope.
     fn eval_reply(value: Value) -> Value {
@@ -435,16 +469,184 @@ mod tests {
         coords
     }
 
-    /// Generic "next outbound command" read, bounded so a finished driver
-    /// ends the drain loop instead of hanging the test.
-    async fn next_cmd(mock: &mut MockConnection) -> Option<(String, u64)> {
-        for _ in 0..300 {
-            if let Some(cmd) = mock.try_recv_cmd() {
-                return Some(cmd);
+    /// Names of every *named* `function` declaration in `src` that sits at
+    /// `{}` depth 0. An anonymous `function (` — the IIFE wrapper itself — is
+    /// a function expression and binds nothing, so it is not counted.
+    ///
+    /// Brace counting is only sound because no injected source puts a brace
+    /// inside a string literal. Keep it that way; the alternative is a JS
+    /// parser for a cookie-name-sized job.
+    fn top_level_function_declarations(src: &str) -> Vec<String> {
+        const KEYWORD: &str = "function";
+        let mut found = Vec::new();
+        let mut depth = 0i32;
+        for (i, ch) in src.char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => depth -= 1,
+                _ => {}
             }
-            tokio::time::sleep(Duration::from_millis(1)).await;
+            if !src[i..].starts_with(KEYWORD) {
+                continue;
+            }
+            let rest = src[i + KEYWORD.len()..].trim_start();
+            let name: String = rest
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_' || *c == '$')
+                .collect();
+            // A name means a declaration; `function (` is an expression.
+            if depth == 0 && !name.is_empty() {
+                found.push(name);
+            }
         }
-        None
+        found
+    }
+
+    /// The leak guard has to be able to fail. Fed the pre-fix shape — the
+    /// walker evaluated beside the IIFE rather than inside it — it must name
+    /// the declaration; fed the shipped shape it must stay quiet.
+    #[test]
+    fn top_level_function_scan_catches_a_leaked_declaration() {
+        assert_eq!(
+            top_level_function_declarations(
+                "function findChallengeIframe(root) { return null; }\n(function(){ return 1; })()"
+            ),
+            vec!["findChallengeIframe".to_string()],
+        );
+        assert!(
+            top_level_function_declarations("(function(){ function nested(){} return 1; })()")
+                .is_empty(),
+            "a declaration inside the wrapper is a local, not a global"
+        );
+    }
+
+    /// `Runtime.evaluate` with no `contextId` runs a classic script in the
+    /// page's main world, where a top-level `function foo() {}` becomes
+    /// `window.foo`. Publishing `findChallengeIframe` / `clickableRect` there
+    /// hands the challenge script — same realm, actively looking — a pair of
+    /// names belonging to an automation library, on every poll tick. Every
+    /// source this crate injects keeps its helpers inside a function scope.
+    #[test]
+    fn injected_sources_declare_no_page_globals() {
+        for (name, src) in [
+            ("poll evaluator", main_world_expr(POLL_JS)),
+            ("scroll evaluator", main_world_expr(SCROLL_JS)),
+            ("detect.js", include_str!("detect.js").to_string()),
+        ] {
+            let leaked = top_level_function_declarations(&src);
+            assert!(
+                leaked.is_empty(),
+                "{name} publishes {leaked:?} onto the page's global object"
+            );
+        }
+
+        // The two composed sources must still *contain* the helpers, so this
+        // cannot pass by the walker having quietly gone missing.
+        for body in [POLL_JS, SCROLL_JS] {
+            let expr = main_world_expr(body);
+            assert!(expr.contains("function findChallengeIframe("));
+            assert!(expr.contains("function clickableRect("));
+            assert!(
+                expr.starts_with("(function(){") && expr.ends_with("})()"),
+                "the composed source must be exactly one IIFE"
+            );
+        }
+    }
+
+    /// `scrollIntoView`'s default `behavior: "auto"` resolves to the
+    /// element's computed `scroll-behavior`, so on a page setting
+    /// `html { scroll-behavior: smooth }` the scroll animates and the
+    /// `clickableRect` call on the next synchronous line reads the
+    /// *pre*-scroll rect — the one thing this extra round-trip exists to
+    /// avoid, leaving the click aimed outside the viewport.
+    #[test]
+    fn scroll_evaluator_pins_instant_scroll_behavior() {
+        const CALL: &str = "scrollIntoView(";
+        let src = main_world_expr(SCROLL_JS);
+        let mut calls = 0;
+        for (idx, _) in src.match_indices(CALL) {
+            let after = &src[idx + CALL.len()..];
+            let end = after.find(')').expect("unterminated scrollIntoView call");
+            let args = &after[..end];
+            assert!(
+                args.contains(r#"behavior: "instant""#),
+                "scrollIntoView({args}) leaves behavior to the page's computed scroll-behavior"
+            );
+            calls += 1;
+        }
+        assert_eq!(calls, 1, "expected one scrollIntoView call to guard");
+    }
+
+    /// The stall hint must fire for the run it is most needed on: a widget
+    /// that stays mounted (the poll evaluator keeps reporting a bbox) but
+    /// never becomes measurable (the scroll evaluator keeps returning null),
+    /// so no click ever lands. That tick used to skip the stall counter
+    /// entirely, which meant the one diagnostic explaining a stuck run could
+    /// never appear on the stuck run it explains.
+    #[tokio::test]
+    async fn stalled_unmeasurable_widget_emits_the_stealth_hint() {
+        /// Stalled ticks to serve before letting the run finish. The hint
+        /// fires on the tenth.
+        const STALLED_TICKS: usize = 12;
+
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let capture = LogCapture::new();
+
+        let poll = poll_value(None, Some(rect(10.0, 20.0, 40.0, 40.0)), true);
+
+        // Not spawned: `LogCapture` follows the future it wraps, not a task
+        // spawned out of it, so the driver and the mock server share a task.
+        // The generous budget is never reached — the server ends the run — so
+        // the tick count is deterministic instead of clock-dependent.
+        let driver = capture.capture(async {
+            CloudflareBypass::new(&sess)
+                .poll_interval(Duration::from_millis(1))
+                .wait_for_clearance(Duration::from_secs(30))
+                .await
+        });
+
+        let serving = async {
+            let mut polls = 0usize;
+            while let Some((method, id)) = mock.recv_cmd_timeout(DRAIN_BUDGET).await {
+                assert_eq!(method, "Runtime.evaluate");
+                let is_scroll = mock.last_sent()["params"]["expression"]
+                    .as_str()
+                    .unwrap()
+                    .contains("scrollIntoView");
+                let value = if is_scroll {
+                    // Mounted on every poll, measurable on none: no click can
+                    // land, so every tick is a tick without progress.
+                    Value::Null
+                } else {
+                    polls += 1;
+                    if polls > STALLED_TICKS {
+                        poll_value(Some("LATE_TOKEN"), None, true)
+                    } else {
+                        poll.clone()
+                    }
+                };
+                mock.reply(id, eval_reply(value)).await;
+            }
+        };
+
+        let (outcome, ()) = tokio::join!(driver, serving);
+
+        match outcome.unwrap() {
+            ClearanceOutcome::TokenAcquired(t) => assert_eq!(t, "LATE_TOKEN"),
+            other => panic!("expected TokenAcquired, got {other:?}"),
+        }
+        assert!(
+            capture.contains("clearance stalled"),
+            "a mounted-but-unmeasurable widget is a stalled run; captured {:?}",
+            capture.events()
+        );
+        assert_eq!(
+            capture.count("clearance stalled"),
+            1,
+            "the hint is latched to one line per run"
+        );
+        conn.shutdown();
     }
 
     /// Interactive happy path: poll #1 yields a bbox → the widget is scrolled
@@ -732,7 +934,7 @@ mod tests {
         let poll = poll_value(None, Some(widget.clone()), true);
 
         let mut clicks: u32 = 0;
-        while let Some((method, id)) = next_cmd(&mut mock).await {
+        while let Some((method, id)) = mock.recv_cmd_timeout(DRAIN_BUDGET).await {
             match method.as_str() {
                 "Runtime.evaluate" => {
                     let is_scroll = mock.last_sent()["params"]["expression"]

--- a/crates/zendriver-cloudflare/src/bypass.rs
+++ b/crates/zendriver-cloudflare/src/bypass.rs
@@ -5,7 +5,7 @@
 //! single CDP poll loop that, per tick:
 //!
 //! 1. Re-evaluates a unified shadow-DOM walker in the page's main world
-//!    (private [`POLL_JS`]) returning, in one round-trip:
+//!    (private `POLL_JS`) returning, in one round-trip:
 //!    - the `cf-turnstile-response` (or legacy `cf_challenge_response`) token
 //!      if present,
 //!    - the Turnstile challenge iframe's bounding box if mounted,
@@ -15,13 +15,18 @@
 //!    non-empty token is observed — including the **invisible Turnstile**
 //!    path where the iframe never mounts and the token is populated
 //!    directly.
-//! 3. If the interactive checkbox iframe is mounted *and we have not yet
-//!    clicked*, dispatches a single raw left-click at the canonical
+//! 3. If a *clickable* challenge iframe is mounted (non-zero size and
+//!    visible), scrolls it into view, re-reads its box, and dispatches a raw
+//!    left-click at the canonical
 //!    `bbox.x + bbox.width * 0.15, bbox.y + bbox.height * 0.50` offset
 //!    (15% from left, 50% from top — Python's `cloudflare.py` convention).
-//! 4. If we previously observed an iframe + clicked, and the iframe is now
-//!    gone without a token, resolves to [`ClearanceOutcome::ChallengeGone`]
-//!    (clearance-cookie shortcut).
+//!    Up to `MAX_CLICK_ATTEMPTS` clicks are spent, spaced
+//!    `CLICK_RETRY_TICKS` ticks apart, so a swallowed first click is not
+//!    the end of the run.
+//! 4. Resolves to [`ClearanceOutcome::ChallengeGone`] when the challenge
+//!    disappears without yielding a token — either the iframe we clicked is
+//!    gone, or every challenge marker observed on an earlier tick has
+//!    vanished (the JS-only interstitial that clears itself).
 //! 5. Resolves to [`ClearanceOutcome::TimedOut`] on deadline, carrying
 //!    `saw_challenge` — `true` when challenge markers were seen but never
 //!    resolved, `false` when the entire timeout window elapsed without
@@ -44,7 +49,9 @@ use crate::error::CloudflareError;
 pub enum ClearanceOutcome {
     /// Turnstile produced a token (value of `cf-turnstile-response`).
     TokenAcquired(String),
-    /// The challenge container disappeared without yielding a token.
+    /// The challenge disappeared without yielding a token — the iframe we
+    /// clicked was torn down, or all challenge markers seen earlier in the
+    /// run have vanished (a JS-only interstitial that cleared itself).
     ChallengeGone,
     /// Deadline elapsed without a terminal clearance state. `saw_challenge`
     /// is `true` if any challenge marker (container, hidden input, or live
@@ -57,6 +64,15 @@ pub enum ClearanceOutcome {
 
 /// Default poll interval for `wait_for_clearance`.
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// How many clicks a single `wait_for_clearance` run may spend on the
+/// interactive widget. Cloudflare drops clicks that land while the widget is
+/// still booting, so one latched attempt strands the run until the deadline.
+const MAX_CLICK_ATTEMPTS: u32 = 3;
+
+/// Poll ticks to wait after a click before spending another attempt. At the
+/// default 500ms interval this leaves the widget ~2s to answer a click.
+const CLICK_RETRY_TICKS: u32 = 4;
 
 /// Drives a Cloudflare Turnstile clearance flow against a single tab's session.
 ///
@@ -98,10 +114,10 @@ impl<'a> CloudflareBypass<'a> {
     ///   `cf-turnstile-response` input picked up a non-empty value, either
     ///   after we clicked the interactive iframe or because the page uses
     ///   invisible Turnstile.
-    /// - `Ok(ClearanceOutcome::ChallengeGone)` — the interactive iframe was
-    ///   present, we clicked it, and the challenge container then
-    ///   disappeared without yielding a token (e.g. a clearance cookie
-    ///   shortcut).
+    /// - `Ok(ClearanceOutcome::ChallengeGone)` — the challenge went away
+    ///   without yielding a token (e.g. a clearance-cookie shortcut): either
+    ///   an iframe we clicked was torn down, or challenge markers observed on
+    ///   an earlier tick are all gone.
     /// - `Ok(ClearanceOutcome::TimedOut { saw_challenge })` — `timeout`
     ///   elapsed without a terminal clearance state. `saw_challenge` is
     ///   `true` if challenge markers were observed (markers present but
@@ -130,7 +146,8 @@ impl<'a> CloudflareBypass<'a> {
         timeout: Duration,
     ) -> Result<ClearanceOutcome, CloudflareError> {
         let deadline = Instant::now() + timeout;
-        let mut clicked = false;
+        let mut clicks: u32 = 0;
+        let mut ticks_since_click: u32 = 0;
         let mut ever_seen_markers = false;
 
         let mut stall_ticks: u32 = 0;
@@ -138,6 +155,10 @@ impl<'a> CloudflareBypass<'a> {
 
         loop {
             let state = poll_state(self.session).await?;
+            // Snapshot the latch *before* folding in this tick: the
+            // markers-vanished terminal below needs "seen on an earlier
+            // tick", not "seen including right now".
+            let seen_markers_before = ever_seen_markers;
             if state.has_markers {
                 ever_seen_markers = true;
             }
@@ -146,17 +167,27 @@ impl<'a> CloudflareBypass<'a> {
                 return Ok(ClearanceOutcome::TokenAcquired(token));
             }
 
+            let may_click = clicks < MAX_CLICK_ATTEMPTS
+                && (clicks == 0 || ticks_since_click >= CLICK_RETRY_TICKS);
+
             match state.bbox {
-                Some(bbox) if !clicked => {
-                    let click_x = bbox.x + bbox.width * 0.15;
-                    let click_y = bbox.y + bbox.height * 0.50;
-                    click_at(self.session, click_x, click_y).await?;
-                    clicked = true;
+                Some(_) if may_click => {
+                    // Raw `Input.dispatchMouseEvent` coordinates are viewport
+                    // relative, so a below-the-fold widget must be scrolled in
+                    // and re-measured before the click can land on it.
+                    if let Some(target) = scroll_into_view(self.session).await? {
+                        let click_x = target.x + target.width * 0.15;
+                        let click_y = target.y + target.height * 0.50;
+                        click_at(self.session, click_x, click_y).await?;
+                        clicks += 1;
+                        ticks_since_click = 0;
+                    }
                 }
-                None if clicked => {
-                    // Iframe was present, we clicked, and now the challenge
-                    // container has been torn down without a token — the
-                    // clearance-cookie shortcut.
+                // The challenge went away without a token: either the iframe
+                // we clicked was torn down, or markers seen on an earlier tick
+                // are all gone (a JS-only interstitial clearing itself). Both
+                // are the clearance-cookie shortcut.
+                None if clicks > 0 || (seen_markers_before && !state.has_markers) => {
                     return Ok(ClearanceOutcome::ChallengeGone);
                 }
                 _ => {
@@ -170,6 +201,8 @@ impl<'a> CloudflareBypass<'a> {
                     }
                 }
             }
+
+            ticks_since_click = ticks_since_click.saturating_add(1);
 
             if Instant::now() >= deadline {
                 return Ok(ClearanceOutcome::TimedOut {
@@ -194,8 +227,10 @@ struct PollState {
     /// any.
     #[serde(default)]
     token: Option<String>,
-    /// Bounding box of the Turnstile challenge iframe, if mounted. Walks
-    /// shadow roots so closed shadow trees still surface the iframe.
+    /// Bounding box of the Turnstile challenge iframe when it is a valid
+    /// click target — mounted, non-zero size, and visible. Walks shadow roots
+    /// so shadow-hosted widgets still surface. `None` for a hidden or 0×0
+    /// iframe, which must never be clicked.
     #[serde(default)]
     bbox: Option<BoundingBox>,
     /// `true` when the page has any of: a `.cf-turnstile` / `.turnstile`
@@ -206,56 +241,96 @@ struct PollState {
     has_markers: bool,
 }
 
-/// Unified in-page evaluator. Returns:
-/// - `token` — non-empty `cf-turnstile-response` (or legacy
-///   `cf_challenge_response`) input value, else null.
-/// - `bbox` — the Turnstile challenge iframe's bounding box (shadow-DOM
-///   aware walk), else null.
-/// - `hasMarkers` — true when *any* Cloudflare challenge marker is present
-///   (container, hidden input, or live iframe).
+/// Shared in-page prelude for the two evaluators below. Declares:
 ///
-/// The shadow-DOM walk is necessary because Cloudflare sometimes hosts the
-/// challenge iframe inside an open shadow root attached to a host element on
-/// the page. The token input itself is in light DOM by design (page JS reads
-/// it to submit forms), so `document.querySelector` is sufficient there.
-const POLL_JS: &str = r#"
-(function () {
-    function findBbox(root) {
-        var iframes = root.querySelectorAll ? root.querySelectorAll("iframe") : [];
-        for (var i = 0; i < iframes.length; i++) {
-            var f = iframes[i];
-            if (f.src && f.src.includes("challenges.cloudflare.com")) {
-                var r = f.getBoundingClientRect();
-                return { x: r.left, y: r.top, width: r.width, height: r.height };
-            }
+/// - `findChallengeIframe(root)` — the first `challenges.cloudflare.com`
+///   iframe reachable from `root`, descending into open shadow roots
+///   (Cloudflare sometimes hosts the widget inside a shadow root), else null.
+/// - `clickableRect(el)` — `el`'s viewport rect *only if it is a real click
+///   target*: non-zero size and not hidden by `visibility` / `display` /
+///   `opacity`. A zero-size or hidden iframe is not a target — invisible
+///   Turnstile mounts a 0×0 iframe whose token is populated with no click,
+///   and clicking it would dispatch mouse events at a meaningless point.
+const WALKER_JS: &str = r#"
+function findChallengeIframe(root) {
+    var iframes = root.querySelectorAll ? root.querySelectorAll("iframe") : [];
+    for (var i = 0; i < iframes.length; i++) {
+        var f = iframes[i];
+        if (f.src && f.src.includes("challenges.cloudflare.com")) return f;
+    }
+    var all = root.querySelectorAll ? root.querySelectorAll("*") : [];
+    for (var j = 0; j < all.length; j++) {
+        if (all[j].shadowRoot) {
+            var sub = findChallengeIframe(all[j].shadowRoot);
+            if (sub) return sub;
         }
-        var all = root.querySelectorAll ? root.querySelectorAll("*") : [];
-        for (var j = 0; j < all.length; j++) {
-            if (all[j].shadowRoot) {
-                var sub = findBbox(all[j].shadowRoot);
-                if (sub) return sub;
-            }
-        }
+    }
+    return null;
+}
+function clickableRect(el) {
+    if (!el) return null;
+    var r = el.getBoundingClientRect();
+    if (!(r.width > 0 && r.height > 0)) return null;
+    var view = el.ownerDocument && el.ownerDocument.defaultView;
+    var style = view && view.getComputedStyle ? view.getComputedStyle(el) : null;
+    if (style && (style.visibility === "hidden" || style.display === "none" || style.opacity === "0")) {
         return null;
     }
-    var bbox = findBbox(document);
+    return { x: r.left, y: r.top, width: r.width, height: r.height };
+}
+"#;
+
+/// Unified poll evaluator (appended to [`WALKER_JS`]). Returns:
+/// - `token` — non-empty `cf-turnstile-response` (or legacy
+///   `cf_challenge_response`) input value, else null.
+/// - `bbox` — the challenge iframe's rect when it is a valid click target,
+///   else null.
+/// - `hasMarkers` — true when *any* Cloudflare challenge marker is present
+///   (container, hidden input, or challenge iframe — visible or not).
+///
+/// The token input is in light DOM by design (page JS reads it to submit
+/// forms), so `document.querySelector` is sufficient there.
+const POLL_JS: &str = r#"
+(function () {
+    var iframe = findChallengeIframe(document);
+    var bbox = clickableRect(iframe);
     var input =
         document.querySelector('[name="cf-turnstile-response"]') ||
         document.querySelector('[name="cf_challenge_response"]');
     var token = (input && input.value) ? input.value : null;
     var hasContainer = !!document.querySelector('.cf-turnstile, .turnstile, [data-sitekey]');
-    var hasMarkers = hasContainer || !!input || !!bbox;
+    var hasMarkers = hasContainer || !!input || !!iframe;
     return { token: token, bbox: bbox, hasMarkers: hasMarkers };
 })()
 "#;
 
-/// Run [`POLL_JS`] against `session`'s main world and decode the result.
-async fn poll_state(session: &SessionHandle) -> Result<PollState, CloudflareError> {
+/// Scroll-into-view evaluator (appended to [`WALKER_JS`]). Brings the
+/// challenge iframe fully into the viewport when it isn't already, then
+/// returns its *post-scroll* rect — or null if the widget vanished or is not
+/// a valid click target.
+const SCROLL_JS: &str = r#"
+(function () {
+    var iframe = findChallengeIframe(document);
+    if (!iframe) return null;
+    var r = iframe.getBoundingClientRect();
+    var vw = window.innerWidth || document.documentElement.clientWidth;
+    var vh = window.innerHeight || document.documentElement.clientHeight;
+    var fullyVisible = r.top >= 0 && r.left >= 0 && r.bottom <= vh && r.right <= vw;
+    if (!fullyVisible && iframe.scrollIntoView) {
+        iframe.scrollIntoView({ block: "center", inline: "center" });
+    }
+    return clickableRect(iframe);
+})()
+"#;
+
+/// Evaluate `WALKER_JS` + `body` in `session`'s main world and return the
+/// result value (`Value::Null` when the script produced nothing).
+async fn eval_main_world(session: &SessionHandle, body: &str) -> Result<Value, CloudflareError> {
     let res = session
         .call(
             "Runtime.evaluate",
             json!({
-                "expression": POLL_JS,
+                "expression": format!("{WALKER_JS}{body}"),
                 "returnByValue": true,
                 "awaitPromise": true,
             }),
@@ -272,14 +347,31 @@ async fn poll_state(session: &SessionHandle) -> Result<PollState, CloudflareErro
         return Err(CloudflareError::JsError(msg));
     }
 
-    let value = res
+    Ok(res
         .get("result")
         .and_then(|r| r.get("value"))
         .cloned()
-        .unwrap_or(Value::Null);
+        .unwrap_or(Value::Null))
+}
 
+/// Run [`POLL_JS`] against `session`'s main world and decode the result.
+async fn poll_state(session: &SessionHandle) -> Result<PollState, CloudflareError> {
+    let value = eval_main_world(session, POLL_JS).await?;
     serde_json::from_value(value)
         .map_err(|e| CloudflareError::JsError(format!("invalid poll payload: {e}")))
+}
+
+/// Run [`SCROLL_JS`] against `session`'s main world: scroll the challenge
+/// iframe into view if needed and return the rect to click, or `None` when
+/// the widget is gone or not clickable.
+async fn scroll_into_view(session: &SessionHandle) -> Result<Option<BoundingBox>, CloudflareError> {
+    let value = eval_main_world(session, SCROLL_JS).await?;
+    if value.is_null() {
+        return Ok(None);
+    }
+    serde_json::from_value(value)
+        .map(Some)
+        .map_err(|e| CloudflareError::JsError(format!("invalid scroll payload: {e}")))
 }
 
 #[cfg(test)]
@@ -288,23 +380,92 @@ mod tests {
     use super::*;
     use zendriver_transport::testing::MockConnection;
 
-    /// Interactive happy path: poll #1 yields a bbox → click_at fires the
-    /// three mouse events at (15% × width, 50% × height) inside the bbox →
-    /// poll #2 observes the token → TokenAcquired.
+    /// Wrap an evaluator result value in the CDP `Runtime.evaluate` envelope.
+    fn eval_reply(value: Value) -> Value {
+        json!({ "result": { "type": "object", "value": value } })
+    }
+
+    /// One poll-evaluator payload.
+    fn poll_value(token: Option<&str>, bbox: Option<Value>, has_markers: bool) -> Value {
+        json!({
+            "token": token,
+            "bbox": bbox,
+            "hasMarkers": has_markers,
+        })
+    }
+
+    /// A rect payload, as either evaluator returns it.
+    fn rect(x: f64, y: f64, w: f64, h: f64) -> Value {
+        json!({ "x": x, "y": y, "width": w, "height": h })
+    }
+
+    /// Answer the next `Runtime.evaluate`, dispatching on which evaluator it
+    /// carries: the scroll helper gets `scroll`, the poll evaluator gets
+    /// `poll`. Returns `true` when the answered call was the scroll helper.
+    async fn answer_eval(mock: &mut MockConnection, poll: &Value, scroll: &Value) -> bool {
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        let expr = mock.last_sent()["params"]["expression"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let is_scroll = expr.contains("scrollIntoView");
+        let value = if is_scroll {
+            scroll.clone()
+        } else {
+            poll.clone()
+        };
+        mock.reply(id, eval_reply(value)).await;
+        is_scroll
+    }
+
+    /// Answer the three `Input.dispatchMouseEvent` calls of one click and
+    /// return the `(x, y)` they landed on.
+    async fn answer_click(mock: &mut MockConnection) -> (f64, f64) {
+        let mut coords = (f64::NAN, f64::NAN);
+        for expected in ["mouseMoved", "mousePressed", "mouseReleased"] {
+            let id = mock.expect_cmd("Input.dispatchMouseEvent").await;
+            let sent = mock.last_sent().clone();
+            assert_eq!(sent["params"]["type"], expected);
+            coords = (
+                sent["params"]["x"].as_f64().unwrap(),
+                sent["params"]["y"].as_f64().unwrap(),
+            );
+            mock.reply(id, json!({})).await;
+        }
+        coords
+    }
+
+    /// Generic "next outbound command" read, bounded so a finished driver
+    /// ends the drain loop instead of hanging the test.
+    async fn next_cmd(mock: &mut MockConnection) -> Option<(String, u64)> {
+        for _ in 0..300 {
+            if let Some(cmd) = mock.try_recv_cmd() {
+                return Some(cmd);
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        None
+    }
+
+    /// Interactive happy path: poll #1 yields a bbox → the widget is scrolled
+    /// into view → click_at fires the three mouse events at (15% × width,
+    /// 50% × height) of the **post-scroll** rect → poll #2 observes the token
+    /// → TokenAcquired.
     #[tokio::test]
-    async fn wait_for_clearance_clicks_at_bbox_offset_then_returns_token() {
+    async fn wait_for_clearance_scrolls_into_view_then_clicks_at_bbox_offset() {
         let (mut mock, conn) = MockConnection::pair();
         let sess = SessionHandle::new(conn.clone(), "S1");
 
-        // bbox at (100, 200) with 60×40 → click at
+        // Widget starts 2000px below the fold; after scrolling it sits at
+        // (100, 300) with 60×40 → click at
         //   x = 100 + 60 * 0.15 = 109
-        //   y = 200 + 40 * 0.50 = 220
-        const BBOX_X: f64 = 100.0;
-        const BBOX_Y: f64 = 200.0;
+        //   y = 300 + 40 * 0.50 = 320
+        const SCROLLED_X: f64 = 100.0;
+        const SCROLLED_Y: f64 = 300.0;
         const BBOX_W: f64 = 60.0;
         const BBOX_H: f64 = 40.0;
-        const EXPECTED_CLICK_X: f64 = BBOX_X + BBOX_W * 0.15;
-        const EXPECTED_CLICK_Y: f64 = BBOX_Y + BBOX_H * 0.50;
+        const EXPECTED_CLICK_X: f64 = SCROLLED_X + BBOX_W * 0.15;
+        const EXPECTED_CLICK_Y: f64 = SCROLLED_Y + BBOX_H * 0.50;
 
         let fut = tokio::spawn({
             let s = sess.clone();
@@ -314,80 +475,59 @@ mod tests {
             }
         });
 
-        // Poll #1: unified evaluator returns bbox, no token, markers present.
+        // Poll #1: unified evaluator returns an off-screen bbox, no token.
         let id_poll1 = mock.expect_cmd("Runtime.evaluate").await;
+        let expr = mock.last_sent()["params"]["expression"]
+            .as_str()
+            .unwrap()
+            .to_string();
         assert!(
-            mock.last_sent()["params"]["expression"]
-                .as_str()
-                .unwrap()
-                .contains("challenges.cloudflare.com"),
-            "poll eval should walk for challenges.cloudflare.com iframe"
+            expr.contains("challenges.cloudflare.com"),
+            "poll eval should walk for the challenges.cloudflare.com iframe"
         );
         assert!(
-            mock.last_sent()["params"]["expression"]
-                .as_str()
-                .unwrap()
-                .contains("cf-turnstile-response"),
+            expr.contains("cf-turnstile-response"),
             "poll eval should look at the cf-turnstile-response input"
         );
         mock.reply(
             id_poll1,
-            json!({
-                "result": {
-                    "type": "object",
-                    "value": {
-                        "token": null,
-                        "bbox": { "x": BBOX_X, "y": BBOX_Y, "width": BBOX_W, "height": BBOX_H },
-                        "hasMarkers": true,
-                    }
-                }
-            }),
+            eval_reply(poll_value(
+                None,
+                Some(rect(SCROLLED_X, 2000.0, BBOX_W, BBOX_H)),
+                true,
+            )),
         )
         .await;
 
-        // click_at → mouseMoved → mousePressed → mouseReleased.
-        let id_move = mock.expect_cmd("Input.dispatchMouseEvent").await;
-        let sent = mock.last_sent();
-        assert_eq!(sent["params"]["type"], "mouseMoved");
-        assert_eq!(sent["params"]["x"], EXPECTED_CLICK_X);
-        assert_eq!(sent["params"]["y"], EXPECTED_CLICK_Y);
-        mock.reply(id_move, json!({})).await;
+        // Scroll helper runs before the click and re-measures the widget.
+        let id_scroll = mock.expect_cmd("Runtime.evaluate").await;
+        assert!(
+            mock.last_sent()["params"]["expression"]
+                .as_str()
+                .unwrap()
+                .contains("scrollIntoView"),
+            "a click must be preceded by a scroll-into-view + re-measure"
+        );
+        mock.reply(
+            id_scroll,
+            eval_reply(rect(SCROLLED_X, SCROLLED_Y, BBOX_W, BBOX_H)),
+        )
+        .await;
 
-        let id_press = mock.expect_cmd("Input.dispatchMouseEvent").await;
-        let sent = mock.last_sent();
-        assert_eq!(sent["params"]["type"], "mousePressed");
-        assert_eq!(sent["params"]["button"], "left");
-        assert_eq!(sent["params"]["clickCount"], 1);
-        assert_eq!(sent["params"]["x"], EXPECTED_CLICK_X);
-        assert_eq!(sent["params"]["y"], EXPECTED_CLICK_Y);
-        mock.reply(id_press, json!({})).await;
-
-        let id_rel = mock.expect_cmd("Input.dispatchMouseEvent").await;
-        let sent = mock.last_sent();
-        assert_eq!(sent["params"]["type"], "mouseReleased");
-        assert_eq!(sent["params"]["button"], "left");
-        assert_eq!(sent["params"]["clickCount"], 1);
-        mock.reply(id_rel, json!({})).await;
+        // The click uses the post-scroll rect, not the stale off-screen one.
+        let (x, y) = answer_click(&mut mock).await;
+        assert_eq!(x, EXPECTED_CLICK_X);
+        assert_eq!(y, EXPECTED_CLICK_Y);
 
         // Poll #2: token appears → TokenAcquired terminates the loop.
         let id_poll2 = mock.expect_cmd("Runtime.evaluate").await;
         mock.reply(
             id_poll2,
-            json!({
-                "result": {
-                    "type": "object",
-                    "value": {
-                        "token": "TOKEN_XYZ",
-                        "bbox": null,
-                        "hasMarkers": true,
-                    }
-                }
-            }),
+            eval_reply(poll_value(Some("TOKEN_XYZ"), None, true)),
         )
         .await;
 
-        let outcome = fut.await.unwrap().unwrap();
-        match outcome {
+        match fut.await.unwrap().unwrap() {
             ClearanceOutcome::TokenAcquired(t) => assert_eq!(t, "TOKEN_XYZ"),
             other => panic!("expected TokenAcquired, got {other:?}"),
         }
@@ -413,21 +553,11 @@ mod tests {
         let id_poll = mock.expect_cmd("Runtime.evaluate").await;
         mock.reply(
             id_poll,
-            json!({
-                "result": {
-                    "type": "object",
-                    "value": {
-                        "token": "INVISIBLE_TOKEN",
-                        "bbox": null,
-                        "hasMarkers": true,
-                    }
-                }
-            }),
+            eval_reply(poll_value(Some("INVISIBLE_TOKEN"), None, true)),
         )
         .await;
 
-        let outcome = fut.await.unwrap().unwrap();
-        match outcome {
+        match fut.await.unwrap().unwrap() {
             ClearanceOutcome::TokenAcquired(t) => assert_eq!(t, "INVISIBLE_TOKEN"),
             other => panic!("expected TokenAcquired, got {other:?}"),
         }
@@ -437,8 +567,114 @@ mod tests {
         conn.shutdown();
     }
 
-    /// ChallengeGone path: poll #1 yields a bbox → click → poll #2 reports
-    /// no bbox and no token → ChallengeGone.
+    /// Markers are present but no clickable widget is mounted yet (invisible
+    /// Turnstile still computing): the loop must keep waiting for the token,
+    /// NOT read "markers seen" as "challenge gone".
+    #[tokio::test]
+    async fn wait_for_clearance_keeps_waiting_while_markers_are_still_present() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                let b = CloudflareBypass::new(&s).poll_interval(Duration::from_millis(1));
+                b.wait_for_clearance(Duration::from_secs(5)).await
+            }
+        });
+
+        // Two ticks with markers but no bbox and no token.
+        for _ in 0..2 {
+            let id = mock.expect_cmd("Runtime.evaluate").await;
+            mock.reply(id, eval_reply(poll_value(None, None, true)))
+                .await;
+        }
+
+        // Third tick: the token finally lands.
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id, eval_reply(poll_value(Some("LATE_TOKEN"), None, true)))
+            .await;
+
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::TokenAcquired(t) => assert_eq!(t, "LATE_TOKEN"),
+            other => panic!("expected TokenAcquired, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    /// JS-only interstitial that clears itself: challenge markers are seen on
+    /// tick #1, no iframe is ever clickable, and on tick #2 every marker is
+    /// gone → ChallengeGone. This terminal used to be unreachable without a
+    /// click, so this flow returned TimedOut instead of success.
+    #[tokio::test]
+    async fn wait_for_clearance_returns_challenge_gone_when_markers_vanish_without_click() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                let b = CloudflareBypass::new(&s).poll_interval(Duration::from_millis(1));
+                b.wait_for_clearance(Duration::from_secs(5)).await
+            }
+        });
+
+        // Tick #1: interstitial markers, no clickable widget.
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id1, eval_reply(poll_value(None, None, true)))
+            .await;
+
+        // Tick #2: the interstitial cleared itself — every marker is gone.
+        let id2 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id2, eval_reply(poll_value(None, None, false)))
+            .await;
+
+        let outcome = fut.await.unwrap().unwrap();
+        assert!(
+            matches!(outcome, ClearanceOutcome::ChallengeGone),
+            "expected ChallengeGone, got {outcome:?}"
+        );
+        conn.shutdown();
+    }
+
+    /// A page with no Cloudflare gate at all must never be reported as
+    /// ChallengeGone: with no markers ever observed, the run ends in
+    /// `TimedOut { saw_challenge: false }`.
+    #[tokio::test]
+    async fn wait_for_clearance_times_out_when_no_markers_ever_seen() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                let b = CloudflareBypass::new(&s).poll_interval(Duration::from_millis(1));
+                b.wait_for_clearance(Duration::from_millis(40)).await
+            }
+        });
+
+        for _ in 0..50 {
+            let Ok(id) = tokio::time::timeout(
+                Duration::from_millis(80),
+                mock.expect_cmd("Runtime.evaluate"),
+            )
+            .await
+            else {
+                break;
+            };
+            mock.reply(id, eval_reply(poll_value(None, None, false)))
+                .await;
+        }
+
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::TimedOut { saw_challenge } => assert!(!saw_challenge),
+            other => panic!("expected TimedOut, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    /// ChallengeGone path: poll #1 yields a bbox → scroll + click → poll #2
+    /// reports no bbox and no token → ChallengeGone.
     #[tokio::test]
     async fn wait_for_clearance_returns_challenge_gone_when_iframe_disappears_after_click() {
         let (mut mock, conn) = MockConnection::pair();
@@ -452,48 +688,82 @@ mod tests {
             }
         });
 
-        // Poll #1: bbox present.
-        let id_poll1 = mock.expect_cmd("Runtime.evaluate").await;
-        mock.reply(
-            id_poll1,
-            json!({
-                "result": {
-                    "type": "object",
-                    "value": {
-                        "token": null,
-                        "bbox": { "x": 10.0, "y": 20.0, "width": 40.0, "height": 40.0 },
-                        "hasMarkers": true,
-                    }
-                }
-            }),
+        // Poll #1: bbox present. Then the scroll helper re-measures it.
+        let widget = rect(10.0, 20.0, 40.0, 40.0);
+        let is_scroll = answer_eval(
+            &mut mock,
+            &poll_value(None, Some(widget.clone()), true),
+            &widget,
         )
         .await;
+        assert!(!is_scroll, "first evaluate is the poll evaluator");
+        let is_scroll = answer_eval(&mut mock, &poll_value(None, None, true), &widget).await;
+        assert!(is_scroll, "second evaluate is the scroll helper");
 
-        // click sequence.
-        for _ in 0..3 {
-            let id = mock.expect_cmd("Input.dispatchMouseEvent").await;
-            mock.reply(id, json!({})).await;
-        }
+        answer_click(&mut mock).await;
 
-        // Poll #2: iframe gone, no token.
+        // Poll #2: iframe gone, no token — markers linger in the DOM.
         let id_poll2 = mock.expect_cmd("Runtime.evaluate").await;
-        mock.reply(
-            id_poll2,
-            json!({
-                "result": {
-                    "type": "object",
-                    "value": {
-                        "token": null,
-                        "bbox": null,
-                        "hasMarkers": true,
-                    }
-                }
-            }),
-        )
-        .await;
+        mock.reply(id_poll2, eval_reply(poll_value(None, None, true)))
+            .await;
 
         let outcome = fut.await.unwrap().unwrap();
         assert!(matches!(outcome, ClearanceOutcome::ChallengeGone));
+        conn.shutdown();
+    }
+
+    /// A widget that stays mounted and unanswered gets clicked again after
+    /// [`CLICK_RETRY_TICKS`] ticks — but never more than
+    /// [`MAX_CLICK_ATTEMPTS`] times in one run.
+    #[tokio::test]
+    async fn wait_for_clearance_retries_click_up_to_max_attempts() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                let b = CloudflareBypass::new(&s).poll_interval(Duration::from_millis(1));
+                b.wait_for_clearance(Duration::from_millis(200)).await
+            }
+        });
+
+        let widget = rect(10.0, 20.0, 40.0, 40.0);
+        let poll = poll_value(None, Some(widget.clone()), true);
+
+        let mut clicks: u32 = 0;
+        while let Some((method, id)) = next_cmd(&mut mock).await {
+            match method.as_str() {
+                "Runtime.evaluate" => {
+                    let is_scroll = mock.last_sent()["params"]["expression"]
+                        .as_str()
+                        .unwrap()
+                        .contains("scrollIntoView");
+                    let value = if is_scroll {
+                        widget.clone()
+                    } else {
+                        poll.clone()
+                    };
+                    mock.reply(id, eval_reply(value)).await;
+                }
+                "Input.dispatchMouseEvent" => {
+                    if mock.last_sent()["params"]["type"] == "mousePressed" {
+                        clicks += 1;
+                    }
+                    mock.reply(id, json!({})).await;
+                }
+                other => panic!("unexpected CDP method {other}"),
+            }
+        }
+
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::TimedOut { saw_challenge } => assert!(saw_challenge),
+            other => panic!("expected TimedOut, got {other:?}"),
+        }
+        assert_eq!(
+            clicks, MAX_CLICK_ATTEMPTS,
+            "a mounted, unanswered widget should be retried up to the cap"
+        );
         conn.shutdown();
     }
 }

--- a/crates/zendriver-cloudflare/src/detect.js
+++ b/crates/zendriver-cloudflare/src/detect.js
@@ -1,18 +1,24 @@
+// `var` + indexed loops, no `for...of`: the crate-wide convention for
+// injected source, stated in full on `WALKER_JS` in `bypass.rs`. Short
+// version: `for...of` over a `NodeList` calls
+// `NodeList.prototype[Symbol.iterator]`, which the page can redefine to
+// watch someone walk its DOM.
 (function () {
     function walk(root) {
-        const iframes = root.querySelectorAll
+        var iframes = root.querySelectorAll
             ? root.querySelectorAll("iframe")
             : [];
-        for (const f of iframes) {
+        for (var i = 0; i < iframes.length; i++) {
+            var f = iframes[i];
             if (f.src && f.src.includes("challenges.cloudflare.com")) {
-                const r = f.getBoundingClientRect();
+                var r = f.getBoundingClientRect();
                 return { x: r.left, y: r.top, width: r.width, height: r.height };
             }
         }
-        const all = root.querySelectorAll ? root.querySelectorAll("*") : [];
-        for (const el of all) {
-            if (el.shadowRoot) {
-                const sub = walk(el.shadowRoot);
+        var all = root.querySelectorAll ? root.querySelectorAll("*") : [];
+        for (var j = 0; j < all.length; j++) {
+            if (all[j].shadowRoot) {
+                var sub = walk(all[j].shadowRoot);
                 if (sub) return sub;
             }
         }

--- a/crates/zendriver-cloudflare/src/detection.rs
+++ b/crates/zendriver-cloudflare/src/detection.rs
@@ -25,19 +25,24 @@ pub(crate) struct BoundingBox {
     pub height: f64,
 }
 
-/// Run the shadow-DOM walker against `session`'s main world.
+/// Evaluate `expression` in `session`'s main world and return its completion
+/// value (`Value::Null` when the script produced nothing).
 ///
-/// Returns `Ok(Some(bbox))` when a Turnstile iframe is mounted, `Ok(None)`
-/// otherwise. Propagates [`CloudflareError::JsError`] if the evaluation
-/// raised, and [`CloudflareError::Call`] if the underlying CDP call failed.
-pub(crate) async fn detect_challenge(
+/// `expression` must already be a self-contained expression: no `contextId`
+/// is sent, so this runs as a classic script in the page's own realm and
+/// anything declared at its top level would land on the page's global object.
+///
+/// Propagates [`CloudflareError::JsError`] when the evaluation raised, and
+/// [`CloudflareError::Call`] when the CDP call itself failed.
+pub(crate) async fn eval_main_world(
     session: &SessionHandle,
-) -> Result<Option<BoundingBox>, CloudflareError> {
+    expression: &str,
+) -> Result<Value, CloudflareError> {
     let res = session
         .call(
             "Runtime.evaluate",
             json!({
-                "expression": include_str!("detect.js"),
+                "expression": expression,
                 "returnByValue": true,
                 "awaitPromise": true,
             }),
@@ -54,11 +59,25 @@ pub(crate) async fn detect_challenge(
         return Err(CloudflareError::JsError(msg));
     }
 
-    let value = res
+    Ok(res
         .get("result")
         .and_then(|r| r.get("value"))
         .cloned()
-        .unwrap_or(Value::Null);
+        .unwrap_or(Value::Null))
+}
+
+/// Run the shadow-DOM walker against `session`'s main world.
+///
+/// Returns `Ok(Some(bbox))` when a Turnstile iframe is mounted, `Ok(None)`
+/// otherwise.
+///
+/// Deliberately a different question from the poll evaluator's `bbox`: this
+/// reports a *mounted* iframe, `PollState::bbox` reports a *clickable* one.
+/// A 0×0 invisible-Turnstile iframe is mounted but must never be clicked.
+pub(crate) async fn detect_challenge(
+    session: &SessionHandle,
+) -> Result<Option<BoundingBox>, CloudflareError> {
+    let value = eval_main_world(session, include_str!("detect.js")).await?;
 
     if value.is_null() {
         return Ok(None);

--- a/crates/zendriver-cloudflare/src/lib.rs
+++ b/crates/zendriver-cloudflare/src/lib.rs
@@ -15,7 +15,10 @@
 //! 2. Dispatch a raw left-click at the 15% × 50% offset inside the iframe
 //!    bbox (the canonical Turnstile checkbox location).
 //! 3. Poll for either the `cf-turnstile-response` input gaining a token, or
-//!    the challenge container disappearing entirely.
+//!    the challenge ceasing to be actionable — the clicked iframe no longer
+//!    a valid click target, or every challenge marker gone. See
+//!    [`ClearanceOutcome::ChallengeGone`] for why the first of those is not
+//!    proof the gate was passed.
 //!
 //! Most users go through `zendriver`'s `Tab::cloudflare()` (feature-gated)
 //! rather than constructing the bypass directly. The

--- a/crates/zendriver-datadome/src/bypass.rs
+++ b/crates/zendriver-datadome/src/bypass.rs
@@ -96,6 +96,11 @@ impl<'tab> DataDomeBypass<'tab> {
     /// cid, hash) and returns a [`DataDomeSolution`] carrying the solved
     /// `datadome` cookie — wire it to a service like 2captcha / capsolver.
     ///
+    /// Invoked at most once per [`wait_for_clearance`](Self::wait_for_clearance)
+    /// — solving is billed per call, and the reloaded page needs time to settle
+    /// before the surface can be judged again — and bounded by that call's
+    /// timeout, so a stalled solver cannot overrun the stated budget.
+    ///
     /// [`DataDomeChallenge`]: crate::captcha::DataDomeChallenge
     /// [`DataDomeSolution`]: crate::captcha::DataDomeSolution
     #[must_use]
@@ -141,32 +146,20 @@ impl<'tab> DataDomeBypass<'tab> {
             Err(_) => return Ok(ClearanceOutcome::TimedOut { last_surface: None }),
         };
 
-        match snapshot.surface {
-            DataDomeSurface::None if snapshot.body_clean => {
-                return Ok(ClearanceOutcome::AlreadyClear);
-            }
-            DataDomeSurface::Block => return Ok(ClearanceOutcome::Blocked),
-            _ => {}
+        // Only the "nothing to clear" fast path is decided out here — it is
+        // the one terminal the loop cannot express (inside the loop, a clean
+        // page means the challenge *resolved*). Block and CAPTCHA escalation
+        // live in the loop so they also fire when the surface changes
+        // mid-flight, which is the normal shape: a device check hands off to
+        // a CAPTCHA, or to a ban, seconds in.
+        if snapshot.surface == DataDomeSurface::None && snapshot.body_clean {
+            return Ok(ClearanceOutcome::AlreadyClear);
         }
 
-        // Pre-loop captcha escalation.
-        if snapshot.surface == DataDomeSurface::Captcha {
-            let Some(solver) = self.on_captcha.clone() else {
-                return Err(DataDomeError::CaptchaRequired);
-            };
-            let challenge = crate::captcha::build_challenge(self.session, &snapshot).await?;
-            let site_url = challenge.site_url.clone();
-            let solution = solver(challenge)
-                .await
-                .map_err(DataDomeError::CaptchaSolver)?;
-            crate::captcha::apply_solution(self.session, &solution, &site_url).await?;
-            // Page reloaded — discard the stale snapshot, force a re-probe.
-            return self.poll_loop(deadline, None, None, None).await;
-        }
-
-        // Optional Fetch-domain fast-path. The guard's `Drop` cooperatively
-        // cancels the spawned task (token check at every loop boundary)
-        // with `abort()` as a backstop.
+        // Optional Fetch-domain fast-path. Spawned before any escalation so
+        // the CAPTCHA route gets the same fast wake-up as the device-check
+        // route. The guard's `Drop` cooperatively cancels the spawned task
+        // (token check at every loop boundary) with `abort()` as a backstop.
         let (interception_rx, interception_guard) = if self.interception_enabled {
             let (rx, guard) = crate::interception::spawn_signal(self.session);
             (Some(rx), Some(guard))
@@ -182,6 +175,28 @@ impl<'tab> DataDomeBypass<'tab> {
         .await
     }
 
+    /// Escalate a CAPTCHA surface to the registered solver and apply the
+    /// solved cookie. Errors with [`DataDomeError::CaptchaRequired`] when no
+    /// solver is registered. On success the page has been reloaded, so the
+    /// caller must re-probe rather than reuse `snap`.
+    async fn solve_captcha(&self, snap: &DetectionSnapshot) -> Result<(), DataDomeError> {
+        let Some(solver) = self.on_captcha.clone() else {
+            return Err(DataDomeError::CaptchaRequired);
+        };
+        let challenge = crate::captcha::build_challenge(self.session, snap).await?;
+        let site_url = challenge.site_url.clone();
+        let solution = solver(challenge)
+            .await
+            .map_err(DataDomeError::CaptchaSolver)?;
+        crate::captcha::apply_solution(self.session, &solution, &site_url).await
+    }
+
+    /// Core poll loop. Owns every mid-flight terminal — clearance, ban, and
+    /// CAPTCHA escalation — so a surface that changes after the pre-loop
+    /// probe is handled exactly like one present from the start.
+    ///
+    /// Factored out so unit tests can drive it with a controlled interception
+    /// receiver without standing up the real `Fetch.enable` plumbing.
     pub(crate) async fn poll_loop(
         self,
         deadline: Instant,
@@ -199,6 +214,10 @@ impl<'tab> DataDomeBypass<'tab> {
         #[allow(unused_assignments)]
         let mut last_surface: Option<DataDomeSurface> = None;
 
+        // One solve attempt per clearance. See the CAPTCHA arm below for why
+        // the surface cannot be relied on to clear itself once a solve returns.
+        let mut captcha_attempted = false;
+
         loop {
             let snap = match next_snapshot.take() {
                 Some(s) => s,
@@ -213,17 +232,63 @@ impl<'tab> DataDomeBypass<'tab> {
                 },
             };
 
-            let cookie = snap.datadome.as_ref().filter(|v| !v.is_empty());
-            match (cookie, snap.body_clean) {
-                (Some(c), true) => {
-                    return Ok(ClearanceOutcome::Cleared {
-                        datadome: c.clone(),
-                    });
+            // Escalations are polled, not assumed to arrive on the first
+            // probe: DataDome routinely upgrades a device check to a CAPTCHA
+            // (or drops it to a ban) a few seconds into the interstitial.
+            //
+            // Deciding the surface before clearance is safe here, unlike the
+            // Imperva sibling, because `detect.js` derives `body_clean` as
+            // `!dd && !captchaUrl`: a `Captcha` or `Block` surface forces
+            // `body_clean == false`, and both clearance terminals below
+            // require it true. No snapshot can be cleared and escalatable at
+            // once. The DataDome surface is also vendor-specific (a
+            // `captcha-delivery.com` iframe), so the site's own reCAPTCHA —
+            // what made Imperva's ordering wrong — cannot flip it.
+            match snap.surface {
+                DataDomeSurface::Block => return Ok(ClearanceOutcome::Blocked),
+                // Latched to a single attempt. `apply_solution` sets the
+                // cookie and fires `Page.reload`, and that command is acked
+                // the moment it lands — not when the replacement document has
+                // loaded. The CAPTCHA document therefore survives at least the
+                // next probe, and forever if the solved cookie was rejected,
+                // so an unlatched loop re-enters the solver on every 250ms
+                // tick: two reproductions counted 29 and 34 invocations inside
+                // one `wait_for_clearance`, each of them a paid solve.
+                DataDomeSurface::Captcha => {
+                    if !captcha_attempted {
+                        captcha_attempted = true;
+                        // The solver is caller-supplied and carries no bound of
+                        // its own. Only the loop-top probe was raced against
+                        // the deadline, so a solve entered just under it ran to
+                        // completion and overran the caller's timeout by a full
+                        // solver latency. Losing this race drops the in-flight
+                        // solve: the stated timeout is the contract.
+                        match tokio::time::timeout_at(deadline, self.solve_captcha(&snap)).await {
+                            Ok(res) => res?,
+                            Err(_) => {
+                                return Ok(ClearanceOutcome::TimedOut {
+                                    last_surface: Some(snap.surface),
+                                });
+                            }
+                        }
+                    }
+                    // Page reloaded — next iteration re-probes from scratch.
+                    last_surface = Some(snap.surface);
                 }
-                (None, true) if snap.surface == DataDomeSurface::None => {
-                    return Ok(ClearanceOutcome::ChallengeGone);
+                _ => {
+                    let cookie = snap.datadome.as_ref().filter(|v| !v.is_empty());
+                    match (cookie, snap.body_clean) {
+                        (Some(c), true) => {
+                            return Ok(ClearanceOutcome::Cleared {
+                                datadome: c.clone(),
+                            });
+                        }
+                        (None, true) if snap.surface == DataDomeSurface::None => {
+                            return Ok(ClearanceOutcome::ChallengeGone);
+                        }
+                        _ => last_surface = Some(snap.surface),
+                    }
                 }
-                _ => last_surface = Some(snap.surface),
             }
 
             if Instant::now() >= deadline {
@@ -535,6 +600,226 @@ mod tests {
         conn.shutdown();
     }
 
+    /// Generic bounded read of the next outbound command, for flows whose
+    /// command order is not fully deterministic (the interception task emits
+    /// `Fetch.enable` from its own spawn).
+    async fn next_cmd(mock: &mut MockConnection) -> Option<(String, u64)> {
+        for _ in 0..300 {
+            if let Some(cmd) = mock.try_recv_cmd() {
+                return Some(cmd);
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        None
+    }
+
+    fn device_check_snap() -> serde_json::Value {
+        json!({"surface":"device_check","datadome":null,"dd":{"cid":"C","hsh":"H","t":"fe","host":"h"},"captcha_url":null,"body_clean":false})
+    }
+
+    fn captcha_snap() -> serde_json::Value {
+        json!({"surface":"captcha","datadome":"OLD","dd":{"cid":"C","hsh":"H","t":"fe","host":"h"},"captcha_url":"https://geo.captcha-delivery.com/captcha/?cid=C","body_clean":false})
+    }
+
+    /// The normal DataDome escalation shape: the interstitial starts as a
+    /// device check and only *then* hands off to a CAPTCHA. Escalation used
+    /// to be checked on the pre-loop probe only, so this arrival never
+    /// reached the registered solver.
+    #[tokio::test]
+    async fn device_check_escalating_to_captcha_invokes_solver() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .on_captcha(|ch| async move {
+                        assert!(ch.captcha_url.contains("captcha-delivery.com"));
+                        Ok(crate::captcha::DataDomeSolution {
+                            datadome_cookie: "FROM_SOLVER".into(),
+                        })
+                    })
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        // Probe 1 (pre-loop): device check — no escalation yet.
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id1, snap_reply(device_check_snap())).await;
+
+        // Probe 2 (in-loop): the device check escalated to a CAPTCHA.
+        let id2 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id2, snap_reply(captcha_snap())).await;
+
+        // Solver path: build_challenge eval → setCookie → reload.
+        let id_ctx = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id_ctx,
+            json!({"result":{"type":"object","value":{"url":"https://shop.example.com/p","ua":"Mozilla/5.0"}}}),
+        )
+        .await;
+        let id_cookie = mock.expect_cmd("Network.setCookie").await;
+        assert_eq!(mock.last_sent()["params"]["value"], "FROM_SOLVER");
+        mock.reply(id_cookie, json!({"success":true})).await;
+        let id_reload = mock.expect_cmd("Page.reload").await;
+        mock.reply(id_reload, json!({})).await;
+
+        // Probe 3: cleared.
+        let id3 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id3,
+            snap_reply(
+                json!({"surface":"none","datadome":"FROM_SOLVER","dd":null,"captcha_url":null,"body_clean":true}),
+            ),
+        )
+        .await;
+
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::Cleared { datadome } => assert_eq!(datadome, "FROM_SOLVER"),
+            other => panic!("expected Cleared, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    /// A CAPTCHA that arrives mid-flight with no solver registered must still
+    /// produce the actionable `CaptchaRequired` error, not a silent timeout.
+    #[tokio::test]
+    async fn mid_flight_captcha_without_solver_errors() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id1, snap_reply(device_check_snap())).await;
+        let id2 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id2, snap_reply(captcha_snap())).await;
+
+        assert!(matches!(
+            fut.await.unwrap().unwrap_err(),
+            DataDomeError::CaptchaRequired
+        ));
+        conn.shutdown();
+    }
+
+    /// A ban that lands after the pre-loop probe must terminate as `Blocked`
+    /// — the caller needs "change your IP", not "timed out".
+    #[tokio::test]
+    async fn device_check_escalating_to_block_returns_blocked() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(id1, snap_reply(device_check_snap())).await;
+        let id2 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id2,
+            snap_reply(
+                json!({"surface":"block","datadome":null,"dd":{"cid":"C","hsh":"H","t":"bv","host":"h"},"captcha_url":null,"body_clean":false}),
+            ),
+        )
+        .await;
+
+        assert!(matches!(
+            fut.await.unwrap().unwrap(),
+            ClearanceOutcome::Blocked
+        ));
+        conn.shutdown();
+    }
+
+    /// `with_interception()` used to be dropped on the CAPTCHA route: that
+    /// branch returned into the poll loop with no receiver and no guard, so
+    /// the fast path was silently off exactly where it matters most. A
+    /// `Fetch.enable` on the wire proves the subscription is armed.
+    #[tokio::test]
+    async fn captcha_route_arms_the_interception_fast_path() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .with_interception()
+                    .on_captcha(|_ch| async move {
+                        Ok(crate::captcha::DataDomeSolution {
+                            datadome_cookie: "FROM_SOLVER".into(),
+                        })
+                    })
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        let mut saw_fetch_enable = false;
+        let mut reloaded = false;
+        while let Some((method, id)) = next_cmd(&mut mock).await {
+            match method.as_str() {
+                "Fetch.enable" => {
+                    saw_fetch_enable = true;
+                    mock.reply(id, json!({})).await;
+                }
+                "Runtime.evaluate" => {
+                    let expr = mock.last_sent()["params"]["expression"]
+                        .as_str()
+                        .unwrap()
+                        .to_string();
+                    if expr.contains("location.href") {
+                        mock.reply(
+                            id,
+                            json!({"result":{"type":"object","value":{"url":"https://shop.example.com/p","ua":"UA"}}}),
+                        )
+                        .await;
+                    } else if reloaded {
+                        mock.reply(
+                            id,
+                            snap_reply(
+                                json!({"surface":"none","datadome":"FROM_SOLVER","dd":null,"captcha_url":null,"body_clean":true}),
+                            ),
+                        )
+                        .await;
+                    } else {
+                        mock.reply(id, snap_reply(captcha_snap())).await;
+                    }
+                }
+                "Network.setCookie" => mock.reply(id, json!({"success":true})).await,
+                "Page.reload" => {
+                    reloaded = true;
+                    mock.reply(id, json!({})).await;
+                }
+                _ => mock.reply(id, json!({})).await,
+            }
+        }
+
+        match fut.await.unwrap().unwrap() {
+            ClearanceOutcome::Cleared { datadome } => assert_eq!(datadome, "FROM_SOLVER"),
+            other => panic!("expected Cleared, got {other:?}"),
+        }
+        assert!(
+            saw_fetch_enable,
+            "with_interception() must arm the Fetch fast path on the captcha route too"
+        );
+        conn.shutdown();
+    }
+
     #[tokio::test]
     async fn interception_signal_triggers_reprobe() {
         let (mut mock, conn) = MockConnection::pair();
@@ -568,6 +853,165 @@ mod tests {
             ClearanceOutcome::Cleared { datadome } => assert_eq!(datadome, "DD"),
             other => panic!("expected Cleared, got {other:?}"),
         }
+        conn.shutdown();
+    }
+
+    /// `apply_solution` sets the cookie and fires `Page.reload`, which is acked
+    /// long before the replacement document loads — so the next probe still
+    /// sees the CAPTCHA, and a page whose solve was rejected never stops
+    /// showing it. Unlatched, the loop re-entered the solver on every tick
+    /// (29 and 34 invocations in two recorded reproductions), each one a paid
+    /// solve.
+    #[tokio::test]
+    async fn captcha_solver_is_invoked_at_most_once_per_clearance() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            let c = Arc::clone(&calls);
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .timeout(Duration::from_millis(400))
+                    .on_captcha(move |_ch| {
+                        let c = Arc::clone(&c);
+                        async move {
+                            c.fetch_add(1, Ordering::SeqCst);
+                            Ok(crate::captcha::DataDomeSolution {
+                                datadome_cookie: "FROM_SOLVER".into(),
+                            })
+                        }
+                    })
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        // Serve a stuck CAPTCHA surface for as long as the loop asks. Replies
+        // are picked by command + expression shape: the detect probe gets the
+        // captcha snapshot, `build_challenge`'s url/ua eval gets a page
+        // context, and `apply_solution`'s setCookie / reload get bare acks.
+        // Nothing here ever clears the surface, so only the latch can stop a
+        // second solve.
+        while let Some((method, id)) = next_cmd(&mut mock).await {
+            match method.as_str() {
+                "Runtime.evaluate" => {
+                    let expr = mock.last_sent()["params"]["expression"]
+                        .as_str()
+                        .unwrap()
+                        .to_string();
+                    if expr.contains("location.href") {
+                        mock.reply(
+                            id,
+                            json!({"result":{"type":"object","value":{"url":"https://shop.example.com/p","ua":"UA"}}}),
+                        )
+                        .await;
+                    } else {
+                        mock.reply(id, snap_reply(captcha_snap())).await;
+                    }
+                }
+                "Network.setCookie" => mock.reply(id, json!({"success":true})).await,
+                _ => mock.reply(id, json!({})).await,
+            }
+        }
+
+        let outcome = fut.await.unwrap().unwrap();
+        assert!(
+            matches!(outcome, ClearanceOutcome::TimedOut { .. }),
+            "a CAPTCHA that never clears must poll to its deadline, got {outcome:?}"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "solver must be latched to one attempt per clearance"
+        );
+        conn.shutdown();
+    }
+
+    /// The solver is a caller-supplied network round-trip with no bound of its
+    /// own. Only the loop-top probe was raced against the deadline, so a solve
+    /// entered just under it ran to completion and overran the caller's stated
+    /// timeout by a full solver latency.
+    #[tokio::test]
+    async fn solver_cannot_overrun_the_configured_timeout() {
+        const SOLVER_LATENCY: Duration = Duration::from_secs(3);
+        const BUDGET: Duration = Duration::from_millis(80);
+
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let started = Instant::now();
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                DataDomeBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .timeout(BUDGET)
+                    .on_captcha(|_ch| async move {
+                        tokio::time::sleep(SOLVER_LATENCY).await;
+                        Ok(crate::captcha::DataDomeSolution {
+                            datadome_cookie: "TOO_LATE".into(),
+                        })
+                    })
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        // Serve the whole flow — detect probe, `build_challenge`'s url/ua eval,
+        // and the setCookie / reload the solve would reach on its way back —
+        // and stay up for as long as the call runs, since a stalled solver
+        // sends nothing for seconds. The unbounded version therefore fails on
+        // the elapsed assertion below rather than on a dropped mock.
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let serving = tokio::spawn({
+            let done = Arc::clone(&done);
+            async move {
+                while !done.load(std::sync::atomic::Ordering::SeqCst) {
+                    let Some((method, id)) = mock.try_recv_cmd() else {
+                        tokio::time::sleep(Duration::from_millis(1)).await;
+                        continue;
+                    };
+                    match method.as_str() {
+                        "Runtime.evaluate" => {
+                            let expr = mock.last_sent()["params"]["expression"]
+                                .as_str()
+                                .unwrap()
+                                .to_string();
+                            if expr.contains("location.href") {
+                                mock.reply(
+                                id,
+                                json!({"result":{"type":"object","value":{"url":"https://shop.example.com/p","ua":"UA"}}}),
+                            )
+                            .await;
+                            } else {
+                                mock.reply(id, snap_reply(captcha_snap())).await;
+                            }
+                        }
+                        "Network.setCookie" => mock.reply(id, json!({"success":true})).await,
+                        _ => mock.reply(id, json!({})).await,
+                    }
+                }
+            }
+        });
+
+        let outcome = fut.await.unwrap().unwrap();
+        let elapsed = started.elapsed();
+        done.store(true, std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            matches!(outcome, ClearanceOutcome::TimedOut { .. }),
+            "expected TimedOut, got {outcome:?}"
+        );
+        assert!(
+            elapsed < SOLVER_LATENCY / 2,
+            "solve must be bounded by the caller's deadline; took {elapsed:?} against a {BUDGET:?} budget"
+        );
+        serving.abort();
         conn.shutdown();
     }
 }

--- a/crates/zendriver-datadome/src/bypass.rs
+++ b/crates/zendriver-datadome/src/bypass.rs
@@ -218,6 +218,10 @@ impl<'tab> DataDomeBypass<'tab> {
         // the surface cannot be relied on to clear itself once a solve returns.
         let mut captcha_attempted = false;
 
+        let mut prev_surface: Option<DataDomeSurface> = None;
+        let mut stall_ticks: u32 = 0;
+        let mut warned_stall = false;
+
         loop {
             let snap = match next_snapshot.take() {
                 Some(s) => s,
@@ -291,6 +295,27 @@ impl<'tab> DataDomeBypass<'tab> {
                 }
             }
 
+            // Stall hint, ported from the Imperva sibling. A device check that
+            // sits on the same surface tick after tick is almost always
+            // stealth being off, and that is precisely what a
+            // `TimedOut { last_surface }` return value cannot tell the caller:
+            // thirty seconds of silence, then a terminal that looks identical
+            // to a site simply being slow. Latched, so a run emits one line.
+            stall_ticks = if Some(snap.surface) == prev_surface {
+                stall_ticks + 1
+            } else {
+                0
+            };
+            prev_surface = Some(snap.surface);
+            if stall_ticks == 10 && !warned_stall {
+                tracing::warn!(
+                    surface = ?snap.surface,
+                    poll_interval_ms = self.poll_interval.as_millis() as u64,
+                    "datadome clearance stalled — is BrowserBuilder::stealth enabled?"
+                );
+                warned_stall = true;
+            }
+
             if Instant::now() >= deadline {
                 return Ok(ClearanceOutcome::TimedOut { last_surface });
             }
@@ -322,7 +347,13 @@ impl<'tab> DataDomeBypass<'tab> {
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use zendriver_transport::testing::MockConnection;
+    use zendriver_transport::testing::{LogCapture, MockConnection};
+
+    /// How long a drain loop waits for the driver's next command before
+    /// deciding the run is over. Long enough to cover a poll interval plus
+    /// scheduling jitter, short enough that a finished driver ends the loop
+    /// promptly instead of hanging the test.
+    const DRAIN_BUDGET: Duration = Duration::from_millis(300);
 
     #[tokio::test]
     async fn builder_defaults_and_overrides() {
@@ -475,6 +506,65 @@ mod tests {
         conn.shutdown();
     }
 
+    /// A device check that sits on the same surface tick after tick is almost
+    /// always stealth being off, and a bare `TimedOut { last_surface }` cannot
+    /// say so. Both siblings emit that hint; DataDome tracked `last_surface`
+    /// but never compared consecutive snapshots, so its users got thirty
+    /// seconds of silence and a terminal indistinguishable from a slow site.
+    #[tokio::test]
+    async fn unchanging_surface_emits_the_stealth_hint() {
+        /// Ticks on an unchanged surface before the page is allowed to clear.
+        /// The hint fires on the tenth.
+        const STALLED_TICKS: usize = 12;
+
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let capture = LogCapture::new();
+
+        // Not spawned: `LogCapture` follows the future it wraps, not a task
+        // spawned out of it. The budget is never reached — the server ends the
+        // run — so the tick count does not depend on the clock.
+        let driver = capture.capture(async {
+            DataDomeBypass::new(&sess)
+                .poll_interval(Duration::from_millis(1))
+                .timeout(Duration::from_secs(30))
+                .wait_for_clearance()
+                .await
+        });
+
+        let serving = async {
+            let mut probes = 0usize;
+            while let Some((method, id)) = mock.recv_cmd_timeout(DRAIN_BUDGET).await {
+                assert_eq!(method, "Runtime.evaluate");
+                probes += 1;
+                let snap = if probes > STALLED_TICKS {
+                    json!({"surface":"none","datadome":"CLEARED","dd":null,"captcha_url":null,"body_clean":true})
+                } else {
+                    device_check_snap()
+                };
+                mock.reply(id, snap_reply(snap)).await;
+            }
+        };
+
+        let (outcome, ()) = tokio::join!(driver, serving);
+
+        match outcome.unwrap() {
+            ClearanceOutcome::Cleared { datadome } => assert_eq!(datadome, "CLEARED"),
+            other => panic!("expected Cleared, got {other:?}"),
+        }
+        assert!(
+            capture.contains("clearance stalled"),
+            "an unchanging device check is a stalled run; captured {:?}",
+            capture.events()
+        );
+        assert_eq!(
+            capture.count("clearance stalled"),
+            1,
+            "the hint is latched to one line per run"
+        );
+        conn.shutdown();
+    }
+
     #[tokio::test]
     async fn captcha_with_solver_applies_cookie_then_clears() {
         let (mut mock, conn) = MockConnection::pair();
@@ -598,19 +688,6 @@ mod tests {
             other => panic!("expected TimedOut, got {other:?}"),
         }
         conn.shutdown();
-    }
-
-    /// Generic bounded read of the next outbound command, for flows whose
-    /// command order is not fully deterministic (the interception task emits
-    /// `Fetch.enable` from its own spawn).
-    async fn next_cmd(mock: &mut MockConnection) -> Option<(String, u64)> {
-        for _ in 0..300 {
-            if let Some(cmd) = mock.try_recv_cmd() {
-                return Some(cmd);
-            }
-            tokio::time::sleep(Duration::from_millis(1)).await;
-        }
-        None
     }
 
     fn device_check_snap() -> serde_json::Value {
@@ -771,7 +848,7 @@ mod tests {
 
         let mut saw_fetch_enable = false;
         let mut reloaded = false;
-        while let Some((method, id)) = next_cmd(&mut mock).await {
+        while let Some((method, id)) = mock.recv_cmd_timeout(DRAIN_BUDGET).await {
             match method.as_str() {
                 "Fetch.enable" => {
                     saw_fetch_enable = true;
@@ -898,7 +975,7 @@ mod tests {
         // context, and `apply_solution`'s setCookie / reload get bare acks.
         // Nothing here ever clears the surface, so only the latch can stop a
         // second solve.
-        while let Some((method, id)) = next_cmd(&mut mock).await {
+        while let Some((method, id)) = mock.recv_cmd_timeout(DRAIN_BUDGET).await {
             match method.as_str() {
                 "Runtime.evaluate" => {
                     let expr = mock.last_sent()["params"]["expression"]

--- a/crates/zendriver-datadome/src/bypass.rs
+++ b/crates/zendriver-datadome/src/bypass.rs
@@ -301,6 +301,20 @@ impl<'tab> DataDomeBypass<'tab> {
             // `TimedOut { last_surface }` return value cannot tell the caller:
             // thirty seconds of silence, then a terminal that looks identical
             // to a site simply being slow. Latched, so a run emits one line.
+            //
+            // Fires on the eleventh unchanged tick, not the tenth: the first
+            // snapshot has no predecessor, so it resets the counter instead of
+            // advancing it.
+            //
+            // Deliberately still a copy of Imperva's five lines rather than a
+            // shared helper, and the reason is the size of the thing, not
+            // crate topology: `zendriver-transport` is a dependency of all
+            // three solver crates and could host it perfectly well. Two copies
+            // of a five-line counter, generic over two unrelated surface enums
+            // (`DataDomeSurface`, `ImpervaSurface`), sit below the point where
+            // an abstraction pays for itself. Cloudflare is not a third
+            // caller: it counts ticks that landed no click, which is a
+            // different question that happens to look the same.
             stall_ticks = if Some(snap.surface) == prev_surface {
                 stall_ticks + 1
             } else {
@@ -514,7 +528,9 @@ mod tests {
     #[tokio::test]
     async fn unchanging_surface_emits_the_stealth_hint() {
         /// Ticks on an unchanged surface before the page is allowed to clear.
-        /// The hint fires on the tenth.
+        /// The hint fires on the eleventh, not the tenth: the first snapshot
+        /// has no predecessor to differ from, so it resets the counter rather
+        /// than advancing it. Proven by mutation — this test fails at 10.
         const STALLED_TICKS: usize = 12;
 
         let (mut mock, conn) = MockConnection::pair();

--- a/crates/zendriver-imperva/src/bypass.rs
+++ b/crates/zendriver-imperva/src/bypass.rs
@@ -416,6 +416,13 @@ impl<'tab> ImpervaBypass<'tab> {
                 }
             }
 
+            // Stall hint: a surface sitting unchanged tick after tick is
+            // almost always stealth being off, which a bare `TimedOut` cannot
+            // say. Latched, so a run emits one line. Fires on the eleventh
+            // unchanged tick, not the tenth — the first snapshot has no
+            // predecessor, so it resets the counter instead of advancing it.
+            // DataDome carries the same five lines; the note on why they are
+            // not shared is on that copy.
             stall_ticks = if Some(snap.surface) == prev_surface {
                 stall_ticks + 1
             } else {

--- a/crates/zendriver-imperva/src/bypass.rs
+++ b/crates/zendriver-imperva/src/bypass.rs
@@ -115,8 +115,23 @@ impl<'tab> ImpervaBypass<'tab> {
         self
     }
 
-    /// Register a user-supplied async CAPTCHA solver. Without this, a
-    /// CAPTCHA surface returns [`ImpervaError::CaptchaRequired`] immediately.
+    /// Register a user-supplied async CAPTCHA solver.
+    ///
+    /// The solver runs when the poll loop reaches a CAPTCHA surface *and* no
+    /// usable reese84 token is in hand; without one registered, that same
+    /// condition yields [`ImpervaError::CaptchaRequired`] on the first tick
+    /// that hits it, with no waiting. A snapshot carrying a reese84 never
+    /// escalates whatever the surface says — the site's own post-clearance
+    /// form routinely mounts a plain reCAPTCHA, and a token in hand outranks
+    /// it — so a registered solver can legitimately go uncalled for a whole
+    /// run.
+    ///
+    /// Invoked at most once per
+    /// [`wait_for_clearance`](Self::wait_for_clearance): solving is billed
+    /// per call, and the injected response field never removes the widget, so
+    /// the surface stays `Captcha` afterwards and an unlatched loop would
+    /// re-enter the solver on every tick. The call is also raced against that
+    /// run's timeout, so a stalled solver cannot overrun the stated budget.
     ///
     /// ```no_run
     /// # async fn ex(tab: &zendriver_transport::SessionHandle)
@@ -191,8 +206,10 @@ impl<'tab> ImpervaBypass<'tab> {
     ///   is a normal "didn't finish, retry or give up" terminal.
     ///
     /// # Errors
-    /// - [`ImpervaError::CaptchaRequired`] — CAPTCHA surface detected
-    ///   but no `on_captcha` solver was registered.
+    /// - [`ImpervaError::CaptchaRequired`] — a CAPTCHA surface was reached
+    ///   with no usable reese84 token in hand and no `on_captcha` solver
+    ///   registered. A snapshot carrying a token keeps polling instead of
+    ///   escalating.
     /// - [`ImpervaError::CaptchaSolver`] — registered solver returned an
     ///   error.
     /// - [`ImpervaError::Interception`] — Fetch-domain hook (when set via
@@ -377,7 +394,22 @@ impl<'tab> ImpervaBypass<'tab> {
                     if let crate::detection::ImpervaSurface::Captcha(kind) = snap.surface {
                         if token.is_none() && !captcha_attempted {
                             captcha_attempted = true;
-                            self.solve_captcha(kind).await?;
+                            // The solver is caller-supplied and carries no bound
+                            // of its own. Only the loop-top probe was raced
+                            // against the deadline, so a solve entered just under
+                            // it ran to completion and overran the caller's
+                            // timeout by a full solver latency. Losing this race
+                            // drops the in-flight solve: the stated timeout is
+                            // the contract.
+                            match tokio::time::timeout_at(deadline, self.solve_captcha(kind)).await
+                            {
+                                Ok(res) => res?,
+                                Err(_) => {
+                                    return Ok(ClearanceOutcome::TimedOut {
+                                        last_surface: Some(snap.surface),
+                                    });
+                                }
+                            }
                         }
                     }
                     last_surface = Some(snap.surface);
@@ -1005,12 +1037,11 @@ mod tests {
             "sessions": [],
             "has_imperva_signal": true,
         }));
-        while let Ok(Ok(id)) = tokio::time::timeout(
+        while let Ok(id) = tokio::time::timeout(
             Duration::from_millis(120),
             mock.expect_cmd("Runtime.evaluate"),
         )
         .await
-        .map(Ok::<u64, ()>)
         {
             mock.reply(id, dirty.clone()).await;
         }
@@ -1102,12 +1133,110 @@ mod tests {
             mock.reply(id, reply).await;
         }
 
-        let _ = fut.await.unwrap();
+        let outcome = fut
+            .await
+            .unwrap()
+            .expect("a latched solve must not turn the run into an error terminal");
+        assert!(
+            matches!(outcome, ClearanceOutcome::TimedOut { .. }),
+            "a CAPTCHA that never clears must poll to its deadline, got {outcome:?}"
+        );
         assert_eq!(
             calls.load(Ordering::SeqCst),
             1,
             "solver must be latched to one attempt per clearance"
         );
+        conn.shutdown();
+    }
+
+    /// The solver is a caller-supplied network round-trip with no bound of its
+    /// own. Only the loop-top probe was raced against the deadline, so a solve
+    /// entered just under it ran to completion and overran the caller's stated
+    /// timeout by a full solver latency. The DataDome sibling bounds the same
+    /// call the same way.
+    #[tokio::test]
+    async fn solver_cannot_overrun_the_configured_timeout() {
+        use std::sync::Arc;
+
+        const SOLVER_LATENCY: Duration = Duration::from_secs(3);
+        const BUDGET: Duration = Duration::from_millis(80);
+
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let started = Instant::now();
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                ImpervaBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .timeout(BUDGET)
+                    .on_captcha(|_c| async move {
+                        tokio::time::sleep(SOLVER_LATENCY).await;
+                        Ok(CaptchaSolution {
+                            token: "TOO_LATE".into(),
+                            form_field: "g-recaptcha-response".into(),
+                        })
+                    })
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        // Serve the whole flow — detect probe, the site-key probe, and the
+        // injection the solve would reach on its way back — and stay up for as
+        // long as the call runs, since a stalled solver sends nothing for
+        // seconds. The unbounded version therefore fails on the elapsed
+        // assertion below rather than on a dropped mock.
+        let stuck = snapshot_reply(json!({
+            "surface": { "kind": "Captcha", "captcha": "Recaptcha" },
+            "reese84": null,
+            "body_clean": false,
+            "sessions": [],
+            "has_imperva_signal": true,
+        }));
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let serving = tokio::spawn({
+            let done = Arc::clone(&done);
+            async move {
+                while !done.load(std::sync::atomic::Ordering::SeqCst) {
+                    let Some((_method, id)) = mock.try_recv_cmd() else {
+                        tokio::time::sleep(Duration::from_millis(1)).await;
+                        continue;
+                    };
+                    let expr = mock.last_sent()["params"]["expression"]
+                        .as_str()
+                        .unwrap_or("")
+                        .to_string();
+                    let reply = if expr.contains("has_imperva_signal") {
+                        stuck.clone()
+                    } else if expr.contains("TOO_LATE") {
+                        json!({ "result": { "type": "boolean", "value": true } })
+                    } else {
+                        json!({
+                            "result": {
+                                "type": "object",
+                                "value": { "hcap": null, "rcap": "KEY_ABC", "url": "https://x.test/p" }
+                            }
+                        })
+                    };
+                    mock.reply(id, reply).await;
+                }
+            }
+        });
+
+        let outcome = fut.await.unwrap().unwrap();
+        let elapsed = started.elapsed();
+        done.store(true, std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            matches!(outcome, ClearanceOutcome::TimedOut { .. }),
+            "expected TimedOut, got {outcome:?}"
+        );
+        assert!(
+            elapsed < SOLVER_LATENCY / 2,
+            "solve must be bounded by the caller's deadline; took {elapsed:?} against a {BUDGET:?} budget"
+        );
+        serving.abort();
         conn.shutdown();
     }
 

--- a/crates/zendriver-imperva/src/bypass.rs
+++ b/crates/zendriver-imperva/src/bypass.rs
@@ -233,31 +233,9 @@ impl<'tab> ImpervaBypass<'tab> {
             });
         }
 
-        // CAPTCHA escalation: dispatch to solver or fast-fail.
-        if let crate::detection::ImpervaSurface::Captcha(kind) = snapshot.surface {
-            let Some(solver) = self.on_captcha.clone() else {
-                return Err(ImpervaError::CaptchaRequired { kind });
-            };
-            let (site_key, url) = extract_captcha_site_key(self.session, kind).await?;
-            let solution = solver(CaptchaChallenge {
-                kind,
-                site_key,
-                url,
-            })
-            .await
-            .map_err(ImpervaError::CaptchaSolver)?;
-            inject_captcha_solution(self.session, &solution).await?;
-            // Drop the pre-injection snapshot so the loop re-probes
-            // immediately rather than wasting an iteration on stale state.
-        }
-
-        // Prime the loop with the pre-loop snapshot UNLESS we just ran the
-        // CAPTCHA branch — in that case the page has been mutated since the
-        // snapshot was taken, so force a re-probe.
-        let next_snapshot = match snapshot.surface {
-            crate::detection::ImpervaSurface::Captcha(_) => None,
-            _ => Some(snapshot),
-        };
+        // CAPTCHA escalation is NOT decided here: Imperva commonly upgrades a
+        // reese84 device check to a CAPTCHA a few seconds in, so the loop owns
+        // that branch and the pre-loop snapshot just primes it.
 
         // Optional Fetch-domain fast-path. The guard's `Drop` cooperatively
         // cancels the spawned task (token check at every loop boundary)
@@ -269,11 +247,39 @@ impl<'tab> ImpervaBypass<'tab> {
             (None, None)
         };
 
-        self.poll_loop(deadline, next_snapshot, interception_rx, interception_guard)
-            .await
+        self.poll_loop(
+            deadline,
+            Some(snapshot),
+            interception_rx,
+            interception_guard,
+        )
+        .await
     }
 
-    /// Core poll loop, factored out so unit tests can drive it with a
+    /// Escalate a CAPTCHA surface to the registered solver and inject the
+    /// solution into the page. Errors with [`ImpervaError::CaptchaRequired`]
+    /// when no solver is registered. On success the page has been mutated, so
+    /// the caller must re-probe rather than reuse the snapshot it came from.
+    async fn solve_captcha(&self, kind: crate::detection::CaptchaKind) -> Result<(), ImpervaError> {
+        let Some(solver) = self.on_captcha.clone() else {
+            return Err(ImpervaError::CaptchaRequired { kind });
+        };
+        let (site_key, url) = extract_captcha_site_key(self.session, kind).await?;
+        let solution = solver(CaptchaChallenge {
+            kind,
+            site_key,
+            url,
+        })
+        .await
+        .map_err(ImpervaError::CaptchaSolver)?;
+        inject_captcha_solution(self.session, &solution).await
+    }
+
+    /// Core poll loop. Owns every mid-flight terminal, CAPTCHA escalation
+    /// included, so a surface that changes after the pre-loop probe is
+    /// handled exactly like one present from the start.
+    ///
+    /// Factored out so unit tests can drive it with a
     /// controlled interception receiver without standing up the real
     /// InterceptBuilder + Fetch.enable plumbing. Production callers go
     /// through [`wait_for_clearance`](Self::wait_for_clearance), which
@@ -302,6 +308,9 @@ impl<'tab> ImpervaBypass<'tab> {
         let mut prev_surface: Option<crate::detection::ImpervaSurface> = None;
         let mut stall_ticks: u32 = 0;
         let mut warned_stall = false;
+        // One solve attempt per clearance. See the escalation branch below for
+        // why the surface cannot clear itself afterwards.
+        let mut captcha_attempted = false;
 
         loop {
             let snap = match next_snapshot.take() {
@@ -314,6 +323,14 @@ impl<'tab> ImpervaBypass<'tab> {
                 },
             };
 
+            // Clearance is decided BEFORE any CAPTCHA escalation. A snapshot
+            // carrying a usable reese84 token over a clean body *is* a cleared
+            // challenge, and stays one even if the page happens to be showing
+            // a CAPTCHA iframe — the site's own post-clearance form routinely
+            // mounts one (a plain Google reCAPTCHA on the page it just let you
+            // reach). Escalating first discarded the very token this call
+            // exists to return, and turned a better clearance into a more
+            // reliable failure.
             let token = snap.reese84.as_ref().filter(|v| !v.is_empty());
             let surface_clear = matches!(snap.surface, crate::detection::ImpervaSurface::None);
             match (token, snap.body_clean, surface_clear) {
@@ -323,14 +340,48 @@ impl<'tab> ImpervaBypass<'tab> {
                         sessions: snap.sessions,
                     });
                 }
-                // ChallengeGone requires `surface_clear` in addition to the
-                // body+no-token spec criteria: lingering Legacy cookies
-                // (`incap_ses_*`, `___utmvc`) indicate the page is still
-                // tracking the challenge even after body markers drop, and
-                // returning ChallengeGone there would race the page's own
-                // post-clearance navigation.
+                // ChallengeGone requires `surface_clear` in addition to
+                // the body+no-token spec criteria: lingering Legacy
+                // cookies (`incap_ses_*`, `___utmvc`) indicate the page is
+                // still tracking the challenge even after body markers
+                // drop, and returning ChallengeGone there would race the
+                // page's own post-clearance navigation.
                 (None, true, true) => return Ok(ClearanceOutcome::ChallengeGone),
-                _ => last_surface = Some(snap.surface),
+                _ => {
+                    // Not cleared. CAPTCHA escalation is polled rather than
+                    // assumed to arrive on the first probe, because Imperva
+                    // routinely upgrades a reese84 device check to a CAPTCHA
+                    // seconds in, and that arrival must reach the registered
+                    // solver too.
+                    //
+                    // Never escalate while a usable token is in hand. A
+                    // snapshot carrying a reese84 is not a page that needs a
+                    // CAPTCHA solved — clean body or not. `detect.js` ranks any
+                    // captcha above `Reese84`, and nothing gates that
+                    // classification on a genuine Imperva signal, so a plain
+                    // Google reCAPTCHA belonging to the site's own form flips
+                    // the surface even while the challenge is still settling.
+                    // Escalating there turns a run that would have kept polling
+                    // (and could still clear) into a hard `CaptchaRequired` on
+                    // the very first tick. Same reasoning as the token-first
+                    // ordering above, one arm over: a token in hand outranks a
+                    // captcha on the page.
+                    //
+                    // Latched: `inject_captcha_solution` writes a hidden
+                    // response field and never removes the widget, so the
+                    // surface stays `Captcha` afterwards. Without the latch a
+                    // 250ms poll over a 30s budget would re-enter the solver
+                    // on every tick — up to ~120 paid solves and twice that in
+                    // main-world evaluates, on exactly the pages that are
+                    // watching for them.
+                    if let crate::detection::ImpervaSurface::Captcha(kind) = snap.surface {
+                        if token.is_none() && !captcha_attempted {
+                            captcha_attempted = true;
+                            self.solve_captcha(kind).await?;
+                        }
+                    }
+                    last_surface = Some(snap.surface);
+                }
             }
 
             stall_ticks = if Some(snap.surface) == prev_surface {
@@ -872,6 +923,346 @@ mod tests {
         assert!(matches!(
             outcome,
             ClearanceOutcome::TokenAcquired { reese84, .. } if reese84 == "TOK_FINAL"
+        ));
+        conn.shutdown();
+    }
+
+    /// A usable token over a clean body IS a cleared challenge, and stays one
+    /// even when the page is showing a CAPTCHA iframe — the site's own
+    /// post-clearance form routinely mounts a plain Google reCAPTCHA on the
+    /// page it just let you reach, and `detect.js` ranks any captcha above
+    /// `Reese84`. Escalating before checking the token threw away the token
+    /// this call exists to return, so the better the clearance worked, the
+    /// more reliably it failed. No solver is registered here, which is what
+    /// turned that into a hard error rather than a wasted tick.
+    #[tokio::test]
+    async fn a_token_over_a_clean_body_wins_over_a_captcha_surface() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                ImpervaBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        let id = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id,
+            snapshot_reply(json!({
+                "surface": { "kind": "Captcha", "captcha": "Recaptcha" },
+                "reese84": "TOK_CLEARED",
+                "body_clean": true,
+                "sessions": [],
+                "has_imperva_signal": true,
+            })),
+        )
+        .await;
+
+        let outcome = fut.await.unwrap().expect("a carried token must not error");
+        match outcome {
+            ClearanceOutcome::TokenAcquired { reese84, .. } => {
+                assert_eq!(reese84, "TOK_CLEARED");
+            }
+            other => panic!("expected TokenAcquired, got {other:?}"),
+        }
+        conn.shutdown();
+    }
+
+    /// The token-first rule holds on the *not-yet-cleared* path too, which is
+    /// the majority regime in practice: most runs never reach a clean body
+    /// inside the budget. A token in hand plus a still-dirty body plus a
+    /// captcha iframe used to escalate and hard-fail on the first tick, so a
+    /// run that would have kept polling — and could still have cleared — was
+    /// converted into `CaptchaRequired` immediately. It must keep polling
+    /// instead, exactly as it does when no captcha is present.
+    #[tokio::test]
+    async fn a_token_suppresses_escalation_even_while_the_body_is_still_dirty() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                ImpervaBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .timeout(Duration::from_millis(150))
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        // Token present, body still dirty, captcha surface up — no solver
+        // registered, so any escalation is an immediate hard error.
+        let dirty = snapshot_reply(json!({
+            "surface": { "kind": "Captcha", "captcha": "Recaptcha" },
+            "reese84": "TOK_IN_HAND",
+            "body_clean": false,
+            "sessions": [],
+            "has_imperva_signal": true,
+        }));
+        while let Ok(Ok(id)) = tokio::time::timeout(
+            Duration::from_millis(120),
+            mock.expect_cmd("Runtime.evaluate"),
+        )
+        .await
+        .map(Ok::<u64, ()>)
+        {
+            mock.reply(id, dirty.clone()).await;
+        }
+
+        let outcome = fut
+            .await
+            .unwrap()
+            .expect("a token in hand must not escalate to a hard CaptchaRequired");
+        assert!(
+            matches!(outcome, ClearanceOutcome::TimedOut { .. }),
+            "expected the run to keep polling to its deadline, got {outcome:?}"
+        );
+        conn.shutdown();
+    }
+
+    /// `inject_captcha_solution` writes a hidden response field and never
+    /// removes the widget, so the surface stays `Captcha` afterwards. Without
+    /// a latch the poll loop re-enters the solver on every tick — real money
+    /// per solve, and a burst of main-world evaluates on a page that is
+    /// watching for exactly that.
+    #[tokio::test]
+    async fn captcha_solver_is_invoked_at_most_once_per_clearance() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            let c = Arc::clone(&calls);
+            async move {
+                ImpervaBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .timeout(Duration::from_millis(600))
+                    .on_captcha(move |_| {
+                        let c = Arc::clone(&c);
+                        async move {
+                            c.fetch_add(1, Ordering::SeqCst);
+                            Ok(CaptchaSolution {
+                                token: "SOLVED".into(),
+                                form_field: "g-recaptcha-response".into(),
+                            })
+                        }
+                    })
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        // Serve a stuck CAPTCHA surface for as long as the loop asks. Each
+        // Runtime.evaluate is answered by shape: the detect probe gets the
+        // snapshot, the site-key probe gets a key, the injection gets `true`.
+        // Nothing here ever clears the surface, so only the latch can stop a
+        // second solve.
+        let stuck = snapshot_reply(json!({
+            "surface": { "kind": "Captcha", "captcha": "Recaptcha" },
+            "reese84": null,
+            "body_clean": false,
+            "sessions": [],
+            "has_imperva_signal": true,
+        }));
+        loop {
+            let Ok(id) = tokio::time::timeout(
+                Duration::from_millis(300),
+                mock.expect_cmd("Runtime.evaluate"),
+            )
+            .await
+            else {
+                break;
+            };
+            let expr = mock.last_sent()["params"]["expression"]
+                .as_str()
+                .unwrap_or("")
+                .to_string();
+            let reply = if expr.contains("has_imperva_signal") {
+                stuck.clone()
+            } else if expr.contains("SOLVED") {
+                json!({ "result": { "type": "boolean", "value": true } })
+            } else {
+                json!({
+                    "result": {
+                        "type": "object",
+                        "value": { "hcap": null, "rcap": "KEY_ABC", "url": "https://x.test/p" }
+                    }
+                })
+            };
+            mock.reply(id, reply).await;
+        }
+
+        let _ = fut.await.unwrap();
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "solver must be latched to one attempt per clearance"
+        );
+        conn.shutdown();
+    }
+
+    /// The normal Imperva escalation shape: the page starts on a reese84
+    /// device check and only *then* swaps in a CAPTCHA. Escalation used to be
+    /// checked on the pre-loop probe only, so this arrival never reached the
+    /// registered solver and the run just timed out.
+    #[tokio::test]
+    async fn mid_flight_captcha_escalation_invokes_solver() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                ImpervaBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .on_captcha(|c| async move {
+                        assert!(matches!(c.kind, CaptchaKind::HCaptcha));
+                        Ok(CaptchaSolution {
+                            token: "SOLVED_TOK".into(),
+                            form_field: "h-captcha-response".into(),
+                        })
+                    })
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        // Probe 1 (pre-loop): plain reese84 device check, no CAPTCHA yet.
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id1,
+            snapshot_reply(json!({
+                "surface": { "kind": "Reese84" },
+                "reese84": null,
+                "body_clean": false,
+                "sessions": [],
+                "has_imperva_signal": true,
+            })),
+        )
+        .await;
+
+        // Probe 2 (in-loop): escalated to hCaptcha.
+        let id2 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id2,
+            snapshot_reply(json!({
+                "surface": { "kind": "Captcha", "captcha": "HCaptcha" },
+                "reese84": null,
+                "body_clean": false,
+                "sessions": [],
+                "has_imperva_signal": true,
+            })),
+        )
+        .await;
+
+        // Site-key probe → solver → injection.
+        let id3 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id3,
+            json!({
+                "result": {
+                    "type": "object",
+                    "value": { "hcap": "KEY_ABC", "rcap": null, "url": "https://x.test/p" }
+                }
+            }),
+        )
+        .await;
+
+        let id4 = mock.expect_cmd("Runtime.evaluate").await;
+        assert!(
+            mock.last_sent()["params"]["expression"]
+                .as_str()
+                .unwrap()
+                .contains("SOLVED_TOK"),
+            "injection script should carry the solver token"
+        );
+        mock.reply(
+            id4,
+            json!({ "result": { "type": "boolean", "value": true } }),
+        )
+        .await;
+
+        // Probe 3: cleared.
+        let id5 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id5,
+            snapshot_reply(json!({
+                "surface": { "kind": "None" },
+                "reese84": "TOK_FINAL",
+                "body_clean": true,
+                "sessions": [{ "name": "reese84", "value": "TOK_FINAL" }],
+                "has_imperva_signal": true,
+            })),
+        )
+        .await;
+
+        let outcome = fut.await.unwrap().unwrap();
+        assert!(matches!(
+            outcome,
+            ClearanceOutcome::TokenAcquired { reese84, .. } if reese84 == "TOK_FINAL"
+        ));
+        conn.shutdown();
+    }
+
+    /// A CAPTCHA that arrives mid-flight with no solver registered must still
+    /// produce the actionable `CaptchaRequired` error, not a silent timeout.
+    #[tokio::test]
+    async fn mid_flight_captcha_without_solver_errors() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+
+        let fut = tokio::spawn({
+            let s = sess.clone();
+            async move {
+                ImpervaBypass::new(&s)
+                    .poll_interval(Duration::from_millis(1))
+                    .wait_for_clearance()
+                    .await
+            }
+        });
+
+        let id1 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id1,
+            snapshot_reply(json!({
+                "surface": { "kind": "Legacy" },
+                "reese84": null,
+                "body_clean": false,
+                "sessions": [{ "name": "incap_ses_123", "value": "X" }],
+                "has_imperva_signal": true,
+            })),
+        )
+        .await;
+
+        let id2 = mock.expect_cmd("Runtime.evaluate").await;
+        mock.reply(
+            id2,
+            snapshot_reply(json!({
+                "surface": { "kind": "Captcha", "captcha": "Recaptcha" },
+                "reese84": null,
+                "body_clean": false,
+                "sessions": [],
+                "has_imperva_signal": true,
+            })),
+        )
+        .await;
+
+        let err = fut.await.unwrap().unwrap_err();
+        assert!(matches!(
+            err,
+            ImpervaError::CaptchaRequired {
+                kind: CaptchaKind::Recaptcha
+            }
         ));
         conn.shutdown();
     }

--- a/crates/zendriver-imperva/src/detect.js
+++ b/crates/zendriver-imperva/src/detect.js
@@ -116,14 +116,18 @@
     var sessionCookies = [];
     for (var m = 0; m < cookieNames.length; m++) {
         var name = cookieNames[m];
-        // Same prefix match as the legacy-cookie scan above: `nlbi_<siteid>`
-        // has to reach the caller's `sessions` snapshot for replay.
+        // `nlbi_<siteid>` has to reach the caller's `sessions` snapshot for
+        // replay even though it is not a surface signal — the scan above
+        // deliberately leaves it out. Anchor the underscore: everything in
+        // `sessions` is replayed to the origin as Imperva state, and a bare
+        // `nlbi` prefix also sweeps up unrelated `nlbistore` / `nlbi2fa`
+        // cookies.
         if (
             name === reese84Key ||
             name === "___utmvc" ||
             name.indexOf("incap_ses_") === 0 ||
             name.indexOf("visid_incap_") === 0 ||
-            name.indexOf("nlbi") === 0
+            name.indexOf("nlbi_") === 0
         ) {
             sessionCookies.push({ name: name, value: cookies[name] });
         }

--- a/crates/zendriver-imperva/src/detect.js
+++ b/crates/zendriver-imperva/src/detect.js
@@ -32,11 +32,18 @@
     var hasLegacyCookies = false;
     for (var j = 0; j < cookieNames.length; j++) {
         var n2 = cookieNames[j];
+        // `nlbi_*` is deliberately NOT a surface signal. It is Imperva's
+        // load-balancer cookie: pure routing state that is set on ordinary
+        // traffic and outlives clearance, unlike `incap_ses_*` / `___utmvc`,
+        // which track the challenge itself. Counting it here pinned the
+        // surface at `Legacy` on pages that had already cleared, which
+        // structurally blocks `ChallengeGone` and burns the whole budget down
+        // to `TimedOut`. It is still collected into `sessions` below, which is
+        // what the caller actually needs it for.
         if (
             n2 === "___utmvc" ||
             n2.indexOf("incap_ses_") === 0 ||
-            n2.indexOf("visid_incap_") === 0 ||
-            n2 === "nlbi"
+            n2.indexOf("visid_incap_") === 0
         ) {
             hasLegacyCookies = true;
             break;
@@ -109,12 +116,14 @@
     var sessionCookies = [];
     for (var m = 0; m < cookieNames.length; m++) {
         var name = cookieNames[m];
+        // Same prefix match as the legacy-cookie scan above: `nlbi_<siteid>`
+        // has to reach the caller's `sessions` snapshot for replay.
         if (
             name === reese84Key ||
             name === "___utmvc" ||
             name.indexOf("incap_ses_") === 0 ||
             name.indexOf("visid_incap_") === 0 ||
-            name === "nlbi"
+            name.indexOf("nlbi") === 0
         ) {
             sessionCookies.push({ name: name, value: cookies[name] });
         }

--- a/crates/zendriver-imperva/src/detection.rs
+++ b/crates/zendriver-imperva/src/detection.rs
@@ -296,6 +296,44 @@ mod tests {
         conn.shutdown();
     }
 
+    /// Imperva names the load-balancer cookie `nlbi_<siteid>`, never a bare
+    /// `nlbi`, so the `sessions` collector must match it by prefix — an
+    /// equality match silently dropped it from every snapshot the caller
+    /// replays.
+    ///
+    /// It must NOT appear in the legacy-surface scan. `nlbi_*` is routing
+    /// state that is set on ordinary traffic and outlives clearance, so
+    /// treating it as a challenge marker pins the surface at `Legacy` on a
+    /// page that has already cleared — which blocks `ChallengeGone` outright
+    /// and turns a success into a full-budget timeout.
+    ///
+    /// Source-level guard: `detect.js` only ever runs inside a real page, so
+    /// its behavior cannot be exercised from a mocked CDP transport.
+    #[test]
+    fn detect_js_prefix_matches_nlbi_for_sessions_but_not_as_a_surface_signal() {
+        let js = include_str!("detect.js");
+        assert_eq!(
+            js.matches(r#"indexOf("nlbi") === 0"#).count(),
+            1,
+            "only the sessions collector may match nlbi_<siteid>"
+        );
+        assert!(
+            !js.contains(r#"=== "nlbi""#),
+            "an exact nlbi match never fires against a real Imperva cookie"
+        );
+
+        // Pin the split structurally: the single surviving match must live
+        // after the `hasLegacyCookies` scan, i.e. in the sessions collector.
+        let legacy_scan = js.find("hasLegacyCookies = true").expect("legacy scan");
+        let nlbi_match = js
+            .find(r#"indexOf("nlbi") === 0"#)
+            .expect("sessions collector");
+        assert!(
+            nlbi_match > legacy_scan,
+            "nlbi must be collected for replay, not counted as a legacy surface"
+        );
+    }
+
     #[tokio::test]
     async fn detect_snapshot_propagates_js_exception_as_jserror() {
         let (mut mock, conn) = MockConnection::pair();

--- a/crates/zendriver-imperva/src/detection.rs
+++ b/crates/zendriver-imperva/src/detection.rs
@@ -308,12 +308,13 @@ mod tests {
     /// and turns a success into a full-budget timeout.
     ///
     /// Source-level guard: `detect.js` only ever runs inside a real page, so
-    /// its behavior cannot be exercised from a mocked CDP transport.
+    /// its behavior cannot be exercised from a mocked CDP transport. This
+    /// checks the cookie names the file matches on, nothing more.
     #[test]
     fn detect_js_prefix_matches_nlbi_for_sessions_but_not_as_a_surface_signal() {
         let js = include_str!("detect.js");
         assert_eq!(
-            js.matches(r#"indexOf("nlbi") === 0"#).count(),
+            js.matches(r#"indexOf("nlbi_") === 0"#).count(),
             1,
             "only the sessions collector may match nlbi_<siteid>"
         );
@@ -321,16 +322,10 @@ mod tests {
             !js.contains(r#"=== "nlbi""#),
             "an exact nlbi match never fires against a real Imperva cookie"
         );
-
-        // Pin the split structurally: the single surviving match must live
-        // after the `hasLegacyCookies` scan, i.e. in the sessions collector.
-        let legacy_scan = js.find("hasLegacyCookies = true").expect("legacy scan");
-        let nlbi_match = js
-            .find(r#"indexOf("nlbi") === 0"#)
-            .expect("sessions collector");
         assert!(
-            nlbi_match > legacy_scan,
-            "nlbi must be collected for replay, not counted as a legacy surface"
+            !js.contains(r#"indexOf("nlbi") === 0"#),
+            "an unanchored nlbi prefix also sweeps nlbistore / nlbi2fa into sessions, \
+             and everything in sessions gets replayed to the origin"
         );
     }
 

--- a/crates/zendriver-mcp/src/tools/cloudflare.rs
+++ b/crates/zendriver-mcp/src/tools/cloudflare.rs
@@ -8,8 +8,8 @@
 //!
 //! - `Ok(ClearanceOutcome::TokenAcquired(t))` — the
 //!   `cf-turnstile-response` input picked up a token.
-//! - `Ok(ClearanceOutcome::ChallengeGone)` — the challenge container
-//!   vanished without a token (e.g. clearance cookie shortcut).
+//! - `Ok(ClearanceOutcome::ChallengeGone)` — the challenge stopped being
+//!   actionable without a token (e.g. clearance cookie shortcut).
 //! - `Ok(ClearanceOutcome::TimedOut { saw_challenge })` — the per-call
 //!   deadline elapsed (whether or not a challenge was ever seen).
 //!
@@ -72,8 +72,12 @@ pub enum Outcome {
     /// Turnstile produced a token (value of `cf-turnstile-response`). The
     /// token is available in [`SolveOutput::token`].
     Solved,
-    /// The challenge container disappeared without yielding a token (e.g.
-    /// a clearance cookie shortcut). `token` will be `None`.
+    /// The challenge stopped being actionable without yielding a token
+    /// (e.g. a clearance cookie shortcut). `token` will be `None`.
+    ///
+    /// Not proof the gate was passed: this also fires when the widget is
+    /// still mounted but hidden or zero-size, so verify the page before
+    /// treating what you read next as post-challenge content.
     ChallengeGone,
     /// `timeout_ms` elapsed without reaching either success state. `token`
     /// will be `None`. Not a hard error — agents can retry or give up.

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__cloudflare_snaps__cloudflare_outcome.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__cloudflare_snaps__cloudflare_outcome.snap
@@ -9,7 +9,7 @@ oneOf:
   - description: "Turnstile produced a token (value of `cf-turnstile-response`). The\ntoken is available in [`SolveOutput::token`]."
     type: string
     const: solved
-  - description: "The challenge container disappeared without yielding a token (e.g.\na clearance cookie shortcut). `token` will be `None`."
+  - description: "The challenge stopped being actionable without yielding a token\n(e.g. a clearance cookie shortcut). `token` will be `None`.\n\nNot proof the gate was passed: this also fires when the widget is\nstill mounted but hidden or zero-size, so verify the page before\ntreating what you read next as post-challenge content."
     type: string
     const: challenge_gone
   - description: "`timeout_ms` elapsed without reaching either success state. `token`\nwill be `None`. Not a hard error — agents can retry or give up."

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__cloudflare_snaps__cloudflare_solve_out.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__cloudflare_snaps__cloudflare_solve_out.snap
@@ -24,7 +24,7 @@ $defs:
       - description: "Turnstile produced a token (value of `cf-turnstile-response`). The\ntoken is available in [`SolveOutput::token`]."
         type: string
         const: solved
-      - description: "The challenge container disappeared without yielding a token (e.g.\na clearance cookie shortcut). `token` will be `None`."
+      - description: "The challenge stopped being actionable without yielding a token\n(e.g. a clearance cookie shortcut). `token` will be `None`.\n\nNot proof the gate was passed: this also fires when the widget is\nstill mounted but hidden or zero-size, so verify the page before\ntreating what you read next as post-challenge content."
         type: string
         const: challenge_gone
       - description: "`timeout_ms` elapsed without reaching either success state. `token`\nwill be `None`. Not a hard error — agents can retry or give up."

--- a/crates/zendriver-transport/src/testing.rs
+++ b/crates/zendriver-transport/src/testing.rs
@@ -313,6 +313,18 @@ impl MockConnection {
 /// fails in the suite. Installing one permissive global subscriber (once per
 /// process) and routing events to a task-local buffer removes the race:
 /// every callsite is registered against a subscriber that is always enabled.
+///
+/// Two consequences for the caller, since that subscriber is process-wide.
+/// It is installed on the first [`capture`](Self::capture) in the binary and
+/// stays for the run, so every other test's events go through it as well;
+/// they are dropped rather than printed, because only a task inside a
+/// `capture` has anywhere to put them. And if the binary already installed a
+/// global subscriber of its own, that one keeps the slot and a capture
+/// collects **nothing** rather than fighting for it. An empty
+/// [`events`](Self::events) therefore means "nothing was logged *or* someone
+/// else owns the subscriber", which is worth remembering before asserting a
+/// count of zero: write the assertion so the hint's presence is what proves
+/// the capture works.
 #[derive(Debug, Clone, Default)]
 pub struct LogCapture {
     events: Arc<std::sync::Mutex<Vec<String>>>,

--- a/crates/zendriver-transport/src/testing.rs
+++ b/crates/zendriver-transport/src/testing.rs
@@ -164,9 +164,32 @@ impl MockConnection {
     /// method already dispatched by a `mut self` consuming method.
     pub fn try_recv_cmd(&mut self) -> Option<(String, u64)> {
         let msg = self.server_out.try_recv().ok()?;
-        let text = match msg {
-            Message::Text(t) => t,
-            _ => return None,
+        self.decode_cmd(msg)
+    }
+
+    /// Bounded read of the next outbound command: waits up to `budget` for one
+    /// to arrive and returns `None` if none does.
+    ///
+    /// Fills the gap between [`Self::expect_cmd`], which waits forever and so
+    /// hangs a test whose driver has already returned, and
+    /// [`Self::try_recv_cmd`], which reports `None` on a channel that is idle
+    /// but still live. Draining a driver whose command sequence is not fully
+    /// deterministic — a poll loop whose tick count depends on timing — wants
+    /// exactly this: keep serving until the driver goes quiet for `budget`,
+    /// then stop.
+    pub async fn recv_cmd_timeout(&mut self, budget: std::time::Duration) -> Option<(String, u64)> {
+        let msg = tokio::time::timeout(budget, self.server_out.recv())
+            .await
+            .ok()??;
+        self.decode_cmd(msg)
+    }
+
+    /// Decode one outbound frame into `(method, id)`, recording it as the
+    /// frame [`Self::last_sent`] will return. `None` for anything that is not
+    /// a text frame carrying both fields.
+    fn decode_cmd(&mut self, msg: Message) -> Option<(String, u64)> {
+        let Message::Text(text) = msg else {
+            return None;
         };
         let v: Value = serde_json::from_str(&text).ok()?;
         self.last_sent = Some(v.clone());
@@ -265,10 +288,171 @@ impl MockConnection {
     }
 }
 
+/// Collects the `tracing` events a future emits, so a test can assert on a
+/// diagnostic whose only effect is a log line.
+///
+/// Drivers in this workspace emit hints that no return value carries — "your
+/// bypass is stuck because stealth is off" being the canonical one. Without a
+/// capture the hint is deletable with the suite still green, which is how a
+/// diagnostic quietly stops working.
+///
+/// # Scope
+/// [`capture`](Self::capture) collects the events emitted while the future it
+/// wraps is being polled. That scope is the *task*, so events from a
+/// `tokio::spawn`ed task are **not** collected — drive the code under test in
+/// the same task instead, `tokio::join!`-ing the driver future with the one
+/// serving its [`MockConnection`], rather than spawning it.
+///
+/// # Why this installs a global subscriber
+/// The obvious implementation — a scoped default subscriber over the future —
+/// silently collects nothing as soon as a sibling test touches the same
+/// `warn!` callsite first. `tracing` caches per-callsite interest, a callsite
+/// evaluated with no subscriber installed caches as "never", and a later
+/// scoped subscriber is never consulted for it again. Because test binaries
+/// run tests concurrently, that turns into a capture that passes alone and
+/// fails in the suite. Installing one permissive global subscriber (once per
+/// process) and routing events to a task-local buffer removes the race:
+/// every callsite is registered against a subscriber that is always enabled.
+#[derive(Debug, Clone, Default)]
+pub struct LogCapture {
+    events: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+tokio::task_local! {
+    /// Buffer the global subscriber writes to while a [`LogCapture::capture`]
+    /// future is being polled. Absent outside one, in which case events are
+    /// dropped.
+    static ACTIVE_CAPTURE: Arc<std::sync::Mutex<Vec<String>>>;
+}
+
+/// Install the collecting subscriber as the process-wide default, once.
+fn install_collector() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        // A binary that installed its own global subscriber keeps it; capture
+        // then collects nothing rather than fighting over the slot.
+        if tracing::subscriber::set_global_default(CollectingSubscriber).is_ok() {
+            // Callsites already registered against the no-op subscriber are
+            // cached as "never"; re-register them against this one.
+            tracing::callsite::rebuild_interest_cache();
+        }
+    });
+}
+
+impl LogCapture {
+    /// A fresh, empty capture.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Run `fut` to completion, collecting the `tracing` events emitted while
+    /// it is polled, and return whatever `fut` returns.
+    pub async fn capture<F: std::future::Future>(&self, fut: F) -> F::Output {
+        install_collector();
+        ACTIVE_CAPTURE.scope(Arc::clone(&self.events), fut).await
+    }
+
+    /// Every captured event, formatted as `LEVEL field=value ...`.
+    #[must_use]
+    pub fn events(&self) -> Vec<String> {
+        self.events.lock().expect("log capture poisoned").clone()
+    }
+
+    /// Whether any captured event contains `needle`.
+    #[must_use]
+    pub fn contains(&self, needle: &str) -> bool {
+        self.events().iter().any(|e| e.contains(needle))
+    }
+
+    /// How many captured events contain `needle`.
+    #[must_use]
+    pub fn count(&self, needle: &str) -> usize {
+        self.events().iter().filter(|e| e.contains(needle)).count()
+    }
+}
+
+/// Minimal `tracing::Subscriber` backing [`LogCapture`]. Records events into
+/// whichever capture is active on the current task and ignores spans — the
+/// drivers under test emit bare events.
+#[derive(Debug)]
+struct CollectingSubscriber;
+
+impl tracing::Subscriber for CollectingSubscriber {
+    fn enabled(&self, _metadata: &tracing::Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+
+    fn event(&self, event: &tracing::Event<'_>) {
+        // Outside a `LogCapture::capture` scope there is nowhere to put it,
+        // which is the normal case for the rest of the suite.
+        let _ = ACTIVE_CAPTURE.try_with(|events| {
+            let mut visitor = FieldVisitor(String::new());
+            event.record(&mut visitor);
+            events.lock().expect("log capture poisoned").push(format!(
+                "{} {}",
+                event.metadata().level(),
+                visitor.0
+            ));
+        });
+    }
+
+    fn enter(&self, _span: &tracing::span::Id) {}
+
+    fn exit(&self, _span: &tracing::span::Id) {}
+}
+
+/// Flattens an event's fields into `name=value` pairs. The `message` field of
+/// a `warn!("literal")` arrives here as `format_args!`, whose `Debug` is the
+/// rendered text.
+struct FieldVisitor(String);
+
+impl tracing::field::Visit for FieldVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if !self.0.is_empty() {
+            self.0.push(' ');
+        }
+        self.0
+            .push_str(&format!("{name}={value:?}", name = field.name()));
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if !self.0.is_empty() {
+            self.0.push(' ');
+        }
+        self.0
+            .push_str(&format!("{name}={value}", name = field.name()));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[tokio::test]
+    async fn log_capture_collects_events_from_the_future_it_wraps() {
+        let capture = LogCapture::new();
+        capture
+            .capture(async {
+                tracing::warn!(answer = 42, "a hint worth asserting");
+            })
+            .await;
+        assert!(
+            capture.contains("a hint worth asserting"),
+            "captured {:?}",
+            capture.events()
+        );
+        assert!(capture.contains("answer=42"));
+    }
 
     #[tokio::test]
     async fn mock_round_trips_a_call() {

--- a/crates/zendriver/examples/cloudflare_bypass.rs
+++ b/crates/zendriver/examples/cloudflare_bypass.rs
@@ -12,17 +12,19 @@
 //!      on the page. When the interactive iframe is present and we have
 //!      not yet clicked it, the driver dispatches a single raw left-click
 //!      at the canonical (15% x, 50% y) offset (Turnstile checkbox).
-//!      Resolves the first tick a token is observed or the iframe is gone
-//!      after a click.
+//!      Resolves the first tick a token is observed, or the iframe stops
+//!      being a valid click target after a click.
 //!   4. Print the [`ClearanceOutcome`] enum variant + the page title.
 //!
 //! Outcomes:
 //!   - `TokenAcquired(_)` — Turnstile yielded a `cf-turnstile-response`
 //!     token, either after clicking the checkbox or directly (invisible
 //!     Turnstile, where the iframe never mounts).
-//!   - `ChallengeGone` — the interactive iframe was clicked and the
-//!     challenge container then disappeared without a token (e.g.
-//!     clearance-cookie shortcut).
+//!   - `ChallengeGone` — the challenge stopped being actionable without a
+//!     token (e.g. clearance-cookie shortcut): the clicked iframe is no
+//!     longer a valid click target, or every marker seen earlier is gone.
+//!     A widget that is merely hidden or zero-size is also not a valid
+//!     click target, so this is not by itself proof the gate was passed.
 //!   - `TimedOut { saw_challenge: false }` — the full timeout window
 //!     elapsed without any challenge markers ever being observed (no
 //!     container, no hidden input, no iframe). The page likely has no

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -2931,8 +2931,9 @@ impl Tab {
     /// [`wait_for_clearance`](zendriver_cloudflare::CloudflareBypass::wait_for_clearance)
     /// to detect the Turnstile checkbox, click it at the canonical 15%
     /// offset, and poll until either the `cf-turnstile-response` token
-    /// appears, the challenge container disappears, or the supplied timeout
-    /// elapses. Use
+    /// appears, the challenge stops being actionable (see
+    /// [`ClearanceOutcome::ChallengeGone`](zendriver_cloudflare::ClearanceOutcome::ChallengeGone),
+    /// which is weaker than it reads), or the supplied timeout elapses. Use
     /// [`is_challenge_present`](zendriver_cloudflare::CloudflareBypass::is_challenge_present)
     /// for a one-shot probe without driving a click.
     ///

--- a/docs/book/src/cloudflare.md
+++ b/docs/book/src/cloudflare.md
@@ -28,55 +28,85 @@ flow.
 {{#include ../../../crates/zendriver/examples/cloudflare_bypass.rs}}
 ```
 
-The driver returns a [`ClearanceOutcome`] on success:
+The driver returns a [`ClearanceOutcome`] on success. All three are
+ordinary terminals, the last one included:
 
 - **`TokenAcquired(token)`** — the `cf-turnstile-response` input picked
   up a non-empty value. The page can now proceed; the token is also
   forwarded to Cloudflare server-side on the next request.
-- **`ChallengeGone`** — the challenge container disappeared without
-  yielding a token, typically because Cloudflare honored a clearance
-  cookie and short-circuited the gate.
+- **`ChallengeGone`** — the challenge went away without yielding a
+  token, typically because Cloudflare honored a clearance cookie and
+  short-circuited the gate. Either an iframe the driver clicked was torn
+  down, or every challenge marker seen on an earlier tick has vanished.
+- **`TimedOut { saw_challenge }`** — the deadline elapsed.
+  `saw_challenge` separates the two cases worth telling apart: `true`
+  means a real challenge sat on the page and never resolved, `false`
+  means no Cloudflare marker ever appeared and the bypass was probably
+  called on a page with no gate on it.
 
 [`ClearanceOutcome`]: https://docs.rs/zendriver/latest/zendriver/enum.ClearanceOutcome.html
 
-Errors are typed via [`CloudflareError`]:
+A deadline is not an error here, so [`CloudflareError`] is left to carry
+genuine faults, of which there are two:
 
-- **`NoChallenge`** — no Turnstile iframe was detected at call time.
-  Often means the page already cleared you (an existing cookie) or
-  there's no CF gate present. Treat as a no-op, not a failure.
-- **`ClearanceTimeout`** — the deadline elapsed without resolution.
-  Usually means Cloudflare escalated to the deeper anti-bot path that
-  this driver doesn't handle.
+- **`Call`** — the underlying CDP call failed, usually a dead tab or a
+  closed connection.
+- **`JsError`** — the in-page evaluator raised, or handed back a payload
+  the driver could not decode.
+
+The enum is `#[non_exhaustive]`, so a `match` on it needs a wildcard
+arm. There is no `NoChallenge` or `ClearanceTimeout` variant — if you
+are looking for those, the first is `TimedOut { saw_challenge: false }`
+and the second is `TimedOut { saw_challenge: true }`.
 
 [`CloudflareError`]: https://docs.rs/zendriver/latest/zendriver/enum.CloudflareError.html
 
 ## How it works
 
-The driver runs four stages internally:
+The driver runs a single poll loop, and each tick costs one CDP
+round-trip. A shadow-DOM-aware walk of the page's main world reports
+three things at once: the
+`cf-turnstile-response` token if one is present, the challenge iframe's
+box if that iframe is a valid click target, and whether any Cloudflare
+marker at all (container, hidden input, or live iframe) is on the page.
+The tick then resolves in this order:
 
-1. **Detect.** A shadow-DOM-aware walk of the page's main world looks
-   for the Turnstile iframe (`<iframe>` whose `src` matches Cloudflare's
-   Turnstile widget origin). It surfaces the bounding box.
-2. **Click.** A raw `mousedown` / `mouseup` is dispatched at offset
+1. **A token wins outright.** A non-empty token returns `TokenAcquired`
+   immediately. This is also the invisible-Turnstile path, where no
+   iframe mounts and Cloudflare's loader script fills the field in
+   without anything to click.
+2. **Scroll, re-measure, click.** Raw mouse events carry viewport
+   coordinates, so a widget below the fold has to be scrolled in and
+   re-measured before a click can land on it. The click goes to
    `(bbox.x + bbox.width * 0.15, bbox.y + bbox.height * 0.5)` — the
-   canonical 15%-from-left, 50%-from-top position of the Turnstile
-   checkbox inside the iframe. No Bezier-path motion; Cloudflare wants a
-   real click on a real checkbox.
-3. **Poll.** Every 500 ms (override via
-   [`poll_interval`](https://docs.rs/zendriver/latest/zendriver/struct.CloudflareBypass.html#method.poll_interval)),
-   the driver checks both `cf-turnstile-response` (for a non-empty
-   token) and the challenge container (for removal from the DOM).
-4. **Return.** First condition to fire wins; deadline elapsed →
-   `ClearanceTimeout`.
+   canonical 15%-from-left, 50%-from-top position of the checkbox inside
+   the iframe. No Bezier-path motion; Cloudflare wants a real click on a
+   real checkbox. A widget that is mounted but hidden or zero-sized is
+   never clicked, since there is no meaningful point to click.
+3. **Retry, up to a cap.** Cloudflare drops clicks that land while the
+   widget is still booting, so one run spends up to three of them, each
+   at least four poll ticks after the last (about two seconds at the
+   default interval). A swallowed first click no longer strands the run
+   until the deadline.
+4. **Otherwise keep polling** — every 500 ms by default, override via
+   [`poll_interval`](https://docs.rs/zendriver/latest/zendriver/struct.CloudflareBypass.html#method.poll_interval)
+   — until a terminal fires or the deadline passes.
+
+After ten consecutive ticks with no progress the driver logs a warning
+asking whether `BrowserBuilder::stealth` is on, which is the answer most
+of the time. See [Pairing with stealth](#pairing-with-stealth) below.
 
 ## Limitations
 
-This driver **only handles the visible interactive Turnstile checkbox**.
-It does not solve:
+The driver **clicks the visible interactive Turnstile checkbox**, and
+picks up the token on the invisible path when Cloudflare's own script
+produces one. It does not solve:
 
-- **Silent / invisible Turnstile** (no UI element to click — relies on
-  passive fingerprinting). For those, stealth alone is your only
-  defense; pair `StealthProfile::spoofed()` with a clean residential IP.
+- **Silent / invisible Turnstile.** There is no UI element to click and
+  the verdict comes from passive fingerprinting. The loop returns
+  `TokenAcquired` the moment the field is populated, but nothing here
+  makes Cloudflare populate it — that is stealth's job. Pair
+  `StealthProfile::spoofed()` with a clean residential IP.
 - **Cloudflare's full Pro / Enterprise managed challenge** (which can
   escalate to image puzzles or even hCaptcha).
 - **Bot Fight Mode soft blocks** that issue 403s without a UI.
@@ -132,19 +162,29 @@ tab.wait_for_load().await?;
 
 match tab.cloudflare()
     .wait_for_clearance(Duration::from_secs(30))
-    .await
+    .await?
 {
-    Ok(_) => { /* cleared */ }
-    Err(CloudflareError::NoChallenge) => { /* already cleared, fine */ }
-    Err(e) => return Err(e.into()),
+    ClearanceOutcome::TokenAcquired(_) | ClearanceOutcome::ChallengeGone => {
+        // Past the gate.
+    }
+    ClearanceOutcome::TimedOut { saw_challenge: false } => {
+        // No Cloudflare marker ever appeared — this page has no gate.
+        // Usually fine to continue.
+    }
+    ClearanceOutcome::TimedOut { saw_challenge: true } => {
+        // A real challenge that never resolved. Worth failing the job.
+        return Err("cloudflare challenge did not clear".into());
+    }
 }
 
 // Now your normal scraping / interaction code.
 let data = tab.find().css(".product-grid").one().await?;
 ```
 
-`NoChallenge` is informational, not an error — code should treat it as
-success. The other variants of [`CloudflareError`] should propagate.
+The `?` propagates the two real faults, `Call` and `JsError`. Everything
+else is a terminal you decide about, and the `saw_challenge` split is
+the one that changes what you do: "no gate on this page" and "a gate we
+could not pass" want opposite handling.
 
 ## Tuning
 

--- a/docs/book/src/cloudflare.md
+++ b/docs/book/src/cloudflare.md
@@ -34,10 +34,17 @@ ordinary terminals, the last one included:
 - **`TokenAcquired(token)`** — the `cf-turnstile-response` input picked
   up a non-empty value. The page can now proceed; the token is also
   forwarded to Cloudflare server-side on the next request.
-- **`ChallengeGone`** — the challenge went away without yielding a
-  token, typically because Cloudflare honored a clearance cookie and
-  short-circuited the gate. Either an iframe the driver clicked was torn
-  down, or every challenge marker seen on an earlier tick has vanished.
+- **`ChallengeGone`** — the challenge stopped being actionable without
+  yielding a token, typically because Cloudflare honored a clearance
+  cookie and short-circuited the gate. Either the iframe the driver
+  clicked is no longer a valid click target, or every challenge marker
+  seen on an earlier tick has vanished. The first case is weaker than it
+  sounds: a widget that is still mounted but hidden or zero-sized is also
+  not a valid click target, so once a click has landed this outcome can
+  arrive on a tick where the widget simply is not clickable at that
+  moment. That case says the driver ran out of things to click, not that
+  the gate is behind you; confirm the page before trusting what you
+  scrape next.
 - **`TimedOut { saw_challenge }`** — the deadline elapsed.
   `saw_challenge` separates the two cases worth telling apart: `true`
   means a real challenge sat on the page and never resolved, `false`

--- a/docs/book/src/datadome.md
+++ b/docs/book/src/datadome.md
@@ -126,6 +126,13 @@ browser by setting this cookie (not a form-field token like hCaptcha/reCAPTCHA).
 The driver applies it via `Network.setCookie` scoped to the registrable domain
 and reloads the page.
 
+The solver runs at most once per `wait_for_clearance`, and within that call's
+timeout. The reload is acked before the new document loads, so the next poll
+still sees the CAPTCHA — an unlatched loop would bill you a solve every 250ms
+until the page settled. After the one attempt the driver goes back to polling
+until the surface clears or the deadline passes; call `wait_for_clearance`
+again if you want a second solve.
+
 `DataDomeChallenge` carries: `captcha_url`, `site_url`, `user_agent`, `cid`
 (DataDome challenge ID), and `hash`. `DataDomeSolution` holds
 `datadome_cookie`.

--- a/docs/book/src/imperva.md
+++ b/docs/book/src/imperva.md
@@ -94,7 +94,8 @@ never set `reese84` resolve to `ChallengeGone` once body markers clear.
 
 ## CAPTCHA handling
 
-Without an `on_captcha` callback, a CAPTCHA surface returns
+A CAPTCHA surface escalates only when no usable `reese84` token is in
+hand. Without an `on_captcha` callback that case returns
 `ImpervaError::CaptchaRequired { kind }` immediately (no waiting). Plug
 in your own solver:
 
@@ -117,6 +118,15 @@ let _ = ImpervaBypass::new(tab)
 `CaptchaChallenge` carries `kind`, `site_key` (when extractable), and
 `url`. `CaptchaSolution` is the token + form field name your solver
 returns.
+
+Two things worth knowing before you wire up a paid service. A snapshot
+that already carries a `reese84` never escalates, whatever the surface
+says — the site's own post-clearance form routinely mounts an ordinary
+reCAPTCHA, and a token in hand outranks it — so a registered solver can
+go uncalled for an entire run. And the solver is invoked at most once
+per `wait_for_clearance`, raced against that call's timeout: injecting
+the response does not remove the widget, so the surface stays `Captcha`
+afterwards, and an unlatched loop would buy a fresh solve every tick.
 
 ## Fetch-domain fast path
 


### PR DESCRIPTION
Cloudflare, Imperva and DataDome each had terminals that could not fire.

- CF `ChallengeGone` was gated on having clicked, so a JS-only interstitial always timed out. The click latch fired once with no scroll and no retry.
- Imperva and DataDome escalated CAPTCHA only on the *pre-loop* probe, so the normal shape (device check, then captcha seconds later) never reached the solver.
- **Imperva decided clearance after escalating**, so a snapshot carrying a valid `reese84` was discarded to solve a captcha the site's own form had mounted. The better the clearance worked, the more reliably the call failed.
- Solvers had no latch: a stuck surface re-entered one **40 times** per call, each a paid solve.
- `nlbi_*` is the load-balancer cookie, routing state that outlives clearance; counting it as a challenge marker pinned cleared pages at `Legacy`.

## Two review rounds since this PR opened

**Round 1** found Imperva's solver had no deadline while its DataDome sibling got exactly that fix five lines away (measured: 3.0s against an 80ms budget), and that the Cloudflare poll evaluator published `findChallengeIframe` and `clickableRect` onto `window` on **every poll tick** — a trace-leaving regression in the crate whose whole purpose is leaving none. The JS had no coverage at all; it now has a scanner asserting no injected source declares a page global, itself proven able to fail.

**Round 2** found two false claims rather than new bugs:

- The `# JavaScript style` rationale said `NodeList.prototype.length` and `String.prototype.includes` are not page-instrumentable. Both are. Measured on Chrome 151: with the iterator, `length`, `querySelectorAll` and `includes` all wrapped, the walk **still returned the correct iframe** — a page instruments this transparently. Worse, hooking `includes` is a *better* detector than the iterator hook the comment warns about, because the walker hands it the literal Cloudflare hostname. The ES5 convention is kept; the reasoning now says it removes one signal rather than achieving unobservability.
- `ChallengeGone` is a **success terminal** documented as "the iframe was torn down". The condition is `clickableRect` returning null, which also covers a mounted widget that is zero-size, hidden or transparent — so after the first landed click, any momentarily unclickable tick reports success and a caller told the gate is behind them scrapes challenge HTML. Corrected across **nine sites**: grepping the phrase found five more the PR had never touched, including agent-facing MCP schema text. Behaviour is deliberately unchanged; the open question is now recorded at the arm instead of living only in a review file.

Also: DataDome's stall docstring was off by one (mutation-proven). Cloudflare's identical-looking claim was checked, found **correct**, and left alone rather than "fixed" to match its sibling.

## Verification

`fmt --check` clean · `clippy --workspace --all-targets -- -D warnings` **0 errors** · **132 tests + 150 schema snapshots**, none pending · `mdbook build` OK · no public API change.

Two items remain reserved for a human and are recorded in the code: the `visid_incap_*` cookie lifetime, and whether real Turnstile ever presents a mounted-but-unclickable widget post-click.

---
Split out of #145. Review records: `docs/review-records` branch. 🤖 Generated with [Claude Code](https://claude.com/claude-code)