### PR TITLE
fix(frame): confirm provisional frames against the tree, warn on geo failure

### DIFF
--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -1485,12 +1485,19 @@ impl BrowserBuilder {
         // A failed probe is NOT "no geo data" — it silently launches the
         // default (US-English) persona behind whatever exit IP the proxy
         // actually has, which is exactly the incoherence `geo_auto` exists
-        // to prevent. The resolver has already logged *why* it gave up;
-        // this records the consequence, since nothing downstream can.
+        // to prevent. This records the consequence, since nothing downstream
+        // can. The *reason* is one line up in the log only when the resolver
+        // is the bundled [`crate::geo_resolver::IpApiResolver`], which logs
+        // every one of its own exits; a resolver supplied through
+        // [`Self::geo_resolver`] need not.
+        //
+        // Prefixed on the function, not on `geo_auto`: this runs for any
+        // installed resolver, and naming a builder method the caller never
+        // called is how a log line sends someone the wrong way at 2am.
         let Some(geo) = resolver.resolve().await else {
             tracing::warn!(
-                "geo_auto: resolver returned no geo; persona keeps its default locale/timezone, \
-                 which may not match the exit IP"
+                "geo overlay: resolver returned no geo; persona keeps its default \
+                 locale/timezone, which may not match the exit IP"
             );
             return;
         };
@@ -2336,17 +2343,27 @@ enum QuitOutcome {
     /// ([`zendriver_transport::TransportError::Disconnected`] covers both), so
     /// this earns the grace without ever claiming an acknowledgement.
     TransportDied,
-    /// No quit can be in flight: Chrome refused it, never answered it, or the
-    /// transport was already shut down so it was never sent at all.
-    NotPending,
+    /// No reply to this call can ever arrive: Chrome refused it, it went
+    /// unanswered within the budget, or the transport was already shut down
+    /// when we called.
+    ///
+    /// Deliberately says nothing about whether the frame reached Chrome,
+    /// because the transport cannot tell us.
+    /// [`zendriver_transport::TransportError::Shutdown`] covers both an
+    /// enqueue that failed outright *and* an already-written command drained
+    /// by a cancelled actor, and the two are indistinguishable here. Skipping
+    /// the grace is a pragmatic call — with no reply coming, waiting can only
+    /// expire — not a claim that nothing was sent.
+    Unanswerable,
 }
 
 impl QuitOutcome {
-    /// Whether a quit might still be in flight, earning Chrome the
-    /// [`SHUTDOWN_GRACE`] to act on it before the signal path takes over.
+    /// Whether Chrome has earned the [`SHUTDOWN_GRACE`] to exit on its own
+    /// before the signal path takes over.
     ///
-    /// Waiting out the grace when nothing was ever sent buys nothing: there is
-    /// no message for Chrome to act on, so the wait can only expire.
+    /// True where a reply is still possible, or where the transport died on a
+    /// call it had already accepted. False for [`Self::Unanswerable`]: no
+    /// reply can reach us, so the grace could only ever expire.
     fn may_be_in_flight(self) -> bool {
         matches!(self, Self::Accepted | Self::TransportDied)
     }
@@ -4435,19 +4452,24 @@ impl Browser {
         let outcome = match quit {
             // Chrome acknowledged the quit.
             Ok(Ok(_)) => QuitOutcome::Accepted,
-            // The transport was already stopped by a caller-requested
-            // `shutdown()` / `reconnect()` — reachable from outside via the
-            // public `Browser::cdp` — so the enqueue failed cleanly and the
-            // frame never reached the socket. Nothing is in flight for the
-            // grace wait to wait on, so go straight to signals.
+            // The transport is gone — stopped by a caller-requested
+            // `shutdown()` / `reconnect()`, reachable from outside via the
+            // public `Browser::cdp`. No reply can arrive, so the grace could
+            // only expire; go straight to signals.
+            //
+            // What we must NOT say is that nothing was sent. `Shutdown` is
+            // returned both for an enqueue that failed before the frame was
+            // written and for a written, pending command drained by a
+            // cancelled actor (`SHUTDOWN_DRAIN_CODE`). In the second case the
+            // quit is on the wire and Chrome may already be acting on it.
             Ok(Err(zendriver_transport::CallError::Transport(
                 zendriver_transport::TransportError::Shutdown,
             ))) => {
                 warn!(
-                    "Browser.close was never sent (the transport was already shut down); \
-                     falling back to signal shutdown",
+                    "Browser.close could not complete: the transport was already shut down, so \
+                     it may never have reached chrome; falling back to signal shutdown",
                 );
-                QuitOutcome::NotPending
+                QuitOutcome::Unanswerable
             }
             // Chrome commonly drops the socket on quit instead of replying, so
             // a transport that dies here usually means the quit landed. Usually
@@ -4464,20 +4486,20 @@ impl Browser {
             // it categorically is not: nothing was heard, let alone declined.
             Ok(Err(e @ zendriver_transport::CallError::Timeout { .. })) => {
                 warn!(error = %e, "Browser.close went unanswered; falling back to signal shutdown");
-                QuitOutcome::NotPending
+                QuitOutcome::Unanswerable
             }
             // An RPC refusal means Chrome heard us and declined — nothing to
             // wait for, go straight to signals.
             Ok(Err(e)) => {
                 warn!(error = %e, "Browser.close was refused; falling back to signal shutdown");
-                QuitOutcome::NotPending
+                QuitOutcome::Unanswerable
             }
             Err(_elapsed) => {
                 warn!(
                     budget = ?browser_close_budget,
                     "Browser.close went unanswered; falling back to signal shutdown",
                 );
-                QuitOutcome::NotPending
+                QuitOutcome::Unanswerable
             }
         };
 
@@ -5130,6 +5152,49 @@ mod tests {
         let p = builder.resolved_persona().unwrap();
         assert_eq!(p.locale.as_deref(), Some("de-DE"));
         assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    /// A resolver that gives up is NOT "this IP has no country". The
+    /// persona quietly keeps its default US-English locale behind whatever
+    /// exit IP the proxy actually has, which is the exact incoherence the
+    /// geo overlay exists to prevent — and nothing downstream can report
+    /// it, so `apply_geo_overlay` has to.
+    ///
+    /// The resolver here is installed through the public
+    /// [`BrowserBuilder::geo_resolver`] and `geo_auto()` is never called,
+    /// which is why the warning must not be prefixed with that builder
+    /// method's name.
+    #[cfg(feature = "geo")]
+    #[tokio::test]
+    async fn a_resolver_that_gives_up_warns_without_naming_geo_auto() {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        // `StubCountryResolver` yields `None` for anything `Country` cannot
+        // parse — the stand-in for a probe that failed.
+        let mut builder = Browser::builder().geo_resolver(StubCountryResolver {
+            cc: "XYZ",
+            calls: calls.clone(),
+        });
+        let ((), logs) = crate::log_capture::with_captured_logs(builder.apply_geo_overlay()).await;
+
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the probe must actually have been attempted",
+        );
+        let warning = crate::log_capture::sole_warning(&logs);
+        assert!(
+            warning.starts_with("geo overlay:"),
+            "the warning must name the overlay, not a builder method the caller never used: \
+             {warning}",
+        );
+        assert!(
+            !warning.contains("geo_auto"),
+            "unexpected geo_auto reference: {warning}",
+        );
+        assert!(
+            builder.persona_overlay.is_none(),
+            "a failed probe must not invent a locale overlay",
+        );
     }
 
     #[cfg(feature = "geo")]

--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -1482,28 +1482,38 @@ impl BrowserBuilder {
         if explicit_locale {
             return;
         }
-        if let Some(geo) = resolver.resolve().await {
-            let mut derived = zendriver_stealth::geo::persona(geo.country);
-            // The exact probe timezone (when the source knows it) beats
-            // `persona`'s country-representative zone — precise beats
-            // approximate for the SAME field, still below anything the
-            // caller pinned explicitly (handled by the overlay direction
-            // just below).
-            if let Some(tz) = geo.timezone {
-                derived.timezone = Some(tz);
-            }
-            self.persona_overlay = Some(match self.persona_overlay.take() {
-                // Same direction as `geo_locale` above: `derived.overlay(existing)`
-                // — `existing` is the ARG so its explicit fields (e.g. a
-                // pinned `.timezone` with no locale) win; `derived` only
-                // fills gaps. The early return above guarantees
-                // `existing.locale` is `None` here, so the derived locale
-                // always comes through — this only changes precedence for
-                // OTHER fields (e.g. `timezone`) that `existing` may have set.
-                Some(existing) => derived.overlay(existing),
-                None => derived,
-            });
+        // A failed probe is NOT "no geo data" — it silently launches the
+        // default (US-English) persona behind whatever exit IP the proxy
+        // actually has, which is exactly the incoherence `geo_auto` exists
+        // to prevent. The resolver has already logged *why* it gave up;
+        // this records the consequence, since nothing downstream can.
+        let Some(geo) = resolver.resolve().await else {
+            tracing::warn!(
+                "geo_auto: resolver returned no geo; persona keeps its default locale/timezone, \
+                 which may not match the exit IP"
+            );
+            return;
+        };
+        let mut derived = zendriver_stealth::geo::persona(geo.country);
+        // The exact probe timezone (when the source knows it) beats
+        // `persona`'s country-representative zone — precise beats
+        // approximate for the SAME field, still below anything the
+        // caller pinned explicitly (handled by the overlay direction
+        // just below).
+        if let Some(tz) = geo.timezone {
+            derived.timezone = Some(tz);
         }
+        self.persona_overlay = Some(match self.persona_overlay.take() {
+            // Same direction as `geo_locale` above: `derived.overlay(existing)`
+            // — `existing` is the ARG so its explicit fields (e.g. a
+            // pinned `.timezone` with no locale) win; `derived` only
+            // fills gaps. The early return above guarantees
+            // `existing.locale` is `None` here, so the derived locale
+            // always comes through — this only changes precedence for
+            // OTHER fields (e.g. `timezone`) that `existing` may have set.
+            Some(existing) => derived.overlay(existing),
+            None => derived,
+        });
     }
 
     /// Override a single fingerprint [`Surface`]'s render [`Strategy`].
@@ -2305,6 +2315,43 @@ const BROWSER_CLOSE_TIMEOUT: Duration = Duration::from_secs(3);
 /// intended per-phase waits, so it only bites on a genuine wedge, never on a
 /// close that is merely slow but still making progress.
 const BROWSER_CLOSE_DEADLINE: Duration = Duration::from_secs(15);
+
+/// What the `Browser.close` round-trip actually established about the quit.
+///
+/// Drives two decisions in [`Browser::close_owning`]: whether Chrome has earned
+/// the [`SHUTDOWN_GRACE`] to exit on its own before signals, and what to say if
+/// it does not. Both used to hang off one `acked: bool` that recorded *every*
+/// [`zendriver_transport::CallError::Transport`] as an acknowledgement — which
+/// silently folded "the frame never reached the socket" in with "Chrome took
+/// the quit and dropped the socket", and then reported the pair as a fact
+/// Chrome had told us.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum QuitOutcome {
+    /// Chrome answered the command. The only outcome that is a real ack.
+    Accepted,
+    /// The transport died on this call, so we will never learn whether Chrome
+    /// saw the quit. Chrome commonly drops the socket on quit instead of
+    /// replying, so the quit most likely landed — but a write that failed
+    /// before the frame left this process reports identically
+    /// ([`zendriver_transport::TransportError::Disconnected`] covers both), so
+    /// this earns the grace without ever claiming an acknowledgement.
+    TransportDied,
+    /// No quit can be in flight: Chrome refused it, never answered it, or the
+    /// transport was already shut down so it was never sent at all.
+    NotPending,
+}
+
+impl QuitOutcome {
+    /// Whether a quit might still be in flight, earning Chrome the
+    /// [`SHUTDOWN_GRACE`] to act on it before the signal path takes over.
+    ///
+    /// Waiting out the grace when nothing was ever sent buys nothing: there is
+    /// no message for Chrome to act on, so the wait can only expire.
+    fn may_be_in_flight(self) -> bool {
+        matches!(self, Self::Accepted | Self::TransportDied)
+    }
+}
+
 /// How long [`resolve_ws_from_http`] waits for the `/json/version` round-trip.
 const JSON_VERSION_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -4385,12 +4432,31 @@ impl Browser {
             self.inner.conn.call_raw("Browser.close", json!({}), None),
         )
         .await;
-        let acked = match quit {
+        let outcome = match quit {
             // Chrome acknowledged the quit.
-            Ok(Ok(_)) => true,
-            // Chrome commonly drops the socket on quit instead of replying;
-            // the transport dying here means the quit landed.
-            Ok(Err(zendriver_transport::CallError::Transport(_))) => true,
+            Ok(Ok(_)) => QuitOutcome::Accepted,
+            // The transport was already stopped by a caller-requested
+            // `shutdown()` / `reconnect()` — reachable from outside via the
+            // public `Browser::cdp` — so the enqueue failed cleanly and the
+            // frame never reached the socket. Nothing is in flight for the
+            // grace wait to wait on, so go straight to signals.
+            Ok(Err(zendriver_transport::CallError::Transport(
+                zendriver_transport::TransportError::Shutdown,
+            ))) => {
+                warn!(
+                    "Browser.close was never sent (the transport was already shut down); \
+                     falling back to signal shutdown",
+                );
+                QuitOutcome::NotPending
+            }
+            // Chrome commonly drops the socket on quit instead of replying, so
+            // a transport that dies here usually means the quit landed. Usually
+            // is not certainly: a local write that failed before the frame left
+            // this process surfaces as the same `Disconnected`, and the
+            // transport deliberately gives both the same variant so a caller's
+            // reconnect-on-`Disconnected` recovery fires either way. Grace it,
+            // but never report it as an acknowledgement.
+            Ok(Err(zendriver_transport::CallError::Transport(_))) => QuitOutcome::TransportDied,
             // Chrome never answered. Unreachable while `browser_close_budget`
             // (3s) stays far tighter than the transport's per-call default
             // (180s) — the outer timeout below wins — but matched explicitly
@@ -4398,20 +4464,20 @@ impl Browser {
             // it categorically is not: nothing was heard, let alone declined.
             Ok(Err(e @ zendriver_transport::CallError::Timeout { .. })) => {
                 warn!(error = %e, "Browser.close went unanswered; falling back to signal shutdown");
-                false
+                QuitOutcome::NotPending
             }
             // An RPC refusal means Chrome heard us and declined — nothing to
             // wait for, go straight to signals.
             Ok(Err(e)) => {
                 warn!(error = %e, "Browser.close was refused; falling back to signal shutdown");
-                false
+                QuitOutcome::NotPending
             }
             Err(_elapsed) => {
                 warn!(
                     budget = ?browser_close_budget,
                     "Browser.close went unanswered; falling back to signal shutdown",
                 );
-                false
+                QuitOutcome::NotPending
             }
         };
 
@@ -4419,14 +4485,25 @@ impl Browser {
 
         let mut child_guard = self.inner.child.lock().await;
         if let Some(mut child) = child_guard.take() {
-            if acked {
-                // Chrome took the quit — give it the same grace to actually
-                // exit. If it does, no signal is ever sent and the whole
-                // process tree went down with it.
+            if outcome.may_be_in_flight() {
+                // A quit may still be working — give Chrome the grace to
+                // actually exit. If it does, no signal is ever sent and the
+                // whole process tree went down with it.
                 if let Ok(Ok(_status)) = timeout(SHUTDOWN_GRACE, child.wait()).await {
                     return Ok(());
                 }
-                warn!("chrome accepted Browser.close but did not exit; hard-killing");
+                // Report what was observed, not what was assumed. Only
+                // `Accepted` is Chrome telling us it took the quit; on
+                // `TransportDied` the command may never have reached Chrome at
+                // all, so claiming it "accepted" states a fact we do not have.
+                if outcome == QuitOutcome::Accepted {
+                    warn!("chrome accepted Browser.close but did not exit; hard-killing");
+                } else {
+                    warn!(
+                        "the transport died during Browser.close and chrome did not exit; \
+                         the quit may never have reached it — hard-killing",
+                    );
+                }
             }
             // Try graceful exit first. On Unix, tokio's `start_kill` is
             // `kill(pid, SIGKILL)` — too aggressive for graceful shutdown.
@@ -7655,6 +7732,51 @@ mod tests {
             "a Browser.close timeout must still hard-kill the process (pid {pid} alive)",
         );
         drop(mock);
+    }
+
+    /// A quit that never reached the socket must not be recorded as one Chrome
+    /// accepted. `close()` classified *every* `CallError::Transport` as an
+    /// acknowledgement, so a `Browser.close` that failed to be sent at all
+    /// bought Chrome the full `SHUTDOWN_GRACE` to act on a message it had
+    /// never received — stalling teardown, then logging that "chrome accepted
+    /// Browser.close", which is a statement about bytes that never left this
+    /// process.
+    ///
+    /// `TransportError::Shutdown` is the unambiguous half of that: the actor
+    /// was stopped by a caller-requested `shutdown()`, so the enqueue failed
+    /// cleanly and nothing is in flight. Reachable from outside through the
+    /// public `Browser::cdp`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn close_skips_the_grace_when_the_quit_was_never_sent() {
+        let (child, pid) = spawn_stand_in_chrome();
+        // `_mock` is held (named, not bare `_`) for the whole test so the
+        // actor's only route out is the cancellation below. Dropping it would
+        // end the inbound stream instead, which the actor latches as an
+        // unexpected disconnect — a different classification than the one
+        // under test.
+        let (_mock, browser) = owning_browser_with_child(Some(child)).await;
+
+        // Tear the transport down before close() can send its quit.
+        browser.cdp().shutdown();
+
+        let start = tokio::time::Instant::now();
+        let closed = tokio::time::timeout(Duration::from_secs(20), browser.close()).await;
+        let elapsed = start.elapsed();
+
+        closed
+            .expect("close() must not hang")
+            .expect("close() returns Ok via the signal fallback");
+
+        // The stand-in never exits on its own, so an unsent quit misread as an
+        // ack burns the whole 5s `SHUTDOWN_GRACE` waiting for it to. The
+        // signal path is the only thing that can end this process, and there
+        // was never a reason to delay reaching for it.
+        assert!(
+            elapsed < SHUTDOWN_GRACE,
+            "an unsent Browser.close must not wait out the {SHUTDOWN_GRACE:?} grace; took {elapsed:?}",
+        );
+        assert!(!pid_alive(pid), "close() must leave no surviving process");
     }
 
     /// The whole close must stay bounded even when a phase that is otherwise

--- a/crates/zendriver/src/frame/lifecycle.rs
+++ b/crates/zendriver/src/frame/lifecycle.rs
@@ -18,14 +18,31 @@
 //!    - `Page.frameAttached` — construct a new [`crate::Frame`] sharing
 //!      the tab's session (same-origin sub-frame; OOPIF frames arrive
 //!      through the [`crate::frame::oopif`] observer path on their own
-//!      child session, NOT this stream) and insert it under `frameId`.
+//!      child session, NOT this stream), insert it under `frameId`, and
+//!      **spawn** `sweep_dead_provisional_siblings` to evict any dead
+//!      provisional sibling it supersedes. That sweep issues a
+//!      `Page.getFrameTree` round-trip, and it is spawned rather than
+//!      awaited here on purpose — see the note below.
 //!    - `Page.frameNavigated` — update the existing entry's URL in
 //!      place (and backfill the frame `name` the attach event could not
 //!      carry); insert a fresh [`crate::Frame`] if no entry exists.
 //!    - `Page.frameDetached` — remove the entry from the registry.
 //!
+//! ## Nothing in an arm may await a CDP round-trip
+//!
+//! A `tokio::select!` arm is not a background job: while an arm's body is
+//! pending the loop cannot advance, so no other frame event is processed.
+//! That is worse than a delay. The event source underneath is
+//! [`zendriver_transport::Connection::subscribe_raw`], a broadcast channel
+//! carrying *every* raw CDP event, and a subscriber that lags past its
+//! capacity has frames dropped silently. A stalled arm on a busy page
+//! therefore loses `Page.frameDetached` events outright, leaving the
+//! registry reporting frames that no longer exist — with no error anywhere.
+//! Keep the arms to registry mutation; spawn anything that talks to Chrome.
+//!
 //! The task runs until its [`tokio_util::sync::CancellationToken`] fires —
-//! typically when the owning Tab is dropped.
+//! typically when the owning Tab is dropped. Sweeps spawned by the attach
+//! arm observe the same token, so they do not outlive it.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Weak};
@@ -38,13 +55,16 @@ use tokio_util::sync::CancellationToken;
 use tracing::{trace, warn};
 use zendriver_transport::SessionHandle;
 
-use crate::frame::Frame;
+use crate::frame::{Frame, FrameInner};
 use crate::tab::TabInner;
 
 /// Wait budget for the `Page.getFrameTree` probe that confirms a
-/// same-parent sibling really is a dead provisional frame. Bounded so a
-/// wedged probe can never stall the event loop that keeps the registry
-/// current; on expiry the sweep fails open (nothing is evicted).
+/// same-parent sibling really is a dead provisional frame.
+///
+/// This bound does **not** protect the event loop — the sweep runs in its
+/// own task, which is what protects the loop. It caps how long a wedged
+/// probe keeps that task (and its clone of the registry `Arc`) alive. On
+/// expiry the sweep fails open: nothing is evicted.
 const PROVISIONAL_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Minimal projection of `Page.frameAttached` — only the fields we need
@@ -135,6 +155,7 @@ pub(crate) async fn run(
                     session.clone(),
                     tab_weak.clone(),
                 );
+                frames.write().await.insert(ev.frame_id.clone(), frame);
                 // Chrome occasionally fires `frameAttached` twice for a
                 // single iframe — once with a provisional `frameId` and
                 // again with the committed one — without an intervening
@@ -143,12 +164,27 @@ pub(crate) async fn run(
                 // registry doesn't accumulate frames that
                 // `Page.createIsolatedWorld` would reject with
                 // "No frame for given id found".
-                let dead = dead_provisional_siblings(&session, &frames, &ev).await;
-                let mut map = frames.write().await;
-                for id in dead {
-                    map.remove(&id);
+                //
+                // Spawned, never awaited here: distinguishing a dead
+                // provisional from a sibling that simply has not navigated
+                // yet needs a `Page.getFrameTree` round-trip, and awaiting
+                // one in this arm parks every other frame event behind it
+                // (see the module header). Nothing waits on the eviction —
+                // it is pure housekeeping, and a stale row is recoverable.
+                if let Some(parent) = ev.parent_frame_id {
+                    let session = session.clone();
+                    let frames = frames.clone();
+                    let cancel = cancel.clone();
+                    let attached_id = ev.frame_id;
+                    tokio::spawn(async move {
+                        tokio::select! {
+                            () = cancel.cancelled() => {}
+                            () = sweep_dead_provisional_siblings(
+                                &session, &frames, &attached_id, &parent,
+                            ) => {}
+                        }
+                    });
                 }
-                map.insert(ev.frame_id, frame);
             }
             Some(ev) = navigated.next() => {
                 let frame_id = ev.frame.id;
@@ -158,18 +194,47 @@ pub(crate) async fn run(
                 // `frameNavigated` as the authoritative one; never clear a
                 // known name from an event that simply omits the field.
                 let new_name = ev.frame.name.filter(|n| !n.is_empty());
-                // Update in place if known; otherwise treat the navigation
-                // as the implicit attach (Chrome may emit `frameNavigated`
-                // for the main frame before any subscriber sees an explicit
-                // `frameAttached`).
-                let mut map = frames.write().await;
-                if let Some(existing) = map.get(&frame_id) {
-                    let name_changed = new_name.is_some()
-                        && new_name.as_deref() != existing.inner.name.as_deref();
-                    if !name_changed {
-                        *existing.inner.url.write().await = new_url;
-                        continue;
+
+                // Fast path, under a READ guard: refreshing a URL mutates
+                // the `Frame`'s own `RwLock`, not the registry map, so the
+                // ordinary navigation never needs exclusive access to the
+                // registry. Only the rename below replaces a map entry.
+                let needs_rename = {
+                    let map = frames.read().await;
+                    match map.get(&frame_id) {
+                        Some(existing) => {
+                            let name_changed = new_name.is_some()
+                                && new_name.as_deref() != existing.inner.name.as_deref();
+                            // Write through the shared `Arc` on BOTH paths.
+                            // Every `Frame` handle a caller already took
+                            // points at THIS inner, and the rename below
+                            // swaps the registry row for a fresh one those
+                            // handles never see — so this is what keeps
+                            // `Frame::url()` live on a handle taken before
+                            // a rename.
+                            *existing.inner.url.write().await = new_url.clone();
+                            if !name_changed {
+                                continue;
+                            }
+                            true
+                        }
+                        // No entry: treat the navigation as the implicit
+                        // attach (Chrome may emit `frameNavigated` for the
+                        // main frame before any subscriber sees an explicit
+                        // `frameAttached`).
+                        None => false,
                     }
+                };
+
+                let mut map = frames.write().await;
+                if needs_rename {
+                    // Re-look up. The registry is mutated concurrently by
+                    // the spawned provisional sweep and by the OOPIF
+                    // observer, so the row seen under the read guard may be
+                    // gone by now. A name backfill is a refinement, never a
+                    // reason to resurrect a row something else deliberately
+                    // removed.
+                    let Some(existing) = map.get(&frame_id) else { continue };
                     // `FrameInner::name` is immutable (it backs
                     // `Frame::name() -> Option<&str>`, which cannot hand out
                     // a lock guard), so backfilling means replacing the
@@ -185,17 +250,17 @@ pub(crate) async fn run(
                         tab_weak.clone(),
                     );
                     map.insert(frame_id, renamed);
-                    continue;
+                } else {
+                    let frame = Frame::new(
+                        frame_id.clone(),
+                        ev.frame.parent_id,
+                        new_url,
+                        new_name,
+                        session.clone(),
+                        tab_weak.clone(),
+                    );
+                    map.insert(frame_id, frame);
                 }
-                let frame = Frame::new(
-                    frame_id.clone(),
-                    ev.frame.parent_id,
-                    new_url,
-                    new_name,
-                    session.clone(),
-                    tab_weak.clone(),
-                );
-                map.insert(frame_id, frame);
             }
             Some(ev) = detached.next() => {
                 frames.write().await.remove(&ev.frame_id);
@@ -208,9 +273,9 @@ pub(crate) async fn run(
     }
 }
 
-/// Registry entries that the freshly-attached `ev` supersedes: same parent,
-/// same session, still URL-less — **and confirmed gone from Chrome's live
-/// frame tree**.
+/// Evict the registry entries that the freshly-attached `attached_id`
+/// supersedes: same parent, same session, still URL-less — **and confirmed
+/// gone from Chrome's live frame tree**.
 ///
 /// The last clause is what separates a dead provisional frame from a
 /// perfectly good sibling that simply has not navigated yet. Both look
@@ -221,24 +286,61 @@ pub(crate) async fn run(
 /// the same reason `Page.createIsolatedWorld` answers "No frame for given
 /// id found" for it.
 ///
-/// Fails open in every ambiguous case (no parent, no candidates, probe
-/// error or timeout): keeping a possibly-dead entry only costs a stale row
-/// in [`crate::Tab::frames`], which
+/// ## Why the candidate snapshot is taken before the probe
+///
+/// The probe answers a question about one instant, and the answer is only
+/// sound for rows that already existed at that instant. Taking the
+/// candidate snapshot first guarantees the returned tree is at least as
+/// recent as the snapshot, so a candidate missing from it is a frame that
+/// either never made the tree or died before it was taken — both dead.
+/// Collecting candidates *after* the probe would invert that: a frame
+/// attached in the gap would be a candidate that is legitimately absent
+/// from an older tree, and evicting it would drop a live frame. The
+/// re-validation below then re-checks each survivor against the registry
+/// as it stands at eviction time, because the round-trip is a real window
+/// in which rows can be detached, replaced, or navigated.
+///
+/// ## Failing open
+///
+/// Every ambiguity this can see is resolved by keeping the row: no
+/// candidates, a probe error or timeout, a row whose identity changed
+/// under the probe, a row that navigated while it was outstanding. A stale
+/// row in [`crate::Tab::frames`] only costs a lookup that
 /// [`crate::Frame::ensure_isolated_world`] already recovers from, whereas
-/// evicting a live frame loses a handle the caller may hold.
-async fn dead_provisional_siblings(
+/// evicting a live frame loses a handle the caller may still hold.
+///
+/// One ambiguity it cannot see: a frame that is genuinely alive but absent
+/// from *this* session's `Page.getFrameTree` is evicted anyway. That covers
+/// two unverified cases, and neither is helped by the re-validation, since
+/// both look exactly like a dead provisional from here.
+///
+/// The first is a frame Chrome has announced via `Page.frameAttached` but
+/// not yet listed in the tree, if such a window exists. Running the sweep
+/// off the event loop widens that window slightly, because the candidate
+/// snapshot is now taken whenever the spawned task is first polled rather
+/// than synchronously in the arm.
+///
+/// The second is an out-of-process iframe. The session-id filter below
+/// only excludes entries already re-homed onto a child session, so a
+/// parent-side placeholder for an OOPIF would still be swept if Chrome
+/// omits remote children from the parent target's tree. Whether it does is
+/// unverified against a real
+/// browser; if it turns out to, this needs an OOPIF-aware filter or a
+/// grace period before a url-less candidate becomes eligible.
+async fn sweep_dead_provisional_siblings(
     session: &SessionHandle,
     frames: &Arc<RwLock<HashMap<String, Frame>>>,
-    ev: &FrameAttachedEvent,
-) -> Vec<String> {
-    let Some(parent) = ev.parent_frame_id.as_deref() else {
-        return Vec::new();
-    };
-    let candidates: Vec<String> = {
+    attached_id: &str,
+    parent: &str,
+) {
+    // Each candidate is carried as (id, `Arc` identity). The identity is
+    // what lets the re-validation below tell "the row I sampled" from "some
+    // other row that now holds this id".
+    let candidates: Vec<(String, Arc<FrameInner>)> = {
         let map = frames.read().await;
         map.iter()
             .filter_map(|(id, f)| {
-                if id == &ev.frame_id {
+                if id == attached_id {
                     return None;
                 }
                 if f.inner.parent_frame_id.as_deref() != Some(parent) {
@@ -251,20 +353,46 @@ async fn dead_provisional_siblings(
                     return None;
                 }
                 let url_slot = f.inner.url.try_read().ok()?;
-                url_slot.is_empty().then(|| id.clone())
+                url_slot
+                    .is_empty()
+                    .then(|| (id.clone(), Arc::clone(&f.inner)))
             })
             .collect()
     };
     if candidates.is_empty() {
-        return Vec::new();
+        return;
     }
     let Some(live) = live_frame_ids(session).await else {
-        return Vec::new();
+        return;
     };
-    candidates
-        .into_iter()
-        .filter(|id| !live.contains(id))
-        .collect()
+
+    let mut map = frames.write().await;
+    for (id, sampled) in candidates {
+        if live.contains(&id) {
+            continue;
+        }
+        let Some(current) = map.get(&id) else {
+            continue;
+        };
+        // A different `Arc` behind the same id means the row we sampled is
+        // already gone and something re-inserted under its id — a detach
+        // plus re-attach, or the `frameNavigated` rename swap. Evicting now
+        // would delete a frame the probe never asked about. Identity also
+        // subsumes re-checking `parent_frame_id` and `session`, which are
+        // immutable on `FrameInner`.
+        if !Arc::ptr_eq(&current.inner, &sampled) {
+            continue;
+        }
+        // A URL means the frame navigated while the probe was in flight,
+        // and only a live frame navigates. `try_read` rather than `read`:
+        // this runs under the registry write guard, so it must not block on
+        // a slot the navigated arm is writing — and failing open there is
+        // the correct answer anyway.
+        if !current.inner.url.try_read().is_ok_and(|u| u.is_empty()) {
+            continue;
+        }
+        map.remove(&id);
+    }
 }
 
 /// Every frame id Chrome currently reports under `Page.getFrameTree`, or
@@ -288,18 +416,10 @@ async fn live_frame_ids(session: &SessionHandle) -> Option<HashSet<String>> {
             return None;
         }
     };
-    fn collect(node: &serde_json::Value, out: &mut HashSet<String>) {
-        if let Some(id) = node["frame"]["id"].as_str() {
-            out.insert(id.to_string());
-        }
-        if let Some(children) = node["childFrames"].as_array() {
-            for c in children {
-                collect(c, out);
-            }
-        }
-    }
     let mut ids = HashSet::new();
-    collect(&tree["frameTree"], &mut ids);
+    crate::frame::tree::walk(&tree["frameTree"], &mut |node| {
+        ids.insert(node.id.to_string());
+    });
     Some(ids)
 }
 
@@ -354,16 +474,51 @@ mod tests {
         frames: &Registry,
         pred: impl Fn(&HashMap<String, Frame>) -> bool,
     ) -> HashMap<String, Frame> {
-        for _ in 0..100 {
+        wait_for_within(frames, Duration::from_secs(1), pred).await
+    }
+
+    /// [`wait_for`] with an explicit budget, for assertions where the
+    /// *deadline itself* is the thing under test.
+    async fn wait_for_within(
+        frames: &Registry,
+        budget: Duration,
+        pred: impl Fn(&HashMap<String, Frame>) -> bool,
+    ) -> HashMap<String, Frame> {
+        let deadline = tokio::time::Instant::now() + budget;
+        loop {
             {
                 let map = frames.read().await;
                 if pred(&map) {
                     return map.clone();
                 }
             }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "registry never reached the expected state within {budget:?}",
+            );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
-        panic!("registry never reached the expected state within 1s");
+    }
+
+    /// Emit a `Page.frameNavigated` for `frame_id` on the test session.
+    async fn navigate(mock: &MockConnection, frame_id: &str, url: &str, name: Option<&str>) {
+        mock.emit_event_for_session(
+            "Page.frameNavigated",
+            json!({
+                "frame": { "id": frame_id, "parentId": "P", "url": url, "name": name }
+            }),
+            SESSION,
+        )
+        .await;
+    }
+
+    /// Wait for the sweep's `Page.getFrameTree` probe and return its command
+    /// id. `expect_cmd` has no timeout of its own and silently discards
+    /// frames that do not match, so every wait on it is wrapped.
+    async fn expect_probe(mock: &mut MockConnection) -> u64 {
+        tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Page.getFrameTree"))
+            .await
+            .expect("attach with an url-less sibling did not probe Page.getFrameTree")
     }
 
     /// Two real iframes under one parent, neither navigated yet, are
@@ -378,9 +533,7 @@ mod tests {
         wait_for(&frames, |m| m.contains_key("F1")).await;
         attach(&mock, "F2", "P").await;
 
-        let id = tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Page.getFrameTree"))
-            .await
-            .expect("attach with an url-less sibling did not probe Page.getFrameTree");
+        let id = expect_probe(&mut mock).await;
         mock.reply(
             id,
             json!({
@@ -414,9 +567,7 @@ mod tests {
         wait_for(&frames, |m| m.contains_key("PROVISIONAL")).await;
         attach(&mock, "COMMITTED", "P").await;
 
-        let id = tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Page.getFrameTree"))
-            .await
-            .expect("attach with an url-less sibling did not probe Page.getFrameTree");
+        let id = expect_probe(&mut mock).await;
         mock.reply(
             id,
             json!({
@@ -447,9 +598,7 @@ mod tests {
         wait_for(&frames, |m| m.contains_key("F1")).await;
         attach(&mock, "F2", "P").await;
 
-        let id = tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Page.getFrameTree"))
-            .await
-            .expect("attach with an url-less sibling did not probe Page.getFrameTree");
+        let id = expect_probe(&mut mock).await;
         mock.reply_err(id, -32000, "Page domain not enabled").await;
 
         let map = wait_for(&frames, |m| m.contains_key("F2")).await;
@@ -462,8 +611,152 @@ mod tests {
         conn.shutdown();
     }
 
+    /// **The regression the spawn exists for.** With a probe deliberately
+    /// left unanswered, an unrelated `Page.frameDetached` must still be
+    /// applied promptly rather than waiting out
+    /// [`PROVISIONAL_PROBE_TIMEOUT`].
+    ///
+    /// Awaiting the probe inside the `frameAttached` arm parks the whole
+    /// loop, and that is worse than a delay: the subscriber sits on a
+    /// bounded broadcast that drops frames for a lagging receiver
+    /// *silently*, so on a busy page a five-second stall does not delay the
+    /// detach, it loses it — leaving `Tab::frames` reporting a frame that no
+    /// longer exists, with nothing logged. Hence the 500ms budget: it is an
+    /// order of magnitude below the probe timeout, so a pass cannot be the
+    /// probe giving up.
+    #[tokio::test]
+    async fn events_are_processed_while_a_frame_tree_probe_is_outstanding() {
+        let (mut mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "F1", "P").await;
+        wait_for(&frames, |m| m.contains_key("F1")).await;
+        // The second attach makes url-less F1 a sweep candidate, which is
+        // what dispatches the probe. It is never replied to.
+        attach(&mock, "F2", "P").await;
+        let _wedged = expect_probe(&mut mock).await;
+
+        mock.emit_event_for_session("Page.frameDetached", json!({ "frameId": "F1" }), SESSION)
+            .await;
+
+        let map = wait_for_within(&frames, Duration::from_millis(500), |m| {
+            !m.contains_key("F1")
+        })
+        .await;
+        assert!(
+            map.contains_key("F2"),
+            "the loop must still be serving the registry, not just draining it",
+        );
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
+    /// The probe answers a question about one instant, but the eviction
+    /// happens a round-trip later. A candidate that navigated while the
+    /// probe was outstanding is provably alive — only a live frame
+    /// navigates — so the deferred sweep must re-check the registry at
+    /// eviction time instead of trusting its pre-probe snapshot.
+    #[tokio::test]
+    async fn a_candidate_that_navigates_during_the_probe_is_not_evicted() {
+        let (mut mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "F1", "P").await;
+        wait_for(&frames, |m| m.contains_key("F1")).await;
+        attach(&mock, "F2", "P").await;
+        // Waiting for the probe proves the candidate snapshot (which
+        // precedes it) already captured a url-less F1.
+        let id = expect_probe(&mut mock).await;
+
+        navigate(&mock, "F1", "https://host.test/one", None).await;
+        wait_for(&frames, |m| {
+            m.get("F1")
+                .is_some_and(|f| f.inner.url.try_read().is_ok_and(|u| !u.is_empty()))
+        })
+        .await;
+
+        // Answer with the tree as it stood BEFORE that navigation: F1
+        // absent. The snapshot says evict; the registry says otherwise, and
+        // the registry is the newer of the two.
+        mock.reply(
+            id,
+            json!({
+                "frameTree": {
+                    "frame": { "id": "P", "url": "https://host.test/" },
+                    "childFrames": [tree_child("F2", "P")],
+                }
+            }),
+        )
+        .await;
+
+        // A negative has no event to wait on, so give the sweep a settle
+        // window it would comfortably finish in (it is one lock acquisition
+        // past the reply) and assert the row survived it.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            frames.read().await.contains_key("F1"),
+            "a candidate that navigated under the probe must survive the sweep",
+        );
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
+    /// The other half of re-validation: a candidate that was detached and
+    /// re-attached under the *same* id while the probe was outstanding is a
+    /// different, live frame. It is still url-less, so the url re-check
+    /// cannot save it — only comparing the row's `Arc` identity against the
+    /// one actually sampled can.
+    #[tokio::test]
+    async fn a_candidate_reattached_under_the_same_id_during_the_probe_is_not_evicted() {
+        let (mut mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "F1", "P").await;
+        wait_for(&frames, |m| m.contains_key("F1")).await;
+        attach(&mock, "F2", "P").await;
+        // Dispatched => the sweep has already sampled the original F1 row.
+        let stale_probe = expect_probe(&mut mock).await;
+
+        mock.emit_event_for_session("Page.frameDetached", json!({ "frameId": "F1" }), SESSION)
+            .await;
+        wait_for(&frames, |m| !m.contains_key("F1")).await;
+        let sampled = Arc::clone(&wait_for(&frames, |m| m.contains_key("F2")).await["F2"].inner);
+        attach(&mock, "F1", "P").await;
+        let live_row = wait_for(&frames, |m| m.contains_key("F1")).await["F1"]
+            .inner
+            .clone();
+
+        // Answer the FIRST probe with the tree as it stood before the
+        // re-attach. Its snapshot named F1; the row under that id is no
+        // longer the one it named.
+        mock.reply(
+            stale_probe,
+            json!({
+                "frameTree": {
+                    "frame": { "id": "P", "url": "https://host.test/" },
+                    "childFrames": [tree_child("F2", "P")],
+                }
+            }),
+        )
+        .await;
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let map = frames.read().await;
+        assert!(
+            map.get("F1")
+                .is_some_and(|f| Arc::ptr_eq(&f.inner, &live_row)),
+            "the re-attached F1 must survive a sweep that sampled its predecessor",
+        );
+        assert!(Arc::ptr_eq(&map["F2"].inner, &sampled), "F2 is untouched");
+        drop(map);
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
     /// A single child needs no probe at all — no `Page.getFrameTree` is
-    /// dispatched, so the common case keeps its zero-round-trip cost.
+    /// dispatched, so a page with one iframe never pays for the sweep. (A
+    /// second iframe under the same parent does dispatch one; it just no
+    /// longer costs the event loop anything.)
     #[tokio::test]
     async fn lone_attach_does_not_probe_the_frame_tree() {
         let (mut mock, conn, frames, cancel) = start().await;
@@ -492,19 +785,7 @@ mod tests {
         let map = wait_for(&frames, |m| m.contains_key("FCHILD")).await;
         assert_eq!(map["FCHILD"].name(), None, "attach cannot know the name");
 
-        mock.emit_event_for_session(
-            "Page.frameNavigated",
-            json!({
-                "frame": {
-                    "id": "FCHILD",
-                    "parentId": "P",
-                    "url": "https://host.test/side",
-                    "name": "sidebar",
-                }
-            }),
-            SESSION,
-        )
-        .await;
+        navigate(&mock, "FCHILD", "https://host.test/side", Some("sidebar")).await;
 
         let map = wait_for(&frames, |m| {
             m.get("FCHILD").is_some_and(|f| f.name().is_some())
@@ -533,17 +814,10 @@ mod tests {
         attach(&mock, "FCHILD", "P").await;
         wait_for(&frames, |m| m.contains_key("FCHILD")).await;
         for (url, name) in [
-            ("https://host.test/one", json!("sidebar")),
-            ("https://host.test/two", json!(null)),
+            ("https://host.test/one", Some("sidebar")),
+            ("https://host.test/two", None),
         ] {
-            mock.emit_event_for_session(
-                "Page.frameNavigated",
-                json!({
-                    "frame": { "id": "FCHILD", "parentId": "P", "url": url, "name": name }
-                }),
-                SESSION,
-            )
-            .await;
+            navigate(&mock, "FCHILD", url, name).await;
         }
 
         // The url is the marker for "the SECOND navigation landed".
@@ -557,6 +831,54 @@ mod tests {
         })
         .await;
         assert_eq!(map["FCHILD"].name(), Some("sidebar"));
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
+    /// A `Frame` is a cheap `Arc` handle and `Tab::frames()` hands out
+    /// clones, so holding one across navigations is the intended usage —
+    /// `loop { if f.url().await.contains("/checkout") { break } }` is the
+    /// obvious way to wait on an iframe.
+    ///
+    /// The name backfill replaces the registry row with a fresh `Frame`, so
+    /// a handle taken in the window between `frameAttached` and the first
+    /// named `frameNavigated` points at an inner nothing would ever touch
+    /// again. Writing the URL through that inner *before* the swap is what
+    /// keeps the polling loop terminating.
+    ///
+    /// Only `url()` is repaired here. `Frame::name()` on the held handle
+    /// still reads `None` forever, because `FrameInner::name` is immutable
+    /// and making it interior-mutable turns `Frame::name()` into an `async
+    /// fn` — a deliberate public break that is a maintainer's call, not
+    /// this fix's.
+    #[tokio::test]
+    async fn a_handle_taken_before_the_name_backfill_still_tracks_the_url() {
+        let (mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "FCHILD", "P").await;
+        let map = wait_for(&frames, |m| m.contains_key("FCHILD")).await;
+        let held = map["FCHILD"].clone();
+        assert_eq!(held.url().await, "", "nothing has navigated yet");
+
+        navigate(
+            &mock,
+            "FCHILD",
+            "https://host.test/checkout",
+            Some("sidebar"),
+        )
+        .await;
+        let map = wait_for(&frames, |m| {
+            m.get("FCHILD").is_some_and(|f| f.name().is_some())
+        })
+        .await;
+        assert_eq!(map["FCHILD"].url().await, "https://host.test/checkout");
+
+        assert_eq!(
+            held.url().await,
+            "https://host.test/checkout",
+            "a handle taken before the rename must not be orphaned on url()",
+        );
 
         cancel.cancel();
         conn.shutdown();

--- a/crates/zendriver/src/frame/lifecycle.rs
+++ b/crates/zendriver/src/frame/lifecycle.rs
@@ -41,8 +41,9 @@
 //! Keep the arms to registry mutation; spawn anything that talks to Chrome.
 //!
 //! The task runs until its [`tokio_util::sync::CancellationToken`] fires —
-//! typically when the owning Tab is dropped. Sweeps spawned by the attach
-//! arm observe the same token, so they do not outlive it.
+//! typically when the owning Tab is dropped. Everything it spawns (the
+//! startup `Page.enable`, and each sweep from the attach arm) observes the
+//! same token, so nothing outlives it waiting out a CDP budget.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Weak};
@@ -130,13 +131,22 @@ pub(crate) async fn run(
     // call, and in production the subscribe streams above are already
     // registered, so awaiting the response would only serialize the
     // first arriving event behind the enable round-trip.
+    //
+    // Cancellation-aware for the same reason the sweep is: an unanswered
+    // call sits on the transport's default budget
+    // ([`zendriver_transport::DEFAULT_CALL_TIMEOUT`], 180s), and nothing
+    // spawned here may outlive the Tab that owns it by that much while
+    // holding a session clone.
     let enable_session = session.clone();
+    let enable_cancel = cancel.clone();
     tokio::spawn(async move {
-        if let Err(e) = enable_session
-            .call("Page.enable", serde_json::json!({}))
-            .await
-        {
-            warn!(error = %e, "frame::lifecycle: Page.enable failed; frame events may be inactive");
+        tokio::select! {
+            () = enable_cancel.cancelled() => {}
+            res = enable_session.call("Page.enable", serde_json::json!({})) => {
+                if let Err(e) = res {
+                    warn!(error = %e, "frame::lifecycle: Page.enable failed; frame events may be inactive");
+                }
+            }
         }
     });
 
@@ -209,9 +219,19 @@ pub(crate) async fn run(
                             // Every `Frame` handle a caller already took
                             // points at THIS inner, and the rename below
                             // swaps the registry row for a fresh one those
-                            // handles never see — so this is what keeps
-                            // `Frame::url()` live on a handle taken before
-                            // a rename.
+                            // handles never see. Writing first means a
+                            // pre-rename handle at least observes the
+                            // navigation that carries the rename.
+                            //
+                            // It does not survive the swap. The NEXT
+                            // `frameNavigated` resolves the new row and
+                            // writes THAT inner, so a handle taken before
+                            // the rename freezes at this URL forever. The
+                            // repair is one navigation deep, not permanent;
+                            // closing it needs interior-mutable
+                            // `FrameInner::name`, which is a public break a
+                            // maintainer has to sign off (see the ignored
+                            // two-navigation test in this module).
                             *existing.inner.url.write().await = new_url.clone();
                             if !name_changed {
                                 continue;
@@ -251,15 +271,38 @@ pub(crate) async fn run(
                     );
                     map.insert(frame_id, renamed);
                 } else {
-                    let frame = Frame::new(
-                        frame_id.clone(),
-                        ev.frame.parent_id,
-                        new_url,
-                        new_name,
-                        session.clone(),
-                        tab_weak.clone(),
-                    );
-                    map.insert(frame_id, frame);
+                    // Re-look up, for the same reason the rename path does.
+                    // The read guard said "no entry", but the OOPIF observer
+                    // and the attach arm both insert into this map, and an
+                    // OOPIF row carries a CHILD session. Inserting blind
+                    // would overwrite one with a `Frame` on the parent
+                    // session, sending every later call on that frame to the
+                    // wrong target — so a row that appeared in the gap is
+                    // refreshed in place instead.
+                    //
+                    // A name on this event is left to the next navigation:
+                    // backfilling it means swapping the row, which is the
+                    // thing being avoided here, and the rename path above
+                    // does it correctly once the row is visible to a read
+                    // guard.
+                    let raced = map.get(&frame_id).map(|f| Arc::clone(&f.inner));
+                    match raced {
+                        Some(inner) => {
+                            drop(map);
+                            *inner.url.write().await = new_url;
+                        }
+                        None => {
+                            let frame = Frame::new(
+                                frame_id.clone(),
+                                ev.frame.parent_id,
+                                new_url,
+                                new_name,
+                                session.clone(),
+                                tab_weak.clone(),
+                            );
+                            map.insert(frame_id, frame);
+                        }
+                    }
                 }
             }
             Some(ev) = detached.next() => {
@@ -500,6 +543,19 @@ mod tests {
         }
     }
 
+    /// Give a spawned sweep room to finish, for the assertions whose
+    /// expected outcome is that it did nothing.
+    ///
+    /// The sweep runs in its own task, so no registry state proves it has
+    /// run: every row it might evict is already in the map before it is
+    /// spawned, and the row it leaves alone looks the same before and
+    /// after. A negative therefore has no event to wait on. Past the probe
+    /// reply the sweep is one lock acquisition from done, so this window is
+    /// orders of magnitude more than it needs.
+    async fn settle() {
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
+
     /// Emit a `Page.frameNavigated` for `frame_id` on the test session.
     async fn navigate(mock: &MockConnection, frame_id: &str, url: &str, name: Option<&str>) {
         mock.emit_event_for_session(
@@ -545,7 +601,8 @@ mod tests {
         )
         .await;
 
-        let map = wait_for(&frames, |m| m.contains_key("F2")).await;
+        settle().await;
+        let map = frames.read().await.clone();
         assert!(
             map.contains_key("F1"),
             "a sibling Chrome still lists in the frame tree must not be swept",
@@ -601,11 +658,13 @@ mod tests {
         let id = expect_probe(&mut mock).await;
         mock.reply_err(id, -32000, "Page domain not enabled").await;
 
-        let map = wait_for(&frames, |m| m.contains_key("F2")).await;
+        settle().await;
+        let map = frames.read().await.clone();
         assert!(
             map.contains_key("F1"),
             "an unanswerable probe must not authorize an eviction",
         );
+        assert!(map.contains_key("F2"));
 
         cancel.cancel();
         conn.shutdown();
@@ -688,10 +747,7 @@ mod tests {
         )
         .await;
 
-        // A negative has no event to wait on, so give the sweep a settle
-        // window it would comfortably finish in (it is one lock acquisition
-        // past the reply) and assert the row survived it.
-        tokio::time::sleep(Duration::from_millis(300)).await;
+        settle().await;
         assert!(
             frames.read().await.contains_key("F1"),
             "a candidate that navigated under the probe must survive the sweep",
@@ -739,7 +795,7 @@ mod tests {
         )
         .await;
 
-        tokio::time::sleep(Duration::from_millis(300)).await;
+        settle().await;
         let map = frames.read().await;
         assert!(
             map.get("F1")
@@ -836,16 +892,48 @@ mod tests {
         conn.shutdown();
     }
 
+    /// Chrome emits `frameNavigated` for the main frame before any
+    /// subscriber sees a `frameAttached` for it, so a navigation with no
+    /// registry row is an implicit attach and has to insert one — off the
+    /// event's own `parentId`, since there was no attach to take it from.
+    ///
+    /// The insert is guarded against a row that appeared while the arm was
+    /// upgrading from the read guard to the write guard, and that guard is
+    /// what this pins: the ordinary uncontended case must still insert.
+    #[tokio::test]
+    async fn navigated_for_an_unknown_frame_inserts_it() {
+        let (mock, conn, frames, cancel) = start().await;
+
+        navigate(&mock, "MAIN", "https://host.test/", Some("top")).await;
+
+        let map = wait_for(&frames, |m| m.contains_key("MAIN")).await;
+        let frame = &map["MAIN"];
+        assert_eq!(frame.url().await, "https://host.test/");
+        assert_eq!(frame.name(), Some("top"));
+        assert_eq!(
+            frame.parent_id(),
+            Some("P"),
+            "the implicit attach takes its parent from the navigation event",
+        );
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
     /// A `Frame` is a cheap `Arc` handle and `Tab::frames()` hands out
-    /// clones, so holding one across navigations is the intended usage —
-    /// `loop { if f.url().await.contains("/checkout") { break } }` is the
-    /// obvious way to wait on an iframe.
+    /// clones, so holding one across navigations is the intended usage.
     ///
     /// The name backfill replaces the registry row with a fresh `Frame`, so
     /// a handle taken in the window between `frameAttached` and the first
     /// named `frameNavigated` points at an inner nothing would ever touch
-    /// again. Writing the URL through that inner *before* the swap is what
-    /// keeps the polling loop terminating.
+    /// again. Writing the URL through that inner *before* the swap repairs
+    /// exactly one navigation: the one carrying the rename, asserted here.
+    ///
+    /// It does **not** make the handle track the frame. Later navigations
+    /// resolve the new row and leave this one frozen — see
+    /// [`a_held_handle_stops_tracking_after_the_rename_swap`], which is the
+    /// same scenario one navigation further along and is `#[ignore]`d
+    /// because it cannot pass without the API break below.
     ///
     /// Only `url()` is repaired here. `Frame::name()` on the held handle
     /// still reads `None` forever, because `FrameInner::name` is immutable
@@ -878,6 +966,63 @@ mod tests {
             held.url().await,
             "https://host.test/checkout",
             "a handle taken before the rename must not be orphaned on url()",
+        );
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
+    /// The write-through's boundary, and the reason it is a stopgap rather
+    /// than a fix: it repairs the navigation that carries the rename and
+    /// nothing after it.
+    ///
+    /// Two navigations, one handle. The first renames the frame and swaps
+    /// the registry row; the second resolves that new row and writes its
+    /// inner. The held handle points at the old one, so it reads `/cart`
+    /// while the registry reads `/checkout` — and
+    /// `loop { if f.url().await.contains("/checkout") { break } }`, the
+    /// obvious way to wait on an iframe, never terminates on that handle.
+    ///
+    /// **Ignored, not deleted.** Passing it requires interior-mutable
+    /// `FrameInner::name` so the backfill mutates the shared inner instead
+    /// of replacing the row, which turns `Frame::name()` into an `async fn`
+    /// and breaks a public signature. That call is reserved for a
+    /// maintainer (founder's review round 1, §5 item 2 — "`Frame::name()`
+    /// and `Frame::id()` interior mutability"). Un-`#[ignore]` this the day
+    /// the break is taken; it is the acceptance test for it.
+    #[tokio::test]
+    #[ignore = "needs interior-mutable FrameInner::name; reserved public API break"]
+    async fn a_held_handle_stops_tracking_after_the_rename_swap() {
+        let (mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "FCHILD", "P").await;
+        let held = wait_for(&frames, |m| m.contains_key("FCHILD")).await["FCHILD"].clone();
+
+        // Navigation 1 carries the name, so it swaps the registry row.
+        navigate(&mock, "FCHILD", "https://host.test/cart", Some("sidebar")).await;
+        wait_for(&frames, |m| {
+            m.get("FCHILD").is_some_and(|f| f.name().is_some())
+        })
+        .await;
+
+        // Navigation 2 lands on the row the swap installed.
+        navigate(&mock, "FCHILD", "https://host.test/checkout", None).await;
+        let map = wait_for(&frames, |m| {
+            m.get("FCHILD").is_some_and(|f| {
+                f.inner
+                    .url
+                    .try_read()
+                    .is_ok_and(|u| u.ends_with("/checkout"))
+            })
+        })
+        .await;
+        assert_eq!(map["FCHILD"].url().await, "https://host.test/checkout");
+
+        assert_eq!(
+            held.url().await,
+            "https://host.test/checkout",
+            "a handle must keep tracking the frame across every navigation, \
+             not just the one that renamed it",
         );
 
         cancel.cancel();

--- a/crates/zendriver/src/frame/lifecycle.rs
+++ b/crates/zendriver/src/frame/lifecycle.rs
@@ -20,14 +20,16 @@
 //!      through the [`crate::frame::oopif`] observer path on their own
 //!      child session, NOT this stream) and insert it under `frameId`.
 //!    - `Page.frameNavigated` — update the existing entry's URL in
-//!      place; insert a fresh [`crate::Frame`] if no entry exists.
+//!      place (and backfill the frame `name` the attach event could not
+//!      carry); insert a fresh [`crate::Frame`] if no entry exists.
 //!    - `Page.frameDetached` — remove the entry from the registry.
 //!
 //! The task runs until its [`tokio_util::sync::CancellationToken`] fires —
 //! typically when the owning Tab is dropped.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Weak};
+use std::time::Duration;
 
 use futures::StreamExt;
 use serde::Deserialize;
@@ -38,6 +40,12 @@ use zendriver_transport::SessionHandle;
 
 use crate::frame::Frame;
 use crate::tab::TabInner;
+
+/// Wait budget for the `Page.getFrameTree` probe that confirms a
+/// same-parent sibling really is a dead provisional frame. Bounded so a
+/// wedged probe can never stall the event loop that keeps the registry
+/// current; on expiry the sweep fails open (nothing is evicted).
+const PROVISIONAL_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Minimal projection of `Page.frameAttached` — only the fields we need
 /// to construct a [`Frame`]. URL/name are not on this payload; they arrive
@@ -131,62 +139,63 @@ pub(crate) async fn run(
                 // single iframe — once with a provisional `frameId` and
                 // again with the committed one — without an intervening
                 // `frameDetached`. Observed on `srcdoc` iframes under
-                // `--headless=new`. The provisional entry always has an
-                // empty URL (it never received a `frameNavigated`); the
-                // newer attach carries the real id. Sweep any
-                // same-parent provisional siblings before inserting so
-                // the registry doesn't accumulate dead frames that
+                // `--headless=new`. Evict those dead entries so the
+                // registry doesn't accumulate frames that
                 // `Page.createIsolatedWorld` would reject with
                 // "No frame for given id found".
+                let dead = dead_provisional_siblings(&session, &frames, &ev).await;
                 let mut map = frames.write().await;
-                if let Some(parent) = ev.parent_frame_id.as_deref() {
-                    let stale: Vec<String> = map
-                        .iter()
-                        .filter_map(|(id, f)| {
-                            if id == &ev.frame_id {
-                                return None;
-                            }
-                            if f.inner.parent_frame_id.as_deref() != Some(parent) {
-                                return None;
-                            }
-                            let url_slot = f.inner.url.try_read().ok()?;
-                            if url_slot.is_empty() {
-                                Some(id.clone())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect();
-                    for id in stale {
-                        map.remove(&id);
-                    }
+                for id in dead {
+                    map.remove(&id);
                 }
                 map.insert(ev.frame_id, frame);
             }
             Some(ev) = navigated.next() => {
-                let frame_id = ev.frame.id.clone();
-                let new_url = ev.frame.url.clone();
+                let frame_id = ev.frame.id;
+                let new_url = ev.frame.url;
+                // `Page.frameAttached` carries no name, so an entry created
+                // from it always starts nameless. Treat a non-empty name on
+                // `frameNavigated` as the authoritative one; never clear a
+                // known name from an event that simply omits the field.
+                let new_name = ev.frame.name.filter(|n| !n.is_empty());
                 // Update in place if known; otherwise treat the navigation
                 // as the implicit attach (Chrome may emit `frameNavigated`
                 // for the main frame before any subscriber sees an explicit
                 // `frameAttached`).
-                {
-                    let map = frames.read().await;
-                    if let Some(existing) = map.get(&frame_id) {
-                        let mut url_slot = existing.inner.url.write().await;
-                        *url_slot = new_url;
+                let mut map = frames.write().await;
+                if let Some(existing) = map.get(&frame_id) {
+                    let name_changed = new_name.is_some()
+                        && new_name.as_deref() != existing.inner.name.as_deref();
+                    if !name_changed {
+                        *existing.inner.url.write().await = new_url;
                         continue;
                     }
+                    // `FrameInner::name` is immutable (it backs
+                    // `Frame::name() -> Option<&str>`, which cannot hand out
+                    // a lock guard), so backfilling means replacing the
+                    // registry entry. Everything else is carried over —
+                    // notably the session, which for an OOPIF is a child
+                    // session and NOT this subscriber's.
+                    let renamed = Frame::new(
+                        frame_id.clone(),
+                        existing.inner.parent_frame_id.clone(),
+                        new_url,
+                        new_name,
+                        existing.inner.session.clone(),
+                        tab_weak.clone(),
+                    );
+                    map.insert(frame_id, renamed);
+                    continue;
                 }
                 let frame = Frame::new(
                     frame_id.clone(),
                     ev.frame.parent_id,
-                    ev.frame.url,
-                    ev.frame.name,
+                    new_url,
+                    new_name,
                     session.clone(),
                     tab_weak.clone(),
                 );
-                frames.write().await.insert(frame_id, frame);
+                map.insert(frame_id, frame);
             }
             Some(ev) = detached.next() => {
                 frames.write().await.remove(&ev.frame_id);
@@ -196,5 +205,360 @@ pub(crate) async fn run(
                 return;
             }
         }
+    }
+}
+
+/// Registry entries that the freshly-attached `ev` supersedes: same parent,
+/// same session, still URL-less — **and confirmed gone from Chrome's live
+/// frame tree**.
+///
+/// The last clause is what separates a dead provisional frame from a
+/// perfectly good sibling that simply has not navigated yet. Both look
+/// identical in the event stream (a second `frameAttached` under one
+/// parent, no `frameNavigated` on the first), so the registry alone cannot
+/// tell them apart; `Page.getFrameTree` can, because Chrome drops a
+/// provisional frame from the tree the moment it commits the real one —
+/// the same reason `Page.createIsolatedWorld` answers "No frame for given
+/// id found" for it.
+///
+/// Fails open in every ambiguous case (no parent, no candidates, probe
+/// error or timeout): keeping a possibly-dead entry only costs a stale row
+/// in [`crate::Tab::frames`], which
+/// [`crate::Frame::ensure_isolated_world`] already recovers from, whereas
+/// evicting a live frame loses a handle the caller may hold.
+async fn dead_provisional_siblings(
+    session: &SessionHandle,
+    frames: &Arc<RwLock<HashMap<String, Frame>>>,
+    ev: &FrameAttachedEvent,
+) -> Vec<String> {
+    let Some(parent) = ev.parent_frame_id.as_deref() else {
+        return Vec::new();
+    };
+    let candidates: Vec<String> = {
+        let map = frames.read().await;
+        map.iter()
+            .filter_map(|(id, f)| {
+                if id == &ev.frame_id {
+                    return None;
+                }
+                if f.inner.parent_frame_id.as_deref() != Some(parent) {
+                    return None;
+                }
+                // OOPIF entries live on their own child session and are
+                // absent from THIS session's frame tree, so the probe below
+                // would read as "gone" for every one of them.
+                if f.inner.session.session_id() != session.session_id() {
+                    return None;
+                }
+                let url_slot = f.inner.url.try_read().ok()?;
+                url_slot.is_empty().then(|| id.clone())
+            })
+            .collect()
+    };
+    if candidates.is_empty() {
+        return Vec::new();
+    }
+    let Some(live) = live_frame_ids(session).await else {
+        return Vec::new();
+    };
+    candidates
+        .into_iter()
+        .filter(|id| !live.contains(id))
+        .collect()
+}
+
+/// Every frame id Chrome currently reports under `Page.getFrameTree`, or
+/// `None` if the probe failed or outran [`PROVISIONAL_PROBE_TIMEOUT`].
+async fn live_frame_ids(session: &SessionHandle) -> Option<HashSet<String>> {
+    let tree = match tokio::time::timeout(
+        PROVISIONAL_PROBE_TIMEOUT,
+        session.call("Page.getFrameTree", serde_json::json!({})),
+    )
+    .await
+    {
+        Ok(Ok(tree)) => tree,
+        Ok(Err(e)) => {
+            warn!(error = %e, "frame::lifecycle: Page.getFrameTree failed; keeping possibly-stale sibling frames");
+            return None;
+        }
+        Err(_) => {
+            warn!(
+                "frame::lifecycle: Page.getFrameTree timed out; keeping possibly-stale sibling frames"
+            );
+            return None;
+        }
+    };
+    fn collect(node: &serde_json::Value, out: &mut HashSet<String>) {
+        if let Some(id) = node["frame"]["id"].as_str() {
+            out.insert(id.to_string());
+        }
+        if let Some(children) = node["childFrames"].as_array() {
+            for c in children {
+                collect(c, out);
+            }
+        }
+    }
+    let mut ids = HashSet::new();
+    collect(&tree["frameTree"], &mut ids);
+    Some(ids)
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use zendriver_transport::Connection;
+    use zendriver_transport::testing::MockConnection;
+
+    type Registry = Arc<RwLock<HashMap<String, Frame>>>;
+
+    /// Session id every test drives events on — the subscriber only sees
+    /// events routed to its own session.
+    const SESSION: &str = "S1";
+
+    /// Spawn the subscriber on a mock connection and drain its startup
+    /// `Page.enable`. Once that command has landed the three `Page.frame*`
+    /// subscriptions are registered, so any later `emit_event_for_session`
+    /// reaches the loop.
+    async fn start() -> (MockConnection, Connection, Registry, CancellationToken) {
+        let (mut mock, conn) = MockConnection::pair();
+        let session = SessionHandle::new(conn.clone(), SESSION);
+        let frames: Registry = Arc::new(RwLock::new(HashMap::new()));
+        let cancel = CancellationToken::new();
+        tokio::spawn(run(session, frames.clone(), Weak::new(), cancel.clone()));
+        let id = tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Page.enable"))
+            .await
+            .expect("frame lifecycle did not send Page.enable within 2s");
+        mock.reply(id, json!({})).await;
+        (mock, conn, frames, cancel)
+    }
+
+    async fn attach(mock: &MockConnection, frame_id: &str, parent: &str) {
+        mock.emit_event_for_session(
+            "Page.frameAttached",
+            json!({ "frameId": frame_id, "parentFrameId": parent }),
+            SESSION,
+        )
+        .await;
+    }
+
+    /// One `childFrames` entry for a canned `Page.getFrameTree` reply.
+    fn tree_child(id: &str, parent: &str) -> serde_json::Value {
+        json!({ "frame": { "id": id, "parentId": parent, "url": "" } })
+    }
+
+    /// Poll the registry until `pred` holds, then return a snapshot. Panics
+    /// on timeout rather than asserting on a half-applied event.
+    async fn wait_for(
+        frames: &Registry,
+        pred: impl Fn(&HashMap<String, Frame>) -> bool,
+    ) -> HashMap<String, Frame> {
+        for _ in 0..100 {
+            {
+                let map = frames.read().await;
+                if pred(&map) {
+                    return map.clone();
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("registry never reached the expected state within 1s");
+    }
+
+    /// Two real iframes under one parent, neither navigated yet, are
+    /// indistinguishable from the provisional double-attach in the event
+    /// stream alone — but Chrome's frame tree still lists both, so the
+    /// second attach must NOT evict the first.
+    #[tokio::test]
+    async fn unnavigated_sibling_present_in_frame_tree_survives_a_second_attach() {
+        let (mut mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "F1", "P").await;
+        wait_for(&frames, |m| m.contains_key("F1")).await;
+        attach(&mock, "F2", "P").await;
+
+        let id = tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Page.getFrameTree"))
+            .await
+            .expect("attach with an url-less sibling did not probe Page.getFrameTree");
+        mock.reply(
+            id,
+            json!({
+                "frameTree": {
+                    "frame": { "id": "P", "url": "https://host.test/" },
+                    "childFrames": [tree_child("F1", "P"), tree_child("F2", "P")],
+                }
+            }),
+        )
+        .await;
+
+        let map = wait_for(&frames, |m| m.contains_key("F2")).await;
+        assert!(
+            map.contains_key("F1"),
+            "a sibling Chrome still lists in the frame tree must not be swept",
+        );
+        assert_eq!(map.len(), 2);
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
+    /// The quirk the sweep exists for: Chrome re-attaches one iframe under a
+    /// fresh id and drops the provisional from its frame tree. That entry is
+    /// dead and must go.
+    #[tokio::test]
+    async fn provisional_sibling_absent_from_frame_tree_is_evicted() {
+        let (mut mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "PROVISIONAL", "P").await;
+        wait_for(&frames, |m| m.contains_key("PROVISIONAL")).await;
+        attach(&mock, "COMMITTED", "P").await;
+
+        let id = tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Page.getFrameTree"))
+            .await
+            .expect("attach with an url-less sibling did not probe Page.getFrameTree");
+        mock.reply(
+            id,
+            json!({
+                "frameTree": {
+                    "frame": { "id": "P", "url": "https://host.test/" },
+                    "childFrames": [tree_child("COMMITTED", "P")],
+                }
+            }),
+        )
+        .await;
+
+        let map = wait_for(&frames, |m| !m.contains_key("PROVISIONAL")).await;
+        assert!(map.contains_key("COMMITTED"));
+        assert_eq!(map.len(), 1);
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
+    /// A failed probe must fail OPEN. Dropping a live frame loses a handle;
+    /// keeping a dead one only leaves a stale row that
+    /// `ensure_isolated_world` recovers from.
+    #[tokio::test]
+    async fn failed_frame_tree_probe_keeps_the_sibling() {
+        let (mut mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "F1", "P").await;
+        wait_for(&frames, |m| m.contains_key("F1")).await;
+        attach(&mock, "F2", "P").await;
+
+        let id = tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd("Page.getFrameTree"))
+            .await
+            .expect("attach with an url-less sibling did not probe Page.getFrameTree");
+        mock.reply_err(id, -32000, "Page domain not enabled").await;
+
+        let map = wait_for(&frames, |m| m.contains_key("F2")).await;
+        assert!(
+            map.contains_key("F1"),
+            "an unanswerable probe must not authorize an eviction",
+        );
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
+    /// A single child needs no probe at all — no `Page.getFrameTree` is
+    /// dispatched, so the common case keeps its zero-round-trip cost.
+    #[tokio::test]
+    async fn lone_attach_does_not_probe_the_frame_tree() {
+        let (mut mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "F1", "P").await;
+        wait_for(&frames, |m| m.contains_key("F1")).await;
+
+        assert_eq!(
+            mock.try_recv_cmd(),
+            None,
+            "no sibling candidates means no frame-tree probe",
+        );
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
+    /// `Page.frameAttached` carries no name, so a named iframe is nameless
+    /// in the registry until `Page.frameNavigated` supplies one. Dropping it
+    /// there leaves `Tab::frame_by_name` unable to find the frame forever.
+    #[tokio::test]
+    async fn navigated_backfills_the_frame_name_onto_an_attached_entry() {
+        let (mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "FCHILD", "P").await;
+        let map = wait_for(&frames, |m| m.contains_key("FCHILD")).await;
+        assert_eq!(map["FCHILD"].name(), None, "attach cannot know the name");
+
+        mock.emit_event_for_session(
+            "Page.frameNavigated",
+            json!({
+                "frame": {
+                    "id": "FCHILD",
+                    "parentId": "P",
+                    "url": "https://host.test/side",
+                    "name": "sidebar",
+                }
+            }),
+            SESSION,
+        )
+        .await;
+
+        let map = wait_for(&frames, |m| {
+            m.get("FCHILD").is_some_and(|f| f.name().is_some())
+        })
+        .await;
+        let frame = &map["FCHILD"];
+        assert_eq!(frame.name(), Some("sidebar"));
+        assert_eq!(frame.url().await, "https://host.test/side");
+        assert_eq!(
+            frame.parent_id(),
+            Some("P"),
+            "parent must survive the backfill"
+        );
+
+        cancel.cancel();
+        conn.shutdown();
+    }
+
+    /// The backfill only ever adds a name. A later navigation that omits
+    /// the field (Chrome does that for the unnamed case) must not erase the
+    /// name a previous event established.
+    #[tokio::test]
+    async fn navigated_without_a_name_keeps_the_known_one() {
+        let (mock, conn, frames, cancel) = start().await;
+
+        attach(&mock, "FCHILD", "P").await;
+        wait_for(&frames, |m| m.contains_key("FCHILD")).await;
+        for (url, name) in [
+            ("https://host.test/one", json!("sidebar")),
+            ("https://host.test/two", json!(null)),
+        ] {
+            mock.emit_event_for_session(
+                "Page.frameNavigated",
+                json!({
+                    "frame": { "id": "FCHILD", "parentId": "P", "url": url, "name": name }
+                }),
+                SESSION,
+            )
+            .await;
+        }
+
+        // The url is the marker for "the SECOND navigation landed".
+        let map = wait_for(&frames, |m| {
+            m.get("FCHILD").is_some_and(|f| {
+                f.inner
+                    .url
+                    .try_read()
+                    .is_ok_and(|u| *u == "https://host.test/two")
+            })
+        })
+        .await;
+        assert_eq!(map["FCHILD"].name(), Some("sidebar"));
+
+        cancel.cancel();
+        conn.shutdown();
     }
 }

--- a/crates/zendriver/src/frame/mod.rs
+++ b/crates/zendriver/src/frame/mod.rs
@@ -127,9 +127,16 @@ impl Frame {
         }
     }
 
-    /// The frame's CDP `frameId`.
+    /// The frame's CDP `frameId`, as recorded when this handle was built.
     ///
-    /// Stable for the lifetime of the frame.
+    /// The value never changes on a given handle, which is not the same as
+    /// naming the frame forever. Chrome sometimes re-attaches an iframe
+    /// under a fresh `frameId` with no `Page.frameDetached` in between (seen
+    /// on `srcdoc` iframes under `--headless=new`), and this handle goes on
+    /// reporting the id it was built with. [`Frame::evaluate`] and the query
+    /// methods recover on their own by rebinding against the live frame
+    /// tree; a caller that hands this id to CDP itself can instead get
+    /// "No frame for given id found".
     ///
     /// # Examples
     ///
@@ -311,8 +318,8 @@ impl Frame {
                         return Err(e);
                     }
                     // Drop the dead context and let `ensure_isolated_world`
-                    // mint a new one. `main_frame_id` is deliberately left
-                    // alone: the frame still exists, only its context died.
+                    // mint a new one, rediscovering the frame id if the one
+                    // recorded at attach time has since been rewritten.
                     self.inner.isolated_world.lock().await.context_id = None;
                 }
             }
@@ -578,7 +585,6 @@ impl Frame {
         // parent, and retry with the live id.
         let frame_id_for_call = match self.create_isolated_world(&self.inner.frame_id).await {
             Ok(ctx) => {
-                cache.main_frame_id = Some(self.inner.frame_id.clone());
                 cache.context_id = Some(ctx);
                 return Ok(ctx);
             }
@@ -592,7 +598,6 @@ impl Frame {
             Err(e) => return Err(e),
         };
         let ctx = self.create_isolated_world(&frame_id_for_call).await?;
-        cache.main_frame_id = Some(frame_id_for_call);
         cache.context_id = Some(ctx);
         Ok(ctx)
     }
@@ -629,6 +634,14 @@ impl Frame {
     /// route through the cache; nothing that reads the id does. Making
     /// `frame_id` interior-mutable would fix that too, and is a separate
     /// change.
+    ///
+    /// The probe runs on the transport's default call budget
+    /// ([`zendriver_transport::DEFAULT_CALL_TIMEOUT`]), like every other CDP
+    /// call the caller is awaiting. [`crate::frame::lifecycle`] bounds its
+    /// copy of the same `Page.getFrameTree` far tighter, and the difference
+    /// is deliberate: that one runs in a detached task with nobody waiting
+    /// on it, so its budget exists to reclaim the task rather than to answer
+    /// a caller.
     ///
     /// A single child under the recorded parent is unambiguous. With
     /// several, the recorded `name` and `url` are the only things that tell
@@ -669,10 +682,17 @@ impl Frame {
             .await?;
         // EVERY child of `parent`, not just the first — the count is what
         // reveals ambiguity. The root is excluded because it is the tree's
-        // own frame rather than a child of anything in the tree; in an
-        // OOPIF's child-target tree that root can itself carry a
-        // `parentId`, so the depth check is not redundant with the
-        // comparison beside it.
+        // own frame rather than a child of anything in the tree.
+        //
+        // That exclusion also costs the OOPIF case, which is why it is
+        // written as a depth check and not folded into the `parent_id`
+        // comparison. Walked on an OOPIF's own child session, the tree's
+        // root IS this frame and carries `parent` as its `parentId` — so
+        // dropping the depth check is exactly what an OOPIF would need, and
+        // it is not done here because the shape of that tree is unverified
+        // against a real browser. Guessing wrong binds a live-looking id
+        // from the wrong target, and the paragraph above says why a wrong
+        // bind is worse than the `FrameNotFound` an OOPIF gets today.
         let mut candidates = Vec::new();
         tree::walk(&tree["frameTree"], &mut |node| {
             if node.depth > 0 && node.parent_id == Some(parent) {

--- a/crates/zendriver/src/frame/mod.rs
+++ b/crates/zendriver/src/frame/mod.rs
@@ -585,7 +585,50 @@ impl Frame {
         })
     }
 
+    /// Re-bind a rejected `frame_id` by finding this frame's current id in
+    /// the live `Page.getFrameTree`.
+    ///
+    /// A single child under the recorded parent is unambiguous. With
+    /// several, the recorded `name` and `url` are the only things that tell
+    /// them apart — and when neither singles one out, this returns
+    /// [`ZendriverError::FrameNotFound`] instead of binding the first
+    /// depth-first hit. A wrong bind is worse than an error: it reports
+    /// `Ok` and then runs every later `evaluate` / query against a
+    /// different iframe's document.
     async fn discover_current_frame_id(&self) -> Result<String> {
+        /// One candidate child frame, as reported by `Page.getFrameTree`.
+        struct Child {
+            id: String,
+            name: Option<String>,
+            url: Option<String>,
+        }
+        /// Depth-first collect of EVERY child of `parent` — all of them,
+        /// not just the first, since the count is what reveals ambiguity.
+        fn collect_children(node: &Value, parent: &str, out: &mut Vec<Child>) {
+            if let Some(children) = node["childFrames"].as_array() {
+                for c in children {
+                    let f = &c["frame"];
+                    if f["parentId"].as_str() == Some(parent) {
+                        if let Some(id) = f["id"].as_str() {
+                            out.push(Child {
+                                id: id.to_string(),
+                                name: f["name"].as_str().map(str::to_string),
+                                url: f["url"].as_str().map(str::to_string),
+                            });
+                        }
+                    }
+                    collect_children(c, parent, out);
+                }
+            }
+        }
+        /// The one candidate satisfying `pred`, or `None` when zero or
+        /// several do — "several" must not resolve to "the first".
+        fn sole_match(candidates: &[Child], pred: impl Fn(&Child) -> bool) -> Option<&Child> {
+            let mut hits = candidates.iter().filter(|c| pred(c));
+            let first = hits.next()?;
+            hits.next().is_none().then_some(first)
+        }
+
         let parent = self.inner.parent_frame_id.as_deref().ok_or_else(|| {
             ZendriverError::Navigation(
                 "frame_id rejected and no parent_frame_id recorded to recover from".into(),
@@ -596,31 +639,37 @@ impl Frame {
             .session
             .call("Page.getFrameTree", json!({}))
             .await?;
-        let main = tree["frameTree"].clone();
-        // Walk: depth-first. Find a child whose parentId matches `parent`
-        // and which is not the main frame. Single-iframe pages always
-        // win; multi-iframe pages get the first matching child, which
-        // is the best we can do without a name/url to disambiguate.
-        fn walk_for_child(node: &serde_json::Value, parent: &str) -> Option<String> {
-            if let Some(children) = node["childFrames"].as_array() {
-                for c in children {
-                    if c["frame"]["parentId"].as_str() == Some(parent) {
-                        if let Some(id) = c["frame"]["id"].as_str() {
-                            return Some(id.to_string());
-                        }
-                    }
-                    if let Some(found) = walk_for_child(c, parent) {
-                        return Some(found);
-                    }
-                }
-            }
-            None
-        }
-        walk_for_child(&main, parent).ok_or_else(|| {
-            ZendriverError::FrameNotFound(format!(
+        let mut candidates = Vec::new();
+        collect_children(&tree["frameTree"], parent, &mut candidates);
+
+        if candidates.is_empty() {
+            return Err(ZendriverError::FrameNotFound(format!(
                 "no child frame found under parent {parent} during recovery"
-            ))
-        })
+            )));
+        }
+        if candidates.len() == 1 {
+            return Ok(candidates.swap_remove(0).id);
+        }
+        // Several siblings: only a unique name or url match may bind.
+        let name = self.inner.name.as_deref().filter(|n| !n.is_empty());
+        if let Some(name) = name {
+            if let Some(hit) = sole_match(&candidates, |c| c.name.as_deref() == Some(name)) {
+                return Ok(hit.id.clone());
+            }
+        }
+        let url = self.inner.url.read().await.clone();
+        if !url.is_empty() {
+            if let Some(hit) = sole_match(&candidates, |c| c.url.as_deref() == Some(url.as_str())) {
+                return Ok(hit.id.clone());
+            }
+        }
+        Err(ZendriverError::FrameNotFound(format!(
+            "frame id recovery under parent {parent} is ambiguous: {} sibling frames, and neither \
+             the recorded name ({}) nor url ({}) matches exactly one",
+            candidates.len(),
+            name.unwrap_or("<none>"),
+            if url.is_empty() { "<none>" } else { &url },
+        )))
     }
 
     /// Shared post-processing for `Runtime.evaluate` responses — checks
@@ -926,6 +975,165 @@ mod tests {
             }
             other => panic!("expected Navigation error, got: {other:?}"),
         }
+        conn.shutdown();
+    }
+
+    // --- stale frame-id recovery (`discover_current_frame_id`) ----------
+
+    /// A `Frame` whose recorded id Chrome will reject, forcing
+    /// `ensure_isolated_world` down the recovery path.
+    fn stale_frame(session: SessionHandle, name: Option<&str>, url: &str) -> Frame {
+        Frame::new(
+            "STALE".to_string(),
+            Some("PARENT".to_string()),
+            url.to_string(),
+            name.map(str::to_string),
+            session,
+            Weak::new(),
+        )
+    }
+
+    /// Drain the rejected first `Page.createIsolatedWorld` and answer the
+    /// recovery `Page.getFrameTree` with `children` under `PARENT`.
+    async fn reject_then_serve_tree(mock: &mut MockConnection, children: Value) {
+        let id_world = mock.expect_cmd("Page.createIsolatedWorld").await;
+        assert_eq!(mock.last_sent()["params"]["frameId"], "STALE");
+        mock.reply_err(id_world, -32602, "No frame for given id found")
+            .await;
+        let id_tree = mock.expect_cmd("Page.getFrameTree").await;
+        mock.reply(
+            id_tree,
+            json!({
+                "frameTree": {
+                    "frame": { "id": "PARENT", "url": "https://host.test/" },
+                    "childFrames": children,
+                }
+            }),
+        )
+        .await;
+    }
+
+    fn tree_frame(id: &str, name: &str, url: &str) -> Value {
+        json!({ "frame": { "id": id, "parentId": "PARENT", "name": name, "url": url } })
+    }
+
+    /// Two sibling iframes and nothing to tell them apart: recovery must
+    /// FAIL. Binding the first depth-first hit would return `Ok` and then
+    /// run every later `evaluate` against the wrong document.
+    #[tokio::test]
+    async fn ambiguous_recovery_errors_instead_of_binding_a_sibling() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let frame = stale_frame(sess, None, "");
+
+        let fut = tokio::spawn({
+            let f = frame.clone();
+            async move { f.ensure_isolated_world().await }
+        });
+        reject_then_serve_tree(
+            &mut mock,
+            json!([
+                tree_frame("F1", "", "https://host.test/a"),
+                tree_frame("F2", "", "https://host.test/b"),
+            ]),
+        )
+        .await;
+
+        match fut.await.unwrap() {
+            Err(ZendriverError::FrameNotFound(m)) => {
+                assert!(m.contains("ambiguous"), "unexpected message: {m}");
+            }
+            other => panic!("expected FrameNotFound on an ambiguous tree, got: {other:?}"),
+        }
+        assert_eq!(
+            mock.try_recv_cmd(),
+            None,
+            "a failed recovery must not retry Page.createIsolatedWorld against a guess",
+        );
+        conn.shutdown();
+    }
+
+    /// The recorded frame `name` singles one sibling out — that is a bind
+    /// we can justify, so recovery proceeds with the live id.
+    #[tokio::test]
+    async fn recovery_uses_the_recorded_name_to_pick_among_siblings() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let frame = stale_frame(sess, Some("sidebar"), "");
+
+        let fut = tokio::spawn({
+            let f = frame.clone();
+            async move { f.ensure_isolated_world().await }
+        });
+        reject_then_serve_tree(
+            &mut mock,
+            json!([
+                tree_frame("F1", "banner", "https://host.test/a"),
+                tree_frame("F2", "sidebar", "https://host.test/b"),
+            ]),
+        )
+        .await;
+
+        let id_retry = mock.expect_cmd("Page.createIsolatedWorld").await;
+        assert_eq!(
+            mock.last_sent()["params"]["frameId"],
+            "F2",
+            "recovery must bind the name-matched sibling",
+        );
+        mock.reply(id_retry, json!({ "executionContextId": 99 }))
+            .await;
+        assert_eq!(fut.await.unwrap().unwrap(), 99);
+        conn.shutdown();
+    }
+
+    /// No name, but the recorded url matches exactly one sibling.
+    #[tokio::test]
+    async fn recovery_falls_back_to_the_recorded_url() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let frame = stale_frame(sess, None, "https://host.test/b");
+
+        let fut = tokio::spawn({
+            let f = frame.clone();
+            async move { f.ensure_isolated_world().await }
+        });
+        reject_then_serve_tree(
+            &mut mock,
+            json!([
+                tree_frame("F1", "", "https://host.test/a"),
+                tree_frame("F2", "", "https://host.test/b"),
+            ]),
+        )
+        .await;
+
+        let id_retry = mock.expect_cmd("Page.createIsolatedWorld").await;
+        assert_eq!(mock.last_sent()["params"]["frameId"], "F2");
+        mock.reply(id_retry, json!({ "executionContextId": 5 }))
+            .await;
+        assert_eq!(fut.await.unwrap().unwrap(), 5);
+        conn.shutdown();
+    }
+
+    /// The unambiguous single-iframe page keeps recovering with no name or
+    /// url to go on — the disambiguation must not make the common case
+    /// stricter.
+    #[tokio::test]
+    async fn lone_child_still_recovers_without_name_or_url() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let frame = stale_frame(sess, None, "");
+
+        let fut = tokio::spawn({
+            let f = frame.clone();
+            async move { f.ensure_isolated_world().await }
+        });
+        reject_then_serve_tree(&mut mock, json!([tree_frame("LIVE", "", "")])).await;
+
+        let id_retry = mock.expect_cmd("Page.createIsolatedWorld").await;
+        assert_eq!(mock.last_sent()["params"]["frameId"], "LIVE");
+        mock.reply(id_retry, json!({ "executionContextId": 3 }))
+            .await;
+        assert_eq!(fut.await.unwrap().unwrap(), 3);
         conn.shutdown();
     }
 }

--- a/crates/zendriver/src/frame/mod.rs
+++ b/crates/zendriver/src/frame/mod.rs
@@ -33,6 +33,7 @@ use crate::tab::{Tab, TabInner};
 
 pub mod lifecycle;
 pub mod oopif;
+pub(crate) mod tree;
 
 /// Default wait window for [`Frame::wait_for_load`]. Mirrors the constant
 /// in [`crate::tab::Tab::wait_for_load`] so single-frame and tab-level
@@ -42,19 +43,17 @@ const DEFAULT_LOAD_TIMEOUT: Duration = Duration::from_secs(30);
 /// Cheap-to-clone handle to a single document frame.
 ///
 /// Construct via [`crate::tab::Tab::main_frame`] (top-level frame for a
-/// tab); sub-frames and OOPIFs arrive via the lifecycle / OOPIF wiring
-/// in later P4 tasks. All accessor methods operate on the inner `Arc`,
-/// so cloning a `Frame` is a single refcount bump.
+/// tab); sub-frames and OOPIFs are registered by the [`lifecycle`] and
+/// [`oopif`] wiring and read back via [`crate::tab::Tab::frames`]. All
+/// accessor methods operate on the inner `Arc`, so cloning a `Frame` is a
+/// single refcount bump — and every clone of one entry observes the same
+/// [`Frame::url`], since the lifecycle subscriber writes through that
+/// shared `Arc`.
 #[derive(Clone, Debug)]
 pub struct Frame {
     inner: Arc<FrameInner>,
 }
 
-// `tab` is populated at construction but consumed by later P4 tasks (frame
-// lifecycle / OOPIF wiring in T15+T16). Silencing dead-code on that single
-// field until those land keeps clippy clean without dropping the (already
-// correct) plumbing. T13 enables `session` + `isolated_world` via the new
-// `Frame::evaluate` / `evaluate_main` / `content` accessors.
 #[derive(Debug)]
 pub(crate) struct FrameInner {
     /// CDP `frameId` (e.g. `"F0"`, a hex string at runtime). Stable for the
@@ -64,19 +63,28 @@ pub(crate) struct FrameInner {
     /// `Some` for every sub-frame and OOPIF.
     pub(crate) parent_frame_id: Option<String>,
     /// Last-known document URL for this frame. Behind an [`RwLock`] because
-    /// the lifecycle subscriber task (T15) mutates it on
-    /// `Page.frameNavigated` while readers concurrently call [`Frame::url`].
+    /// the lifecycle subscriber mutates it on `Page.frameNavigated` while
+    /// readers concurrently call [`Frame::url`].
     pub(crate) url: RwLock<String>,
-    /// `<frame name>` / `<iframe name>` attribute if present. Captured at
-    /// construction time; the spec does not currently track renames after
-    /// the fact since `Page.frameNavigated` does not carry the name field.
+    /// `<frame name>` / `<iframe name>` attribute if present.
+    ///
+    /// Set from `Page.frameNavigated`'s `frame.name` whenever Chrome
+    /// supplies a non-empty one. `Page.frameAttached` carries no name, so
+    /// an entry created from an attach starts `None` and is backfilled on
+    /// the first navigation that reports one; an event that simply omits
+    /// the field never clears a name already established.
+    ///
+    /// Immutable, which is what makes that backfill a *replacement* of the
+    /// registry entry rather than a write in place — see
+    /// [`lifecycle::run`]. Interior mutability here would make it a write,
+    /// at the cost of turning [`Frame::name`] into an `async fn`.
     pub(crate) name: Option<String>,
     /// CDP session used to dispatch commands against this frame. The main
-    /// frame shares the owning tab's session; OOPIFs (T16) attach to a
-    /// distinct child session whose handle is plumbed in at construction.
+    /// frame shares the owning tab's session; OOPIFs attach to a distinct
+    /// child session whose handle is plumbed in at construction.
     pub(crate) session: SessionHandle,
     /// Per-frame isolated-world cache. Same shape as the tab-level cache —
-    /// `Frame::evaluate` (T13) populates `executionContextId` on first call
+    /// [`Frame::evaluate`] populates `executionContextId` on first call
     /// via `Page.createIsolatedWorld { frameId: self.frame_id }` and reuses
     /// it on subsequent calls. Distinct from the tab-level cache so that
     /// per-frame contexts don't collide when the tab has multiple frames.
@@ -95,8 +103,8 @@ impl Frame {
     /// dispatch commands against it.
     ///
     /// Called by [`crate::tab::Tab::main_frame`] (main-frame path, shares
-    /// the tab's session) and — in later P4 tasks — by the lifecycle
-    /// subscriber (sub-frame attach) and the OOPIF attach observer
+    /// the tab's session), by the [`lifecycle`] subscriber (sub-frame
+    /// attach and name backfill) and by the [`oopif`] attach observer
     /// (distinct child session).
     pub(crate) fn new(
         frame_id: String,
@@ -144,9 +152,8 @@ impl Frame {
     /// session for [`crate::query::FindBuilder::new_for_frame`] queries.
     ///
     /// For the main frame and same-origin sub-frames this is identical
-    /// to the parent tab's session; for out-of-process iframes (T16
-    /// onward) it is a distinct child session attached via
-    /// `Target.attachedToTarget`.
+    /// to the parent tab's session; for out-of-process iframes it is a
+    /// distinct child session attached via `Target.attachedToTarget`.
     pub(crate) fn session(&self) -> &SessionHandle {
         &self.inner.session
     }
@@ -254,6 +261,12 @@ impl Frame {
     /// "zendriver-eval" }` on the frame's session and caches the returned
     /// `executionContextId`. Subsequent calls reuse the cached id.
     ///
+    /// A navigation inside the frame destroys that context. When Chrome
+    /// answers `Cannot find context with specified id`, the cached id is
+    /// dropped and the call retried once against a freshly created world,
+    /// so a `Frame` handle kept across a navigation keeps working — same
+    /// recovery [`crate::Tab::evaluate`] performs.
+    ///
     /// # Errors
     ///
     /// Returns [`ZendriverError::JsException`] when the expression raises;
@@ -271,21 +284,40 @@ impl Frame {
     /// # Ok(()) }
     /// ```
     pub async fn evaluate<T: DeserializeOwned>(&self, js: impl AsRef<str>) -> Result<T> {
-        let ctx_id = self.ensure_isolated_world().await?;
-        let res = self
-            .inner
-            .session
-            .call(
-                "Runtime.evaluate",
-                json!({
-                    "expression": js.as_ref(),
-                    "contextId": ctx_id,
-                    "returnByValue": true,
-                    "awaitPromise": true,
-                }),
-            )
-            .await?;
-        Self::extract_value(&res)
+        let js = js.as_ref();
+        for attempt in 0..2 {
+            let ctx_id = self.ensure_isolated_world().await?;
+            let res = self
+                .inner
+                .session
+                .call(
+                    "Runtime.evaluate",
+                    json!({
+                        "expression": js,
+                        "contextId": ctx_id,
+                        "returnByValue": true,
+                        "awaitPromise": true,
+                    }),
+                )
+                .await;
+            match res {
+                Ok(v) => return Self::extract_value(&v),
+                Err(e) => {
+                    // Convert once here: unlike `Tab::evaluate`, which goes
+                    // through a `Tab::call` wrapper, this dispatches on the
+                    // raw session and gets back a `CallError`.
+                    let e = ZendriverError::from(e);
+                    if attempt > 0 || !crate::isolated_world::is_stale_context(&e) {
+                        return Err(e);
+                    }
+                    // Drop the dead context and let `ensure_isolated_world`
+                    // mint a new one. `main_frame_id` is deliberately left
+                    // alone: the frame still exists, only its context died.
+                    self.inner.isolated_world.lock().await.context_id = None;
+                }
+            }
+        }
+        unreachable!("the retry loop returns on both the Ok and the second-attempt Err arm")
     }
 
     /// Evaluate JS in this frame's **main world** (page globals visible).
@@ -585,8 +617,18 @@ impl Frame {
         })
     }
 
-    /// Re-bind a rejected `frame_id` by finding this frame's current id in
-    /// the live `Page.getFrameTree`.
+    /// Find the frame id Chrome currently uses for this frame, by locating
+    /// it in the live `Page.getFrameTree`.
+    ///
+    /// Only the isolated-world cache is rebound by the result.
+    /// [`FrameInner::frame_id`] is immutable, so [`Frame::id`] keeps
+    /// returning the id Chrome rejected, and so does anything filtering on
+    /// it — notably [`Frame::wait_for_load`], whose
+    /// `Page.frameStoppedLoading` filter can then never match and always
+    /// burns its full timeout. `evaluate` / `find` recover because they
+    /// route through the cache; nothing that reads the id does. Making
+    /// `frame_id` interior-mutable would fix that too, and is a separate
+    /// change.
     ///
     /// A single child under the recorded parent is unambiguous. With
     /// several, the recorded `name` and `url` are the only things that tell
@@ -598,28 +640,14 @@ impl Frame {
     async fn discover_current_frame_id(&self) -> Result<String> {
         /// One candidate child frame, as reported by `Page.getFrameTree`.
         struct Child {
+            /// The live CDP `frameId` — what a successful recovery binds.
             id: String,
+            /// Chrome's reported frame name, absent when it sends none.
+            /// Compared against our own recorded name below.
             name: Option<String>,
+            /// Chrome's reported document URL, absent when it sends none.
+            /// Empty for a frame that has not navigated.
             url: Option<String>,
-        }
-        /// Depth-first collect of EVERY child of `parent` — all of them,
-        /// not just the first, since the count is what reveals ambiguity.
-        fn collect_children(node: &Value, parent: &str, out: &mut Vec<Child>) {
-            if let Some(children) = node["childFrames"].as_array() {
-                for c in children {
-                    let f = &c["frame"];
-                    if f["parentId"].as_str() == Some(parent) {
-                        if let Some(id) = f["id"].as_str() {
-                            out.push(Child {
-                                id: id.to_string(),
-                                name: f["name"].as_str().map(str::to_string),
-                                url: f["url"].as_str().map(str::to_string),
-                            });
-                        }
-                    }
-                    collect_children(c, parent, out);
-                }
-            }
         }
         /// The one candidate satisfying `pred`, or `None` when zero or
         /// several do — "several" must not resolve to "the first".
@@ -639,8 +667,22 @@ impl Frame {
             .session
             .call("Page.getFrameTree", json!({}))
             .await?;
+        // EVERY child of `parent`, not just the first — the count is what
+        // reveals ambiguity. The root is excluded because it is the tree's
+        // own frame rather than a child of anything in the tree; in an
+        // OOPIF's child-target tree that root can itself carry a
+        // `parentId`, so the depth check is not redundant with the
+        // comparison beside it.
         let mut candidates = Vec::new();
-        collect_children(&tree["frameTree"], parent, &mut candidates);
+        tree::walk(&tree["frameTree"], &mut |node| {
+            if node.depth > 0 && node.parent_id == Some(parent) {
+                candidates.push(Child {
+                    id: node.id.to_string(),
+                    name: node.name.map(str::to_string),
+                    url: node.url.map(str::to_string),
+                });
+            }
+        });
 
         if candidates.is_empty() {
             return Err(ZendriverError::FrameNotFound(format!(
@@ -727,6 +769,19 @@ mod tests {
     use super::*;
     use zendriver_transport::testing::MockConnection;
 
+    /// Wait for the driver's next `method` command and return its id.
+    ///
+    /// Always used in place of `MockConnection::expect_cmd` directly:
+    /// that method has no timeout of its own and silently discards frames
+    /// that do not match, so a command the driver never sends hangs the
+    /// test forever instead of failing it. A regression that removes a
+    /// round-trip should turn CI red, not wedge it.
+    async fn next_cmd(mock: &mut MockConnection, method: &str) -> u64 {
+        tokio::time::timeout(Duration::from_secs(2), mock.expect_cmd(method))
+            .await
+            .unwrap_or_else(|_| panic!("driver never sent {method} within 2s"))
+    }
+
     /// Build a synthetic `Frame` whose session sits on the supplied mock
     /// connection. Mirrors `Tab::new_for_test` ergonomics — no parent tab,
     /// no parent frame, fixed frameId / url, ready for evaluate dispatch.
@@ -758,12 +813,12 @@ mod tests {
             let f = frame.clone();
             async move { f.evaluate::<i32>("1").await }
         });
-        let id_world = mock.expect_cmd("Page.createIsolatedWorld").await;
+        let id_world = next_cmd(&mut mock, "Page.createIsolatedWorld").await;
         assert_eq!(mock.last_sent()["params"]["frameId"], "FRAME_A");
         assert_eq!(mock.last_sent()["params"]["worldName"], "zendriver-eval");
         mock.reply(id_world, json!({ "executionContextId": 7 }))
             .await;
-        let id_eval1 = mock.expect_cmd("Runtime.evaluate").await;
+        let id_eval1 = next_cmd(&mut mock, "Runtime.evaluate").await;
         assert_eq!(mock.last_sent()["params"]["contextId"], 7);
         assert_eq!(mock.last_sent()["params"]["expression"], "1");
         mock.reply(
@@ -780,7 +835,7 @@ mod tests {
             let f = frame.clone();
             async move { f.evaluate::<i32>("2").await }
         });
-        let id_eval2 = mock.expect_cmd("Runtime.evaluate").await;
+        let id_eval2 = next_cmd(&mut mock, "Runtime.evaluate").await;
         assert_eq!(mock.last_sent()["params"]["contextId"], 7);
         assert_eq!(mock.last_sent()["params"]["expression"], "2");
         mock.reply(
@@ -790,6 +845,81 @@ mod tests {
         .await;
         assert_eq!(fut2.await.unwrap().unwrap(), 2);
 
+        conn.shutdown();
+    }
+
+    /// A navigation inside the frame destroys the cached execution
+    /// context. `Frame::evaluate` must then do what `Tab::evaluate` does:
+    /// drop the dead `contextId`, create a fresh isolated world and retry
+    /// once, transparently.
+    ///
+    /// Without it a `Frame` handle is permanently broken by the first
+    /// navigation of its own iframe — `evaluate` returns the same error
+    /// forever, while the identical call on the tab recovers.
+    #[tokio::test]
+    async fn evaluate_recreates_the_isolated_world_after_a_stale_context() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let frame = frame_on(sess, "FRAME_C");
+
+        let fut = tokio::spawn({
+            let f = frame.clone();
+            async move { f.evaluate::<i32>("1").await }
+        });
+
+        let id_world = next_cmd(&mut mock, "Page.createIsolatedWorld").await;
+        mock.reply(id_world, json!({ "executionContextId": 7 }))
+            .await;
+        let id_eval = next_cmd(&mut mock, "Runtime.evaluate").await;
+        assert_eq!(mock.last_sent()["params"]["contextId"], 7);
+        // Chrome's answer once the context behind id 7 is gone.
+        mock.reply_err(id_eval, -32000, "Cannot find context with specified id")
+            .await;
+
+        // The retry: a NEW isolated world, then the same expression again.
+        let id_world2 = next_cmd(&mut mock, "Page.createIsolatedWorld").await;
+        mock.reply(id_world2, json!({ "executionContextId": 9 }))
+            .await;
+        let id_eval2 = next_cmd(&mut mock, "Runtime.evaluate").await;
+        assert_eq!(mock.last_sent()["params"]["contextId"], 9);
+        assert_eq!(mock.last_sent()["params"]["expression"], "1");
+        mock.reply(
+            id_eval2,
+            json!({ "result": { "value": 1, "type": "number" } }),
+        )
+        .await;
+
+        assert_eq!(fut.await.unwrap().unwrap(), 1);
+        conn.shutdown();
+    }
+
+    /// The retry is bounded at one. A context that is stale again on the
+    /// second attempt surfaces the error instead of looping.
+    #[tokio::test]
+    async fn evaluate_retries_a_stale_context_only_once() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let frame = frame_on(sess, "FRAME_D");
+
+        let fut = tokio::spawn({
+            let f = frame.clone();
+            async move { f.evaluate::<i32>("1").await }
+        });
+
+        for ctx in [7, 9] {
+            let id_world = next_cmd(&mut mock, "Page.createIsolatedWorld").await;
+            mock.reply(id_world, json!({ "executionContextId": ctx }))
+                .await;
+            let id_eval = next_cmd(&mut mock, "Runtime.evaluate").await;
+            mock.reply_err(id_eval, -32000, "Cannot find context with specified id")
+                .await;
+        }
+
+        let err = fut.await.unwrap().expect_err("second stale must surface");
+        assert!(
+            matches!(err, ZendriverError::Navigation(ref m) if m.contains("Cannot find context")),
+            "unexpected error: {err:?}",
+        );
         conn.shutdown();
     }
 
@@ -811,7 +941,7 @@ mod tests {
         // Next outbound frame is Runtime.evaluate itself — no isolated-world
         // bootstrap. `last_sent()` after `expect_cmd` confirms there is no
         // `contextId` field on the params.
-        let id = mock.expect_cmd("Runtime.evaluate").await;
+        let id = next_cmd(&mut mock, "Runtime.evaluate").await;
         assert_eq!(mock.last_sent()["params"]["expression"], "1+1");
         assert!(mock.last_sent()["params"].get("contextId").is_none());
         mock.reply(id, json!({ "result": { "value": 2, "type": "number" } }))
@@ -864,7 +994,7 @@ mod tests {
         // rather than the session's default — i.e. the parent tab's
         // main frame). Reply with a stub executionContextId so the
         // selector can attach it to the evaluate call below.
-        let id_iso = mock.expect_cmd("Page.createIsolatedWorld").await;
+        let id_iso = next_cmd(&mut mock, "Page.createIsolatedWorld").await;
         assert_eq!(mock.last_sent()["params"]["frameId"], "FRAME_FIND");
         mock.reply(id_iso, json!({ "executionContextId": 4242 }))
             .await;
@@ -872,7 +1002,7 @@ mod tests {
         // Next dispatch: Runtime.evaluate with the document.querySelectorAll
         // expression (resolve_css_many goes through the array path), now
         // pinned to the frame's isolated-world contextId.
-        let id_q = mock.expect_cmd("Runtime.evaluate").await;
+        let id_q = next_cmd(&mut mock, "Runtime.evaluate").await;
         assert_eq!(mock.last_sent()["params"]["contextId"], 4242);
         let sent = mock.last_sent()["params"]["expression"]
             .as_str()
@@ -889,7 +1019,7 @@ mod tests {
         .await;
 
         // Enumerate the array — one match at index 0.
-        let id_p = mock.expect_cmd("Runtime.getProperties").await;
+        let id_p = next_cmd(&mut mock, "Runtime.getProperties").await;
         assert_eq!(mock.last_sent()["params"]["objectId"], "RArrF");
         mock.reply(
             id_p,
@@ -909,7 +1039,7 @@ mod tests {
         .await;
 
         // describeNode resolves the backendNodeId for the picked element.
-        let id_d = mock.expect_cmd("DOM.describeNode").await;
+        let id_d = next_cmd(&mut mock, "DOM.describeNode").await;
         assert_eq!(mock.last_sent()["params"]["objectId"], "RFN0");
         mock.reply(id_d, json!({ "node": { "backendNodeId": 77 } }))
             .await;
@@ -937,10 +1067,10 @@ mod tests {
             async move { f.goto("https://example.com").await }
         });
 
-        let id_enable = mock.expect_cmd("Page.enable").await;
+        let id_enable = next_cmd(&mut mock, "Page.enable").await;
         mock.reply(id_enable, json!({})).await;
 
-        let id_nav = mock.expect_cmd("Page.navigate").await;
+        let id_nav = next_cmd(&mut mock, "Page.navigate").await;
         assert_eq!(mock.last_sent()["params"]["url"], "https://example.com");
         mock.reply(id_nav, json!({ "frameId": "FRAME_MAIN" })).await;
 
@@ -996,11 +1126,11 @@ mod tests {
     /// Drain the rejected first `Page.createIsolatedWorld` and answer the
     /// recovery `Page.getFrameTree` with `children` under `PARENT`.
     async fn reject_then_serve_tree(mock: &mut MockConnection, children: Value) {
-        let id_world = mock.expect_cmd("Page.createIsolatedWorld").await;
+        let id_world = next_cmd(mock, "Page.createIsolatedWorld").await;
         assert_eq!(mock.last_sent()["params"]["frameId"], "STALE");
         mock.reply_err(id_world, -32602, "No frame for given id found")
             .await;
-        let id_tree = mock.expect_cmd("Page.getFrameTree").await;
+        let id_tree = next_cmd(mock, "Page.getFrameTree").await;
         mock.reply(
             id_tree,
             json!({
@@ -1074,7 +1204,7 @@ mod tests {
         )
         .await;
 
-        let id_retry = mock.expect_cmd("Page.createIsolatedWorld").await;
+        let id_retry = next_cmd(&mut mock, "Page.createIsolatedWorld").await;
         assert_eq!(
             mock.last_sent()["params"]["frameId"],
             "F2",
@@ -1106,7 +1236,7 @@ mod tests {
         )
         .await;
 
-        let id_retry = mock.expect_cmd("Page.createIsolatedWorld").await;
+        let id_retry = next_cmd(&mut mock, "Page.createIsolatedWorld").await;
         assert_eq!(mock.last_sent()["params"]["frameId"], "F2");
         mock.reply(id_retry, json!({ "executionContextId": 5 }))
             .await;
@@ -1129,7 +1259,7 @@ mod tests {
         });
         reject_then_serve_tree(&mut mock, json!([tree_frame("LIVE", "", "")])).await;
 
-        let id_retry = mock.expect_cmd("Page.createIsolatedWorld").await;
+        let id_retry = next_cmd(&mut mock, "Page.createIsolatedWorld").await;
         assert_eq!(mock.last_sent()["params"]["frameId"], "LIVE");
         mock.reply(id_retry, json!({ "executionContextId": 3 }))
             .await;

--- a/crates/zendriver/src/frame/tree.rs
+++ b/crates/zendriver/src/frame/tree.rs
@@ -1,0 +1,134 @@
+//! One depth-first walk over a `Page.getFrameTree` reply — internal.
+//!
+//! Chrome answers `Page.getFrameTree` with a recursive
+//! `{ frame: {...}, childFrames: [ ... ] }` shape. Two callers traverse it
+//! for different reasons — [`crate::frame::lifecycle`] collects every live
+//! frame id to confirm a provisional sibling is gone, and
+//! `Frame::discover_current_frame_id` collects the children of one parent
+//! to re-bind a rejected frame id — and both encode the same protocol
+//! fact. It lives here once so a change to Chrome's shape has one place to
+//! land, and so the walk has one obvious place to hang a real-Chrome test.
+//!
+//! Depth is not bounded here. It does not need to be: `serde_json` rejects
+//! nesting past its own recursion limit while parsing the reply, so a
+//! hostile tree never reaches [`walk`].
+
+use serde_json::Value;
+
+/// The `frame` object at one node of the tree, projected to the fields
+/// this crate reads.
+///
+/// Borrowed from the reply rather than owned — a walk over a large tree
+/// allocates nothing, and callers copy only the fields they keep.
+pub(crate) struct FrameNode<'a> {
+    /// Distance below the walked root; `0` is the root itself. Lets a
+    /// caller exclude the tree's own frame, which is not a child of
+    /// anything in the tree.
+    pub(crate) depth: usize,
+    /// CDP `frameId`.
+    pub(crate) id: &'a str,
+    /// The `frameId` of this node's parent. Absent on the main frame.
+    pub(crate) parent_id: Option<&'a str>,
+    /// `<frame name>` / `<iframe name>` when Chrome reports one.
+    pub(crate) name: Option<&'a str>,
+    /// Committed document URL. Chrome reports `""` for a frame that has
+    /// been attached but has not navigated yet.
+    pub(crate) url: Option<&'a str>,
+}
+
+/// Visit every node of `root` depth-first, the root included.
+///
+/// `root` is the `frameTree` value of a `Page.getFrameTree` reply (i.e.
+/// `reply["frameTree"]`), or any `childFrames` entry, which has the same
+/// shape.
+///
+/// A node whose `frame.id` is missing or not a string is skipped — it
+/// carries nothing any caller can key on — but its `childFrames` are still
+/// descended into, so one malformed node cannot hide a live subtree.
+pub(crate) fn walk<'a>(root: &'a Value, visit: &mut impl FnMut(FrameNode<'a>)) {
+    walk_at(root, 0, visit);
+}
+
+fn walk_at<'a>(node: &'a Value, depth: usize, visit: &mut impl FnMut(FrameNode<'a>)) {
+    let frame = &node["frame"];
+    if let Some(id) = frame["id"].as_str() {
+        visit(FrameNode {
+            depth,
+            id,
+            parent_id: frame["parentId"].as_str(),
+            name: frame["name"].as_str(),
+            url: frame["url"].as_str(),
+        });
+    }
+    if let Some(children) = node["childFrames"].as_array() {
+        for child in children {
+            walk_at(child, depth + 1, visit);
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn tree() -> Value {
+        json!({
+            "frame": { "id": "ROOT", "url": "https://host.test/" },
+            "childFrames": [
+                {
+                    "frame": { "id": "A", "parentId": "ROOT", "url": "", "name": "sidebar" },
+                    "childFrames": [
+                        { "frame": { "id": "A1", "parentId": "A", "url": "https://host.test/a1" } }
+                    ],
+                },
+                { "frame": { "id": "B", "parentId": "ROOT", "url": "https://host.test/b" } },
+            ],
+        })
+    }
+
+    #[test]
+    fn walks_every_node_depth_first_including_the_root() {
+        let t = tree();
+        let mut seen = Vec::new();
+        walk(&t, &mut |n| seen.push((n.depth, n.id.to_string())));
+        assert_eq!(
+            seen,
+            vec![
+                (0, "ROOT".into()),
+                (1, "A".into()),
+                (2, "A1".into()),
+                (1, "B".into()),
+            ],
+        );
+    }
+
+    #[test]
+    fn projects_the_fields_callers_read() {
+        let t = tree();
+        let mut a = None;
+        walk(&t, &mut |n| {
+            if n.id == "A" {
+                a = Some((n.parent_id, n.name, n.url));
+            }
+        });
+        assert_eq!(a.unwrap(), (Some("ROOT"), Some("sidebar"), Some("")));
+    }
+
+    /// A node Chrome sent without a usable `frame.id` must not swallow its
+    /// children — the subtree below it is still real.
+    #[test]
+    fn a_node_without_an_id_is_skipped_but_still_descended_into() {
+        let t = json!({
+            "frame": { "id": "ROOT" },
+            "childFrames": [{
+                "frame": { "parentId": "ROOT" },
+                "childFrames": [{ "frame": { "id": "DEEP", "parentId": "?" } }],
+            }],
+        });
+        let mut seen = Vec::new();
+        walk(&t, &mut |n| seen.push(n.id.to_string()));
+        assert_eq!(seen, vec!["ROOT".to_string(), "DEEP".to_string()]);
+    }
+}

--- a/crates/zendriver/src/geo_resolver.rs
+++ b/crates/zendriver/src/geo_resolver.rs
@@ -166,23 +166,42 @@ impl GeoResolver for IpApiResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::log_capture::{CapturedLog, sole_warning, warnings, with_captured_logs};
+
+    /// Stand a mock endpoint up answering `status` with `body`, run a
+    /// default [`IpApiResolver`] against it, and return the resolution plus
+    /// everything logged while it ran.
+    ///
+    /// Every probe test needs the same four lines of wiremock scaffolding;
+    /// this is them, once.
+    async fn probe(status: u16, body: &str) -> (Option<ResolvedGeo>, Vec<CapturedLog>) {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(wiremock::ResponseTemplate::new(status).set_body_string(body))
+            .mount(&server)
+            .await;
+        let resolver = IpApiResolver::new().endpoint(server.uri());
+        with_captured_logs(async move { resolver.resolve().await }).await
+    }
+
+    fn country(cc: &str) -> Country {
+        Country::try_from(cc).expect("test country code must be valid")
+    }
 
     #[tokio::test]
     async fn resolves_country_from_ipapi_json() {
-        let server = wiremock::MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::method("GET"))
-            .respond_with(
-                wiremock::ResponseTemplate::new(200).set_body_string(r#"{"countryCode":"DE"}"#),
-            )
-            .mount(&server)
-            .await;
-        let r = IpApiResolver::new().endpoint(server.uri());
+        let (geo, logs) = probe(200, r#"{"countryCode":"DE"}"#).await;
         assert_eq!(
-            r.resolve().await,
+            geo,
             Some(ResolvedGeo {
-                country: Country::try_from("DE").unwrap(),
+                country: country("DE"),
                 timezone: None,
             })
+        );
+        assert!(
+            warnings(&logs).is_empty(),
+            "a probe that succeeded must warn about nothing: {:?}",
+            warnings(&logs),
         );
     }
 
@@ -190,19 +209,15 @@ mod tests {
     /// the EXACT probe timezone, not just the country.
     #[tokio::test]
     async fn resolves_exact_timezone_from_ipapi_json() {
-        let server = wiremock::MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::method("GET"))
-            .respond_with(
-                wiremock::ResponseTemplate::new(200)
-                    .set_body_string(r#"{"countryCode":"US","timezone":"America/Los_Angeles"}"#),
-            )
-            .mount(&server)
-            .await;
-        let r = IpApiResolver::new().endpoint(server.uri());
+        let (geo, _) = probe(
+            200,
+            r#"{"countryCode":"US","timezone":"America/Los_Angeles"}"#,
+        )
+        .await;
         assert_eq!(
-            r.resolve().await,
+            geo,
             Some(ResolvedGeo {
-                country: Country::try_from("US").unwrap(),
+                country: country("US"),
                 timezone: Some("America/Los_Angeles".to_string()),
             })
         );
@@ -213,67 +228,67 @@ mod tests {
     /// downstream), not an error.
     #[tokio::test]
     async fn missing_timezone_field_yields_none_timezone() {
-        let server = wiremock::MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::method("GET"))
-            .respond_with(
-                wiremock::ResponseTemplate::new(200).set_body_string(r#"{"countryCode":"US"}"#),
-            )
-            .mount(&server)
-            .await;
-        let r = IpApiResolver::new().endpoint(server.uri());
-        let resolved = r.resolve().await.unwrap();
-        assert_eq!(resolved.country, Country::try_from("US").unwrap());
+        let (geo, logs) = probe(200, r#"{"countryCode":"US"}"#).await;
+        let resolved = geo.expect("a country with no timezone is still a resolution");
+        assert_eq!(resolved.country, country("US"));
         assert_eq!(resolved.timezone, None);
+        assert!(
+            warnings(&logs).is_empty(),
+            "a missing timezone is not a failure: {:?}",
+            warnings(&logs),
+        );
     }
 
     /// Well-formed JSON that simply has no `countryCode` (ip-api answers
     /// `{"status":"fail",...}` for a reserved-range IP) is a probe FAILURE,
-    /// not geo data. It yields `None` — and, unlike before, says so in the
-    /// log rather than downgrading the persona in silence.
+    /// not geo data.
+    ///
+    /// It yielded `None` before this change too — the change is that it now
+    /// says so instead of downgrading the persona in silence, so the
+    /// warning is the only thing here worth asserting.
     #[tokio::test]
-    async fn missing_country_code_yields_none() {
-        let server = wiremock::MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::method("GET"))
-            .respond_with(
-                wiremock::ResponseTemplate::new(200)
-                    .set_body_string(r#"{"status":"fail","message":"reserved range"}"#),
-            )
-            .mount(&server)
-            .await;
-        assert_eq!(
-            IpApiResolver::new().endpoint(server.uri()).resolve().await,
-            None
+    async fn missing_country_code_warns_and_yields_none() {
+        let (geo, logs) = probe(200, r#"{"status":"fail","message":"reserved range"}"#).await;
+        assert_eq!(geo, None);
+        let warning = sole_warning(&logs);
+        assert!(
+            warning.contains("no string `countryCode` field"),
+            "unexpected warning: {warning}",
         );
     }
 
-    /// A non-2xx answer whose body is not JSON at all (a proxy's HTML error
-    /// page is the realistic case) is likewise a logged failure, not data.
+    /// A body that is not JSON at all is one failure with one cause,
+    /// whether it arrives as a 200 or as a proxy's 502 HTML error page:
+    /// same `resp.json()` code path, same warning. Both cases live here
+    /// rather than in two tests that differ only in bytes neither asserts
+    /// on.
     #[tokio::test]
-    async fn non_json_error_page_yields_none() {
-        let server = wiremock::MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::method("GET"))
-            .respond_with(
-                wiremock::ResponseTemplate::new(502)
-                    .set_body_string("<html><body>Bad Gateway</body></html>"),
-            )
-            .mount(&server)
-            .await;
-        assert_eq!(
-            IpApiResolver::new().endpoint(server.uri()).resolve().await,
-            None
-        );
+    async fn a_non_json_body_warns_and_yields_none() {
+        for (status, body) in [
+            (200, "nope"),
+            (502, "<html><body>Bad Gateway</body></html>"),
+        ] {
+            let (geo, logs) = probe(status, body).await;
+            assert_eq!(geo, None, "status {status}");
+            let warning = sole_warning(&logs);
+            assert!(
+                warning.contains("response body was not JSON"),
+                "status {status}: unexpected warning: {warning}",
+            );
+        }
     }
 
+    /// A `countryCode` that is not a two-letter code is a failure too, and
+    /// a distinct one — the body parsed, the field was there, the value was
+    /// junk. It must not be reported as a missing field.
     #[tokio::test]
-    async fn bad_body_yields_none() {
-        let server = wiremock::MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::method("GET"))
-            .respond_with(wiremock::ResponseTemplate::new(200).set_body_string("nope"))
-            .mount(&server)
-            .await;
-        assert_eq!(
-            IpApiResolver::new().endpoint(server.uri()).resolve().await,
-            None
+    async fn an_unparseable_country_code_warns_and_yields_none() {
+        let (geo, logs) = probe(200, r#"{"countryCode":"XYZ"}"#).await;
+        assert_eq!(geo, None);
+        let warning = sole_warning(&logs);
+        assert!(
+            warning.contains("unrecognized country code"),
+            "unexpected warning: {warning}",
         );
     }
 
@@ -304,10 +319,7 @@ mod tests {
         let r = IpApiResolver::new()
             .endpoint("http://geo-probe.invalid/json")
             .with_proxy(Some(proxy.uri()), Some(("bob".into(), "s3cret".into())));
-        assert_eq!(
-            r.resolve().await.map(|g| g.country),
-            Some(Country::try_from("DE").unwrap())
-        );
+        assert_eq!(r.resolve().await.map(|g| g.country), Some(country("DE")));
     }
 
     /// Without credentials, the mock (which requires `Proxy-Authorization`)
@@ -330,5 +342,29 @@ mod tests {
         // No `Proxy-Authorization` header sent -> mock doesn't match -> 404
         // from wiremock -> `.json()` fails -> `resolve()` yields `None`.
         assert_eq!(r.resolve().await, None);
+    }
+
+    /// A proxy URL reqwest cannot parse is a failure before any request is
+    /// made, and the warning must not carry the credentials that would have
+    /// gone with it.
+    #[tokio::test]
+    async fn a_bad_proxy_url_warns_without_leaking_credentials() {
+        let resolver = IpApiResolver::new()
+            .endpoint("http://geo-probe.invalid/json")
+            .with_proxy(
+                Some("not a url".into()),
+                Some(("bob".into(), "s3cret".into())),
+            );
+        let (geo, logs) = with_captured_logs(async move { resolver.resolve().await }).await;
+        assert_eq!(geo, None);
+        let warning = sole_warning(&logs);
+        assert!(
+            warning.contains("bad proxy"),
+            "unexpected warning: {warning}"
+        );
+        assert!(
+            !warning.contains("s3cret") && !warning.contains("bob"),
+            "proxy credentials must never reach the log: {warning}",
+        );
     }
 }

--- a/crates/zendriver/src/geo_resolver.rs
+++ b/crates/zendriver/src/geo_resolver.rs
@@ -109,7 +109,16 @@ impl GeoResolver for IpApiResolver {
                 }
             }
         }
-        let client = builder.build().ok()?;
+        // Every `None` below is a *failure*, not "this IP has no country" —
+        // the caller downgrades the persona either way, so each exit says
+        // which one it was.
+        let client = match builder.build() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(error = %e, "geo probe: HTTP client build failed; skipping");
+                return None;
+            }
+        };
         let resp = match client.get(&self.endpoint).send().await {
             Ok(r) => r,
             Err(e) => {
@@ -117,8 +126,27 @@ impl GeoResolver for IpApiResolver {
                 return None;
             }
         };
-        let body: serde_json::Value = resp.json().await.ok()?;
-        let cc = body.get("countryCode").and_then(|v| v.as_str())?;
+        let status = resp.status();
+        let body: serde_json::Value = match resp.json().await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    status = %status,
+                    endpoint = %self.endpoint,
+                    "geo probe: response body was not JSON"
+                );
+                return None;
+            }
+        };
+        let Some(cc) = body.get("countryCode").and_then(|v| v.as_str()) else {
+            tracing::warn!(
+                status = %status,
+                endpoint = %self.endpoint,
+                "geo probe: response has no string `countryCode` field"
+            );
+            return None;
+        };
         let country = match Country::try_from(cc) {
             Ok(c) => c,
             Err(_) => {
@@ -196,6 +224,44 @@ mod tests {
         let resolved = r.resolve().await.unwrap();
         assert_eq!(resolved.country, Country::try_from("US").unwrap());
         assert_eq!(resolved.timezone, None);
+    }
+
+    /// Well-formed JSON that simply has no `countryCode` (ip-api answers
+    /// `{"status":"fail",...}` for a reserved-range IP) is a probe FAILURE,
+    /// not geo data. It yields `None` — and, unlike before, says so in the
+    /// log rather than downgrading the persona in silence.
+    #[tokio::test]
+    async fn missing_country_code_yields_none() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_string(r#"{"status":"fail","message":"reserved range"}"#),
+            )
+            .mount(&server)
+            .await;
+        assert_eq!(
+            IpApiResolver::new().endpoint(server.uri()).resolve().await,
+            None
+        );
+    }
+
+    /// A non-2xx answer whose body is not JSON at all (a proxy's HTML error
+    /// page is the realistic case) is likewise a logged failure, not data.
+    #[tokio::test]
+    async fn non_json_error_page_yields_none() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(502)
+                    .set_body_string("<html><body>Bad Gateway</body></html>"),
+            )
+            .mount(&server)
+            .await;
+        assert_eq!(
+            IpApiResolver::new().endpoint(server.uri()).resolve().await,
+            None
+        );
     }
 
     #[tokio::test]

--- a/crates/zendriver/src/isolated_world.rs
+++ b/crates/zendriver/src/isolated_world.rs
@@ -1,8 +1,7 @@
 //! Per-frame isolated-world execution-context cache.
 //!
 //! Shared between [`crate::tab::Tab`] (main-frame eval) and
-//! [`crate::frame::Frame`] (per-frame eval). Holds the discovered main frame
-//! id (cached after the first `Page.getFrameTree` round-trip) and the
+//! [`crate::frame::Frame`] (per-frame eval). Holds the
 //! `executionContextId` returned by `Page.createIsolatedWorld` (cached
 //! after first use; invalidated when Chrome reports
 //! "Cannot find context with specified id", typically after a navigation
@@ -11,26 +10,28 @@
 //! Pre-P4 this lived as a private type inside `tab.rs`. P4 promotes it to
 //! a shared module so [`crate::frame::Frame`] can carry its own per-frame
 //! cache without duplicating the struct definition. The visibility stays
-//! `pub(crate)` — neither the cache nor its fields are part of the public
+//! `pub(crate)` — neither the cache nor its contents are part of the public
 //! API.
 
-/// Cache of the discovered main-frame id + the executionContextId for that
-/// frame's `zendriver-eval` isolated world.
+/// Cache of the `executionContextId` for one frame's `zendriver-eval`
+/// isolated world.
 ///
-/// Both fields start `None`; the first call to
-/// [`crate::tab::Tab::ensure_isolated_world`] populates them in one
-/// round-trip pair (`Page.getFrameTree` then `Page.createIsolatedWorld`).
-/// Subsequent calls short-circuit on the cached `context_id`.
+/// Starts `None`. [`crate::tab::Tab::ensure_isolated_world`] populates it
+/// with a `Page.getFrameTree` + `Page.createIsolatedWorld` pair;
+/// [`crate::frame::Frame::ensure_isolated_world`] already knows its own
+/// `frameId` and skips the first of those. Later calls short-circuit on the
+/// cached value.
 ///
 /// When [`crate::tab::Tab::evaluate`] or [`crate::frame::Frame::evaluate`]
 /// catches Chrome's `-32000 Cannot find context with specified id` error
-/// (see [`is_stale_context`]), it sets `context_id = None` (leaving
-/// `main_frame_id` intact since the frame is still around) and retries —
-/// the next `ensure_isolated_world` call re-runs `Page.createIsolatedWorld`
-/// only, skipping the `Page.getFrameTree` round-trip.
+/// (see [`is_stale_context`]), it sets `context_id = None` and retries, so
+/// the next `ensure_isolated_world` call runs that discovery again from
+/// scratch. The frame id is deliberately not cached alongside it: reusing
+/// one across the navigation that invalidated the context is how a stale
+/// `frameId` reaches `Page.createIsolatedWorld`, and the round-trip it
+/// would save is one per navigation.
 #[derive(Default, Debug)]
 pub(crate) struct IsolatedWorldCache {
-    pub(crate) main_frame_id: Option<String>,
     pub(crate) context_id: Option<i64>,
 }
 

--- a/crates/zendriver/src/isolated_world.rs
+++ b/crates/zendriver/src/isolated_world.rs
@@ -22,8 +22,9 @@
 /// round-trip pair (`Page.getFrameTree` then `Page.createIsolatedWorld`).
 /// Subsequent calls short-circuit on the cached `context_id`.
 ///
-/// When [`crate::tab::Tab::evaluate`] catches Chrome's `-32000 Cannot find
-/// context with specified id` error, it sets `context_id = None` (leaving
+/// When [`crate::tab::Tab::evaluate`] or [`crate::frame::Frame::evaluate`]
+/// catches Chrome's `-32000 Cannot find context with specified id` error
+/// (see [`is_stale_context`]), it sets `context_id = None` (leaving
 /// `main_frame_id` intact since the frame is still around) and retries —
 /// the next `ensure_isolated_world` call re-runs `Page.createIsolatedWorld`
 /// only, skipping the `Page.getFrameTree` round-trip.
@@ -31,4 +32,22 @@
 pub(crate) struct IsolatedWorldCache {
     pub(crate) main_frame_id: Option<String>,
     pub(crate) context_id: Option<i64>,
+}
+
+/// Whether `e` is Chrome telling us the `executionContextId` we cached no
+/// longer exists — the signal to drop `context_id` and retry once.
+///
+/// Chrome reports this as `-32000 Cannot find context with specified id`,
+/// but [`crate::error::ZendriverError`]'s `From<CallError>` maps `-32000`
+/// onto [`crate::error::ZendriverError::Navigation`], so the match is on
+/// that variant and not on `Cdp`.
+///
+/// Single source of truth on purpose: [`crate::tab::Tab::evaluate`] and
+/// [`crate::frame::Frame::evaluate`] both need it, and a magic string
+/// duplicated across two files is exactly the thing that drifts. (It did:
+/// `Frame::evaluate` had no retry at all until this was hoisted, so a
+/// navigated iframe's handle failed permanently while the tab-level call
+/// recovered transparently.)
+pub(crate) fn is_stale_context(e: &crate::error::ZendriverError) -> bool {
+    matches!(e, crate::error::ZendriverError::Navigation(m) if m.contains("Cannot find context"))
 }

--- a/crates/zendriver/src/lib.rs
+++ b/crates/zendriver/src/lib.rs
@@ -90,6 +90,9 @@ mod geo_resolver;
 pub mod input;
 pub(crate) mod io;
 pub(crate) mod isolated_world;
+/// Test-only helper for asserting on `tracing` output.
+#[cfg(test)]
+pub(crate) mod log_capture;
 #[cfg(feature = "monitor")]
 pub mod monitor;
 pub mod network_idle;

--- a/crates/zendriver/src/log_capture.rs
+++ b/crates/zendriver/src/log_capture.rs
@@ -1,0 +1,102 @@
+//! Capture `tracing` events emitted by the code under test — test-only.
+//!
+//! Some behaviour in this crate is observable *only* as a log line. A geo
+//! probe that fails returns `None` and tells the operator why; the `None`
+//! was already there before the telling was, so a test asserting on the
+//! return value alone stays green against code that logs nothing at all.
+//! That is precisely the shape of the two geo tests this module was added
+//! to repair: both passed against the unfixed `resolve()`.
+//!
+//! Asserting the warning is what makes such a test non-vacuous.
+
+// Today every consumer sits behind the `geo` feature, so a default-feature
+// test build legitimately uses none of this. Unused here means "no test in
+// this configuration needed it", not "nothing needs it".
+#![allow(dead_code)]
+
+use std::sync::{Arc, Mutex};
+
+use tracing::Level;
+use tracing::field::{Field, Visit};
+
+/// One captured event: its level, and its `message` field rendered.
+pub(crate) type CapturedLog = (Level, String);
+
+/// A `tracing_subscriber` layer recording every event that carries a
+/// `message` field into a shared buffer.
+#[derive(Clone, Default)]
+pub(crate) struct LogCapture(Arc<Mutex<Vec<CapturedLog>>>);
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for LogCapture {
+    fn on_event(&self, event: &tracing::Event<'_>, _: tracing_subscriber::layer::Context<'_, S>) {
+        let mut visitor = MessageVisitor(None);
+        event.record(&mut visitor);
+        if let Some(message) = visitor.0 {
+            // A poisoned buffer means some other thread panicked mid-push.
+            // There is nothing here worth recovering, and turning it into a
+            // second panic would bury the first one's message.
+            if let Ok(mut buf) = self.0.lock() {
+                buf.push((*event.metadata().level(), message));
+            }
+        }
+    }
+}
+
+/// Pulls out the `message` field. `tracing` records it as the `Debug` of a
+/// `format_args!`, whose `Debug` rendering is the plain text — no
+/// surrounding quotes, no escaping.
+struct MessageVisitor(Option<String>);
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.0 = Some(format!("{value:?}"));
+        }
+    }
+}
+
+/// Run `fut` with a capturing subscriber attached, returning its output
+/// alongside everything it logged.
+///
+/// Attached to the *future* rather than installed as a thread-local
+/// default, so it survives the executor moving the future across threads.
+pub(crate) async fn with_captured_logs<T>(fut: impl Future<Output = T>) -> (T, Vec<CapturedLog>) {
+    use tracing::instrument::WithSubscriber;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    let capture = LogCapture::default();
+    let subscriber = tracing_subscriber::registry().with(capture.clone());
+    let out = fut.with_subscriber(subscriber).await;
+    let logs = capture.0.lock().expect("log buffer poisoned").clone();
+    (out, logs)
+}
+
+/// Just the `WARN` messages.
+///
+/// Capture is deliberately unfiltered — a caller may want to assert on any
+/// level — but dependencies are chatty (hyper alone emits a dozen
+/// connection-pool traces per request), so anything asserting on *absence*
+/// has to say which level it means.
+pub(crate) fn warnings(logs: &[CapturedLog]) -> Vec<&str> {
+    logs.iter()
+        .filter(|(level, _)| *level == Level::WARN)
+        .map(|(_, message)| message.as_str())
+        .collect()
+}
+
+/// The message of the single `WARN` in `logs`, panicking unless there is
+/// exactly one.
+///
+/// Every failure exit these tests cover is meant to log exactly one
+/// reason. Zero means the operator gets silence; several means the test is
+/// not pinning down which one actually fired.
+#[track_caller]
+pub(crate) fn sole_warning(logs: &[CapturedLog]) -> &str {
+    let warnings = warnings(logs);
+    assert_eq!(
+        warnings.len(),
+        1,
+        "expected exactly one WARN, got {warnings:?}",
+    );
+    warnings[0]
+}

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -1115,15 +1115,11 @@ impl Tab {
                         .unwrap_or(Value::Null);
                     return serde_json::from_value(value).map_err(ZendriverError::Serde);
                 }
-                // Chrome returns -32000 "Cannot find context with specified
-                // id" when the execution context we cached was destroyed
-                // (typically by a navigation). `From<CallError>` maps that
-                // to `Navigation` (see `error.rs`), so we match on that
-                // variant here — not on `Cdp` as the original P2 plan
-                // suggested.
-                Err(ZendriverError::Navigation(ref m))
-                    if attempt == 0 && m.contains("Cannot find context") =>
-                {
+                // The execution context we cached was destroyed, typically
+                // by a navigation. Drop it and let `ensure_isolated_world`
+                // mint a new one. `Frame::evaluate` runs the same recovery
+                // off the same predicate so the two cannot drift.
+                Err(ref e) if attempt == 0 && crate::isolated_world::is_stale_context(e) => {
                     self.inner.isolated_world.lock().await.context_id = None;
                     continue;
                 }

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -1262,7 +1262,6 @@ impl Tab {
                 "Page.createIsolatedWorld did not return executionContextId".into(),
             )
         })?;
-        cache.main_frame_id = Some(frame_id);
         cache.context_id = Some(ctx_id);
         Ok(ctx_id)
     }

--- a/docs/book/src/faq.md
+++ b/docs/book/src/faq.md
@@ -223,6 +223,12 @@ special-cased. Wait for `wait_for_load()` / `wait_for_idle()` before
 the call, or use [`expect_response`](./expect.md) to pin the wait to
 the specific event you care about.
 
+`Tab::evaluate` and `Frame::evaluate` already recover from this on
+their own: they drop the dead execution context, create a fresh
+isolated world and retry once. Seeing the error surface from either of
+those means the context died twice in a row, which normally points at a
+page navigating in a loop rather than at a one-off race.
+
 [`ZendriverError::Navigation`]: https://docs.rs/zendriver/latest/zendriver/enum.ZendriverError.html#variant.Navigation
 
 ## `wait_for_idle` never returns on a page with a long-poll, SSE, or analytics-beacon request


### PR DESCRIPTION
- The lifecycle sweep evicted every same-parent URL-less sibling on each `frameAttached`. **No purely local predicate can separate a provisional from a legitimate un-navigated frame** — both produce the same event shape — so it now confirms against a live `Page.getFrameTree`, and fails open on any error: keeping a stale row is recoverable, dropping a live one loses a handle the caller holds.
- `frameNavigated` dropped the frame name.
- Frame id recovery picked the first depth-first match, so an ambiguous tree **returned the wrong iframe as `Ok`**.
- Geo probe failure downgraded the persona in total silence — a timeout over a slow proxy launched a US-English persona behind a German exit IP.
- `Browser::close` read every transport error as an acknowledged quit.

## Two review rounds since this PR opened

**Round 1** found the probe was awaited **inline in a `select!` arm**, parking the whole lifecycle loop for a measured 5.0s. The event source underneath is a 1024-slot broadcast that silently drops lagged frames, so the stall corrupted the frame registry rather than merely delaying it. It was moved to a spawned task with deferred eviction, ordered so the tree is always at least as recent as the candidate set, and each survivor re-validated by registry presence, `Arc::ptr_eq` against the sampled inner, and a `try_read` URL check. Every check fails open.

**Round 2 found that refactor had made two tests vacuous** — the loop's only HIGH findings, and both self-inflicted. The tests waited on `F2` appearing in the registry, but `F2` is inserted *synchronously in the attach arm, before the sweep is even spawned*, so they asserted against a snapshot taken before the sweep could act.

Deleting the live-tree containment check — **the entire point of the probe** — left all ten tests green. So did inverting the probe to fail *closed*, the exact opposite of the documented safety property. Both mutations now die on the specific test that covers them: `a sibling Chrome still lists in the frame tree must not be swept`, and `an unanswerable probe must not authorize an eviction`.

Round 2 also found the write-through stopgap's comment claimed it keeps `Frame::url()` live on a pre-rename handle. It repairs only the navigation carrying the rename; afterwards the handle freezes. Corrected, with the two-navigation case shipped as an `#[ignore]`d acceptance test pointing at the reserved API decision — **the ignore reason is verified, not assumed** (it reproduces `/cart` vs `/checkout`).

Two judgement calls worth knowing: `main_frame_id` was deleted (three writes, no reads — `derive(Debug)` was hiding it from the dead-code lint), and the `depth > 0` root exclusion was **deliberately kept** even though it breaks OOPIF recovery, because removing it only helps if our model of Chrome's child-target tree is right, and a wrong bind is worse than the `FrameNotFound` an OOPIF gets today.

## Verification

`fmt --check` clean · clippy clean on default **and** `--features geo` (which CI never lints) · **427 tests** with geo · Windows target checked locally for cfg-only breakage · no public API change.

`Frame::name()`/`id()` interior mutability stays reserved for a human; the ignored test is its acceptance criterion.

---
Split out of #145. Review records: `docs/review-records` branch. 🤖 Generated with [Claude Code](https://claude.com/claude-code)