### PR TITLE
fix(io): bound the blocklist fetch, write cookies atomically and safely

### DIFF
--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -1011,6 +1011,20 @@ impl BrowserBuilder {
     /// exceeds any of them fails [`Self::launch`] rather than stalling or
     /// buffering it — so if the mirror you want is slow or enormous, seed the
     /// cache yourself or use [`Self::tracker_blocklist_file`] instead.
+    ///
+    /// The body is decoded as UTF-8 **lossily**: a byte sequence that is not
+    /// valid UTF-8 becomes `U+FFFD` rather than failing the launch. The three
+    /// bounds above are about resources this process must spend, and each of
+    /// them is a real reason to give up; a stray encoding byte is not. Host
+    /// lines are ASCII, so in practice the bad bytes sit in a comment or
+    /// licence header — a latin-1 `©`, a Windows-1252 apostrophe — that the
+    /// parser discards either way. Failing instead would cost more than it
+    /// buys, because this download happens inside [`Self::launch`] and nothing
+    /// is cached when it fails: every later launch would re-fetch and fail
+    /// identically, over a file the user does not control and whose offending
+    /// bytes never reach the matcher. If you need the bytes to be exactly what
+    /// the mirror served, fetch the list yourself and pass it via
+    /// [`Self::tracker_blocklist_file`].
     #[cfg(feature = "tracker-blocking")]
     #[must_use]
     pub fn tracker_blocklist_url(mut self, url: impl Into<String>) -> Self {

--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -1005,6 +1005,12 @@ impl BrowserBuilder {
     /// Use this to point at an external list (uBlock, Peter Lowe's, …) under
     /// your own acceptance of that list's license — the bundle ships only our
     /// own clean list.
+    ///
+    /// The fetch is bounded and the bounds are not configurable: 5s to
+    /// connect, 20s for the whole request, and 32 MiB of body. A source that
+    /// exceeds any of them fails [`Self::launch`] rather than stalling or
+    /// buffering it — so if the mirror you want is slow or enormous, seed the
+    /// cache yourself or use [`Self::tracker_blocklist_file`] instead.
     #[cfg(feature = "tracker-blocking")]
     #[must_use]
     pub fn tracker_blocklist_url(mut self, url: impl Into<String>) -> Self {

--- a/crates/zendriver/src/cookies/persistence.rs
+++ b/crates/zendriver/src/cookies/persistence.rs
@@ -21,20 +21,148 @@
 //! `url` re-inference. If you hand-author a JSON file with a non-null
 //! `url`, it round-trips faithfully too (serde preserves `Some` values).
 
-use std::path::Path;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use tokio::fs;
 
 use crate::cookies::CookieJar;
 use crate::error::Result;
 
+/// Write `bytes` to `path` atomically: fill a uniquely-named sibling temp
+/// file, then `rename` it over the destination.
+///
+/// A same-directory `rename` is atomic on every platform zendriver targets, so
+/// a process killed mid-write leaves either the previous file or the complete
+/// new one — never a truncated prefix. That matters most for the cookie jar: a
+/// half-written `cookies.json` fails to parse on the next `load_from_file`,
+/// losing exactly the authenticated session the file existed to preserve.
+///
+/// The temp name carries the process id plus a per-process counter, so two
+/// writers targeting the same destination cannot fill each other's temp file.
+/// A failure at either step removes the temp file rather than leaving litter
+/// next to the destination.
+///
+/// Scope: this buys atomicity against a killed process, not fsync-level
+/// durability against a power loss (neither the temp file nor the containing
+/// directory is synced). Losing an unsynced write leaves the previous file,
+/// which is the same outcome as never having called `save_to_file`.
+///
+/// Shared with the `tracker-blocking` blocklist cache
+/// (`crate::tracker::load_or_download_blocklist`), which wants the same
+/// guarantee; it lives here because this module is compiled unconditionally
+/// while that one is feature-gated.
+///
+/// # Permissions and symlinks
+///
+/// The rename installs the *temp file's* inode at `path`, so the destination
+/// afterwards is a different file than it was before. Two consequences that a
+/// plain `fs::write` does not have:
+///
+/// - **The mode comes from the temp file.** Left alone that would be the
+///   process umask (commonly `0644`), silently widening a jar the user
+///   deliberately created `chmod 600` into a world-readable file full of live
+///   session cookies. [`apply_destination_mode`] therefore stamps the
+///   destination's current mode onto the temp file before the rename, and
+///   falls back to owner-only `0600` when the destination does not exist yet.
+///   No-op on non-Unix targets, which have no mode to carry over.
+/// - **A symlinked destination is replaced, not followed.** If `path` is a
+///   symlink, the rename unlinks it and leaves a regular file in its place —
+///   the link target keeps its old contents and stops receiving writes.
+///   `fs::write` followed the link and wrote through to the target, so a
+///   caller who symlinked their cookie jar at some canonical store must point
+///   zendriver at the real path instead. (The mode is still read through the
+///   link, so the replacement inherits the target's permissions.)
+pub(crate) async fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = temp_path(path);
+    if let Err(e) = fs::write(&tmp, bytes).await {
+        let _ = fs::remove_file(&tmp).await;
+        return Err(e);
+    }
+    if let Err(e) = apply_destination_mode(&tmp, path).await {
+        let _ = fs::remove_file(&tmp).await;
+        return Err(e);
+    }
+    if let Err(e) = fs::rename(&tmp, path).await {
+        let _ = fs::remove_file(&tmp).await;
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// Give `tmp` the permissions `dest` should still have once the rename has
+/// swapped one for the other.
+///
+/// An existing destination's mode wins outright: preserving what the user (or
+/// their prior save) chose is the only behavior that keeps `write_atomic`
+/// indistinguishable from the `fs::write` it replaced.
+#[cfg(unix)]
+async fn apply_destination_mode(tmp: &Path, dest: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Mode for a destination that does not exist yet.
+    ///
+    /// `0600` rather than the process umask because the caller that matters
+    /// here — [`CookieJar::save_to_file`] — writes authentication material:
+    /// session cookies that are equivalent to a password for as long as they
+    /// live. Nothing else on the machine has a reason to read them, so the
+    /// safe default is owner-only and a user who genuinely wants the file
+    /// shared can widen it once — the branch above then preserves that choice
+    /// on every later save.
+    const NEW_FILE_MODE: u32 = 0o600;
+
+    let mode = match fs::metadata(dest).await {
+        // Mask off the file-type bits; keep the full permission set (including
+        // setuid/setgid/sticky) so nothing the user set is quietly dropped.
+        Ok(meta) => meta.permissions().mode() & 0o7777,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => NEW_FILE_MODE,
+        Err(e) => return Err(e),
+    };
+    fs::set_permissions(tmp, std::fs::Permissions::from_mode(mode)).await
+}
+
+/// No-op counterpart for targets without Unix mode bits — Windows carries its
+/// ACLs on the containing directory, so the renamed file picks them up.
+#[cfg(not(unix))]
+#[allow(clippy::unused_async)]
+async fn apply_destination_mode(_tmp: &Path, _dest: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// Sibling temp path for [`write_atomic`] — same directory, so the `rename`
+/// stays on one filesystem (and is therefore atomic), and unique per process
+/// and per call.
+fn temp_path(path: &Path) -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let mut name = path
+        .file_name()
+        .unwrap_or_else(|| OsStr::new("zendriver"))
+        .to_os_string();
+    name.push(format!(
+        ".{}.{}.tmp",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    path.with_file_name(name)
+}
+
 impl CookieJar {
     /// Snapshot the cookie store to a JSON file at `path`.
     ///
     /// Issues a single `Storage.getCookies` round-trip, then writes the
-    /// pretty-printed array via [`tokio::fs::write`]. The file is
-    /// overwritten if it already exists. Parent directories must already
-    /// exist — `save_to_file` does not create them.
+    /// pretty-printed array. The write is atomic — a sibling temp file is
+    /// filled and renamed over the destination — so an interrupted save
+    /// leaves the previous file intact instead of a truncated one that no
+    /// longer parses. The file is overwritten if it already exists. Parent
+    /// directories must already exist — `save_to_file` does not create them.
+    ///
+    /// On Unix an existing file keeps its permissions across saves, and a file
+    /// created by this call is `0600`: it holds live session cookies, so the
+    /// default is owner-only rather than whatever the process umask allows.
+    /// Because the write finishes with a `rename`, a `path` that is a *symlink*
+    /// is replaced by a regular file — the link target stops receiving saves.
+    /// Pass the real path if you were relying on that indirection.
     ///
     /// # Errors
     ///
@@ -52,7 +180,7 @@ impl CookieJar {
     pub async fn save_to_file(&self, path: impl AsRef<Path>) -> Result<()> {
         let cookies = self.all().await?;
         let bytes = serde_json::to_vec_pretty(&cookies)?;
-        fs::write(path, bytes).await?;
+        write_atomic(path.as_ref(), &bytes).await?;
         Ok(())
     }
 
@@ -84,11 +212,12 @@ impl CookieJar {
 
     /// Snapshot only the cookies matching `filter` to a JSON file at `path`.
     ///
-    /// Like [`Self::save_to_file`], but applies the `filter` predicate to
-    /// the result of [`CookieJar::all`] before writing — handy for
-    /// persisting just one site's cookies out of a shared store. The
-    /// predicate receives each [`crate::cookies::Cookie`] by reference and
-    /// returns `true` to keep it.
+    /// Like [`Self::save_to_file`] — including the atomic temp-file-then-
+    /// rename write and its permission/symlink behavior — but applies the
+    /// `filter` predicate to the result of
+    /// [`CookieJar::all`] before writing, handy for persisting just one
+    /// site's cookies out of a shared store. The predicate receives each
+    /// [`crate::cookies::Cookie`] by reference and returns `true` to keep it.
     ///
     /// # Errors
     ///
@@ -118,7 +247,7 @@ impl CookieJar {
             .filter(|c| filter(c))
             .collect();
         let bytes = serde_json::to_vec_pretty(&cookies)?;
-        fs::write(path, bytes).await?;
+        write_atomic(path.as_ref(), &bytes).await?;
         Ok(())
     }
 
@@ -165,8 +294,204 @@ mod tests {
     use serde_json::json;
     use zendriver_transport::testing::MockConnection;
 
+    use super::write_atomic;
     use crate::cookies::{CookieJar, SameSite};
     use crate::error::ZendriverError;
+
+    /// Count the entries in a directory — the cheap proxy for "the temp file
+    /// was renamed, not left behind".
+    fn dir_entry_count(dir: &std::path::Path) -> usize {
+        std::fs::read_dir(dir).unwrap().count()
+    }
+
+    /// The atomic write replaces existing content in place and leaves no
+    /// `.tmp` sibling behind: after the call the directory holds exactly the
+    /// destination file, carrying the new bytes.
+    #[tokio::test]
+    async fn write_atomic_replaces_existing_and_leaves_no_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("cookies.json");
+        std::fs::write(&dest, b"stale").unwrap();
+
+        write_atomic(&dest, b"fresh").await.unwrap();
+
+        assert_eq!(std::fs::read(&dest).unwrap(), b"fresh");
+        assert_eq!(
+            dir_entry_count(dir.path()),
+            1,
+            "temp file must be renamed away, not left next to the destination"
+        );
+    }
+
+    /// When the `rename` step fails, the error surfaces AND the temp file is
+    /// cleaned up. A destination that is an existing directory is the
+    /// simplest way to make `rename` fail after a successful temp write.
+    #[tokio::test]
+    async fn write_atomic_cleans_up_temp_file_when_rename_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("occupied");
+        std::fs::create_dir(&dest).unwrap();
+
+        let err = write_atomic(&dest, b"fresh").await.unwrap_err();
+        let _ = err;
+
+        assert_eq!(
+            dir_entry_count(dir.path()),
+            1,
+            "only the pre-existing directory should remain; the temp file must be removed"
+        );
+    }
+
+    /// Mode of `path`, permission bits only. Unix-only helper for the
+    /// permission tests below.
+    #[cfg(unix)]
+    fn mode_of(path: &std::path::Path) -> u32 {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    /// A jar deliberately created `chmod 600` must still be `0600` after a
+    /// save. The rename installs the temp file's inode, so without an explicit
+    /// carry-over the mode collapses to the process umask (0644 on a stock
+    /// box) and a file full of live session cookies goes world-readable.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_preserves_an_existing_restrictive_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("cookies.json");
+        std::fs::write(&dest, b"stale").unwrap();
+        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        write_atomic(&dest, b"fresh").await.unwrap();
+
+        let mode = mode_of(&dest);
+        assert_eq!(
+            mode, 0o600,
+            "a 0600 cookie jar must not widen across a save, got {mode:o}"
+        );
+        assert_eq!(std::fs::read(&dest).unwrap(), b"fresh");
+        assert_eq!(dir_entry_count(dir.path()), 1, "no temp file may be left");
+    }
+
+    /// A mode the user widened on purpose is preserved too — the rule is
+    /// "carry the destination's mode", not "force 0600 on everything".
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_preserves_an_existing_permissive_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("trackers.txt");
+        std::fs::write(&dest, b"stale").unwrap();
+        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_atomic(&dest, b"fresh").await.unwrap();
+
+        let mode = mode_of(&dest);
+        assert_eq!(mode, 0o644, "a widened mode must survive too, got {mode:o}");
+    }
+
+    /// With no destination to inherit from, the new file is owner-only rather
+    /// than whatever the ambient umask would have allowed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_creates_a_new_file_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("cookies.json");
+        assert!(!dest.exists());
+
+        write_atomic(&dest, b"fresh").await.unwrap();
+
+        let mode = mode_of(&dest);
+        assert_eq!(
+            mode, 0o600,
+            "a freshly created cookie jar must default to owner-only, got {mode:o}"
+        );
+        assert_eq!(std::fs::read(&dest).unwrap(), b"fresh");
+        assert_eq!(dir_entry_count(dir.path()), 1, "no temp file may be left");
+    }
+
+    /// Pins the behavior the rustdoc warns about: because the write ends in a
+    /// `rename`, a symlinked destination is *replaced* by a regular file
+    /// instead of written through. If this ever changes, the docs on
+    /// `write_atomic` and `save_to_file` change with it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_replaces_a_symlinked_destination() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.json");
+        let link = dir.path().join("cookies.json");
+        std::fs::write(&real, b"original").unwrap();
+        std::fs::set_permissions(&real, std::fs::Permissions::from_mode(0o600)).unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        write_atomic(&link, b"fresh").await.unwrap();
+
+        assert!(
+            !std::fs::symlink_metadata(&link).unwrap().is_symlink(),
+            "the rename unlinks the symlink and leaves a regular file"
+        );
+        assert_eq!(std::fs::read(&link).unwrap(), b"fresh");
+        assert_eq!(
+            std::fs::read(&real).unwrap(),
+            b"original",
+            "the link target stops receiving writes"
+        );
+        // The mode is still read through the link, so the replacement keeps
+        // the target's restrictive permissions.
+        let mode = mode_of(&link);
+        assert_eq!(
+            mode, 0o600,
+            "the replacement must inherit the link target's mode, got {mode:o}"
+        );
+    }
+
+    /// The regression as reported, end to end through the public API: a jar
+    /// file at 0600 that a real `save_to_file` must not widen.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn save_to_file_preserves_a_restrictive_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (mut mock, conn) = MockConnection::pair();
+        let jar = CookieJar::new(conn.clone());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cookies.json");
+        std::fs::write(&path, b"stale").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        let save = tokio::spawn({
+            let j = jar.clone();
+            let p = path.clone();
+            async move { j.save_to_file(p).await }
+        });
+
+        let id = mock.expect_cmd("Storage.getCookies").await;
+        mock.reply(
+            id,
+            json!({
+                "cookies": [
+                    { "name": "session", "value": "secret", "domain": ".x.test", "path": "/",
+                      "httpOnly": true, "secure": true },
+                ]
+            }),
+        )
+        .await;
+        save.await.unwrap().unwrap();
+
+        let mode = mode_of(&path);
+        assert_eq!(
+            mode, 0o600,
+            "save_to_file must not widen a 0600 jar holding session cookies, got {mode:o}"
+        );
+        assert_eq!(dir_entry_count(dir.path()), 1, "no temp file may be left");
+
+        conn.shutdown();
+    }
 
     /// End-to-end round-trip: dump the cookie store to disk, then load it back
     /// into a fresh jar. The mock receives `Storage.getCookies` on save,
@@ -373,5 +698,57 @@ mod tests {
         load.await.unwrap().unwrap();
 
         conn.shutdown();
+    }
+
+    /// Both save paths must go through the atomic helper: the destination
+    /// ends up holding the full pretty-printed JSON, and no `.tmp` sibling is
+    /// left in the directory. Writing over an existing file also proves the
+    /// rename replaces stale content rather than appending to it.
+    #[tokio::test]
+    async fn both_save_paths_write_atomically() {
+        for matching in [false, true] {
+            let (mut mock, conn) = MockConnection::pair();
+            let jar = CookieJar::new(conn.clone());
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("cookies.json");
+            std::fs::write(&path, b"stale-and-longer-than-the-new-content").unwrap();
+
+            let save = tokio::spawn({
+                let j = jar.clone();
+                let p = path.clone();
+                async move {
+                    if matching {
+                        j.save_to_file_matching(p, |_| true).await
+                    } else {
+                        j.save_to_file(p).await
+                    }
+                }
+            });
+
+            let id = mock.expect_cmd("Storage.getCookies").await;
+            mock.reply(
+                id,
+                json!({
+                    "cookies": [
+                        { "name": "a", "value": "1", "domain": ".x.test", "path": "/",
+                          "httpOnly": false, "secure": false },
+                    ]
+                }),
+            )
+            .await;
+            save.await.unwrap().unwrap();
+
+            let parsed: Vec<crate::cookies::Cookie> =
+                serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+            assert_eq!(parsed.len(), 1, "matching={matching}");
+            assert_eq!(parsed[0].name, "a");
+            assert_eq!(
+                dir_entry_count(dir.path()),
+                1,
+                "matching={matching}: save must leave no temp file behind"
+            );
+
+            conn.shutdown();
+        }
     }
 }

--- a/crates/zendriver/src/cookies/persistence.rs
+++ b/crates/zendriver/src/cookies/persistence.rs
@@ -21,131 +21,13 @@
 //! `url` re-inference. If you hand-author a JSON file with a non-null
 //! `url`, it round-trips faithfully too (serde preserves `Some` values).
 
-use std::ffi::OsStr;
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::path::Path;
 
 use tokio::fs;
 
 use crate::cookies::CookieJar;
 use crate::error::Result;
-
-/// Write `bytes` to `path` atomically: fill a uniquely-named sibling temp
-/// file, then `rename` it over the destination.
-///
-/// A same-directory `rename` is atomic on every platform zendriver targets, so
-/// a process killed mid-write leaves either the previous file or the complete
-/// new one — never a truncated prefix. That matters most for the cookie jar: a
-/// half-written `cookies.json` fails to parse on the next `load_from_file`,
-/// losing exactly the authenticated session the file existed to preserve.
-///
-/// The temp name carries the process id plus a per-process counter, so two
-/// writers targeting the same destination cannot fill each other's temp file.
-/// A failure at either step removes the temp file rather than leaving litter
-/// next to the destination.
-///
-/// Scope: this buys atomicity against a killed process, not fsync-level
-/// durability against a power loss (neither the temp file nor the containing
-/// directory is synced). Losing an unsynced write leaves the previous file,
-/// which is the same outcome as never having called `save_to_file`.
-///
-/// Shared with the `tracker-blocking` blocklist cache
-/// (`crate::tracker::load_or_download_blocklist`), which wants the same
-/// guarantee; it lives here because this module is compiled unconditionally
-/// while that one is feature-gated.
-///
-/// # Permissions and symlinks
-///
-/// The rename installs the *temp file's* inode at `path`, so the destination
-/// afterwards is a different file than it was before. Two consequences that a
-/// plain `fs::write` does not have:
-///
-/// - **The mode comes from the temp file.** Left alone that would be the
-///   process umask (commonly `0644`), silently widening a jar the user
-///   deliberately created `chmod 600` into a world-readable file full of live
-///   session cookies. [`apply_destination_mode`] therefore stamps the
-///   destination's current mode onto the temp file before the rename, and
-///   falls back to owner-only `0600` when the destination does not exist yet.
-///   No-op on non-Unix targets, which have no mode to carry over.
-/// - **A symlinked destination is replaced, not followed.** If `path` is a
-///   symlink, the rename unlinks it and leaves a regular file in its place —
-///   the link target keeps its old contents and stops receiving writes.
-///   `fs::write` followed the link and wrote through to the target, so a
-///   caller who symlinked their cookie jar at some canonical store must point
-///   zendriver at the real path instead. (The mode is still read through the
-///   link, so the replacement inherits the target's permissions.)
-pub(crate) async fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let tmp = temp_path(path);
-    if let Err(e) = fs::write(&tmp, bytes).await {
-        let _ = fs::remove_file(&tmp).await;
-        return Err(e);
-    }
-    if let Err(e) = apply_destination_mode(&tmp, path).await {
-        let _ = fs::remove_file(&tmp).await;
-        return Err(e);
-    }
-    if let Err(e) = fs::rename(&tmp, path).await {
-        let _ = fs::remove_file(&tmp).await;
-        return Err(e);
-    }
-    Ok(())
-}
-
-/// Give `tmp` the permissions `dest` should still have once the rename has
-/// swapped one for the other.
-///
-/// An existing destination's mode wins outright: preserving what the user (or
-/// their prior save) chose is the only behavior that keeps `write_atomic`
-/// indistinguishable from the `fs::write` it replaced.
-#[cfg(unix)]
-async fn apply_destination_mode(tmp: &Path, dest: &Path) -> std::io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
-    /// Mode for a destination that does not exist yet.
-    ///
-    /// `0600` rather than the process umask because the caller that matters
-    /// here — [`CookieJar::save_to_file`] — writes authentication material:
-    /// session cookies that are equivalent to a password for as long as they
-    /// live. Nothing else on the machine has a reason to read them, so the
-    /// safe default is owner-only and a user who genuinely wants the file
-    /// shared can widen it once — the branch above then preserves that choice
-    /// on every later save.
-    const NEW_FILE_MODE: u32 = 0o600;
-
-    let mode = match fs::metadata(dest).await {
-        // Mask off the file-type bits; keep the full permission set (including
-        // setuid/setgid/sticky) so nothing the user set is quietly dropped.
-        Ok(meta) => meta.permissions().mode() & 0o7777,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => NEW_FILE_MODE,
-        Err(e) => return Err(e),
-    };
-    fs::set_permissions(tmp, std::fs::Permissions::from_mode(mode)).await
-}
-
-/// No-op counterpart for targets without Unix mode bits — Windows carries its
-/// ACLs on the containing directory, so the renamed file picks them up.
-#[cfg(not(unix))]
-#[allow(clippy::unused_async)]
-async fn apply_destination_mode(_tmp: &Path, _dest: &Path) -> std::io::Result<()> {
-    Ok(())
-}
-
-/// Sibling temp path for [`write_atomic`] — same directory, so the `rename`
-/// stays on one filesystem (and is therefore atomic), and unique per process
-/// and per call.
-fn temp_path(path: &Path) -> PathBuf {
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let mut name = path
-        .file_name()
-        .unwrap_or_else(|| OsStr::new("zendriver"))
-        .to_os_string();
-    name.push(format!(
-        ".{}.{}.tmp",
-        std::process::id(),
-        SEQ.fetch_add(1, Ordering::Relaxed)
-    ));
-    path.with_file_name(name)
-}
+use crate::io::write_atomic;
 
 impl CookieJar {
     /// Snapshot the cookie store to a JSON file at `path`.
@@ -289,12 +171,11 @@ impl CookieJar {
 }
 
 #[cfg(test)]
-#[allow(clippy::panic, clippy::unwrap_used)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use serde_json::json;
     use zendriver_transport::testing::MockConnection;
 
-    use super::write_atomic;
     use crate::cookies::{CookieJar, SameSite};
     use crate::error::ZendriverError;
 
@@ -304,150 +185,15 @@ mod tests {
         std::fs::read_dir(dir).unwrap().count()
     }
 
-    /// The atomic write replaces existing content in place and leaves no
-    /// `.tmp` sibling behind: after the call the directory holds exactly the
-    /// destination file, carrying the new bytes.
-    #[tokio::test]
-    async fn write_atomic_replaces_existing_and_leaves_no_temp_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let dest = dir.path().join("cookies.json");
-        std::fs::write(&dest, b"stale").unwrap();
-
-        write_atomic(&dest, b"fresh").await.unwrap();
-
-        assert_eq!(std::fs::read(&dest).unwrap(), b"fresh");
-        assert_eq!(
-            dir_entry_count(dir.path()),
-            1,
-            "temp file must be renamed away, not left next to the destination"
-        );
-    }
-
-    /// When the `rename` step fails, the error surfaces AND the temp file is
-    /// cleaned up. A destination that is an existing directory is the
-    /// simplest way to make `rename` fail after a successful temp write.
-    #[tokio::test]
-    async fn write_atomic_cleans_up_temp_file_when_rename_fails() {
-        let dir = tempfile::tempdir().unwrap();
-        let dest = dir.path().join("occupied");
-        std::fs::create_dir(&dest).unwrap();
-
-        let err = write_atomic(&dest, b"fresh").await.unwrap_err();
-        let _ = err;
-
-        assert_eq!(
-            dir_entry_count(dir.path()),
-            1,
-            "only the pre-existing directory should remain; the temp file must be removed"
-        );
-    }
-
     /// Mode of `path`, permission bits only. Unix-only helper for the
-    /// permission tests below.
+    /// permission test below. (The helper's exhaustive coverage — the
+    /// setuid/setgid carry-over, the mid-write window, the symlinked
+    /// destination — lives with the helper itself in [`crate::io`]; what is
+    /// left here is the jar's own end-to-end behavior.)
     #[cfg(unix)]
     fn mode_of(path: &std::path::Path) -> u32 {
         use std::os::unix::fs::PermissionsExt;
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
-    }
-
-    /// A jar deliberately created `chmod 600` must still be `0600` after a
-    /// save. The rename installs the temp file's inode, so without an explicit
-    /// carry-over the mode collapses to the process umask (0644 on a stock
-    /// box) and a file full of live session cookies goes world-readable.
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn write_atomic_preserves_an_existing_restrictive_mode() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = tempfile::tempdir().unwrap();
-        let dest = dir.path().join("cookies.json");
-        std::fs::write(&dest, b"stale").unwrap();
-        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o600)).unwrap();
-
-        write_atomic(&dest, b"fresh").await.unwrap();
-
-        let mode = mode_of(&dest);
-        assert_eq!(
-            mode, 0o600,
-            "a 0600 cookie jar must not widen across a save, got {mode:o}"
-        );
-        assert_eq!(std::fs::read(&dest).unwrap(), b"fresh");
-        assert_eq!(dir_entry_count(dir.path()), 1, "no temp file may be left");
-    }
-
-    /// A mode the user widened on purpose is preserved too — the rule is
-    /// "carry the destination's mode", not "force 0600 on everything".
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn write_atomic_preserves_an_existing_permissive_mode() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = tempfile::tempdir().unwrap();
-        let dest = dir.path().join("trackers.txt");
-        std::fs::write(&dest, b"stale").unwrap();
-        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o644)).unwrap();
-
-        write_atomic(&dest, b"fresh").await.unwrap();
-
-        let mode = mode_of(&dest);
-        assert_eq!(mode, 0o644, "a widened mode must survive too, got {mode:o}");
-    }
-
-    /// With no destination to inherit from, the new file is owner-only rather
-    /// than whatever the ambient umask would have allowed.
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn write_atomic_creates_a_new_file_owner_only() {
-        let dir = tempfile::tempdir().unwrap();
-        let dest = dir.path().join("cookies.json");
-        assert!(!dest.exists());
-
-        write_atomic(&dest, b"fresh").await.unwrap();
-
-        let mode = mode_of(&dest);
-        assert_eq!(
-            mode, 0o600,
-            "a freshly created cookie jar must default to owner-only, got {mode:o}"
-        );
-        assert_eq!(std::fs::read(&dest).unwrap(), b"fresh");
-        assert_eq!(dir_entry_count(dir.path()), 1, "no temp file may be left");
-    }
-
-    /// Pins the behavior the rustdoc warns about: because the write ends in a
-    /// `rename`, a symlinked destination is *replaced* by a regular file
-    /// instead of written through. If this ever changes, the docs on
-    /// `write_atomic` and `save_to_file` change with it.
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn write_atomic_replaces_a_symlinked_destination() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = tempfile::tempdir().unwrap();
-        let real = dir.path().join("real.json");
-        let link = dir.path().join("cookies.json");
-        std::fs::write(&real, b"original").unwrap();
-        std::fs::set_permissions(&real, std::fs::Permissions::from_mode(0o600)).unwrap();
-        std::os::unix::fs::symlink(&real, &link).unwrap();
-
-        write_atomic(&link, b"fresh").await.unwrap();
-
-        assert!(
-            !std::fs::symlink_metadata(&link).unwrap().is_symlink(),
-            "the rename unlinks the symlink and leaves a regular file"
-        );
-        assert_eq!(std::fs::read(&link).unwrap(), b"fresh");
-        assert_eq!(
-            std::fs::read(&real).unwrap(),
-            b"original",
-            "the link target stops receiving writes"
-        );
-        // The mode is still read through the link, so the replacement keeps
-        // the target's restrictive permissions.
-        let mode = mode_of(&link);
-        assert_eq!(
-            mode, 0o600,
-            "the replacement must inherit the link target's mode, got {mode:o}"
-        );
     }
 
     /// The regression as reported, end to end through the public API: a jar

--- a/crates/zendriver/src/cookies/persistence.rs
+++ b/crates/zendriver/src/cookies/persistence.rs
@@ -51,6 +51,15 @@ impl CookieJar {
     /// Returns [`crate::ZendriverError::Io`] if the path is unwritable;
     /// [`crate::ZendriverError::Transport`] / `Cdp` on CDP failures.
     ///
+    /// Because the save fills a sibling temp file and renames it over the
+    /// destination, it needs more than a writable destination: the *parent
+    /// directory* must be writable and executable, and the rename must be able
+    /// to replace what is at `path`. A destination that cannot be replaced by a
+    /// rename therefore fails even though it is perfectly writable — a
+    /// bind-mounted single file (`docker run -v $PWD/cookies.json:/app/cookies.json`)
+    /// is the common case, and a file held open by another process is the
+    /// Windows one.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -104,7 +113,10 @@ impl CookieJar {
     /// # Errors
     ///
     /// Returns [`crate::ZendriverError::Io`] if the path is unwritable;
-    /// [`crate::ZendriverError::Transport`] / `Cdp` on CDP failures.
+    /// [`crate::ZendriverError::Transport`] / `Cdp` on CDP failures. The
+    /// temp-file-and-rename requirements are [`Self::save_to_file`]'s, in
+    /// full: a writable, executable parent directory, and a destination a
+    /// rename can replace.
     ///
     /// # Examples
     ///
@@ -186,34 +198,39 @@ mod tests {
     }
 
     /// Mode of `path`, permission bits only. Unix-only helper for the
-    /// permission test below. (The helper's exhaustive coverage — the
-    /// setuid/setgid carry-over, the mid-write window, the symlinked
-    /// destination — lives with the helper itself in [`crate::io`]; what is
-    /// left here is the jar's own end-to-end behavior.)
+    /// permission tests below. (The helper's exhaustive coverage — the
+    /// setuid/setgid carry-over, the mid-write window, the exclusive create —
+    /// lives with the helper itself in [`crate::io`]; what is left here is the
+    /// jar's own end-to-end behavior.)
     #[cfg(unix)]
     fn mode_of(path: &std::path::Path) -> u32 {
         use std::os::unix::fs::PermissionsExt;
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
     }
 
-    /// The regression as reported, end to end through the public API: a jar
-    /// file at 0600 that a real `save_to_file` must not widen.
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn save_to_file_preserves_a_restrictive_mode() {
-        use std::os::unix::fs::PermissionsExt;
-
+    /// Drive one save through the chosen public entry point, answering the
+    /// `Storage.getCookies` round-trip with a single cookie, and return once
+    /// the file is on disk.
+    ///
+    /// `matching` picks `save_to_file_matching` (with a keep-everything
+    /// predicate) over `save_to_file`, so a caller that loops over both values
+    /// asserts its property against *both* save paths — which is the whole
+    /// point of the tests below, since the two call the write helper
+    /// independently and only one of them might be changed.
+    async fn save_one_cookie(path: &std::path::Path, matching: bool) {
         let (mut mock, conn) = MockConnection::pair();
         let jar = CookieJar::new(conn.clone());
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("cookies.json");
-        std::fs::write(&path, b"stale").unwrap();
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
 
         let save = tokio::spawn({
             let j = jar.clone();
-            let p = path.clone();
-            async move { j.save_to_file(p).await }
+            let p = path.to_path_buf();
+            async move {
+                if matching {
+                    j.save_to_file_matching(p, |_| true).await
+                } else {
+                    j.save_to_file(p).await
+                }
+            }
         });
 
         let id = mock.expect_cmd("Storage.getCookies").await;
@@ -221,22 +238,53 @@ mod tests {
             id,
             json!({
                 "cookies": [
-                    { "name": "session", "value": "secret", "domain": ".x.test", "path": "/",
-                      "httpOnly": true, "secure": true },
+                    { "name": "a", "value": "1", "domain": ".x.test", "path": "/",
+                      "httpOnly": false, "secure": false },
                 ]
             }),
         )
         .await;
         save.await.unwrap().unwrap();
 
+        conn.shutdown();
+    }
+
+    /// Read back what [`save_one_cookie`] wrote.
+    fn saved_cookies(path: &std::path::Path) -> Vec<crate::cookies::Cookie> {
+        serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap()
+    }
+
+    /// A mode the user chose on the jar survives a save.
+    ///
+    /// `0640` rather than `0600` on purpose: it is both narrower than the
+    /// `0644` a default umask produces *and* different from the `0600` the temp
+    /// file is created with, so this is the fixture that notices if the
+    /// destination-mode carry-over inside [`crate::io::write_atomic`] is
+    /// dropped. A `0600` jar would come back `0600` either way and assert
+    /// nothing.
+    ///
+    /// It says nothing about *which* write the jar used — `fs::write` on an
+    /// existing inode preserves its mode too. The two tests that can tell the
+    /// writes apart are [`both_save_paths_write_atomically`] and
+    /// [`both_save_paths_replace_a_symlinked_destination`].
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn save_to_file_preserves_the_destination_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cookies.json");
+        std::fs::write(&path, b"stale").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+
+        save_one_cookie(&path, false).await;
+
         let mode = mode_of(&path);
         assert_eq!(
-            mode, 0o600,
-            "save_to_file must not widen a 0600 jar holding session cookies, got {mode:o}"
+            mode, 0o640,
+            "a save must carry the destination's own mode over, got {mode:o}"
         );
         assert_eq!(dir_entry_count(dir.path()), 1, "no temp file may be left");
-
-        conn.shutdown();
     }
 
     /// End-to-end round-trip: dump the cookie store to disk, then load it back
@@ -446,55 +494,100 @@ mod tests {
         conn.shutdown();
     }
 
-    /// Both save paths must go through the atomic helper: the destination
-    /// ends up holding the full pretty-printed JSON, and no `.tmp` sibling is
-    /// left in the directory. Writing over an existing file also proves the
-    /// rename replaces stale content rather than appending to it.
+    /// Both save paths must reach the destination through
+    /// [`crate::io::write_atomic`] rather than a plain `fs::write`, and the
+    /// assertion that separates the two is the mode of a **jar that did not
+    /// exist yet**: the helper creates its temp file `0600` whatever the
+    /// ambient umask is, while `fs::write` creates at `0666 & ~umask`.
+    ///
+    /// Asserting on an *existing* destination cannot make that distinction —
+    /// `O_WRONLY|O_CREAT|O_TRUNC` on a live inode ignores its mode argument, so
+    /// both writes leave the previous permissions in place. That is why this
+    /// test starts from an empty directory.
+    ///
+    /// One environment caveat on the discriminating power, the same one
+    /// [`crate::io`]'s own mid-write test carries: under a `0077` umask or
+    /// tighter `fs::write` also lands on `0600` and this proves nothing.
+    /// [`both_save_paths_replace_a_symlinked_destination`] is the half that
+    /// holds regardless of umask.
+    ///
+    /// The second save, over a longer stale file, then shows the rename
+    /// replacing the content rather than overwriting a prefix of it, and the
+    /// directory count shows the temp file was renamed rather than abandoned.
     #[tokio::test]
     async fn both_save_paths_write_atomically() {
         for matching in [false, true] {
-            let (mut mock, conn) = MockConnection::pair();
-            let jar = CookieJar::new(conn.clone());
             let dir = tempfile::tempdir().unwrap();
             let path = dir.path().join("cookies.json");
-            std::fs::write(&path, b"stale-and-longer-than-the-new-content").unwrap();
+            assert!(
+                !path.exists(),
+                "matching={matching}: the mode assertion below only means something \
+                 for a destination this save creates"
+            );
 
-            let save = tokio::spawn({
-                let j = jar.clone();
-                let p = path.clone();
-                async move {
-                    if matching {
-                        j.save_to_file_matching(p, |_| true).await
-                    } else {
-                        j.save_to_file(p).await
-                    }
-                }
-            });
+            save_one_cookie(&path, matching).await;
 
-            let id = mock.expect_cmd("Storage.getCookies").await;
-            mock.reply(
-                id,
-                json!({
-                    "cookies": [
-                        { "name": "a", "value": "1", "domain": ".x.test", "path": "/",
-                          "httpOnly": false, "secure": false },
-                    ]
-                }),
-            )
-            .await;
-            save.await.unwrap().unwrap();
-
-            let parsed: Vec<crate::cookies::Cookie> =
-                serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-            assert_eq!(parsed.len(), 1, "matching={matching}");
-            assert_eq!(parsed[0].name, "a");
+            #[cfg(unix)]
+            {
+                let mode = mode_of(&path);
+                assert_eq!(
+                    mode, 0o600,
+                    "matching={matching}: a jar created by a save holds live session \
+                     cookies and must be owner-only, got {mode:o}"
+                );
+            }
+            assert_eq!(saved_cookies(&path).len(), 1, "matching={matching}");
             assert_eq!(
                 dir_entry_count(dir.path()),
                 1,
                 "matching={matching}: save must leave no temp file behind"
             );
 
-            conn.shutdown();
+            std::fs::write(&path, b"stale-and-longer-than-the-new-content").unwrap();
+            save_one_cookie(&path, matching).await;
+
+            let parsed = saved_cookies(&path);
+            assert_eq!(parsed.len(), 1, "matching={matching}");
+            assert_eq!(parsed[0].name, "a", "matching={matching}");
+            assert_eq!(
+                dir_entry_count(dir.path()),
+                1,
+                "matching={matching}: the second save must leave no temp file either"
+            );
+        }
+    }
+
+    /// The umask-independent half: `fs::write` follows a symlinked destination
+    /// and writes through to its target, while the atomic write finishes with a
+    /// `rename` that unlinks the symlink and leaves a regular file in its
+    /// place. No ambient setting changes that, so this separates the two writes
+    /// on every box.
+    ///
+    /// It doubles as the pin for the behavior change `save_to_file`'s rustdoc
+    /// warns about: a caller who symlinked their jar at some canonical store
+    /// stops feeding that store.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn both_save_paths_replace_a_symlinked_destination() {
+        for matching in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let real = dir.path().join("real.json");
+            let link = dir.path().join("cookies.json");
+            std::fs::write(&real, b"original").unwrap();
+            std::os::unix::fs::symlink(&real, &link).unwrap();
+
+            save_one_cookie(&link, matching).await;
+
+            assert!(
+                !std::fs::symlink_metadata(&link).unwrap().is_symlink(),
+                "matching={matching}: the rename must leave a regular file where the link was"
+            );
+            assert_eq!(saved_cookies(&link).len(), 1, "matching={matching}");
+            assert_eq!(
+                std::fs::read(&real).unwrap(),
+                b"original",
+                "matching={matching}: the link target must stop receiving saves"
+            );
         }
     }
 }

--- a/crates/zendriver/src/expect/request.rs
+++ b/crates/zendriver/src/expect/request.rs
@@ -173,10 +173,24 @@ struct RequestPayload {
 /// subscribe loop selects on that. Otherwise a caller who gave up would leave
 /// a task decoding every request on the session for as long as it lives.
 pub(crate) fn register(session: &SessionHandle, matcher: UrlMatcher) -> RequestExpectation {
+    // Dropping the handle detaches the task, which is exactly what this used
+    // to do; `register_with_handle` exists so the tests can join it.
+    register_with_handle(session, matcher).0
+}
+
+/// [`register`], plus the subscriber task's handle.
+///
+/// Split out for the tests: proving the task exits on drop needs a join point,
+/// and the alternative — watching the runtime's alive-task count — is a claim
+/// about what else happens to be running, which silently stops holding.
+fn register_with_handle(
+    session: &SessionHandle,
+    matcher: UrlMatcher,
+) -> (RequestExpectation, tokio::task::JoinHandle<()>) {
     let (mut tx, rx) = oneshot::channel();
     let mut stream =
         crate::expect::watch::<RequestWillBeSentEvent>(session, "Network.requestWillBeSent");
-    tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         let outcome = loop {
             tokio::select! {
                 // The caller dropped the expectation, so nobody is waiting
@@ -207,11 +221,14 @@ pub(crate) fn register(session: &SessionHandle, matcher: UrlMatcher) -> RequestE
         // poll and here; in that case the caller no longer cares.
         let _ = tx.send(outcome);
     });
-    RequestExpectation {
-        rx,
-        timeout: DEFAULT_EXPECT_TIMEOUT,
-        sleep: None,
-    }
+    (
+        RequestExpectation {
+            rx,
+            timeout: DEFAULT_EXPECT_TIMEOUT,
+            sleep: None,
+        },
+        task,
+    )
 }
 
 #[cfg(test)]
@@ -365,33 +382,30 @@ mod tests {
 
     /// Dropping the expectation must stop the subscriber task. Otherwise every
     /// abandoned (or timed-out) `expect_request` leaves a task decoding every
-    /// request on the session for as long as the session lives. Observed
-    /// through the runtime's alive-task count: it rises when `register` spawns
-    /// the subscriber and must fall back to the baseline once the receiver is
-    /// gone.
+    /// request on the session for as long as the session lives.
+    ///
+    /// Joined through the task's own handle rather than watched through the
+    /// runtime's alive-task count — that count depends on what else happens to
+    /// be running, and the day it stops holding this test reads its answer
+    /// early and passes.
     #[tokio::test]
     async fn subscriber_task_exits_when_expectation_is_dropped() {
         let (_mock, conn) = MockConnection::pair();
         let session = SessionHandle::new(conn.clone(), "S1");
-        let metrics = tokio::runtime::Handle::current().metrics();
 
-        let baseline = metrics.num_alive_tasks();
-        let expectation = register(&session, UrlMatcher::from("/api/"));
+        let (expectation, task) = register_with_handle(&session, UrlMatcher::from("/api/"));
         tokio::task::yield_now().await;
         assert!(
-            metrics.num_alive_tasks() > baseline,
+            !task.is_finished(),
             "subscriber task should be running while the expectation is alive"
         );
 
         drop(expectation);
 
-        tokio::time::timeout(Duration::from_secs(2), async {
-            while metrics.num_alive_tasks() > baseline {
-                tokio::time::sleep(Duration::from_millis(5)).await;
-            }
-        })
-        .await
-        .expect("subscriber task still alive 2s after the expectation was dropped");
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("subscriber task still alive 2s after the expectation was dropped")
+            .expect("subscriber task panicked");
 
         conn.shutdown();
     }

--- a/crates/zendriver/src/expect/request.rs
+++ b/crates/zendriver/src/expect/request.rs
@@ -167,36 +167,45 @@ struct RequestPayload {
 /// the `tx`, and exits. Subscription registers synchronously before the
 /// returned [`RequestExpectation`] is constructed so events fired
 /// immediately after a trigger action cannot slip past us.
+///
+/// The task also exits as soon as the receiver goes away — dropping the
+/// [`RequestExpectation`] (including on timeout) closes the channel, and the
+/// subscribe loop selects on that. Otherwise a caller who gave up would leave
+/// a task decoding every request on the session for as long as it lives.
 pub(crate) fn register(session: &SessionHandle, matcher: UrlMatcher) -> RequestExpectation {
-    let (tx, rx) = oneshot::channel();
+    let (mut tx, rx) = oneshot::channel();
     let mut stream =
         crate::expect::watch::<RequestWillBeSentEvent>(session, "Network.requestWillBeSent");
     tokio::spawn(async move {
-        while let Some(res) = stream.next().await {
-            match res {
-                Ok(ev) => {
-                    if matcher.matches(&ev.request.url) {
-                        let matched = MatchedRequest {
-                            url: ev.request.url,
-                            method: ev.request.method,
-                            headers: ev.request.headers,
-                            post_data: ev.request.post_data.map(String::into_bytes),
-                            request_id: ev.request_id,
-                        };
-                        // Send is fallible only if the receiver was
-                        // dropped; in that case the caller no longer
-                        // cares and we just exit.
-                        let _ = tx.send(Ok(matched));
-                        return;
+        let outcome = loop {
+            tokio::select! {
+                // The caller dropped the expectation, so nobody is waiting
+                // for a result. Exit instead of consuming events for the
+                // rest of the session.
+                () = tx.closed() => return,
+                next = stream.next() => match next {
+                    Some(Ok(ev)) => {
+                        if matcher.matches(&ev.request.url) {
+                            break Ok(MatchedRequest {
+                                url: ev.request.url,
+                                method: ev.request.method,
+                                headers: ev.request.headers,
+                                post_data: ev.request.post_data.map(String::into_bytes),
+                                request_id: ev.request_id,
+                            });
+                        }
+                        // Non-matching request — keep waiting.
                     }
-                    // Non-matching request — keep waiting.
-                }
-                Err(e) => {
-                    let _ = tx.send(Err(e));
-                    return;
-                }
+                    Some(Err(e)) => break Err(e),
+                    // Stream ended without a match; drop `tx` so the
+                    // expectation resolves via its `Poll::Ready(Err(_))` arm.
+                    None => return,
+                },
             }
-        }
+        };
+        // Send is fallible only if the receiver was dropped between the last
+        // poll and here; in that case the caller no longer cares.
+        let _ = tx.send(outcome);
     });
     RequestExpectation {
         rx,
@@ -350,6 +359,39 @@ mod tests {
             matches!(res, Err(ZendriverError::EventStreamIncomplete)),
             "expected EventStreamIncomplete after a Lagged boundary, got {res:?}",
         );
+
+        conn.shutdown();
+    }
+
+    /// Dropping the expectation must stop the subscriber task. Otherwise every
+    /// abandoned (or timed-out) `expect_request` leaves a task decoding every
+    /// request on the session for as long as the session lives. Observed
+    /// through the runtime's alive-task count: it rises when `register` spawns
+    /// the subscriber and must fall back to the baseline once the receiver is
+    /// gone.
+    #[tokio::test]
+    async fn subscriber_task_exits_when_expectation_is_dropped() {
+        let (_mock, conn) = MockConnection::pair();
+        let session = SessionHandle::new(conn.clone(), "S1");
+        let metrics = tokio::runtime::Handle::current().metrics();
+
+        let baseline = metrics.num_alive_tasks();
+        let expectation = register(&session, UrlMatcher::from("/api/"));
+        tokio::task::yield_now().await;
+        assert!(
+            metrics.num_alive_tasks() > baseline,
+            "subscriber task should be running while the expectation is alive"
+        );
+
+        drop(expectation);
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while metrics.num_alive_tasks() > baseline {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("subscriber task still alive 2s after the expectation was dropped");
 
         conn.shutdown();
     }

--- a/crates/zendriver/src/expect/response.rs
+++ b/crates/zendriver/src/expect/response.rs
@@ -4,8 +4,8 @@
 //! Mirrors [`crate::expect::request`] but watches `Network.responseReceived`
 //! and exposes [`MatchedResponse::body`] for fetching the response body via
 //! `Network.getResponseBody`. The subscriber task self-cancels after sending
-//! the first match — or as soon as the expectation is dropped — so each
-//! `expect_response` call is observably one-shot and outlives nothing.
+//! the first match, and exits the moment the caller drops the expectation, so
+//! it never outlives the `expect_response` that created it.
 //!
 //! `Network.enable` is already on for every Tab via the per-Tab in-flight
 //! network tracker, so this module does not re-enable the domain.
@@ -277,11 +277,25 @@ struct ResponsePayload {
 /// subscribe loop selects on that. Otherwise a caller who gave up would leave
 /// a task decoding every response on the session for as long as it lives.
 pub(crate) fn register(session: &SessionHandle, matcher: UrlMatcher) -> ResponseExpectation {
+    // Dropping the handle detaches the task, which is exactly what this used
+    // to do; `register_with_handle` exists so the tests can join it.
+    register_with_handle(session, matcher).0
+}
+
+/// [`register`], plus the subscriber task's handle.
+///
+/// Split out for the tests: proving the task exits on drop needs a join point,
+/// and the alternative — watching the runtime's alive-task count — is a claim
+/// about what else happens to be running, which silently stops holding.
+fn register_with_handle(
+    session: &SessionHandle,
+    matcher: UrlMatcher,
+) -> (ResponseExpectation, tokio::task::JoinHandle<()>) {
     let (mut tx, rx) = oneshot::channel();
     let mut stream =
         crate::expect::watch::<ResponseReceivedEvent>(session, "Network.responseReceived");
     let session_for_match = session.clone();
-    tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         let outcome = loop {
             tokio::select! {
                 // The caller dropped the expectation, so nobody is waiting
@@ -313,11 +327,14 @@ pub(crate) fn register(session: &SessionHandle, matcher: UrlMatcher) -> Response
         // poll and here; in that case the caller no longer cares.
         let _ = tx.send(outcome);
     });
-    ResponseExpectation {
-        rx,
-        timeout: DEFAULT_EXPECT_TIMEOUT,
-        sleep: None,
-    }
+    (
+        ResponseExpectation {
+            rx,
+            timeout: DEFAULT_EXPECT_TIMEOUT,
+            sleep: None,
+        },
+        task,
+    )
 }
 
 #[cfg(test)]
@@ -509,33 +526,30 @@ mod tests {
 
     /// Dropping the expectation must stop the subscriber task. Otherwise every
     /// abandoned (or timed-out) `expect_response` leaves a task decoding every
-    /// response on the session for as long as the session lives. Observed
-    /// through the runtime's alive-task count: it rises when `register` spawns
-    /// the subscriber and must fall back to the baseline once the receiver is
-    /// gone.
+    /// response on the session for as long as the session lives.
+    ///
+    /// Joined through the task's own handle rather than watched through the
+    /// runtime's alive-task count — that count depends on what else happens to
+    /// be running, and the day it stops holding this test reads its answer
+    /// early and passes.
     #[tokio::test]
     async fn subscriber_task_exits_when_expectation_is_dropped() {
         let (_mock, conn) = MockConnection::pair();
         let session = SessionHandle::new(conn.clone(), "S1");
-        let metrics = tokio::runtime::Handle::current().metrics();
 
-        let baseline = metrics.num_alive_tasks();
-        let expectation = register(&session, UrlMatcher::from("/api/"));
+        let (expectation, task) = register_with_handle(&session, UrlMatcher::from("/api/"));
         tokio::task::yield_now().await;
         assert!(
-            metrics.num_alive_tasks() > baseline,
+            !task.is_finished(),
             "subscriber task should be running while the expectation is alive"
         );
 
         drop(expectation);
 
-        tokio::time::timeout(Duration::from_secs(2), async {
-            while metrics.num_alive_tasks() > baseline {
-                tokio::time::sleep(Duration::from_millis(5)).await;
-            }
-        })
-        .await
-        .expect("subscriber task still alive 2s after the expectation was dropped");
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("subscriber task still alive 2s after the expectation was dropped")
+            .expect("subscriber task panicked");
 
         conn.shutdown();
     }

--- a/crates/zendriver/src/expect/response.rs
+++ b/crates/zendriver/src/expect/response.rs
@@ -4,7 +4,8 @@
 //! Mirrors [`crate::expect::request`] but watches `Network.responseReceived`
 //! and exposes [`MatchedResponse::body`] for fetching the response body via
 //! `Network.getResponseBody`. The subscriber task self-cancels after sending
-//! the first match so each `expect_response` call is observably one-shot.
+//! the first match — or as soon as the expectation is dropped — so each
+//! `expect_response` call is observably one-shot and outlives nothing.
 //!
 //! `Network.enable` is already on for every Tab via the per-Tab in-flight
 //! network tracker, so this module does not re-enable the domain.
@@ -270,38 +271,47 @@ struct ResponsePayload {
 /// `tx`, and exits. Subscription registers synchronously before the returned
 /// [`ResponseExpectation`] is constructed so events fired immediately after
 /// a trigger action cannot slip past us.
+///
+/// The task also exits as soon as the receiver goes away — dropping the
+/// [`ResponseExpectation`] (including on timeout) closes the channel, and the
+/// subscribe loop selects on that. Otherwise a caller who gave up would leave
+/// a task decoding every response on the session for as long as it lives.
 pub(crate) fn register(session: &SessionHandle, matcher: UrlMatcher) -> ResponseExpectation {
-    let (tx, rx) = oneshot::channel();
+    let (mut tx, rx) = oneshot::channel();
     let mut stream =
         crate::expect::watch::<ResponseReceivedEvent>(session, "Network.responseReceived");
     let session_for_match = session.clone();
     tokio::spawn(async move {
-        while let Some(res) = stream.next().await {
-            match res {
-                Ok(ev) => {
-                    if matcher.matches(&ev.response.url) {
-                        let matched = MatchedResponse {
-                            url: ev.response.url,
-                            status: ev.response.status,
-                            status_text: ev.response.status_text,
-                            headers: ev.response.headers,
-                            request_id: ev.request_id,
-                            session: session_for_match,
-                        };
-                        // Send is fallible only if the receiver was
-                        // dropped; in that case the caller no longer
-                        // cares and we just exit.
-                        let _ = tx.send(Ok(matched));
-                        return;
+        let outcome = loop {
+            tokio::select! {
+                // The caller dropped the expectation, so nobody is waiting
+                // for a result. Exit instead of consuming events for the
+                // rest of the session.
+                () = tx.closed() => return,
+                next = stream.next() => match next {
+                    Some(Ok(ev)) => {
+                        if matcher.matches(&ev.response.url) {
+                            break Ok(MatchedResponse {
+                                url: ev.response.url,
+                                status: ev.response.status,
+                                status_text: ev.response.status_text,
+                                headers: ev.response.headers,
+                                request_id: ev.request_id,
+                                session: session_for_match,
+                            });
+                        }
+                        // Non-matching response — keep waiting.
                     }
-                    // Non-matching response — keep waiting.
-                }
-                Err(e) => {
-                    let _ = tx.send(Err(e));
-                    return;
-                }
+                    Some(Err(e)) => break Err(e),
+                    // Stream ended without a match; drop `tx` so the
+                    // expectation resolves via its `Poll::Ready(Err(_))` arm.
+                    None => return,
+                },
             }
-        }
+        };
+        // Send is fallible only if the receiver was dropped between the last
+        // poll and here; in that case the caller no longer cares.
+        let _ = tx.send(outcome);
     });
     ResponseExpectation {
         rx,
@@ -493,6 +503,39 @@ mod tests {
             .expect("body task panicked")
             .expect("body returned Err");
         assert_eq!(bytes, raw);
+
+        conn.shutdown();
+    }
+
+    /// Dropping the expectation must stop the subscriber task. Otherwise every
+    /// abandoned (or timed-out) `expect_response` leaves a task decoding every
+    /// response on the session for as long as the session lives. Observed
+    /// through the runtime's alive-task count: it rises when `register` spawns
+    /// the subscriber and must fall back to the baseline once the receiver is
+    /// gone.
+    #[tokio::test]
+    async fn subscriber_task_exits_when_expectation_is_dropped() {
+        let (_mock, conn) = MockConnection::pair();
+        let session = SessionHandle::new(conn.clone(), "S1");
+        let metrics = tokio::runtime::Handle::current().metrics();
+
+        let baseline = metrics.num_alive_tasks();
+        let expectation = register(&session, UrlMatcher::from("/api/"));
+        tokio::task::yield_now().await;
+        assert!(
+            metrics.num_alive_tasks() > baseline,
+            "subscriber task should be running while the expectation is alive"
+        );
+
+        drop(expectation);
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while metrics.num_alive_tasks() > baseline {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("subscriber task still alive 2s after the expectation was dropped");
 
         conn.shutdown();
     }

--- a/crates/zendriver/src/io.rs
+++ b/crates/zendriver/src/io.rs
@@ -1,0 +1,523 @@
+//! Filesystem primitives shared across the crate.
+//!
+//! One thing lives here today: [`write_atomic`], the temp-file-then-rename
+//! write used by the cookie jar ([`crate::cookies::persistence`]) and by the
+//! `tracker-blocking` blocklist cache (`crate::tracker`). Neither of those
+//! owns it, so it sits at the crate root instead of inside whichever module
+//! happened to need it first.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+
+/// Write `bytes` to `path` atomically: fill a uniquely-named sibling temp
+/// file, then `rename` it over the destination.
+///
+/// On Unix a same-directory `rename` is atomic, so a process killed mid-write
+/// leaves either the previous file or the complete new one — never a truncated
+/// prefix. That matters most for the cookie jar: a half-written `cookies.json`
+/// fails to parse on the next `load_from_file`, losing exactly the
+/// authenticated session the file existed to preserve. Windows offers no
+/// documented atomic replace here, and the rename additionally fails outright
+/// when the destination is held open by another process without
+/// `FILE_SHARE_DELETE`, or is marked read-only.
+///
+/// The temp name carries the process id, a per-process counter and the
+/// sub-second clock, and the file is created with `O_EXCL`. So two writers
+/// targeting the same destination cannot fill each other's temp file, nothing
+/// pre-planted at the path is followed or truncated, and a stray file left
+/// behind by a killed process would have to match the pid, the counter *and*
+/// the nanosecond to get in the way. Once the temp file exists, a failure at
+/// any later step removes it rather than leaving litter next to the
+/// destination.
+///
+/// Scope: this buys atomicity against a killed process, not fsync-level
+/// durability against a power loss (neither the temp file nor the containing
+/// directory is synced). Losing an unsynced write leaves the previous file,
+/// which is the same outcome as never having called `save_to_file`.
+///
+/// # Permissions and symlinks
+///
+/// The rename installs the *temp file's* inode at `path`, so the destination
+/// afterwards is a different file than it was before. Two consequences that a
+/// plain `fs::write` does not have:
+///
+/// - **The mode comes from the temp file.** It is created `0600`, before the
+///   first payload byte reaches the disk, rather than created at the process
+///   umask and narrowed afterwards: Unix checks permissions at `open()`, so
+///   another local uid that opened the file during a wide window would keep
+///   reading through that descriptor however the mode ended up.
+///   [`apply_destination_mode`] then stamps an *existing* destination's mode
+///   onto it, so a jar the user deliberately widened stays wide and one they
+///   deliberately narrowed stays narrow; a destination that does not exist yet
+///   keeps the `0600` it was created with. No-op on non-Unix targets, which
+///   have no mode to carry over.
+/// - **A symlinked destination is replaced, not followed.** If `path` is a
+///   symlink, the rename unlinks it and leaves a regular file in its place —
+///   the link target keeps its old contents and stops receiving writes.
+///   `fs::write` followed the link and wrote through to the target, so a
+///   caller who symlinked their cookie jar at some canonical store must point
+///   zendriver at the real path instead. (The mode is still read through the
+///   link, so the replacement inherits the target's permissions.)
+pub(crate) async fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = temp_path(path)?;
+
+    // Deliberately outside the cleanup below. A failed `create_new` means the
+    // path was already occupied by something this call did not create, and
+    // removing that something would be destroying a stranger's file.
+    let file = create_temp_file(&tmp).await?;
+
+    match fill_then_rename(file, &tmp, path, bytes).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = fs::remove_file(&tmp).await;
+            Err(e)
+        }
+    }
+}
+
+/// The fallible middle of [`write_atomic`], split out so the temp-file cleanup
+/// is written once rather than once per step that can fail.
+async fn fill_then_rename(
+    mut file: fs::File,
+    tmp: &Path,
+    dest: &Path,
+    bytes: &[u8],
+) -> std::io::Result<()> {
+    file.write_all(bytes).await?;
+    // `tokio::fs::File` buffers and its `Drop` does not wait for the in-flight
+    // write, so the rename could otherwise publish a short file.
+    file.flush().await?;
+    drop(file);
+    apply_destination_mode(tmp, dest).await?;
+    fs::rename(tmp, dest).await
+}
+
+/// Mode the temp file is created with, before any payload byte exists on disk.
+///
+/// `0600` rather than the process umask because the caller that matters here —
+/// [`crate::cookies::CookieJar::save_to_file`] — writes authentication
+/// material: session cookies equivalent to a password for as long as they
+/// live. A user who genuinely wants the file shared can widen the destination
+/// once, and [`apply_destination_mode`] preserves that choice on every later
+/// save.
+#[cfg(unix)]
+const TEMP_FILE_MODE: u32 = 0o600;
+
+/// Create the temp file, refusing to touch a path that already exists.
+///
+/// `create_new` brings `O_EXCL`, which is what makes a temp name derived from
+/// the destination safe: without it the open follows a symlink planted at that
+/// path and writes the payload through to a target of someone else's choosing,
+/// with this process's privileges.
+#[cfg(unix)]
+async fn create_temp_file(tmp: &Path) -> std::io::Result<fs::File> {
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(TEMP_FILE_MODE)
+        .open(tmp)
+        .await
+}
+
+/// Non-Unix counterpart. `create_new` still applies — it is what refuses a
+/// pre-planted path — but there is no mode to request.
+#[cfg(not(unix))]
+async fn create_temp_file(tmp: &Path) -> std::io::Result<fs::File> {
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(tmp)
+        .await
+}
+
+/// Give `tmp` the permissions `dest` should still have once the rename has
+/// swapped one for the other.
+///
+/// An existing destination's mode wins outright: preserving what the user (or
+/// their prior save) chose is the only behavior that keeps `write_atomic`
+/// indistinguishable from the `fs::write` it replaced. With no destination to
+/// inherit from there is nothing to do — the temp file already carries
+/// [`TEMP_FILE_MODE`], which is the default this module wants.
+#[cfg(unix)]
+async fn apply_destination_mode(tmp: &Path, dest: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mode = match fs::metadata(dest).await {
+        // Mask off the file-type bits; keep the full permission set (including
+        // setuid/setgid/sticky) so nothing the user set is quietly dropped.
+        // Carrying them over is best-effort rather than a guarantee: the
+        // kernel clears `S_ISGID` on a `chmod` by a caller who is not in the
+        // file's group, and a `nosuid` mount ignores the bits it stores.
+        Ok(meta) => meta.permissions().mode() & 0o7777,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    fs::set_permissions(tmp, std::fs::Permissions::from_mode(mode)).await
+}
+
+/// No-op counterpart for targets without Unix mode bits.
+///
+/// Windows keeps a DACL on every file rather than on the directory alone, and
+/// the rename installs a *new* inode at the destination. What the replacement
+/// picks up is the set of inheritable ACEs the containing directory seeds into
+/// files created in it — the same set the previous file got, for the default
+/// case. What it does not pick up is an explicit DACL somebody set on the
+/// destination itself (`icacls cookies.json /inheritance:r`); preserving that
+/// would need `GetNamedSecurityInfo` / `SetNamedSecurityInfo` or
+/// `ReplaceFileW`, neither of which is wired up.
+#[cfg(not(unix))]
+#[allow(clippy::unused_async)]
+async fn apply_destination_mode(_tmp: &Path, _dest: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// Sibling temp path for [`write_atomic`] — same directory, so the `rename`
+/// stays on one filesystem (and is therefore atomic).
+///
+/// The suffix combines the process id, a per-process counter and the
+/// sub-second clock. The counter separates concurrent writers inside one
+/// process; the clock separates a run from a stray temp file an earlier,
+/// SIGKILL'd run left behind, which matters because the exclusive create in
+/// [`create_temp_file`] turns a collision into a hard error rather than a
+/// silent overwrite.
+///
+/// Fails when `path` names no file — a trailing `/`, `.` or `..`, all of which
+/// are directories that `write_atomic` could never have written to anyway.
+/// Inventing a filename for those would put a stray file somewhere the caller
+/// never named on the way to the failure it was always going to get.
+fn temp_path(path: &Path) -> std::io::Result<PathBuf> {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+
+    let mut name = path
+        .file_name()
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("{} does not name a file to write", path.display()),
+            )
+        })?
+        .to_os_string();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.subsec_nanos());
+    name.push(format!(
+        ".{}.{}.{nanos}.tmp",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    Ok(path.with_file_name(name))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::{create_temp_file, temp_path, write_atomic};
+
+    /// Count the entries in a directory — the cheap proxy for "the temp file
+    /// was renamed, not left behind".
+    fn dir_entry_count(dir: &std::path::Path) -> usize {
+        std::fs::read_dir(dir).unwrap().count()
+    }
+
+    /// Full mode of `path`, including the setuid/setgid/sticky bits the
+    /// carry-over mask exists to preserve. Unix-only helper for the permission
+    /// tests below.
+    #[cfg(unix)]
+    fn mode_of(path: &std::path::Path) -> u32 {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o7777
+    }
+
+    /// The atomic write replaces existing content in place and leaves no
+    /// `.tmp` sibling behind: after the call the directory holds exactly the
+    /// destination file, carrying the new bytes.
+    #[tokio::test]
+    async fn write_atomic_replaces_existing_and_leaves_no_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("cookies.json");
+        std::fs::write(&dest, b"stale").unwrap();
+
+        write_atomic(&dest, b"fresh").await.unwrap();
+
+        assert_eq!(std::fs::read(&dest).unwrap(), b"fresh");
+        assert_eq!(
+            dir_entry_count(dir.path()),
+            1,
+            "temp file must be renamed away, not left next to the destination"
+        );
+    }
+
+    /// When the `rename` step fails, the error surfaces AND the temp file is
+    /// cleaned up. A destination that is an existing directory is the
+    /// simplest way to make `rename` fail after a successful temp write — and
+    /// the assertion names that step rather than settling for "some error",
+    /// so the test cannot quietly start passing because an earlier step began
+    /// failing instead.
+    #[tokio::test]
+    async fn write_atomic_cleans_up_temp_file_when_rename_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("occupied");
+        std::fs::create_dir(&dest).unwrap();
+
+        let err = write_atomic(&dest, b"fresh").await.unwrap_err();
+
+        // Naming the step the test is about: `rename` onto a directory is
+        // `EISDIR` on Linux, `ENOTDIR` on macOS/BSD and access-denied on
+        // Windows. The three earlier steps fail differently — `AlreadyExists`
+        // from the exclusive create, `NotFound` from the metadata read — so
+        // this cannot quietly start passing on a different failure.
+        #[cfg(unix)]
+        let expected: &[std::io::ErrorKind] = &[
+            std::io::ErrorKind::IsADirectory,
+            std::io::ErrorKind::NotADirectory,
+        ];
+        #[cfg(not(unix))]
+        let expected: &[std::io::ErrorKind] = &[std::io::ErrorKind::PermissionDenied];
+
+        assert!(
+            expected.contains(&err.kind()),
+            "expected the rename step to fail with one of {expected:?}, got {err:?}"
+        );
+        assert_eq!(
+            dir_entry_count(dir.path()),
+            1,
+            "only the pre-existing directory should remain; the temp file must be removed"
+        );
+    }
+
+    /// A jar deliberately created `chmod 600` must still be `0600` after a
+    /// save. The rename installs the temp file's inode, so without an explicit
+    /// carry-over the mode collapses to the process umask (0644 on a stock
+    /// box) and a file full of live session cookies goes world-readable.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_preserves_an_existing_restrictive_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("cookies.json");
+        std::fs::write(&dest, b"stale").unwrap();
+        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        write_atomic(&dest, b"fresh").await.unwrap();
+
+        let mode = mode_of(&dest);
+        assert_eq!(
+            mode, 0o600,
+            "a 0600 cookie jar must not widen across a save, got {mode:o}"
+        );
+        assert_eq!(std::fs::read(&dest).unwrap(), b"fresh");
+        assert_eq!(dir_entry_count(dir.path()), 1, "no temp file may be left");
+    }
+
+    /// A mode the user widened on purpose is preserved too — the rule is
+    /// "carry the destination's mode", not "force 0600 on everything".
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_preserves_an_existing_permissive_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("trackers.txt");
+        std::fs::write(&dest, b"stale").unwrap();
+        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_atomic(&dest, b"fresh").await.unwrap();
+
+        let mode = mode_of(&dest);
+        assert_eq!(mode, 0o644, "a widened mode must survive too, got {mode:o}");
+    }
+
+    /// The carry-over keeps the whole permission set, not just `rwx`. Setgid
+    /// is the bit the `& 0o7777` mask exists for, and nothing else in the
+    /// suite exercises it — narrow the mask to `0o777` and this is the only
+    /// test that notices.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_preserves_bits_outside_the_rwx_triplets() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("cookies.json");
+        std::fs::write(&dest, b"stale").unwrap();
+        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o2600)).unwrap();
+        assert_eq!(
+            mode_of(&dest),
+            0o2600,
+            "precondition: this box lets a non-privileged chmod set setgid"
+        );
+
+        write_atomic(&dest, b"fresh").await.unwrap();
+
+        let mode = mode_of(&dest);
+        assert_eq!(mode, 0o2600, "setgid must survive the save, got {mode:o}");
+    }
+
+    /// With no destination to inherit from, the new file is owner-only rather
+    /// than whatever the ambient umask would have allowed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_creates_a_new_file_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("cookies.json");
+        assert!(!dest.exists());
+
+        write_atomic(&dest, b"fresh").await.unwrap();
+
+        let mode = mode_of(&dest);
+        assert_eq!(
+            mode, 0o600,
+            "a freshly created cookie jar must default to owner-only, got {mode:o}"
+        );
+        assert_eq!(std::fs::read(&dest).unwrap(), b"fresh");
+        assert_eq!(dir_entry_count(dir.path()), 1, "no temp file may be left");
+    }
+
+    /// The temp file must be *created* owner-only, not created at the process
+    /// umask and narrowed once the payload is already on disk: Unix checks
+    /// permissions at `open()`, so another local uid that opened the file
+    /// during a wide window keeps reading through that descriptor no matter
+    /// what the mode becomes afterwards.
+    ///
+    /// Samples the `.tmp` sibling *while the write is in flight*. Asserting
+    /// only on the destination after the rename proves nothing here — the
+    /// mode is corrected before the rename either way, so that assertion
+    /// passes against the broken shape too.
+    ///
+    /// One environment caveat on the non-vacuity: the broken shape creates at
+    /// `0666 & ~umask`, which coincides with `0600` on a box whose umask is
+    /// `0077` or tighter. Under the `0022` every CI runner and default shell
+    /// uses, it is `0644` and this fails.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn temp_file_is_owner_only_for_the_whole_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("cookies.json");
+
+        // Big enough that `tokio::fs` splits the write across several blocking
+        // hops, each of which parks the writer and lets the sampler run.
+        let payload = vec![b'c'; 2 * 1024 * 1024];
+        let writer = {
+            let dest = dest.clone();
+            tokio::spawn(async move { write_atomic(&dest, &payload).await })
+        };
+
+        let mut samples: Vec<u32> = Vec::new();
+        while !writer.is_finished() {
+            for entry in std::fs::read_dir(dir.path()).unwrap().flatten() {
+                let path = entry.path();
+                if path.extension().and_then(std::ffi::OsStr::to_str) == Some("tmp") {
+                    if let Ok(meta) = entry.metadata() {
+                        use std::os::unix::fs::PermissionsExt;
+                        samples.push(meta.permissions().mode() & 0o7777);
+                    }
+                }
+            }
+            tokio::task::yield_now().await;
+        }
+        writer.await.unwrap().unwrap();
+
+        assert!(
+            !samples.is_empty(),
+            "the sampler never caught the temp file, so this test proved nothing"
+        );
+        let octal: Vec<String> = samples.iter().map(|m| format!("{m:o}")).collect();
+        assert!(
+            samples.iter().all(|m| *m == 0o600),
+            "the temp file holds the full payload and must be owner-only for every \
+             instant it exists; observed modes {octal:?} across {} samples",
+            samples.len()
+        );
+    }
+
+    /// The temp name is derived from the destination, so the create must be
+    /// exclusive. Plant a symlink where the open is about to land: it has to
+    /// be refused, not followed through to the decoy.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn create_temp_file_refuses_a_planted_path_instead_of_following_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let decoy = dir.path().join("decoy");
+        std::fs::write(&decoy, b"do-not-touch").unwrap();
+        let tmp = dir.path().join("cookies.json.4242.0.tmp");
+        std::os::unix::fs::symlink(&decoy, &tmp).unwrap();
+
+        let err = create_temp_file(&tmp).await.unwrap_err();
+
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::AlreadyExists,
+            "an occupied temp path must fail the open, got {err:?}"
+        );
+        assert_eq!(
+            std::fs::read(&decoy).unwrap(),
+            b"do-not-touch",
+            "the symlink target must not be written through or truncated"
+        );
+    }
+
+    /// Pins the behavior the rustdoc warns about: because the write ends in a
+    /// `rename`, a symlinked destination is *replaced* by a regular file
+    /// instead of written through. If this ever changes, the docs on
+    /// `write_atomic` and `save_to_file` change with it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_atomic_replaces_a_symlinked_destination() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.json");
+        let link = dir.path().join("cookies.json");
+        std::fs::write(&real, b"original").unwrap();
+        std::fs::set_permissions(&real, std::fs::Permissions::from_mode(0o600)).unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        write_atomic(&link, b"fresh").await.unwrap();
+
+        assert!(
+            !std::fs::symlink_metadata(&link).unwrap().is_symlink(),
+            "the rename unlinks the symlink and leaves a regular file"
+        );
+        assert_eq!(std::fs::read(&link).unwrap(), b"fresh");
+        assert_eq!(
+            std::fs::read(&real).unwrap(),
+            b"original",
+            "the link target stops receiving writes"
+        );
+        // The mode is still read through the link, so the replacement keeps
+        // the target's restrictive permissions.
+        let mode = mode_of(&link);
+        assert_eq!(
+            mode, 0o600,
+            "the replacement must inherit the link target's mode, got {mode:o}"
+        );
+    }
+
+    /// A path that names no file is rejected up front instead of being handed
+    /// a made-up filename the caller never asked for.
+    #[test]
+    fn temp_path_rejects_a_path_with_no_file_name() {
+        for input in ["", "/", "/tmp/.."] {
+            let err = temp_path(std::path::Path::new(input)).unwrap_err();
+            assert_eq!(
+                err.kind(),
+                std::io::ErrorKind::InvalidInput,
+                "{input} names no file and must be rejected, got {err:?}"
+            );
+        }
+    }
+
+    /// Two calls for the same destination never collide, so concurrent writers
+    /// cannot fill each other's temp file.
+    #[test]
+    fn temp_path_is_unique_per_call() {
+        let dest = std::path::Path::new("/tmp/cookies.json");
+        let a = temp_path(dest).unwrap();
+        let b = temp_path(dest).unwrap();
+        assert_ne!(a, b);
+        assert_eq!(a.parent(), dest.parent());
+    }
+}

--- a/crates/zendriver/src/io.rs
+++ b/crates/zendriver/src/io.rs
@@ -214,7 +214,12 @@ fn temp_path(path: &Path) -> std::io::Result<PathBuf> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::{create_temp_file, temp_path, write_atomic};
+    use super::{temp_path, write_atomic};
+    // Only the symlink-refusal test calls this directly, and that test is
+    // `#[cfg(unix)]` — an unconditional import is an unused-import error on
+    // Windows, where `-D warnings` makes it a build failure.
+    #[cfg(unix)]
+    use super::create_temp_file;
 
     /// Count the entries in a directory — the cheap proxy for "the temp file
     /// was renamed, not left behind".

--- a/crates/zendriver/src/lib.rs
+++ b/crates/zendriver/src/lib.rs
@@ -88,6 +88,7 @@ pub mod frame;
 #[cfg(feature = "geo")]
 mod geo_resolver;
 pub mod input;
+pub(crate) mod io;
 pub(crate) mod isolated_world;
 #[cfg(feature = "monitor")]
 pub mod monitor;

--- a/crates/zendriver/src/monitor/mod.rs
+++ b/crates/zendriver/src/monitor/mod.rs
@@ -35,8 +35,8 @@ use futures::{Stream, StreamExt};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
-use zendriver_transport::{AccountedRawEvent, SessionHandle};
+use tracing::{debug, warn};
+use zendriver_transport::{AccountedRawEvent, CallError, SessionHandle};
 
 use crate::url_matcher::UrlMatcher;
 use events::{
@@ -650,11 +650,13 @@ async fn run_monitor(
                                     && filter_allows(filter.as_ref(), Some(p.request.url.as_str()))
                                 {
                                     // Once one `streamResourceContent` call has
-                                    // failed (old Chrome / unsupported), skip
-                                    // future enable attempts — the whole-body
+                                    // come back "method not found" (old Chrome),
+                                    // skip future enable attempts — the whole-body
                                     // `body()` path is the fallback, and there's
                                     // no point re-spending a doomed CDP round-trip
-                                    // per request. Matches the warn message.
+                                    // per request. Only that error latches the
+                                    // flag; a lost `-32602` race is per-request
+                                    // and leaves streaming on.
                                     streaming.insert(p.request_id.clone());
                                     spawn_stream_resource_content(
                                         &session,
@@ -940,6 +942,11 @@ async fn emit_decode_failed(tx: &mpsc::Sender<NetworkEvent>) -> bool {
     emit_boundary(tx, NetworkDeliveryBoundary::DecodeFailed).await
 }
 
+/// JSON-RPC "method not found" — the one CDP error code that means this
+/// Chrome build does not implement the command at all, as opposed to
+/// refusing this particular invocation of it.
+const JSON_RPC_METHOD_NOT_FOUND: i32 = -32601;
+
 /// Enable `Network.streamResourceContent` for `request_id` in a spawned
 /// task, mirroring the correlator's existing fire-and-forget
 /// `Network.enable` call: the CDP round-trip must not block the main
@@ -948,11 +955,18 @@ async fn emit_decode_failed(tx: &mpsc::Sender<NetworkEvent>) -> bool {
 /// On success, any `bufferedData` (bytes Chrome already had before the
 /// enable call landed) is emitted as the first [`NetworkEvent::HttpData`]
 /// chunk for this request — so nothing received in that pre-enable window is
-/// lost. On failure (old Chrome / unsupported), logs one `tracing::warn!`
-/// via `warned` (shared across every call this monitor makes, so the warning
-/// fires once per monitor rather than once per request) and otherwise does
-/// nothing — the monitor keeps running and [`NetworkExchange::body`] remains
-/// the working fallback for this request.
+/// lost.
+///
+/// Failures split two ways. A JSON-RPC `-32601` ("method not found") is the
+/// only reply that proves this Chrome build has no
+/// `Network.streamResourceContent` at all: it latches `warned` — shared
+/// across every call this monitor makes — so the warning fires once and the
+/// caller stops spending a doomed CDP round-trip per request. Every other
+/// error is per-request (most often the `-32602` "already finished loading"
+/// race documented at the call site) and is logged at debug without
+/// disabling streaming for later requests. Either way the monitor keeps
+/// running and [`NetworkExchange::body`] remains the working fallback for
+/// this request.
 fn spawn_stream_resource_content(
     session: &SessionHandle,
     tx: &mpsc::Sender<NetworkEvent>,
@@ -985,11 +999,28 @@ fn spawn_stream_resource_content(
                 }
             }
             Err(e) => {
-                if !warned.swap(true, Ordering::Relaxed) {
-                    warn!(
+                // Only "method not found" proves the browser lacks the
+                // command; that is the sole justification for disabling
+                // streaming for the monitor's whole lifetime. Anything else
+                // is about this one request — above all the `-32602`
+                // "Request with the provided ID has already finished
+                // loading" race, which a single fast favicon can lose
+                // without saying anything about the next request.
+                if matches!(&e, CallError::Rpc(code, ..) if *code == JSON_RPC_METHOD_NOT_FOUND) {
+                    if !warned.swap(true, Ordering::Relaxed) {
+                        warn!(
+                            error = %e,
+                            "network monitor: Network.streamResourceContent is unsupported by this \
+                             browser (needs Chrome ~124+); stream_bodies falling back to whole-body \
+                             capture for this and future requests"
+                        );
+                    }
+                } else {
+                    debug!(
                         error = %e,
-                        "network monitor: Network.streamResourceContent failed (needs Chrome ~124+); \
-                         stream_bodies falling back to whole-body capture for this and future requests"
+                        %request_id,
+                        "network monitor: Network.streamResourceContent failed for this request; \
+                         falling back to whole-body capture (streaming stays enabled)"
                     );
                 }
             }
@@ -1063,6 +1094,70 @@ mod tests {
     use super::*;
 
     const SID: &str = "S1";
+
+    /// Drive one `spawn_stream_resource_content` call, answer it with the
+    /// given JSON-RPC error, and return the latch once the spawned task has
+    /// actually finished — so the assertion never races the reply. Task
+    /// completion is observed via the runtime's alive-task count; the only
+    /// other task on this runtime is the mock connection's actor, which stays
+    /// alive for the whole test.
+    async fn latch_after_stream_error(code: i32, message: &str) -> bool {
+        let (mut mock, conn) = MockConnection::pair();
+        let session = SessionHandle::new(conn.clone(), SID);
+        let (tx, _rx) = mpsc::channel::<NetworkEvent>(8);
+        let warned = Arc::new(AtomicBool::new(false));
+
+        let metrics = tokio::runtime::Handle::current().metrics();
+        let baseline = metrics.num_alive_tasks();
+        spawn_stream_resource_content(&session, &tx, &warned, "R1".to_string());
+
+        let id = tokio::time::timeout(
+            Duration::from_secs(2),
+            mock.expect_cmd("Network.streamResourceContent"),
+        )
+        .await
+        .expect("no Network.streamResourceContent command was sent");
+        assert_eq!(mock.last_sent()["params"]["requestId"], "R1");
+        mock.reply_err(id, code, message).await;
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while metrics.num_alive_tasks() > baseline {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("streamResourceContent task did not finish after the error reply");
+
+        let latched = warned.load(Ordering::Relaxed);
+        conn.shutdown();
+        latched
+    }
+
+    /// The `-32602` "already finished loading" race is per-request — a single
+    /// fast favicon losing it must not disable body streaming for the rest of
+    /// the monitor's life.
+    #[tokio::test]
+    async fn stream_resource_content_race_error_keeps_streaming_enabled() {
+        assert!(
+            !latch_after_stream_error(
+                -32602,
+                "Request with the provided ID has already finished loading",
+            )
+            .await,
+            "a lost -32602 race must not disable streaming"
+        );
+    }
+
+    /// `-32601` "method not found" is the one reply that proves the browser
+    /// has no `Network.streamResourceContent` — that latches the flag so the
+    /// monitor stops spending a doomed round-trip per request.
+    #[tokio::test]
+    async fn stream_resource_content_method_not_found_disables_streaming() {
+        assert!(
+            latch_after_stream_error(-32601, "'Network.streamResourceContent' wasn't found").await,
+            "method-not-found must disable streaming for this monitor"
+        );
+    }
 
     /// Spawn a monitor over a fresh mock session and return the live monitor
     /// plus the mock (to emit events) and connection (to shut down).

--- a/crates/zendriver/src/monitor/mod.rs
+++ b/crates/zendriver/src/monitor/mod.rs
@@ -551,7 +551,12 @@ async fn run_monitor(
     // Shared across every spawned `streamResourceContent` enable task so an
     // unsupported-Chrome error is logged once for the whole monitor, not once
     // per streamed request (every subsequent call would fail identically).
+    // This one also gates the call site: it means "this browser has no
+    // `streamResourceContent`", not merely "we warned".
     let warned_stream_unsupported = Arc::new(AtomicBool::new(false));
+    // Log-dedup only, and deliberately separate: an unexpected error does not
+    // disable streaming, so it must not share the gate above.
+    let warned_stream_error = Arc::new(AtomicBool::new(false));
     // Subscribe to the accounted event stream BEFORE issuing `Network.enable`:
     // the accounted bus is a `broadcast` receiver that only sees frames sent
     // after it registers, so any event Chrome fires between `enable`'s reply
@@ -644,26 +649,33 @@ async fn run_monitor(
                                 // arrived in the meantime, so no data is lost
                                 // either way — only the odds of winning the
                                 // race improve.
+                                //
+                                // The `warned_stream_unsupported` clause below
+                                // is the "old Chrome" gate: once one
+                                // `streamResourceContent` call has come back
+                                // "method not found", skip future enable
+                                // attempts — the whole-body `body()` path is
+                                // the fallback, and there's no point
+                                // re-spending a doomed CDP round-trip per
+                                // request. Only that error latches the flag; a
+                                // lost `-32602` race is per-request and leaves
+                                // streaming on.
                                 if stream_bodies
                                     && !warned_stream_unsupported.load(Ordering::Relaxed)
                                     && !streaming.contains(&p.request_id)
                                     && filter_allows(filter.as_ref(), Some(p.request.url.as_str()))
                                 {
-                                    // Once one `streamResourceContent` call has
-                                    // come back "method not found" (old Chrome),
-                                    // skip future enable attempts — the whole-body
-                                    // `body()` path is the fallback, and there's
-                                    // no point re-spending a doomed CDP round-trip
-                                    // per request. Only that error latches the
-                                    // flag; a lost `-32602` race is per-request
-                                    // and leaves streaming on.
                                     streaming.insert(p.request_id.clone());
-                                    spawn_stream_resource_content(
+                                    // Fire-and-forget: the handle exists for
+                                    // the tests, which join it instead of
+                                    // guessing when the call has landed.
+                                    drop(spawn_stream_resource_content(
                                         &session,
                                         &tx,
                                         &warned_stream_unsupported,
+                                        &warned_stream_error,
                                         p.request_id.clone(),
-                                    );
+                                    ));
                                 }
                                 let req = MonitoredRequest {
                                     url: p.request.url,
@@ -947,6 +959,12 @@ async fn emit_decode_failed(tx: &mpsc::Sender<NetworkEvent>) -> bool {
 /// refusing this particular invocation of it.
 const JSON_RPC_METHOD_NOT_FOUND: i32 = -32601;
 
+/// JSON-RPC "invalid params". Chrome answers `Network.streamResourceContent`
+/// with this when the request has already finished loading — a race a single
+/// fast (especially loopback) response can lose, saying nothing about the
+/// next request.
+const JSON_RPC_INVALID_PARAMS: i32 = -32602;
+
 /// Enable `Network.streamResourceContent` for `request_id` in a spawned
 /// task, mirroring the correlator's existing fire-and-forget
 /// `Network.enable` call: the CDP round-trip must not block the main
@@ -957,25 +975,33 @@ const JSON_RPC_METHOD_NOT_FOUND: i32 = -32601;
 /// chunk for this request — so nothing received in that pre-enable window is
 /// lost.
 ///
-/// Failures split two ways. A JSON-RPC `-32601` ("method not found") is the
+/// Failures split three ways. A JSON-RPC `-32601` ("method not found") is the
 /// only reply that proves this Chrome build has no
-/// `Network.streamResourceContent` at all: it latches `warned` — shared
-/// across every call this monitor makes — so the warning fires once and the
-/// caller stops spending a doomed CDP round-trip per request. Every other
-/// error is per-request (most often the `-32602` "already finished loading"
-/// race documented at the call site) and is logged at debug without
-/// disabling streaming for later requests. Either way the monitor keeps
-/// running and [`NetworkExchange::body`] remains the working fallback for
-/// this request.
+/// `Network.streamResourceContent` at all: it latches `stream_unsupported` —
+/// shared across every call this monitor makes — so the warning fires once and
+/// the caller stops spending a doomed CDP round-trip per request. A `-32602`
+/// is the expected "already finished loading" race documented at the call
+/// site, so it is logged at debug and changes nothing. Anything else is
+/// unexpected, and if it is persistent it costs one doomed round-trip per
+/// request forever, so it warns once (via `warned_other_error`) where an
+/// operator running a default subscriber will actually see it. In every case
+/// the monitor keeps running and [`NetworkExchange::body`] remains the working
+/// fallback for this request.
+///
+/// Returns the spawned task's handle. Production drops it — the task is
+/// fire-and-forget — but a test that needs to observe the latch can join it
+/// instead of inferring completion from runtime-wide task counts.
 fn spawn_stream_resource_content(
     session: &SessionHandle,
     tx: &mpsc::Sender<NetworkEvent>,
-    warned: &Arc<AtomicBool>,
+    stream_unsupported: &Arc<AtomicBool>,
+    warned_other_error: &Arc<AtomicBool>,
     request_id: String,
-) {
+) -> JoinHandle<()> {
     let session = session.clone();
     let tx = tx.clone();
-    let warned = Arc::clone(warned);
+    let stream_unsupported = Arc::clone(stream_unsupported);
+    let warned_other_error = Arc::clone(warned_other_error);
     tokio::spawn(async move {
         match session
             .call(
@@ -1006,8 +1032,12 @@ fn spawn_stream_resource_content(
                 // "Request with the provided ID has already finished
                 // loading" race, which a single fast favicon can lose
                 // without saying anything about the next request.
-                if matches!(&e, CallError::Rpc(code, ..) if *code == JSON_RPC_METHOD_NOT_FOUND) {
-                    if !warned.swap(true, Ordering::Relaxed) {
+                let code = match &e {
+                    CallError::Rpc(code, ..) => Some(*code),
+                    _ => None,
+                };
+                if code == Some(JSON_RPC_METHOD_NOT_FOUND) {
+                    if !stream_unsupported.swap(true, Ordering::Relaxed) {
                         warn!(
                             error = %e,
                             "network monitor: Network.streamResourceContent is unsupported by this \
@@ -1015,17 +1045,31 @@ fn spawn_stream_resource_content(
                              capture for this and future requests"
                         );
                     }
-                } else {
+                } else if code == Some(JSON_RPC_INVALID_PARAMS) {
                     debug!(
                         error = %e,
                         %request_id,
-                        "network monitor: Network.streamResourceContent failed for this request; \
-                         falling back to whole-body capture (streaming stays enabled)"
+                        "network monitor: Network.streamResourceContent lost the finished-loading \
+                         race for this request; falling back to whole-body capture (streaming \
+                         stays enabled)"
+                    );
+                } else if !warned_other_error.swap(true, Ordering::Relaxed) {
+                    // Streaming deliberately stays on: one unexplained failure
+                    // says nothing about the next request. But if it turns out
+                    // to be permanent, every request pays a doomed round-trip
+                    // from here on, and a `debug!` under a default subscriber
+                    // would leave no trace of why bodies stopped streaming.
+                    warn!(
+                        error = %e,
+                        %request_id,
+                        "network monitor: Network.streamResourceContent failed unexpectedly; \
+                         falling back to whole-body capture and leaving streaming enabled — if \
+                         this is persistent every request pays a failed call (logged once)"
                     );
                 }
             }
         }
-    });
+    })
 }
 
 /// Apply the optional URL filter. With no filter every event passes. With a
@@ -1097,19 +1141,25 @@ mod tests {
 
     /// Drive one `spawn_stream_resource_content` call, answer it with the
     /// given JSON-RPC error, and return the latch once the spawned task has
-    /// actually finished — so the assertion never races the reply. Task
-    /// completion is observed via the runtime's alive-task count; the only
-    /// other task on this runtime is the mock connection's actor, which stays
-    /// alive for the whole test.
+    /// actually finished — so the assertion never races the reply. Completion
+    /// is observed by joining the task's own handle, not by watching the
+    /// runtime's alive-task count: that count is a claim about what else is
+    /// running, and when it stops holding the failure is a test that reads the
+    /// latch too early and passes.
     async fn latch_after_stream_error(code: i32, message: &str) -> bool {
         let (mut mock, conn) = MockConnection::pair();
         let session = SessionHandle::new(conn.clone(), SID);
         let (tx, _rx) = mpsc::channel::<NetworkEvent>(8);
-        let warned = Arc::new(AtomicBool::new(false));
+        let unsupported = Arc::new(AtomicBool::new(false));
+        let other_error = Arc::new(AtomicBool::new(false));
 
-        let metrics = tokio::runtime::Handle::current().metrics();
-        let baseline = metrics.num_alive_tasks();
-        spawn_stream_resource_content(&session, &tx, &warned, "R1".to_string());
+        let task = spawn_stream_resource_content(
+            &session,
+            &tx,
+            &unsupported,
+            &other_error,
+            "R1".to_string(),
+        );
 
         let id = tokio::time::timeout(
             Duration::from_secs(2),
@@ -1120,15 +1170,12 @@ mod tests {
         assert_eq!(mock.last_sent()["params"]["requestId"], "R1");
         mock.reply_err(id, code, message).await;
 
-        tokio::time::timeout(Duration::from_secs(2), async {
-            while metrics.num_alive_tasks() > baseline {
-                tokio::time::sleep(Duration::from_millis(5)).await;
-            }
-        })
-        .await
-        .expect("streamResourceContent task did not finish after the error reply");
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("streamResourceContent task did not finish after the error reply")
+            .expect("streamResourceContent task panicked");
 
-        let latched = warned.load(Ordering::Relaxed);
+        let latched = unsupported.load(Ordering::Relaxed);
         conn.shutdown();
         latched
     }
@@ -1591,6 +1638,111 @@ mod tests {
             }
             other => panic!("expected NetworkEvent::Http, got {other:?}"),
         }
+
+        monitor.stop();
+        conn.shutdown();
+    }
+
+    /// Emit `requestWillBeSent` for `request_id` and let the correlator's
+    /// spawned enable task settle.
+    ///
+    /// The correlator does not hand out a handle for that task, so there is no
+    /// join point — the sleep is the barrier. It matters in one direction
+    /// only: too short and a build that latches on *any* error would still be
+    /// holding an unset flag when the next request is processed, and the
+    /// caller's assertion would pass for the wrong reason.
+    async fn emit_request_and_settle(mock: &mut MockConnection, request_id: &str) {
+        mock.emit_event_for_session(
+            "Network.requestWillBeSent",
+            json!({
+                "requestId": request_id,
+                "request": { "url": format!("https://example.com/{request_id}"), "method": "GET" }
+            }),
+            SID,
+        )
+        .await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    /// The consequence the `-32601` narrowing exists for, observed at the call
+    /// site rather than on the flag: after one request loses the `-32602`
+    /// finished-loading race, the *next* request must still get its
+    /// `Network.streamResourceContent`.
+    ///
+    /// Asserting the `AtomicBool` tests the wire; this tests the circuit. The
+    /// bug lives in the interaction between the spawned task and the guard
+    /// that reads the flag, so a reordering of that guard would leave the flag
+    /// tests green while body streaming stopped after the first fast favicon
+    /// on every page — the originally reported symptom.
+    #[tokio::test]
+    async fn a_lost_race_on_one_request_leaves_streaming_on_for_the_next() {
+        let (monitor, mut mock, conn) = spawn_monitor_streaming(None).await;
+
+        mock.emit_event_for_session(
+            "Network.requestWillBeSent",
+            json!({
+                "requestId": "r1",
+                "request": { "url": "https://example.com/favicon.ico", "method": "GET" }
+            }),
+            SID,
+        )
+        .await;
+        let id = mock.expect_cmd("Network.streamResourceContent").await;
+        assert_eq!(mock.last_sent()["params"]["requestId"], "r1");
+        mock.reply_err(
+            id,
+            -32602,
+            "Request with the provided ID has already finished loading",
+        )
+        .await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        emit_request_and_settle(&mut mock, "r2").await;
+
+        let id = tokio::time::timeout(
+            Duration::from_secs(2),
+            mock.expect_cmd("Network.streamResourceContent"),
+        )
+        .await
+        .expect(
+            "the second request got no Network.streamResourceContent — one lost -32602 race \
+             disabled body streaming for the rest of the monitor's life",
+        );
+        assert_eq!(mock.last_sent()["params"]["requestId"], "r2");
+        mock.reply(id, json!({ "bufferedData": "" })).await;
+
+        monitor.stop();
+        conn.shutdown();
+    }
+
+    /// The other half of the same circuit, pinning the behavior that is being
+    /// kept: after `-32601` the guard stops issuing the call altogether, so a
+    /// browser without `streamResourceContent` pays one doomed round-trip in
+    /// total rather than one per request.
+    #[tokio::test]
+    async fn method_not_found_on_one_request_stops_the_call_for_the_next() {
+        let (monitor, mut mock, conn) = spawn_monitor_streaming(None).await;
+
+        mock.emit_event_for_session(
+            "Network.requestWillBeSent",
+            json!({
+                "requestId": "r1",
+                "request": { "url": "https://example.com/old-chrome", "method": "GET" }
+            }),
+            SID,
+        )
+        .await;
+        let id = mock.expect_cmd("Network.streamResourceContent").await;
+        mock.reply_err(id, -32601, "'Network.streamResourceContent' wasn't found")
+            .await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        emit_request_and_settle(&mut mock, "r2").await;
+
+        assert!(
+            mock.try_recv_cmd().is_none(),
+            "a browser that answered -32601 must not be asked again on the next request"
+        );
 
         monitor.stop();
         conn.shutdown();

--- a/crates/zendriver/src/monitor/mod.rs
+++ b/crates/zendriver/src/monitor/mod.rs
@@ -666,9 +666,13 @@ async fn run_monitor(
                                     && filter_allows(filter.as_ref(), Some(p.request.url.as_str()))
                                 {
                                     streaming.insert(p.request_id.clone());
-                                    // Fire-and-forget: the handle exists for
-                                    // the tests, which join it instead of
-                                    // guessing when the call has landed.
+                                    // Fire-and-forget *here*: the correlator
+                                    // must keep draining events rather than
+                                    // wait on a CDP round-trip, so this handle
+                                    // is dropped and no test can join it
+                                    // through the correlator. The handle exists
+                                    // for tests that call
+                                    // `spawn_stream_resource_content` directly.
                                     drop(spawn_stream_resource_content(
                                         &session,
                                         &tx,
@@ -975,18 +979,22 @@ const JSON_RPC_INVALID_PARAMS: i32 = -32602;
 /// chunk for this request — so nothing received in that pre-enable window is
 /// lost.
 ///
-/// Failures split three ways. A JSON-RPC `-32601` ("method not found") is the
+/// Failures split four ways. A JSON-RPC `-32601` ("method not found") is the
 /// only reply that proves this Chrome build has no
 /// `Network.streamResourceContent` at all: it latches `stream_unsupported` —
 /// shared across every call this monitor makes — so the warning fires once and
 /// the caller stops spending a doomed CDP round-trip per request. A `-32602`
 /// is the expected "already finished loading" race documented at the call
-/// site, so it is logged at debug and changes nothing. Anything else is
-/// unexpected, and if it is persistent it costs one doomed round-trip per
-/// request forever, so it warns once (via `warned_other_error`) where an
-/// operator running a default subscriber will actually see it. In every case
-/// the monitor keeps running and [`NetworkExchange::body`] remains the working
-/// fallback for this request.
+/// site, so it is logged at debug and changes nothing. Any *other* JSON-RPC
+/// code is Chrome refusing for a reason this code does not recognise, and if
+/// that is persistent it costs one doomed round-trip per request forever, so it
+/// warns once (via `warned_other_error`) where an operator running a default
+/// subscriber will actually see it. A transport failure or an unanswered call
+/// is not Chrome refusing anything at all — it is the connection going away
+/// with this call in flight, which is what every ordinary browser close looks
+/// like — so it stays at debug and latches nothing. In every case the monitor
+/// keeps running and [`NetworkExchange::body`] remains the working fallback for
+/// this request.
 ///
 /// Returns the spawned task's handle. Production drops it — the task is
 /// fire-and-forget — but a test that needs to observe the latch can join it
@@ -1025,6 +1033,10 @@ fn spawn_stream_resource_content(
                 }
             }
             Err(e) => {
+                // Matched on the error itself rather than on an extracted
+                // code, because the three `CallError` variants mean different
+                // things here and only one of them is Chrome answering.
+                //
                 // Only "method not found" proves the browser lacks the
                 // command; that is the sole justification for disabling
                 // streaming for the monitor's whole lifetime. Anything else
@@ -1032,40 +1044,63 @@ fn spawn_stream_resource_content(
                 // "Request with the provided ID has already finished
                 // loading" race, which a single fast favicon can lose
                 // without saying anything about the next request.
-                let code = match &e {
-                    CallError::Rpc(code, ..) => Some(*code),
-                    _ => None,
-                };
-                if code == Some(JSON_RPC_METHOD_NOT_FOUND) {
-                    if !stream_unsupported.swap(true, Ordering::Relaxed) {
-                        warn!(
+                match &e {
+                    CallError::Rpc(code, ..) if *code == JSON_RPC_METHOD_NOT_FOUND => {
+                        if !stream_unsupported.swap(true, Ordering::Relaxed) {
+                            warn!(
+                                error = %e,
+                                "network monitor: Network.streamResourceContent is unsupported by \
+                                 this browser (needs Chrome ~124+); stream_bodies falling back to \
+                                 whole-body capture for this and future requests"
+                            );
+                        }
+                    }
+                    CallError::Rpc(code, ..) if *code == JSON_RPC_INVALID_PARAMS => {
+                        debug!(
                             error = %e,
-                            "network monitor: Network.streamResourceContent is unsupported by this \
-                             browser (needs Chrome ~124+); stream_bodies falling back to whole-body \
-                             capture for this and future requests"
+                            %request_id,
+                            "network monitor: Network.streamResourceContent lost the \
+                             finished-loading race for this request; falling back to whole-body \
+                             capture (streaming stays enabled)"
                         );
                     }
-                } else if code == Some(JSON_RPC_INVALID_PARAMS) {
-                    debug!(
-                        error = %e,
-                        %request_id,
-                        "network monitor: Network.streamResourceContent lost the finished-loading \
-                         race for this request; falling back to whole-body capture (streaming \
-                         stays enabled)"
-                    );
-                } else if !warned_other_error.swap(true, Ordering::Relaxed) {
-                    // Streaming deliberately stays on: one unexplained failure
-                    // says nothing about the next request. But if it turns out
-                    // to be permanent, every request pays a doomed round-trip
-                    // from here on, and a `debug!` under a default subscriber
-                    // would leave no trace of why bodies stopped streaming.
-                    warn!(
-                        error = %e,
-                        %request_id,
-                        "network monitor: Network.streamResourceContent failed unexpectedly; \
-                         falling back to whole-body capture and leaving streaming enabled — if \
-                         this is persistent every request pays a failed call (logged once)"
-                    );
+                    CallError::Transport(_) | CallError::Timeout { .. } => {
+                        // Not Chrome refusing anything: the connection went
+                        // away, or never answered, with this call in flight.
+                        // Closing a browser resolves every in-flight call this
+                        // way, so warning here would fire at the most ordinary
+                        // end of a session — and the "every request pays a
+                        // failed call" clause below would be false there,
+                        // because there is no next request to spend a
+                        // round-trip on.
+                        debug!(
+                            error = %e,
+                            %request_id,
+                            "network monitor: Network.streamResourceContent did not complete \
+                             because the connection is going away; no body stream for this request"
+                        );
+                    }
+                    // Chrome heard the command and said no for a reason this
+                    // code does not recognise — or, since `CallError` is
+                    // `#[non_exhaustive]`, a variant added upstream since this
+                    // was written. Streaming deliberately stays on: one
+                    // unexplained refusal says nothing about the next request.
+                    // But if it turns out to be permanent, every request pays a
+                    // doomed round-trip from here on, and a `debug!` under a
+                    // default subscriber would leave no trace of why bodies
+                    // stopped streaming.
+                    _ => {
+                        if !warned_other_error.swap(true, Ordering::Relaxed) {
+                            warn!(
+                                error = %e,
+                                %request_id,
+                                "network monitor: Network.streamResourceContent failed \
+                                 unexpectedly; falling back to whole-body capture and leaving \
+                                 streaming enabled — if this is persistent every request pays a \
+                                 failed call (logged once)"
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -1203,6 +1238,60 @@ mod tests {
         assert!(
             latch_after_stream_error(-32601, "'Network.streamResourceContent' wasn't found").await,
             "method-not-found must disable streaming for this monitor"
+        );
+    }
+
+    /// Ordinary teardown must be silent. Closing a connection resolves every
+    /// in-flight call as [`CallError::Transport`], so a browser closing with an
+    /// enable call on the wire arrives at the same `Err` arm a Chrome refusal
+    /// does — and treating it the same way puts a warning at the most ordinary
+    /// end of a session, trailing a clause about what "every request" will pay
+    /// when there is no next request at all.
+    ///
+    /// Both flags are the observable proxy for "nothing was warned": each
+    /// `swap(true, ..)` sits *inside* the condition of its own `warn!`, so a
+    /// latched flag and an emitted warning are the same event.
+    /// `stream_unsupported` also carries a second claim — that this browser
+    /// lacks the command — which a closing connection has no standing to make.
+    #[tokio::test]
+    async fn connection_shutdown_with_a_call_in_flight_stays_quiet() {
+        let (mut mock, conn) = MockConnection::pair();
+        let session = SessionHandle::new(conn.clone(), SID);
+        let (tx, _rx) = mpsc::channel::<NetworkEvent>(8);
+        let unsupported = Arc::new(AtomicBool::new(false));
+        let other_error = Arc::new(AtomicBool::new(false));
+
+        let task = spawn_stream_resource_content(
+            &session,
+            &tx,
+            &unsupported,
+            &other_error,
+            "R1".to_string(),
+        );
+
+        // Wait for the command to actually be on the wire, so the connection
+        // dies with the call in flight rather than before it was ever sent.
+        let _id = tokio::time::timeout(
+            Duration::from_secs(2),
+            mock.expect_cmd("Network.streamResourceContent"),
+        )
+        .await
+        .expect("no Network.streamResourceContent command was sent");
+        conn.shutdown();
+
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("the task must not outlive the connection it was waiting on")
+            .expect("streamResourceContent task panicked");
+
+        assert!(
+            !unsupported.load(Ordering::Relaxed),
+            "a closing connection says nothing about whether this browser has \
+             streamResourceContent, and must not disable streaming"
+        );
+        assert!(
+            !other_error.load(Ordering::Relaxed),
+            "a closing connection is not an unexpected failure and must not warn"
         );
     }
 
@@ -1643,15 +1732,17 @@ mod tests {
         conn.shutdown();
     }
 
-    /// Emit `requestWillBeSent` for `request_id` and let the correlator's
-    /// spawned enable task settle.
+    /// Emit `requestWillBeSent` for `request_id`.
     ///
-    /// The correlator does not hand out a handle for that task, so there is no
-    /// join point — the sleep is the barrier. It matters in one direction
-    /// only: too short and a build that latches on *any* error would still be
-    /// holding an unset flag when the next request is processed, and the
-    /// caller's assertion would pass for the wrong reason.
-    async fn emit_request_and_settle(mock: &mut MockConnection, request_id: &str) {
+    /// Carries no barrier of its own, deliberately. The correlator handles the
+    /// event asynchronously, so a caller that wants to assert on what the
+    /// streaming guard did has to establish for itself that the guard has
+    /// already run — and the two callers below need different barriers for
+    /// that. The positive one gets it free from its own `expect_cmd`, since a
+    /// command can only arrive after the guard let it through. The negative one
+    /// is waiting for a command that must *never* arrive, so it drives the
+    /// request through to its exchange instead.
+    async fn emit_request(mock: &mut MockConnection, request_id: &str) {
         mock.emit_event_for_session(
             "Network.requestWillBeSent",
             json!({
@@ -1661,7 +1752,39 @@ mod tests {
             SID,
         )
         .await;
-        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    /// Drive `request_id` to `loadingFinished` and wait for its exchange.
+    ///
+    /// The barrier the negative test needs: the correlator processes events in
+    /// order on a single task, so an emitted exchange for `request_id` is proof
+    /// that the same task already ran the streaming guard for the *same*
+    /// request. A fixed sleep only ever assumed that.
+    async fn settle_by_completing(
+        monitor: &mut NetworkMonitor,
+        mock: &MockConnection,
+        request_id: &str,
+    ) {
+        mock.emit_event_for_session(
+            "Network.responseReceived",
+            json!({ "requestId": request_id, "response": { "status": 200 } }),
+            SID,
+        )
+        .await;
+        mock.emit_event_for_session(
+            "Network.loadingFinished",
+            json!({ "requestId": request_id }),
+            SID,
+        )
+        .await;
+        match next_event(monitor).await {
+            NetworkEvent::Http(exchange) => assert_eq!(
+                exchange.request.url,
+                format!("https://example.com/{request_id}"),
+                "the barrier must be {request_id}'s own exchange"
+            ),
+            other => panic!("expected {request_id}'s exchange, got {other:?}"),
+        }
     }
 
     /// The consequence the `-32601` narrowing exists for, observed at the call
@@ -1697,7 +1820,7 @@ mod tests {
         .await;
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        emit_request_and_settle(&mut mock, "r2").await;
+        emit_request(&mut mock, "r2").await;
 
         let id = tokio::time::timeout(
             Duration::from_secs(2),
@@ -1719,9 +1842,19 @@ mod tests {
     /// kept: after `-32601` the guard stops issuing the call altogether, so a
     /// browser without `streamResourceContent` pays one doomed round-trip in
     /// total rather than one per request.
+    ///
+    /// This is an assert-absence, which is the shape that degrades quietly, so
+    /// the two waits below are deliberately different. The first is a bare
+    /// sleep because the latch has no observable signal — but it fails in the
+    /// safe direction: too short and the flag is still unset when r2 is
+    /// processed, the guard lets the call through, and the final assertion goes
+    /// *red* rather than passing for the wrong reason. The second is a real
+    /// barrier ([`settle_by_completing`]), because a sleep there would fail in
+    /// the dangerous direction: `try_recv_cmd().is_none()` is satisfied by
+    /// "nothing has happened yet" just as well as by "nothing will".
     #[tokio::test]
     async fn method_not_found_on_one_request_stops_the_call_for_the_next() {
-        let (monitor, mut mock, conn) = spawn_monitor_streaming(None).await;
+        let (mut monitor, mut mock, conn) = spawn_monitor_streaming(None).await;
 
         mock.emit_event_for_session(
             "Network.requestWillBeSent",
@@ -1737,7 +1870,15 @@ mod tests {
             .await;
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        emit_request_and_settle(&mut mock, "r2").await;
+        emit_request(&mut mock, "r2").await;
+        settle_by_completing(&mut monitor, &mock, "r2").await;
+        // The guard has provably run for r2. What is left between a spawned
+        // enable task and its command reaching the mock is one scheduling hop,
+        // and that is all this remaining slack is for — not for the guard.
+        // Measured: with the call-site latch guard deleted, the barrier above
+        // fails this test on its own with this sleep removed entirely, so the
+        // assertion no longer rests on a wait.
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
         assert!(
             mock.try_recv_cmd().is_none(),

--- a/crates/zendriver/src/tracker.rs
+++ b/crates/zendriver/src/tracker.rs
@@ -26,6 +26,21 @@ const DOWNLOAD_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// to keep the worst case a bounded, reported failure.
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(20);
 
+/// Ceiling on the body of a `tracker_blocklist_url` download.
+///
+/// The time bound above is not a resource bound: it caps how long a source may
+/// keep sending, and on a datacentre link twenty seconds of chunked response is
+/// gigabytes of `String` inside `Browser::launch()`, followed by
+/// [`write_atomic`](crate::io::write_atomic) copying all of it into the cache
+/// directory. The URL is one the user pasted in — typically a third-party list
+/// mirror — so "the source is honest about its size" is not something this
+/// path gets to assume.
+///
+/// 32 MiB is roughly thirty times the largest lists in circulation (uBlock's
+/// and Peter Lowe's are around 1 MB), so it is a ceiling on abuse rather than a
+/// limit a real source will meet.
+const MAX_BLOCKLIST_BYTES: usize = 32 * 1024 * 1024;
+
 /// Parse the bundled list into hosts.
 pub(crate) fn bundled_hosts() -> Vec<String> {
     parse_blocklist(BUNDLED)
@@ -63,16 +78,22 @@ fn cache_path(url: &str) -> PathBuf {
         .join(format!("{:016x}.txt", h.finish()))
 }
 
-/// Download a blocklist over HTTP with both bounds applied.
+/// Download a blocklist over HTTP with all three bounds applied.
 ///
-/// Split out from [`load_or_download_blocklist`] so the timeouts are
-/// injectable in tests; production callers pass the two constants above.
-/// `reqwest` failures are surfaced as [`std::io::Error`] so the caller folds
-/// them into `ZendriverError::Io` without a new public error variant.
+/// Split out from [`load_or_download_blocklist`] so the bounds are injectable
+/// in tests; production callers pass the three constants above. `reqwest`
+/// failures are surfaced as [`std::io::Error`] so the caller folds them into
+/// `ZendriverError::Io` without a new public error variant.
+///
+/// The body is accumulated chunk by chunk rather than through
+/// `Response::text()`, because `max_bytes` has to hold against a source that
+/// simply keeps sending: a `Content-Length` check only helps when the server
+/// is honest, and a chunked response advertises nothing at all.
 async fn download_blocklist(
     url: &str,
     connect_timeout: Duration,
     request_timeout: Duration,
+    max_bytes: usize,
 ) -> Result<String, std::io::Error> {
     // reqwest 0.13 installs no rustls crypto provider of its own (see the
     // workspace manifest), and the omission surfaces as a runtime panic rather
@@ -83,26 +104,47 @@ async fn download_blocklist(
         .timeout(request_timeout)
         .build()
         .map_err(std::io::Error::other)?;
-    client
+    let mut resp = client
         .get(url)
         .send()
         .await
         .and_then(reqwest::Response::error_for_status)
-        .map_err(std::io::Error::other)?
-        .text()
-        .await
-        .map_err(std::io::Error::other)
+        .map_err(std::io::Error::other)?;
+
+    // Cheap rejection when the server declares its size, before a byte of body
+    // is read.
+    if let Some(len) = resp.content_length() {
+        if len > max_bytes as u64 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("blocklist at {url} advertises {len} bytes, over the {max_bytes} cap"),
+            ));
+        }
+    }
+
+    let mut body: Vec<u8> = Vec::new();
+    while let Some(chunk) = resp.chunk().await.map_err(std::io::Error::other)? {
+        if body.len() + chunk.len() > max_bytes {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("blocklist at {url} exceeded the {max_bytes} byte cap while downloading"),
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    String::from_utf8(body)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.utf8_error()))
 }
 
 /// Load a host list from local cache, or download from `url` and cache it.
 ///
 /// Mirrors the atomic-write download-on-first-use pattern in
 /// `zendriver-fingerprints` `pool::load_or_download` (write a temp sibling,
-/// then `rename`) via the shared [`crate::cookies::persistence::write_atomic`]
-/// helper. The download is bounded by [`DOWNLOAD_CONNECT_TIMEOUT`] /
-/// [`DOWNLOAD_TIMEOUT`]; `reqwest`/IO failures are surfaced as
-/// [`std::io::Error`] so the caller folds them into `ZendriverError::Io`
-/// without a new public error variant.
+/// then `rename`) via the shared [`crate::io::write_atomic`] helper. The
+/// download is bounded by [`DOWNLOAD_CONNECT_TIMEOUT`] / [`DOWNLOAD_TIMEOUT`]
+/// in time and [`MAX_BLOCKLIST_BYTES`] in size; `reqwest`/IO failures are
+/// surfaced as [`std::io::Error`] so the caller folds them into
+/// `ZendriverError::Io` without a new public error variant.
 ///
 /// The cache file inherits that helper's owner-only `0600` default. Nothing in
 /// a public blocklist is secret, so the restriction buys no confidentiality
@@ -114,27 +156,50 @@ async fn download_blocklist(
 pub(crate) async fn load_or_download_blocklist(url: &str) -> Result<Vec<String>, std::io::Error> {
     let cache = cache_path(url);
 
-    // Fast path: cache hit.
-    if let Ok(text) = std::fs::read_to_string(&cache) {
-        tracing::debug!(path = %cache.display(), "tracker blocklist cache hit");
-        return Ok(parse_blocklist(&text));
+    // Fast path: cache hit. A miss is the expected `NotFound`; anything else
+    // (a cache file the process cannot read, a broken cache root) would
+    // otherwise re-download silently on every single launch, so it gets said
+    // out loud.
+    match tokio::fs::read_to_string(&cache).await {
+        Ok(text) => {
+            tracing::debug!(path = %cache.display(), "tracker blocklist cache hit");
+            return Ok(parse_blocklist(&text));
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::debug!(url, "tracker blocklist cache miss — downloading");
+        }
+        Err(e) => {
+            tracing::warn!(
+                path = %cache.display(),
+                error = %e,
+                "tracker blocklist cache is unreadable — re-downloading (this repeats every launch \
+                 until the cache file is readable or removed)"
+            );
+        }
     }
 
-    tracing::debug!(url, "tracker blocklist cache miss — downloading");
-    let body = download_blocklist(url, DOWNLOAD_CONNECT_TIMEOUT, DOWNLOAD_TIMEOUT).await?;
+    let body = download_blocklist(
+        url,
+        DOWNLOAD_CONNECT_TIMEOUT,
+        DOWNLOAD_TIMEOUT,
+        MAX_BLOCKLIST_BYTES,
+    )
+    .await?;
 
     if let Some(parent) = cache.parent() {
-        std::fs::create_dir_all(parent)?;
+        tokio::fs::create_dir_all(parent).await?;
     }
-    crate::cookies::persistence::write_atomic(&cache, body.as_bytes()).await?;
+    crate::io::write_atomic(&cache, body.as_bytes()).await?;
 
     tracing::debug!(path = %cache.display(), "tracker blocklist cached");
     Ok(parse_blocklist(&body))
 }
 
 #[cfg(test)]
-#[allow(clippy::panic, clippy::unwrap_used)]
+#[allow(clippy::unwrap_used)]
 mod tests {
+    use tokio::io::AsyncWriteExt;
+
     use super::*;
 
     #[test]
@@ -176,7 +241,12 @@ mod tests {
         // timeout the inner future never resolves and this expect() fires.
         let res = tokio::time::timeout(
             Duration::from_secs(5),
-            download_blocklist(&url, Duration::from_millis(500), Duration::from_millis(200)),
+            download_blocklist(
+                &url,
+                Duration::from_millis(500),
+                Duration::from_millis(200),
+                MAX_BLOCKLIST_BYTES,
+            ),
         )
         .await
         .expect("download_blocklist hung past its own request timeout");
@@ -190,6 +260,89 @@ mod tests {
             "the 200ms request timeout should fire promptly, took {:?}",
             started.elapsed()
         );
+    }
+
+    /// A source that declares an oversized body is rejected on the headers,
+    /// before any of it is buffered.
+    #[tokio::test]
+    async fn download_rejects_an_oversized_content_length() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/trackers.txt"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![b'x'; 8192]))
+            .mount(&server)
+            .await;
+
+        let err = download_blocklist(
+            &format!("{}/trackers.txt", server.uri()),
+            Duration::from_secs(2),
+            Duration::from_secs(5),
+            1024,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("advertises 8192 bytes"),
+            "the declared size should be rejected up front, got {err}"
+        );
+    }
+
+    /// The real bound: a chunked response advertises no length at all, so the
+    /// cap has to hold against the accumulating body. Without it this streams
+    /// until the request timeout and buffers everything it received — the
+    /// gigabytes-in-`Browser::launch()` case.
+    #[tokio::test]
+    async fn download_caps_a_chunked_body_that_never_ends() {
+        const CAP: usize = 64 * 1024;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        // `wiremock` only serves fixed bodies, so the endless chunked source
+        // is hand-rolled. It writes until the client hangs up.
+        let server = tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            // Enough of the request to get past the headers; the body is what
+            // is under test, not the parsing.
+            let mut scratch = vec![0u8; 4096];
+            let _ = tokio::io::AsyncReadExt::read(&mut stream, &mut scratch).await;
+            if stream
+                .write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n")
+                .await
+                .is_err()
+            {
+                return;
+            }
+            let chunk = format!("1000\r\n{}\r\n", "x".repeat(0x1000));
+            while stream.write_all(chunk.as_bytes()).await.is_ok() {}
+        });
+
+        let url = format!("http://{addr}/trackers.txt");
+        let err = tokio::time::timeout(
+            Duration::from_secs(10),
+            // A request timeout far longer than the test's own: if the cap
+            // never fires, this fails on the outer timeout rather than
+            // passing because a *different* bound rescued it.
+            download_blocklist(&url, Duration::from_secs(2), Duration::from_secs(60), CAP),
+        )
+        .await
+        .expect("the size cap never fired — the download ran past its own bound")
+        .unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string()
+                .contains(&format!("exceeded the {CAP} byte cap")),
+            "expected the accumulating-body cap, got {err}"
+        );
+
+        server.abort();
     }
 
     #[test]

--- a/crates/zendriver/src/tracker.rs
+++ b/crates/zendriver/src/tracker.rs
@@ -89,6 +89,13 @@ fn cache_path(url: &str) -> PathBuf {
 /// `Response::text()`, because `max_bytes` has to hold against a source that
 /// simply keeps sending: a `Content-Length` check only helps when the server
 /// is honest, and a chunked response advertises nothing at all.
+///
+/// The decode is deliberately **lossy**, which keeps the behavior
+/// `Response::text()` had (reqwest is pulled without the `charset` feature, so
+/// its `text()` is `from_utf8_lossy` too). A strict decode would turn one
+/// latin-1 byte in a third-party list's licence header into a hard
+/// `Browser::launch()` failure — see [`crate::BrowserBuilder::tracker_blocklist_url`]
+/// for why that trade goes this way.
 async fn download_blocklist(
     url: &str,
     connect_timeout: Duration,
@@ -132,8 +139,7 @@ async fn download_blocklist(
         }
         body.extend_from_slice(&chunk);
     }
-    String::from_utf8(body)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.utf8_error()))
+    Ok(String::from_utf8_lossy(&body).into_owned())
 }
 
 /// Load a host list from local cache, or download from `url` and cache it.
@@ -343,6 +349,49 @@ mod tests {
         );
 
         server.abort();
+    }
+
+    /// A third-party list whose *comments* are latin-1 must still load. The
+    /// decode is lossy on purpose: `download_blocklist` runs inside
+    /// `Browser::launch()` and caches nothing on failure, so a strict decode
+    /// makes one cosmetic byte in a licence header an unrecoverable launch
+    /// error. Host lines are ASCII, so the replacement character lands only in
+    /// text `parse_blocklist` throws away.
+    #[tokio::test]
+    async fn download_decodes_a_latin1_body_instead_of_failing() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // `\xa9` is `©` in Windows-1252 and an invalid UTF-8 sequence on its
+        // own — exactly the byte a mirror's copyright line carries.
+        let body: Vec<u8> =
+            b"# Peter Lowe's list \xa9 2026\n0.0.0.0 tracker.test\nevil.test\n".to_vec();
+        assert!(
+            std::str::from_utf8(&body).is_err(),
+            "precondition: the fixture must actually be invalid UTF-8"
+        );
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/trackers.txt"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+            .mount(&server)
+            .await;
+
+        let text = download_blocklist(
+            &format!("{}/trackers.txt", server.uri()),
+            Duration::from_secs(2),
+            Duration::from_secs(5),
+            MAX_BLOCKLIST_BYTES,
+        )
+        .await
+        .expect("a latin-1 comment must not fail the download");
+
+        assert_eq!(
+            parse_blocklist(&text),
+            vec!["tracker.test".to_string(), "evil.test".to_string()],
+            "every host line must survive the lossy decode"
+        );
     }
 
     #[test]

--- a/crates/zendriver/src/tracker.rs
+++ b/crates/zendriver/src/tracker.rs
@@ -9,10 +9,22 @@
 //! [`HostMatcher`]: zendriver_interception::HostMatcher
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// Bundled curated list, embedded at compile time (feature-gated, so it only
 /// costs binary size when `tracker-blocking` is enabled).
 const BUNDLED: &str = include_str!("trackers.txt");
+
+/// Connect timeout for a `tracker_blocklist_url` download.
+const DOWNLOAD_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Whole-request timeout (connect, headers, and body) for a
+/// `tracker_blocklist_url` download.
+///
+/// This download runs on the `Browser::launch()` path, so an unbounded fetch
+/// against a half-open host would hang the launch forever. Both bounds exist
+/// to keep the worst case a bounded, reported failure.
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Parse the bundled list into hosts.
 pub(crate) fn bundled_hosts() -> Vec<String> {
@@ -51,13 +63,54 @@ fn cache_path(url: &str) -> PathBuf {
         .join(format!("{:016x}.txt", h.finish()))
 }
 
+/// Download a blocklist over HTTP with both bounds applied.
+///
+/// Split out from [`load_or_download_blocklist`] so the timeouts are
+/// injectable in tests; production callers pass the two constants above.
+/// `reqwest` failures are surfaced as [`std::io::Error`] so the caller folds
+/// them into `ZendriverError::Io` without a new public error variant.
+async fn download_blocklist(
+    url: &str,
+    connect_timeout: Duration,
+    request_timeout: Duration,
+) -> Result<String, std::io::Error> {
+    // reqwest 0.13 installs no rustls crypto provider of its own (see the
+    // workspace manifest), and the omission surfaces as a runtime panic rather
+    // than a build error. Install before the client exists.
+    crate::tls::install_default_crypto_provider();
+    let client = reqwest::Client::builder()
+        .connect_timeout(connect_timeout)
+        .timeout(request_timeout)
+        .build()
+        .map_err(std::io::Error::other)?;
+    client
+        .get(url)
+        .send()
+        .await
+        .and_then(reqwest::Response::error_for_status)
+        .map_err(std::io::Error::other)?
+        .text()
+        .await
+        .map_err(std::io::Error::other)
+}
+
 /// Load a host list from local cache, or download from `url` and cache it.
 ///
 /// Mirrors the atomic-write download-on-first-use pattern in
-/// `zendriver-fingerprints` `pool::load_or_download` (write `<path>.tmp`, then
-/// `rename`). `reqwest`/IO failures are surfaced as [`std::io::Error`] so the
-/// caller folds them into `ZendriverError::Io` without a new public error
-/// variant.
+/// `zendriver-fingerprints` `pool::load_or_download` (write a temp sibling,
+/// then `rename`) via the shared [`crate::cookies::persistence::write_atomic`]
+/// helper. The download is bounded by [`DOWNLOAD_CONNECT_TIMEOUT`] /
+/// [`DOWNLOAD_TIMEOUT`]; `reqwest`/IO failures are surfaced as
+/// [`std::io::Error`] so the caller folds them into `ZendriverError::Io`
+/// without a new public error variant.
+///
+/// The cache file inherits that helper's owner-only `0600` default. Nothing in
+/// a public blocklist is secret, so the restriction buys no confidentiality
+/// here — but it costs nothing either (the cache root is already per-user, and
+/// a miss just re-downloads), and one rule across both callers beats a second
+/// mode knob threaded through the helper for a file nobody needs to share.
+/// An operator who does want it group-readable can `chmod` once; the helper
+/// preserves an existing destination's mode on every later refresh.
 pub(crate) async fn load_or_download_blocklist(url: &str) -> Result<Vec<String>, std::io::Error> {
     let cache = cache_path(url);
 
@@ -68,29 +121,19 @@ pub(crate) async fn load_or_download_blocklist(url: &str) -> Result<Vec<String>,
     }
 
     tracing::debug!(url, "tracker blocklist cache miss — downloading");
-    crate::tls::install_default_crypto_provider();
-    let body = reqwest::get(url)
-        .await
-        .and_then(reqwest::Response::error_for_status)
-        .map_err(std::io::Error::other)?
-        .text()
-        .await
-        .map_err(std::io::Error::other)?;
+    let body = download_blocklist(url, DOWNLOAD_CONNECT_TIMEOUT, DOWNLOAD_TIMEOUT).await?;
 
-    // Atomic write: tmp -> rename.
     if let Some(parent) = cache.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let tmp = cache.with_extension("tmp");
-    std::fs::write(&tmp, &body)?;
-    std::fs::rename(&tmp, &cache)?;
+    crate::cookies::persistence::write_atomic(&cache, body.as_bytes()).await?;
 
     tracing::debug!(path = %cache.display(), "tracker blocklist cached");
     Ok(parse_blocklist(&body))
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -109,6 +152,43 @@ mod tests {
         assert_eq!(
             hosts,
             vec!["tracker.com".to_string(), "fp.example.org".to_string()]
+        );
+    }
+
+    /// A host that completes the TCP handshake and then never answers must
+    /// not hang the caller — and with it `Browser::launch()`. The request
+    /// timeout has to turn it into a bounded error.
+    #[tokio::test]
+    async fn download_times_out_against_a_silent_server() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        // Accept connections and hold them open, never writing a response.
+        let _server = tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                held.push(stream);
+            }
+        });
+
+        let url = format!("http://{addr}/trackers.txt");
+        let started = std::time::Instant::now();
+        // The outer timeout is the failure mode under test: without a client
+        // timeout the inner future never resolves and this expect() fires.
+        let res = tokio::time::timeout(
+            Duration::from_secs(5),
+            download_blocklist(&url, Duration::from_millis(500), Duration::from_millis(200)),
+        )
+        .await
+        .expect("download_blocklist hung past its own request timeout");
+
+        assert!(
+            res.is_err(),
+            "a server that never answers must surface as an error, got {res:?}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "the 200ms request timeout should fire promptly, took {:?}",
+            started.elapsed()
         );
     }
 

--- a/docs/book/src/interception.md
+++ b/docs/book/src/interception.md
@@ -181,6 +181,11 @@ whole request, 32 MiB of body. None of those are configurable, and a source that
 exceeds one fails the launch. For a mirror that is slow or unusually large,
 pre-seed the cache or point `tracker_blocklist_file` at a local copy.
 
+Those three bounds are the only things about a URL source that can fail a
+launch. The body is decoded as UTF-8 lossily, so a list whose licence header
+carries a latin-1 byte still loads: host lines are ASCII, and the replacement
+character only ever lands in text the parser discards.
+
 [`block_trackers(true)`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.block_trackers
 [`tracker_blocklist_add`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.tracker_blocklist_add
 [`tracker_blocklist_file`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.tracker_blocklist_file

--- a/docs/book/src/interception.md
+++ b/docs/book/src/interception.md
@@ -170,11 +170,16 @@ let browser = Browser::builder()
 | [`block_trackers(true)`] | Enable blocking with the curated bundled list (`include_str!`-embedded — only adds binary size when the feature is on) |
 | [`tracker_blocklist_add`] | Add extra hosts (repeatable; implicitly enables blocking) |
 | [`tracker_blocklist_file`] | Add hosts from a local file (one host per line; `0.0.0.0 host` hosts-file lines tolerated) |
-| [`tracker_blocklist_url`] | Add hosts fetched from a URL at launch |
+| [`tracker_blocklist_url`] | Add hosts fetched from a URL at launch (cached on disk after the first fetch) |
 
 Matching is host-based: a blocked host also blocks its subdomains. The bundle
 ships only our own clean list — point `tracker_blocklist_url` at a third-party
 list only if you accept that list's license.
+
+The URL fetch runs inside `launch()` and is bounded: 5s to connect, 20s for the
+whole request, 32 MiB of body. None of those are configurable, and a source that
+exceeds one fails the launch. For a mirror that is slow or unusually large,
+pre-seed the cache or point `tracker_blocklist_file` at a local copy.
 
 [`block_trackers(true)`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.block_trackers
 [`tracker_blocklist_add`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.tracker_blocklist_add

--- a/docs/book/src/network-monitor.md
+++ b/docs/book/src/network-monitor.md
@@ -98,11 +98,19 @@ already buffered before the enable call landed are emitted as the first
 chunk, so nothing from that window is lost.
 
 **Chrome version / graceful fallback:** `Network.streamResourceContent`
-needs roughly Chrome 124+. On an older Chrome the enable call errors — the
-monitor logs one `tracing::warn!` (not once per request) and simply never
-emits `HttpData` for that session; [`NetworkExchange::body`] keeps working as
-the whole-body fallback the entire time. The monitor never fails or ends over
-this.
+needs roughly Chrome 124+. On an older Chrome the enable call comes back
+"method not found" — the monitor logs one `tracing::warn!` (not once per
+request), stops issuing the call, and simply never emits `HttpData` for that
+session.
+
+Other enable errors are treated as being about that one request rather than
+about the browser, and streaming stays on for the next one. The common case is
+a response that finished loading before the enable call landed, which a fast
+(especially loopback) resource can lose without saying anything about anything
+else; that one is logged at debug. Anything else warns once.
+
+Either way [`NetworkExchange::body`] keeps working as the whole-body fallback
+the entire time, and the monitor never fails or ends over this.
 
 Off by default — streaming every response is wasted CDP round-trips when
 bodies are small; opt in only when you need bytes as they arrive rather than


### PR DESCRIPTION
- The tracker blocklist fetch was a bare `reqwest::get` with **no timeout**, so a half-open host hung `Browser::launch()` indefinitely.
- Cookie persistence wrote non-atomically — a kill mid-write left a truncated `cookies.json` that fails to parse, losing the session the file existed to preserve.
- `streamResourceContent` latched itself off on *any* error, including the `-32602` race its own comment anticipates, so one favicon disabled body streaming for the monitor's lifetime while the warning blamed the Chrome version.
- Expect subscribers kept running after the caller dropped the expectation.

## Two review rounds since this PR opened

**Round 1 found the atomic-write fix had introduced the exposure it was meant to prevent.** `fs::write` creates the temp file at the process umask **and writes the full cookie JSON into it**, narrowing to `0600` only afterwards — so live session cookies were world-readable for that window. A sampler reading the sibling's mode mid-write caught `644` on **eight of eight** samples. The original `fs::write` never widened anything, because writing to an existing `0600` file truncates rather than recreating.

Fixed with `create_new(true).mode(0o600)`, which also brings `O_EXCL` — without it the open followed a planted symlink through to a decoy. The temp path gained a clock component, because `create_new` turns a stale sibling into a permanent failure and the old name was reproducible across runs.

**Round 2 found the tests around it asserted nothing.** Reverting *both* save paths to plain `fs::write` left all six green — including the one named `both_save_paths_write_atomically`. The reason they could not discriminate: `O_CREAT|O_TRUNC` on an existing inode **ignores its mode argument**, so asserting on a destination that already exists can never tell the two apart. The tests now save to a path that does not exist yet, plus a symlink case that is umask-independent. Mutating only `save_to_file_matching` fails too, so the second path is independently covered.

A **seventh** test in the same family was found guarding nothing: `save_to_file_preserves_a_restrictive_mode` used a `0600` fixture while `TEMP_FILE_MODE` is also `0600`, so deleting the mode logic entirely left it green. That is the shape all seven share — *the fixture was chosen to match the value the code already produces*, so the broken path satisfies the assertion too.

Round 2 also found the strict UTF-8 decode failed `Browser::launch()` unrecoverably on one latin-1 byte in a third-party comment line, and identically on every retry since nothing is cached on failure. Now lossy, with the rationale in `tracker_blocklist_url`'s rustdoc and the book — **that policy choice is flagged for ratification**, not decided silently.

## Verification

`fmt --check` clean · both clippy gates **0 errors** · **382 / 475 tests** · no public API change.

One coverage gap stated rather than papered over: `load_or_download_blocklist` has no test at any level, because `cache_path` reads `dirs::cache_dir()` with no injection point. The decode fix is covered; the launch-path integration is not.

---
Split out of #145. Review records: `docs/review-records` branch. 🤖 Generated with [Claude Code](https://claude.com/claude-code)