### PR TITLE
docs(fetcher): stop claiming a cache hit skips the network

### DIFF
--- a/crates/zendriver-fetcher/src/error.rs
+++ b/crates/zendriver-fetcher/src/error.rs
@@ -30,7 +30,9 @@ pub enum FetcherError {
     /// SHA256 checksum mismatch on the downloaded archive.
     #[error("integrity check failed: expected {expected}, got {actual}")]
     IntegrityFailed {
-        /// SHA256 from the manifest.
+        /// The SHA256 the caller pinned via [`crate::Fetcher::expected_sha256`].
+        /// The CfT manifest publishes no per-download hashes, so this never
+        /// comes from the manifest.
         expected: String,
         /// SHA256 computed from the downloaded bytes.
         actual: String,

--- a/crates/zendriver-fetcher/src/fetcher.rs
+++ b/crates/zendriver-fetcher/src/fetcher.rs
@@ -211,7 +211,11 @@ impl Fetcher {
     /// Resolve, download, extract (on cache miss), and return the path
     /// to the cached Chrome binary.
     ///
-    /// On a cache hit, returns immediately without touching the network.
+    /// Resolution runs on every call, *before* the cache is consulted: the
+    /// cache is keyed by the resolved build id, so the manifest has to be
+    /// fetched to know which key to look for. A cache hit therefore skips the
+    /// download and the extraction, but not the manifest request — a fully
+    /// populated cache still fails without egress.
     ///
     /// # Errors
     ///

--- a/crates/zendriver-fetcher/src/lib.rs
+++ b/crates/zendriver-fetcher/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! See the [Fetcher chapter](https://turtiesocks.github.io/zendriver-rs/fetcher.html)
 //! of the [zendriver-rs user guide](https://turtiesocks.github.io/zendriver-rs/)
-//! for cache-layout details, offline-mode workflows, and CI integration tips.
+//! for cache-layout details and CI integration tips.
 //!
 //! Resolves a [`Distribution`] + [`VersionSpec`] + [`Platform`] triple against
 //! that distribution's index, downloads the matching archive, unpacks it into

--- a/crates/zendriver/examples/fetcher_demo.rs
+++ b/crates/zendriver/examples/fetcher_demo.rs
@@ -8,9 +8,10 @@
 //!
 //! [`Fetcher::ensure_chrome`] resolves the manifest, downloads + extracts
 //! into the OS-conventional cache dir on a cache miss, and returns a
-//! [`PathBuf`] to a runnable Chrome binary. On a cache hit (binary already
-//! extracted under `<cache>/<version>/`), it skips the network entirely
-//! and returns the cached path.
+//! [`PathBuf`] to a runnable Chrome binary. The manifest is resolved on
+//! every call, before the cache is probed, so a cache hit (binary already
+//! extracted under `<cache>/<build-id>/`) skips the download and the
+//! extraction but still needs to reach the manifest host.
 //!
 //! After resolving the path, you can hand it to a [`Browser`] launch:
 //! `Browser::builder().executable(path).launch().await?` — or use the

--- a/docs/book/src/fetcher.md
+++ b/docs/book/src/fetcher.md
@@ -42,8 +42,13 @@ let browser = zendriver::Browser::builder()
 
 `ensure_chrome` resolves the latest stable CFT version for the host
 platform, downloads + extracts it on cache miss, and points the
-[`BrowserBuilder`] at the resulting binary. On a cache hit the call
-returns in milliseconds and skips the network.
+[`BrowserBuilder`] at the resulting binary.
+
+Resolution runs on every call, before the cache is consulted — the cache
+is keyed by the resolved build id, so the manifest has to be fetched to
+know which key to look for. A cache hit skips the download and the
+extraction, not the manifest request, so `ensure_chrome` is not an
+offline path.
 
 ## The full builder
 
@@ -303,17 +308,22 @@ A minimal `.github/workflows/test.yml` snippet:
 - run: cargo test --features fetcher
 ```
 
-`actions/cache` rehydrates the cache dir; the fetcher detects the cache
-hit and skips the download. First run takes ~30 s on GitHub's free
-runners; cached runs take &lt;1 s in `ensure_chrome`.
+`actions/cache` rehydrates the cache dir; the fetcher resolves the
+manifest, detects the cache hit, and skips the download. First run takes
+~30 s on GitHub's free runners; cached runs take &lt;1 s in
+`ensure_chrome` — the manifest request, not the archive transfer. The
+runner still needs egress to the manifest host either way.
 
 ## When NOT to use it
 
 - **You already have Chrome on the host** and don't care about
   version-pinning — the built-in PATH discovery is faster.
 - **Network-restricted environments** that can't reach
-  `https://googlechromelabs.github.io` or the CFT CDN — pre-populate
-  the cache out-of-band or ship a Docker image with Chrome baked in.
+  `https://googlechromelabs.github.io` or the CFT CDN. Pre-populating the
+  cache dir is not enough — the manifest is resolved before the cache is
+  probed, so `ensure_chrome` still errors. Point
+  [`BrowserBuilder::executable`] at the binary directly, or ship a Docker
+  image with Chrome baked in.
 - **You need Chrome stable on Linux ARM64** — CFT doesn't ship a
   `linux-arm64` build today;
   [`Platform::auto_detect`] returns `None` on that host and


### PR DESCRIPTION
**Rebased onto current `main` and reduced to docs only.** The branch was 35 commits stale; #161 reworked the fetcher extensively and landed three of this PR's four fixes independently.

## Dropped as redundant — #161 already has these

| was in this PR | landed on main |
|---|---|
| per-fetch unique staging paths | `staging_stamp()` with an `AtomicU64`, namespaced like the final directory — and it fixes a worse case than mine: two concurrent fetches each deleting the other's half-written tree, then renaming what was left into the cache under the canonical name |
| archive modes masked to `0o777` | `Permissions::from_mode(mode & 0o777)` in `extract.rs` |
| partial `.tmp.zip` cleanup on a failed download | `remove_file(&tmp_archive)` on both failure paths, with a test asserting no leftover |

#161's versions are better than what this PR carried, so they are dropped rather than merged. Nothing of mine is reapplied over them.

## What survives — six false doc claims, all still present on `main`

The ordering that makes them false is unchanged: `ensure_chrome` runs `self.resolve(platform).await?` and only *then* reaches the `is_runnable` early return. The cache is keyed by the resolved build id, so the manifest must be fetched to know which key to look for.

- [`fetcher.rs:214`](crates/zendriver-fetcher/src/fetcher.rs:214) — "On a cache hit, returns immediately without touching the network."
- [`fetcher.md:46`](docs/book/src/fetcher.md:46) — "returns in milliseconds and skips the network."
- `fetcher.md` CI section — "cached runs take &lt;1 s" with no mention that the manifest request still happens.
- `fetcher.md` "When NOT to use it" — advises network-restricted users to **"pre-populate the cache out-of-band"**, which cannot work for the same reason. Now points at `BrowserBuilder::executable`.
- `zendriver-fetcher/src/lib.rs:5` — "offline-mode workflows", which the crate supports none of.
- `examples/fetcher_demo.rs` — "it skips the network entirely".

Separately, `IntegrityFailed`'s field doc says the expected hash is the **"SHA256 from the manifest"**. It is the value the caller pinned via `Fetcher::expected_sha256`; the CfT manifest publishes no per-download hashes, and the check is skipped entirely when that field is `None`.

## Scope

Docs only. **The resolve/cache ordering itself is deliberately not changed** — making the cache genuinely authoritative is a `NetworkPolicy`-shaped API decision, not a doc fix.

**30 insertions, 13 deletions** across 5 files. Was 475 insertions before the rebase.

Gates: `fmt --all --check` clean, `clippy --workspace --all-targets -- -D warnings` **0 errors**, `zendriver-fetcher` 105 + 15 tests green, `mdbook build docs/book` OK.

---
Split out of #145. 🤖 Generated with [Claude Code](https://claude.com/claude-code)