### PR TITLE
fix(input): send buttons and modifiers, type whitespace, gate the real point

### DIFF
--- a/crates/zendriver/src/element/actions.rs
+++ b/crates/zendriver/src/element/actions.rs
@@ -119,8 +119,11 @@ pub struct ClickOptions {
     pub button: MouseButton,
     /// Modifier keys held during the dispatch. Empty by default.
     pub modifiers: KeyModifiers,
-    /// `clickCount` for the CDP dispatch. `1` by default; set `2` for a
-    /// double-click in a single `click_with` call.
+    /// Number of press/release pairs to emit. `1` by default; `2` sends the
+    /// two pairs carrying `clickCount` 1 then 2 that Chrome produces for a
+    /// real double-click, rather than one pair carrying `clickCount: 2`
+    /// (which a page counting `mousedown` events cannot distinguish from a
+    /// single click). `0` is treated as `1`.
     pub click_count: u32,
     /// Skip the actionability gate when true. Use sparingly — bypasses the
     /// visibility/stability/pointer checks. Mirrors Playwright's
@@ -231,9 +234,11 @@ impl Element {
             if !opts.force {
                 actionability::wait_actionable(
                     self,
-                    ActionabilityCheck::FULL,
+                    ActionabilityCheck {
+                        hit_point: opts.position,
+                        ..ActionabilityCheck::FULL
+                    },
                     DEFAULT_ACTIONABILITY_TIMEOUT,
-                    opts.position,
                 )
                 .await?;
             }
@@ -287,7 +292,6 @@ impl Element {
                 self,
                 ActionabilityCheck::FULL,
                 DEFAULT_ACTIONABILITY_TIMEOUT,
-                None,
             )
             .await?;
             let bbox = self
@@ -323,14 +327,8 @@ impl Element {
             self.scroll_into_view().await?;
             actionability::wait_actionable(
                 self,
-                ActionabilityCheck {
-                    visible: true,
-                    stable: true,
-                    enabled: false,
-                    receives_pointer: true,
-                },
+                ActionabilityCheck::HOVER,
                 DEFAULT_ACTIONABILITY_TIMEOUT,
-                None,
             )
             .await?;
             let bbox = self
@@ -368,14 +366,8 @@ impl Element {
             self.scroll_into_view().await?;
             actionability::wait_actionable(
                 self,
-                ActionabilityCheck {
-                    visible: true,
-                    stable: true,
-                    enabled: false,
-                    receives_pointer: true,
-                },
+                ActionabilityCheck::HOVER,
                 DEFAULT_ACTIONABILITY_TIMEOUT,
-                None,
             )
             .await?;
             let bbox = self
@@ -415,7 +407,6 @@ impl Element {
                 self,
                 ActionabilityCheck::TEXT_INPUT,
                 DEFAULT_ACTIONABILITY_TIMEOUT,
-                None,
             )
             .await?;
             let _ = self
@@ -586,9 +577,19 @@ impl Element {
     /// 1. [`Element::focus`] the element.
     /// 2. Select-all chord — `Cmd+A` on macOS, `Ctrl+A` elsewhere — so the
     ///    whole value is selected before deletion.
-    /// 3. Read the current `value.length`, then press
-    ///    [`SpecialKey::Backspace`] that many times plus a small slack
-    ///    ([`CLEAR_BY_DELETING_SLACK`]), bounded by [`CLEAR_BY_DELETING_MAX`].
+    /// 3. Read the current `value.length` to size a Backspace budget: that
+    ///    many presses plus a small slack ([`CLEAR_BY_DELETING_SLACK`]),
+    ///    bounded by [`CLEAR_BY_DELETING_MAX`].
+    /// 4. Press [`SpecialKey::Backspace`] up to that budget, re-reading
+    ///    `value.length` every [`PROBE_EVERY_N_BACKSPACES`] strokes and
+    ///    returning as soon as the field reports empty. The budget is a
+    ///    ceiling, not a keystroke count: a field the select-all chord
+    ///    already cleared costs 16 strokes and a probe, not `len + slack`.
+    ///
+    /// One consequence of trusting the field's own report: an element whose
+    /// `value` getter under-reports — a custom element backing its text with
+    /// a shadow-DOM node, say — can stop the loop early and leave the field
+    /// partly filled.
     ///
     /// Deletes backward (Backspace) only — never forward-Delete — because
     /// `VK_DELETE` at caret position 0 is treated as a backward delete on some
@@ -886,30 +887,9 @@ z-index:2147483647;pointer-events:none;opacity:0.85;'; \
 mod tests {
     use super::*;
     use crate::tab::Tab;
-    use crate::test_support::{expect, serve_gate_probes, serve_scroll_into_view};
+    use crate::test_support::{expect, js_params, serve_gate_probes, serve_scroll_into_view};
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
-
-    /// Parameter names of a `function(a, b, ...){ ... }` declaration, in order.
-    ///
-    /// `call_on_main` prepends the element handle to the argument list, so the
-    /// parameter at index `i` binds to `arguments[i]`. Asserting the parameter
-    /// list against the emitted arguments is what catches an off-by-one — a
-    /// body declared `function(v)` reads the *element* out of `arguments[0]`
-    /// while the caller's value sits unread at `arguments[1]`, and every
-    /// assertion about the arguments array alone still passes.
-    ///
-    /// The first `(`/`)` pair is the parameter list: parameter names can't
-    /// contain parentheses, so a body that does (`setTimeout(...)`) is safe.
-    fn js_params(decl: &str) -> Vec<&str> {
-        let open = decl.find('(').expect("declaration opens a param list");
-        let close = decl.find(')').expect("declaration closes its param list");
-        decl[open + 1..close]
-            .split(',')
-            .map(str::trim)
-            .filter(|p| !p.is_empty())
-            .collect()
-    }
 
     #[tokio::test]
     async fn hover_dispatches_input_dispatchmouseevent_with_type_mousemoved() {
@@ -942,7 +922,7 @@ mod tests {
         // Step 2: actionability gate — visible → stable → receives_pointer
         // (gate order is visible → enabled → stable → receives_pointer, and
         // hover doesn't require enabled).
-        serve_gate_probes(&mut mock, 3).await;
+        serve_gate_probes(&mut mock, ActionabilityCheck::HOVER).await;
 
         // Step 3: bounding_box → DOM.getBoxModel.
         let id = expect(&mut mock, "DOM.getBoxModel").await;
@@ -1021,7 +1001,7 @@ mod tests {
 
         // Step 2: actionability gate (FULL = visible → enabled → stable →
         // receives_pointer); reply true to each.
-        serve_gate_probes(&mut mock, 4).await;
+        serve_gate_probes(&mut mock, ActionabilityCheck::FULL).await;
 
         // Step 3: bounding_box → DOM.getBoxModel.
         let id = expect(&mut mock, "DOM.getBoxModel").await;
@@ -1113,7 +1093,7 @@ mod tests {
 
         // Step 2: actionability gate (FULL = visible → enabled → stable →
         // receives_pointer), matching `click`'s gate.
-        serve_gate_probes(&mut mock, 4).await;
+        serve_gate_probes(&mut mock, ActionabilityCheck::FULL).await;
 
         // Step 3: bounding_box → DOM.getBoxModel. Box top-left (10,20),
         // 100x50 ⇒ center (60, 45).
@@ -1294,7 +1274,7 @@ mod tests {
         // the visibility gate is a viewport check: a field under the fold
         // fails it outright without one.
         serve_scroll_into_view(&mut mock).await;
-        serve_gate_probes(&mut mock, 2).await;
+        serve_gate_probes(&mut mock, ActionabilityCheck::TEXT_INPUT).await;
         let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         assert!(
@@ -1313,7 +1293,7 @@ mod tests {
         // four dispatches: modifier keyDown → 'a' keyDown → 'a' keyUp →
         // modifier keyUp. Ctrl on Windows/Linux, Meta on macOS.
         serve_scroll_into_view(&mut mock).await;
-        serve_gate_probes(&mut mock, 2).await;
+        serve_gate_probes(&mut mock, ActionabilityCheck::TEXT_INPUT).await;
         let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
@@ -1374,7 +1354,7 @@ mod tests {
         for _ in 0..CLEAR_BY_DELETING_SLACK {
             // press(Backspace) focus: scroll + 2 gate probes + this.focus().
             serve_scroll_into_view(&mut mock).await;
-            serve_gate_probes(&mut mock, 2).await;
+            serve_gate_probes(&mut mock, ActionabilityCheck::TEXT_INPUT).await;
             let id = expect(&mut mock, "Runtime.callFunctionOn").await;
             mock.reply(id, json!({ "result": { "type": "undefined" } }))
                 .await;

--- a/crates/zendriver/src/element/actions.rs
+++ b/crates/zendriver/src/element/actions.rs
@@ -625,9 +625,11 @@ impl Element {
             // Re-probe the value periodically and stop as soon as it is empty
             // instead of always spending the full `len + slack` budget. Every
             // `press` is a CDP round-trip (and re-runs the focus gate), so on a
-            // field the select-all chord already cleared this turns thousands of
-            // round-trips into one probe. The cadence keeps the probe overhead
-            // proportional rather than doubling the round-trips on short fields.
+            // field the select-all chord already cleared this caps thousands of
+            // round-trips at `PROBE_EVERY_N_BACKSPACES` strokes plus one probe,
+            // matching what the rustdoc's step 4 promises. The cadence keeps the
+            // probe overhead proportional rather than doubling the round-trips
+            // on short fields.
             for i in 0..presses {
                 // Deliberately never probes within the first
                 // `PROBE_EVERY_N_BACKSPACES` strokes: `CLEAR_BY_DELETING_SLACK`

--- a/crates/zendriver/src/element/actions.rs
+++ b/crates/zendriver/src/element/actions.rs
@@ -19,9 +19,14 @@
 //!      `hover` uses a realistic Bezier path; `hover_fast` uses a single
 //!      teleport dispatch for test/automation paths.
 //!
-//! `focus`: actionability gate (visible + enabled — no pointer or stability
-//! requirement; focus routes through the focused element, not the cursor's
-//! position), then `el.focus()` in the main world.
+//! `focus`: `scroll_into_view`, then the actionability gate (visible +
+//! enabled — no pointer or stability requirement; focus routes through the
+//! focused element, not the cursor's position), then `el.focus()` in the main
+//! world. The scroll leads for the same reason it does under `hover` and
+//! `click`: the visibility check is a viewport intersection, so a field below
+//! the fold — the ordinary case for a sign-up or checkout form, and the whole
+//! typing surface (`type_text`, `press`, `type_keys`) focuses first — would
+//! otherwise fail the gate outright.
 //!
 //! `scroll_into_view`: no actionability gate (this *is* the visibility
 //! prereq other actions wait for). Calls `el.scrollIntoView({ block:
@@ -78,6 +83,13 @@ const CLEAR_BY_DELETING_SLACK: usize = 2;
 /// Bounds the keystroke loop so a pathological / lying `value.length` can't
 /// spin it unboundedly.
 const CLEAR_BY_DELETING_MAX: usize = 4096;
+
+/// How often [`Element::clear_by_deleting`] re-reads the field to see whether
+/// it is already empty. Each Backspace is a CDP round-trip, so probing lets the
+/// common case (the select-all chord cleared the whole value in one stroke)
+/// exit after a single extra read instead of spending the full budget; probing
+/// every stroke would double the round-trips on fields that do need them.
+const PROBE_EVERY_N_BACKSPACES: usize = 16;
 
 /// Per-call knobs for [`Element::click_with`].
 ///
@@ -221,6 +233,7 @@ impl Element {
                     self,
                     ActionabilityCheck::FULL,
                     DEFAULT_ACTIONABILITY_TIMEOUT,
+                    opts.position,
                 )
                 .await?;
             }
@@ -233,16 +246,7 @@ impl Element {
                 None => (bbox.x + bbox.width / 2.0, bbox.y + bbox.height / 2.0),
             };
             let input = self.inner.tab.input().clone();
-            mouse::click_at(
-                &input,
-                &self.inner.tab,
-                tx,
-                ty,
-                opts.button,
-                opts.click_count,
-                opts.realistic,
-            )
-            .await
+            mouse::click_at(&input, &self.inner.tab, tx, ty, &opts).await
         })
         .await
     }
@@ -283,6 +287,7 @@ impl Element {
                 self,
                 ActionabilityCheck::FULL,
                 DEFAULT_ACTIONABILITY_TIMEOUT,
+                None,
             )
             .await?;
             let bbox = self
@@ -325,6 +330,7 @@ impl Element {
                     receives_pointer: true,
                 },
                 DEFAULT_ACTIONABILITY_TIMEOUT,
+                None,
             )
             .await?;
             let bbox = self
@@ -334,7 +340,7 @@ impl Element {
             let cx = bbox.x + bbox.width / 2.0;
             let cy = bbox.y + bbox.height / 2.0;
             let input = self.inner.tab.input().clone();
-            mouse::move_realistic(&input, &self.inner.tab, cx, cy).await
+            mouse::move_realistic(&input, &self.inner.tab, cx, cy, KeyModifiers::empty()).await
         })
         .await
     }
@@ -369,6 +375,7 @@ impl Element {
                     receives_pointer: true,
                 },
                 DEFAULT_ACTIONABILITY_TIMEOUT,
+                None,
             )
             .await?;
             let bbox = self
@@ -378,7 +385,7 @@ impl Element {
             let cx = bbox.x + bbox.width / 2.0;
             let cy = bbox.y + bbox.height / 2.0;
             let input = self.inner.tab.input().clone();
-            mouse::move_raw(&input, &self.inner.tab, cx, cy).await
+            mouse::move_raw(&input, &self.inner.tab, cx, cy, KeyModifiers::empty()).await
         })
         .await
     }
@@ -403,10 +410,12 @@ impl Element {
     /// ```
     pub async fn focus(&self) -> Result<()> {
         self.with_refresh(|| async move {
+            self.scroll_into_view().await?;
             actionability::wait_actionable(
                 self,
                 ActionabilityCheck::TEXT_INPUT,
                 DEFAULT_ACTIONABILITY_TIMEOUT,
+                None,
             )
             .await?;
             let _ = self
@@ -551,9 +560,13 @@ impl Element {
         self.with_refresh(|| {
             let value = value.clone();
             async move {
+                // Leading `el` absorbs the element handle `call_on_main`
+                // prepends, so `v` binds to the caller's text (same shape as
+                // `NATIVE_VALUE_SETTER_JS`); the body reads the element off
+                // `this`, which `Runtime.callFunctionOn` binds to it.
                 let _ = self
                     .call_on_main(
-                        "function(v){ this.textContent = v; }",
+                        "function(el, v){ this.textContent = v; }",
                         json!([{ "value": value }]),
                     )
                     .await?;
@@ -604,24 +617,47 @@ impl Element {
             };
             self.press_with(Key::Char('a'), select_all).await?;
 
-            let len: usize = {
-                let res = self
-                    .call_on_main("function(){ return (this.value || '').length; }", json!([]))
-                    .await?;
-                res.get("value")
-                    .and_then(serde_json::Value::as_u64)
-                    .and_then(|n| usize::try_from(n).ok())
-                    .unwrap_or(0)
-            };
+            let len = self.value_len().await?;
             let presses = len
                 .saturating_add(CLEAR_BY_DELETING_SLACK)
                 .min(CLEAR_BY_DELETING_MAX);
-            for _ in 0..presses {
+            // Re-probe the value periodically and stop as soon as it is empty
+            // instead of always spending the full `len + slack` budget. Every
+            // `press` is a CDP round-trip (and re-runs the focus gate), so on a
+            // field the select-all chord already cleared this turns thousands of
+            // round-trips into one probe. The cadence keeps the probe overhead
+            // proportional rather than doubling the round-trips on short fields.
+            for i in 0..presses {
+                // Deliberately never probes within the first
+                // `PROBE_EVERY_N_BACKSPACES` strokes: `CLEAR_BY_DELETING_SLACK`
+                // exists precisely because `value.length` under-reports on
+                // off-by-one and IME-composition tails, so exiting early on a
+                // near-empty field would trust the number the slack is there to
+                // distrust. Long fields are where the budget actually hurts, and
+                // by stroke 16 a reported-empty field really is empty.
+                if i > 0 && i % PROBE_EVERY_N_BACKSPACES == 0 && self.value_len().await? == 0 {
+                    return Ok(());
+                }
                 self.press(Key::Special(SpecialKey::Backspace)).await?;
             }
             Ok(())
         })
         .await
+    }
+
+    /// Length of this element's `value`, or 0 if it has none.
+    ///
+    /// Used by [`Element::clear_by_deleting`] to size its Backspace budget and
+    /// then to detect early that the field is already empty.
+    async fn value_len(&self) -> Result<usize> {
+        let res = self
+            .call_on_main("function(){ return (this.value || '').length; }", json!([]))
+            .await?;
+        Ok(res
+            .get("value")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| usize::try_from(n).ok())
+            .unwrap_or(0))
     }
 
     /// Attach files to this `<input type="file">` element via
@@ -718,9 +754,11 @@ impl Element {
             let cy = bbox.y + bbox.height / 2.0;
             // Inject the dot in the main world with the element bound (house
             // pattern); the args carry the viewport-center coords + lifetime.
+            // Leading `el` absorbs the element handle `call_on_main` prepends,
+            // so `cx`/`cy`/`ms` line up with the args passed below.
             // The dot is `position:fixed` so the coords are viewport-relative,
             // matching `bounding_box`'s frame and `Tab::flash_point`.
-            let js = "function(cx, cy, ms){ \
+            let js = "function(el, cx, cy, ms){ \
                     const d = document.createElement('div'); \
                     d.style.cssText = 'position:fixed;left:'+cx+'px;top:'+cy+'px;\
 width:10px;height:10px;margin:-5px 0 0 -5px;border-radius:50%;background:red;\
@@ -848,8 +886,30 @@ z-index:2147483647;pointer-events:none;opacity:0.85;'; \
 mod tests {
     use super::*;
     use crate::tab::Tab;
+    use crate::test_support::{expect, serve_gate_probes, serve_scroll_into_view};
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
+
+    /// Parameter names of a `function(a, b, ...){ ... }` declaration, in order.
+    ///
+    /// `call_on_main` prepends the element handle to the argument list, so the
+    /// parameter at index `i` binds to `arguments[i]`. Asserting the parameter
+    /// list against the emitted arguments is what catches an off-by-one — a
+    /// body declared `function(v)` reads the *element* out of `arguments[0]`
+    /// while the caller's value sits unread at `arguments[1]`, and every
+    /// assertion about the arguments array alone still passes.
+    ///
+    /// The first `(`/`)` pair is the parameter list: parameter names can't
+    /// contain parentheses, so a body that does (`setTimeout(...)`) is safe.
+    fn js_params(decl: &str) -> Vec<&str> {
+        let open = decl.find('(').expect("declaration opens a param list");
+        let close = decl.find(')').expect("declaration closes its param list");
+        decl[open + 1..close]
+            .split(',')
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+            .collect()
+    }
 
     #[tokio::test]
     async fn hover_dispatches_input_dispatchmouseevent_with_type_mousemoved() {
@@ -868,7 +928,7 @@ mod tests {
         });
 
         // Step 1: scroll_into_view → Runtime.callFunctionOn.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         assert!(
             sent["params"]["functionDeclaration"]
@@ -879,31 +939,13 @@ mod tests {
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
-        // Step 2: actionability gate runs check_visible first.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-        mock.reply(
-            id,
-            json!({ "result": { "value": true, "type": "boolean" } }),
-        )
-        .await;
-        // check_stable (gate order: visible → enabled → stable → receives_pointer;
-        // enabled is disabled for hover, so stable is next).
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-        mock.reply(
-            id,
-            json!({ "result": { "value": true, "type": "boolean" } }),
-        )
-        .await;
-        // check_receives_pointer.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-        mock.reply(
-            id,
-            json!({ "result": { "value": true, "type": "boolean" } }),
-        )
-        .await;
+        // Step 2: actionability gate — visible → stable → receives_pointer
+        // (gate order is visible → enabled → stable → receives_pointer, and
+        // hover doesn't require enabled).
+        serve_gate_probes(&mut mock, 3).await;
 
         // Step 3: bounding_box → DOM.getBoxModel.
-        let id = mock.expect_cmd("DOM.getBoxModel").await;
+        let id = expect(&mut mock, "DOM.getBoxModel").await;
         mock.reply(
             id,
             json!({
@@ -973,23 +1015,16 @@ mod tests {
         });
 
         // Step 1: scroll_into_view → Runtime.callFunctionOn.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
         // Step 2: actionability gate (FULL = visible → enabled → stable →
         // receives_pointer); reply true to each.
-        for _ in 0..4 {
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-            mock.reply(
-                id,
-                json!({ "result": { "value": true, "type": "boolean" } }),
-            )
-            .await;
-        }
+        serve_gate_probes(&mut mock, 4).await;
 
         // Step 3: bounding_box → DOM.getBoxModel.
-        let id = mock.expect_cmd("DOM.getBoxModel").await;
+        let id = expect(&mut mock, "DOM.getBoxModel").await;
         mock.reply(
             id,
             json!({
@@ -1072,24 +1107,17 @@ mod tests {
         });
 
         // Step 1: scroll_into_view → Runtime.callFunctionOn.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
         // Step 2: actionability gate (FULL = visible → enabled → stable →
-        // receives_pointer); reply true to each, matching `click`'s gate.
-        for _ in 0..4 {
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-            mock.reply(
-                id,
-                json!({ "result": { "value": true, "type": "boolean" } }),
-            )
-            .await;
-        }
+        // receives_pointer), matching `click`'s gate.
+        serve_gate_probes(&mut mock, 4).await;
 
         // Step 3: bounding_box → DOM.getBoxModel. Box top-left (10,20),
         // 100x50 ⇒ center (60, 45).
-        let id = mock.expect_cmd("DOM.getBoxModel").await;
+        let id = expect(&mut mock, "DOM.getBoxModel").await;
         mock.reply(
             id,
             json!({
@@ -1106,7 +1134,7 @@ mod tests {
         .await;
 
         // Step 4: touchStart at the bbox center, then touchEnd empty.
-        let id = mock.expect_cmd("Input.dispatchTouchEvent").await;
+        let id = expect(&mut mock, "Input.dispatchTouchEvent").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["type"], "touchStart");
         let points = sent["params"]["touchPoints"].as_array().unwrap();
@@ -1115,7 +1143,7 @@ mod tests {
         assert_eq!(points[0]["y"], 45.0);
         mock.reply(id, json!({})).await;
 
-        let id = mock.expect_cmd("Input.dispatchTouchEvent").await;
+        let id = expect(&mut mock, "Input.dispatchTouchEvent").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["type"], "touchEnd");
         assert_eq!(sent["params"]["touchPoints"].as_array().unwrap().len(), 0);
@@ -1137,7 +1165,7 @@ mod tests {
             async move { e.set_value("hello world").await }
         });
 
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         let decl = sent["params"]["functionDeclaration"].as_str().unwrap();
         // Assign through the native prototype value-setter so React's
@@ -1157,6 +1185,14 @@ mod tests {
         assert_eq!(args.len(), 2);
         assert_eq!(args[0]["objectId"], "R1");
         assert_eq!(args[1]["value"], "hello world");
+        // ...and the JS reads it there: the leading parameter absorbs the
+        // prepended element handle so `v` binds to arguments[1]. `clear`
+        // shares this declaration, so this pins the shape for both.
+        assert_eq!(
+            js_params(decl),
+            vec!["el", "v"],
+            "value must land on the parameter the body assigns"
+        );
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
@@ -1176,7 +1212,7 @@ mod tests {
             async move { e.clear().await }
         });
 
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         let decl = sent["params"]["functionDeclaration"].as_str().unwrap();
         // `clear` routes through the same native-setter JS as `set_value`,
@@ -1187,11 +1223,14 @@ mod tests {
         assert!(decl.contains("HTMLInputElement"));
         assert!(decl.contains("'input'"));
         assert!(decl.contains("'change'"));
-        // The cleared value is the empty string, passed at arguments[1].
+        // The cleared value is the empty string, passed at arguments[1] — and
+        // read there, since the leading parameter absorbs the prepended
+        // element handle.
         let args = sent["params"]["arguments"].as_array().unwrap();
         assert_eq!(args.len(), 2);
         assert_eq!(args[0]["objectId"], "R1");
         assert_eq!(args[1]["value"], "");
+        assert_eq!(js_params(decl), vec!["el", "v"]);
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
@@ -1211,7 +1250,7 @@ mod tests {
             async move { e.set_text("New title").await }
         });
 
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         let decl = sent["params"]["functionDeclaration"].as_str().unwrap();
         // Faithful-simpler port of nodriver's DOM.setNodeValue: assign
@@ -1223,6 +1262,14 @@ mod tests {
         assert_eq!(args.len(), 2);
         assert_eq!(args[0]["objectId"], "R1");
         assert_eq!(args[1]["value"], "New title");
+        // The body must READ it at arguments[1] too. Without the leading `el`
+        // the assigned parameter binds to the element handle and the element's
+        // text becomes "[object HTMLDivElement]" instead of the caller's text.
+        assert_eq!(
+            js_params(decl),
+            vec!["el", "v"],
+            "assigned parameter must bind to the caller's text, not the element"
+        );
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
@@ -1242,17 +1289,13 @@ mod tests {
             async move { e.clear_by_deleting().await }
         });
 
-        // Step 1: explicit focus() — actionability gate (visible → enabled)
-        // then this.focus().
-        for _ in 0..2 {
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-            mock.reply(
-                id,
-                json!({ "result": { "value": true, "type": "boolean" } }),
-            )
-            .await;
-        }
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        // Step 1: explicit focus() — scroll_into_view, actionability gate
+        // (visible → enabled), then this.focus(). The scroll leads because
+        // the visibility gate is a viewport check: a field under the fold
+        // fails it outright without one.
+        serve_scroll_into_view(&mut mock).await;
+        serve_gate_probes(&mut mock, 2).await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         assert!(
             sent["params"]["functionDeclaration"]
@@ -1264,26 +1307,20 @@ mod tests {
             .await;
 
         // Step 2: select-all chord via press_with(Key::Char('a'), Ctrl|Meta).
-        // press_with focuses first (gate visible → enabled, then this.focus()),
-        // then emits the chord. Since A2 (full keyboard parity) press_with
+        // press_with focuses first (scroll, gate visible → enabled, then
+        // this.focus()), then emits the chord. Since A2 (full keyboard parity) press_with
         // dispatches the modifier as REAL wrapper key events, so the chord is
         // four dispatches: modifier keyDown → 'a' keyDown → 'a' keyUp →
         // modifier keyUp. Ctrl on Windows/Linux, Meta on macOS.
-        for _ in 0..2 {
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-            mock.reply(
-                id,
-                json!({ "result": { "value": true, "type": "boolean" } }),
-            )
-            .await;
-        }
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        serve_scroll_into_view(&mut mock).await;
+        serve_gate_probes(&mut mock, 2).await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
         let ctrl = i64::from(KeyModifiers::CTRL.cdp_bits());
         let meta = i64::from(KeyModifiers::META.cdp_bits());
         // 1: modifier keyDown (Meta or Control).
-        let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+        let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["type"], "keyDown");
         let mod_key = sent["params"]["key"].as_str().unwrap();
@@ -1293,7 +1330,7 @@ mod tests {
         );
         mock.reply(id, json!({})).await;
         // 2: 'a' keyDown with the modifier bit set.
-        let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+        let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["type"], "keyDown");
         assert_eq!(sent["params"]["key"], "a");
@@ -1304,11 +1341,11 @@ mod tests {
         );
         mock.reply(id, json!({})).await;
         // 3: 'a' keyUp.
-        let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+        let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
         assert_eq!(mock.last_sent()["params"]["type"], "keyUp");
         mock.reply(id, json!({})).await;
         // 4: modifier keyUp.
-        let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+        let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
         assert_eq!(mock.last_sent()["params"]["type"], "keyUp");
         mock.reply(id, json!({})).await;
 
@@ -1316,7 +1353,7 @@ mod tests {
         // so only the fixed slack-count of Backspaces follows — keeps the
         // remaining frame sequence deterministic regardless of the value the
         // page reports.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         assert!(
             sent["params"]["functionDeclaration"]
@@ -1329,26 +1366,20 @@ mod tests {
 
         // Step 4: with reported length 0 the impl still presses Backspace a
         // small fixed slack number of times so a near-empty field still gets
-        // a couple of deletes. Each press(Backspace) re-focuses (gate:
-        // visible → enabled, then this.focus()) then dispatches
+        // a couple of deletes. Each press(Backspace) re-focuses (scroll,
+        // gate: visible → enabled, then this.focus()) then dispatches
         // rawKeyDown + keyUp for the Backspace virtual key. The whole
         // sequence is deterministic; drive every frame explicitly.
         let mut saw_backspace = false;
         for _ in 0..CLEAR_BY_DELETING_SLACK {
-            // press(Backspace) focus: 2 gate calls + this.focus().
-            for _ in 0..2 {
-                let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-                mock.reply(
-                    id,
-                    json!({ "result": { "value": true, "type": "boolean" } }),
-                )
-                .await;
-            }
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+            // press(Backspace) focus: scroll + 2 gate probes + this.focus().
+            serve_scroll_into_view(&mut mock).await;
+            serve_gate_probes(&mut mock, 2).await;
+            let id = expect(&mut mock, "Runtime.callFunctionOn").await;
             mock.reply(id, json!({ "result": { "type": "undefined" } }))
                 .await;
             // rawKeyDown for Backspace (never forward Delete).
-            let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+            let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
             let sent = mock.last_sent();
             assert_eq!(sent["params"]["type"], "rawKeyDown");
             assert_eq!(sent["params"]["key"], "Backspace");
@@ -1356,7 +1387,7 @@ mod tests {
             saw_backspace = true;
             mock.reply(id, json!({})).await;
             // keyUp.
-            let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+            let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
             assert_eq!(mock.last_sent()["params"]["type"], "keyUp");
             mock.reply(id, json!({})).await;
         }
@@ -1385,7 +1416,7 @@ mod tests {
             async move { e.upload_files(&paths).await }
         });
 
-        let id = mock.expect_cmd("DOM.setFileInputFiles").await;
+        let id = expect(&mut mock, "DOM.setFileInputFiles").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["backendNodeId"], 42);
         let files = sent["params"]["files"].as_array().unwrap();
@@ -1411,7 +1442,7 @@ mod tests {
         });
 
         // Step 1: scroll_into_view → Runtime.callFunctionOn.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         assert!(
             mock.last_sent()["params"]["functionDeclaration"]
                 .as_str()
@@ -1423,7 +1454,7 @@ mod tests {
 
         // Step 2: bounding_box → DOM.getBoxModel. Box top-left (10,20), 100x50
         // ⇒ center (60, 45).
-        let id = mock.expect_cmd("DOM.getBoxModel").await;
+        let id = expect(&mut mock, "DOM.getBoxModel").await;
         mock.reply(
             id,
             json!({
@@ -1442,7 +1473,7 @@ mod tests {
         // Step 3: overlay injected via Runtime.callFunctionOn carrying the
         // dot-building JS (createElement + setTimeout/remove), with the
         // viewport-center coords + duration passed as arguments.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         let decl = sent["params"]["functionDeclaration"].as_str().unwrap();
         assert!(decl.contains("createElement"), "should build a dot element");
@@ -1452,10 +1483,19 @@ mod tests {
         );
         let args = sent["params"]["arguments"].as_array().unwrap();
         // call_on_main prepends the element {objectId}; then cx, cy, ms.
+        assert_eq!(args.len(), 4);
         assert_eq!(args[0]["objectId"], "R1");
         assert_eq!(args[1]["value"], 60.0); // center x
         assert_eq!(args[2]["value"], 45.0); // center y
         assert_eq!(args[3]["value"], 500); // duration ms
+        // Each coordinate must be read at the index it was sent. Without the
+        // leading `el` every parameter shifts by one: the dot is positioned
+        // at the stringified element, and `ms` reads undefined.
+        assert_eq!(
+            js_params(decl),
+            vec!["el", "cx", "cy", "ms"],
+            "coords/duration must bind to the parameters the body reads"
+        );
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
 
@@ -1476,11 +1516,11 @@ mod tests {
         });
 
         // Step 1: Overlay.enable (highlightNode is a no-op without it).
-        let id = mock.expect_cmd("Overlay.enable").await;
+        let id = expect(&mut mock, "Overlay.enable").await;
         mock.reply(id, json!({})).await;
 
         // Step 2: Overlay.highlightNode { backendNodeId, highlightConfig }.
-        let id = mock.expect_cmd("Overlay.highlightNode").await;
+        let id = expect(&mut mock, "Overlay.highlightNode").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["backendNodeId"], 42);
         assert!(
@@ -1506,7 +1546,7 @@ mod tests {
         });
 
         // Step 1: scroll_into_view → Runtime.callFunctionOn.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         assert!(
             mock.last_sent()["params"]["functionDeclaration"]
                 .as_str()
@@ -1518,7 +1558,7 @@ mod tests {
 
         // Step 2: bounding_box → DOM.getBoxModel. Box top-left (10,20), 100x50
         // ⇒ center (60, 45) = the drag source.
-        let id = mock.expect_cmd("DOM.getBoxModel").await;
+        let id = expect(&mut mock, "DOM.getBoxModel").await;
         mock.reply(
             id,
             json!({

--- a/crates/zendriver/src/element/input.rs
+++ b/crates/zendriver/src/element/input.rs
@@ -194,6 +194,7 @@ mod tests {
     use super::*;
     use crate::input::keyboard::SpecialKey;
     use crate::tab::Tab;
+    use crate::test_support::{expect, serve_gate_probes, serve_scroll_into_view};
     use serde_json::{Value, json};
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
@@ -213,18 +214,14 @@ mod tests {
             async move { e.type_text_fast("hi").await }
         });
 
-        // focus() runs the actionability gate first: visible → enabled.
+        // focus() scrolls the element into view first — the visibility gate
+        // below is a viewport check, so a field under the fold would fail it.
+        serve_scroll_into_view(&mut mock).await;
+        // focus() then runs the actionability gate: visible → enabled.
         // ActionabilityCheck::TEXT_INPUT skips stable + receives_pointer.
-        for _ in 0..2 {
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-            mock.reply(
-                id,
-                json!({ "result": { "value": true, "type": "boolean" } }),
-            )
-            .await;
-        }
+        serve_gate_probes(&mut mock, 2).await;
         // focus() then calls el.focus() — one more Runtime.callFunctionOn.
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
         assert!(
             sent["params"]["functionDeclaration"]
@@ -244,7 +241,7 @@ mod tests {
             ("i", "keyUp"),
         ];
         for (ch, kind) in expected {
-            let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+            let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
             let last = mock.last_sent();
             assert_eq!(last["params"]["text"].as_str().unwrap(), ch);
             assert_eq!(last["params"]["type"].as_str().unwrap(), kind);
@@ -255,18 +252,13 @@ mod tests {
         conn.shutdown();
     }
 
-    /// Drain the focus() actionability gate (visible → enabled) plus the
-    /// final `this.focus()` call, replying to each.
+    /// Drain the focus() sequence — `scroll_into_view`, the actionability
+    /// gate (visible → enabled), then the final `this.focus()` call —
+    /// replying to each.
     async fn drain_focus(mock: &mut MockConnection) {
-        for _ in 0..2 {
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-            mock.reply(
-                id,
-                json!({ "result": { "value": true, "type": "boolean" } }),
-            )
-            .await;
-        }
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
+        serve_scroll_into_view(mock).await;
+        serve_gate_probes(mock, 2).await;
+        let id = expect(mock, "Runtime.callFunctionOn").await;
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;
     }
@@ -295,7 +287,7 @@ mod tests {
             ("ControlLeft", "keyUp", 0),
         ];
         for (code, kind, mods) in expected {
-            let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+            let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
             let last = mock.last_sent();
             assert_eq!(last["params"]["code"].as_str().unwrap(), code);
             assert_eq!(last["params"]["type"].as_str().unwrap(), kind);
@@ -329,14 +321,15 @@ mod tests {
 
         drain_focus(&mut mock).await;
 
-        // "hi" → h/i down+up; Enter → rawKeyDown+keyUp; Ctrl+a → Control
-        // wrap around a. 10 dispatch events total.
+        // "hi" → h/i down+up; Enter → keyDown+keyUp (Enter inserts text, so
+        // it carries it like any printable key); Ctrl+a → Control wrap around
+        // a. 10 dispatch events total.
         let expected = [
             ("h", "keyDown"),
             ("h", "keyUp"),
             ("i", "keyDown"),
             ("i", "keyUp"),
-            ("Enter", "rawKeyDown"),
+            ("Enter", "keyDown"),
             ("Enter", "keyUp"),
             ("Control", "keyDown"),
             ("a", "keyDown"),
@@ -344,7 +337,7 @@ mod tests {
             ("Control", "keyUp"),
         ];
         for (key, kind) in expected {
-            let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+            let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
             let last = mock.last_sent();
             assert_eq!(last["params"]["key"].as_str().unwrap(), key);
             assert_eq!(last["params"]["type"].as_str().unwrap(), kind);
@@ -370,7 +363,7 @@ mod tests {
         drain_focus(&mut mock).await;
 
         // Emoji has no physical-key descriptor → one `char`-type event.
-        let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
+        let id = expect(&mut mock, "Input.dispatchKeyEvent").await;
         let last = mock.last_sent();
         assert_eq!(last["params"]["type"].as_str().unwrap(), "char");
         assert_eq!(last["params"]["text"].as_str().unwrap(), "🚀");

--- a/crates/zendriver/src/element/input.rs
+++ b/crates/zendriver/src/element/input.rs
@@ -193,6 +193,7 @@ async fn dispatch_key(tab: &crate::tab::Tab, key: Key, mods: KeyModifiers) -> Re
 mod tests {
     use super::*;
     use crate::input::keyboard::SpecialKey;
+    use crate::query::actionability::ActionabilityCheck;
     use crate::tab::Tab;
     use crate::test_support::{expect, serve_gate_probes, serve_scroll_into_view};
     use serde_json::{Value, json};
@@ -219,7 +220,7 @@ mod tests {
         serve_scroll_into_view(&mut mock).await;
         // focus() then runs the actionability gate: visible → enabled.
         // ActionabilityCheck::TEXT_INPUT skips stable + receives_pointer.
-        serve_gate_probes(&mut mock, 2).await;
+        serve_gate_probes(&mut mock, ActionabilityCheck::TEXT_INPUT).await;
         // focus() then calls el.focus() — one more Runtime.callFunctionOn.
         let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         let sent = mock.last_sent();
@@ -257,7 +258,7 @@ mod tests {
     /// replying to each.
     async fn drain_focus(mock: &mut MockConnection) {
         serve_scroll_into_view(mock).await;
-        serve_gate_probes(mock, 2).await;
+        serve_gate_probes(mock, ActionabilityCheck::TEXT_INPUT).await;
         let id = expect(mock, "Runtime.callFunctionOn").await;
         mock.reply(id, json!({ "result": { "type": "undefined" } }))
             .await;

--- a/crates/zendriver/src/element/screenshot.rs
+++ b/crates/zendriver/src/element/screenshot.rs
@@ -1,19 +1,28 @@
 //! [`Element::screenshot`] — element-scoped PNG capture.
 //!
-//! Dispatch sequence (with internal refresh-on-stale recovery):
-//!   1. Visibility gate — we need pixels to capture; overlay occlusion +
+//! Dispatch sequence (with internal refresh-on-stale recovery), matching the
+//! `scroll → gate → measure → dispatch` shape every action in
+//! [`mod@crate::element::actions`] uses:
+//!   1. [`Element::scroll_into_view`] — the clip in step 4 is
+//!      viewport-relative, so the element must be on-screen before it is
+//!      measured (and before the gate, which requires the same).
+//!   2. Visibility gate — we need pixels to capture; overlay occlusion +
 //!      disabled state are irrelevant here, so the gate is the lightest
 //!      preset.
-//!   2. [`Element::bounding_box`] — viewport-relative quad of the element.
-//!   3. `Page.captureScreenshot { format: "png", clip: { x, y, width,
-//!      height, scale: 1 } }` — crop to the element's bbox at native scale.
-//!   4. base64-decode the `data` field into raw PNG bytes.
+//!   3. [`Element::bounding_box`] — viewport-relative quad of the element.
+//!   4. `Page.getLayoutMetrics` — the visual viewport's page offset, added
+//!      to that quad. `Page.captureScreenshot` reads `clip` in document
+//!      coordinates, so a viewport-relative rect would crop the wrong band
+//!      of a scrolled page.
+//!   5. `Page.captureScreenshot { format: "png", clip: { x, y, width,
+//!      height, scale: 1 } }` — crop to the element's rect at native scale.
+//!   6. base64-decode the `data` field into raw PNG bytes.
 
 use std::time::Duration;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use serde_json::json;
+use serde_json::{Value, json};
 
 use crate::element::Element;
 use crate::error::{Result, ZendriverError};
@@ -27,10 +36,16 @@ const DEFAULT_ACTIONABILITY_TIMEOUT: Duration = Duration::from_secs(5);
 impl Element {
     /// Capture a PNG screenshot cropped to this element's bounding box.
     ///
-    /// Waits up to 5 s for the element to become visible, reads its
-    /// viewport-relative bbox via `DOM.getBoxModel`, then sends
+    /// Scrolls the element into view, waits up to 5 s for it to become
+    /// visible, reads its bbox via `DOM.getBoxModel`, converts that to
+    /// document coordinates with `Page.getLayoutMetrics`, then sends
     /// `Page.captureScreenshot` with a matching `clip` rect (at `scale: 1`).
     /// Returns the raw PNG bytes.
+    ///
+    /// The scroll leads because an off-screen element is neither rendered nor
+    /// judged visible by the gate; the coordinate conversion follows because
+    /// Chrome reads the clip in document space while the box model is
+    /// viewport-relative.
     ///
     /// For full-viewport captures, see [`crate::Tab::screenshot`].
     ///
@@ -54,16 +69,46 @@ impl Element {
     /// ```
     pub async fn screenshot(&self) -> Result<Vec<u8>> {
         self.with_refresh(|| async move {
+            // Scroll first, exactly as every action in `element::actions`
+            // does. Two reasons: the clip below is viewport-relative, so an
+            // element measured while off-screen is cropped from the wrong
+            // place; and the visibility predicate itself requires the element
+            // to overlap the viewport, so gating before the scroll would
+            // reject every below-the-fold element.
+            self.scroll_into_view().await?;
             actionability::wait_actionable(
                 self,
                 ActionabilityCheck::VISIBLE_ONLY,
                 DEFAULT_ACTIONABILITY_TIMEOUT,
+                None,
             )
             .await?;
             let bbox = self
                 .bounding_box()
                 .await?
                 .ok_or_else(|| ZendriverError::Navigation("element has no bounding box".into()))?;
+
+            // Chrome reads `clip` in DOCUMENT coordinates while
+            // `bounding_box` is viewport-relative, so the scroll offset has
+            // to be added back or a scrolled page gets cropped from the wrong
+            // region entirely. The offset comes from CDP rather than
+            // `window.scrollX` — one less page-controlled input on a path a
+            // page would happily lie to.
+            let metrics = self
+                .inner
+                .tab
+                .call("Page.getLayoutMetrics", json!({}))
+                .await?;
+            let viewport = metrics.get("cssVisualViewport");
+            let page_x = viewport
+                .and_then(|v| v.get("pageX"))
+                .and_then(Value::as_f64)
+                .unwrap_or(0.0);
+            let page_y = viewport
+                .and_then(|v| v.get("pageY"))
+                .and_then(Value::as_f64)
+                .unwrap_or(0.0);
+
             let res = self
                 .inner
                 .tab
@@ -72,8 +117,8 @@ impl Element {
                     json!({
                         "format": "png",
                         "clip": {
-                            "x": bbox.x,
-                            "y": bbox.y,
+                            "x": bbox.x + page_x,
+                            "y": bbox.y + page_y,
                             "width": bbox.width,
                             "height": bbox.height,
                             "scale": 1,
@@ -97,6 +142,7 @@ impl Element {
 mod tests {
     use super::*;
     use crate::tab::Tab;
+    use crate::test_support::{expect, serve_call_js};
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
 
@@ -112,25 +158,33 @@ mod tests {
             async move { e.screenshot().await }
         });
 
-        // Step 1: actionability gate (VISIBLE_ONLY = only check_visible).
-        let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-        let sent = mock.last_sent();
-        // Sanity-check we're calling the visibility predicate, not some
-        // other JS thunk.
+        // Step 1: scroll_into_view — MUST land before both the gate and the
+        // measurement, or an off-screen element is rejected as "not visible"
+        // and, past that, clipped from stale coordinates.
+        let id = expect(&mut mock, "Runtime.callFunctionOn").await;
         assert!(
-            sent["params"]["functionDeclaration"]
+            mock.last_sent()["params"]["functionDeclaration"]
                 .as_str()
                 .unwrap()
-                .contains("offsetParent")
+                .contains("scrollIntoView"),
+            "the scroll must be dispatched before the gate and DOM.getBoxModel",
         );
-        mock.reply(
-            id,
-            json!({ "result": { "value": true, "type": "boolean" } }),
-        )
-        .await;
+        mock.reply(id, json!({ "result": { "type": "undefined" } }))
+            .await;
 
-        // Step 2: bounding_box → DOM.getBoxModel.
-        let id = mock.expect_cmd("DOM.getBoxModel").await;
+        // Step 2: actionability gate (VISIBLE_ONLY = only check_visible).
+        //
+        // The predicate is asserted by what it is NOT: its JS is owned by
+        // `query::actionability` and gets rewritten there, but "the gate is
+        // not the scroll" is the property this test needs.
+        let gate_js = serve_call_js(&mut mock, json!({ "value": true, "type": "boolean" })).await;
+        assert!(
+            gate_js.contains("getBoundingClientRect") && !gate_js.contains("scrollIntoView"),
+            "expected the visibility predicate after the scroll, got: {gate_js}",
+        );
+
+        // Step 3: bounding_box → DOM.getBoxModel.
+        let id = expect(&mut mock, "DOM.getBoxModel").await;
         mock.reply(
             id,
             json!({
@@ -146,13 +200,30 @@ mod tests {
         )
         .await;
 
-        // Step 3: Page.captureScreenshot with clip { x=10, y=20, w=100, h=50, scale=1 }.
-        let id = mock.expect_cmd("Page.captureScreenshot").await;
+        // Step 4: the scroll offset that turns the viewport-relative box into
+        // the document-relative rect Chrome's clip actually wants.
+        let id = expect(&mut mock, "Page.getLayoutMetrics").await;
+        mock.reply(
+            id,
+            json!({
+                "cssVisualViewport": { "pageX": 5.0, "pageY": 3000.0, "clientWidth": 800,
+                                        "clientHeight": 600, "offsetX": 0, "offsetY": 0,
+                                        "scale": 1, "zoom": 1 },
+            }),
+        )
+        .await;
+
+        // Step 5: Page.captureScreenshot, clip offset into document space:
+        // x = 10 + 5, y = 20 + 3000.
+        let id = expect(&mut mock, "Page.captureScreenshot").await;
         let sent = mock.last_sent();
         assert_eq!(sent["params"]["format"], "png");
         let clip = &sent["params"]["clip"];
-        assert_eq!(clip["x"], 10.0);
-        assert_eq!(clip["y"], 20.0);
+        assert_eq!(clip["x"], 15.0);
+        assert_eq!(
+            clip["y"], 3020.0,
+            "the clip must be in document coordinates, not viewport ones",
+        );
         assert_eq!(clip["width"], 100.0);
         assert_eq!(clip["height"], 50.0);
         assert_eq!(clip["scale"], 1);

--- a/crates/zendriver/src/element/screenshot.rs
+++ b/crates/zendriver/src/element/screenshot.rs
@@ -3,9 +3,11 @@
 //! Dispatch sequence (with internal refresh-on-stale recovery), matching the
 //! `scroll → gate → measure → dispatch` shape every action in
 //! [`mod@crate::element::actions`] uses:
-//!   1. [`Element::scroll_into_view`] — the clip in step 4 is
-//!      viewport-relative, so the element must be on-screen before it is
-//!      measured (and before the gate, which requires the same).
+//!   1. [`Element::scroll_into_view`] — the visibility gate in step 2
+//!      requires the element to overlap the viewport, so a below-the-fold
+//!      element has to be scrolled to before it can be gated. The clip in
+//!      step 4 does *not* need the scroll: it is document-relative and the
+//!      conversion there is correct wherever the element sits.
 //!   2. Visibility gate — we need pixels to capture; overlay occlusion +
 //!      disabled state are irrelevant here, so the gate is the lightest
 //!      preset.
@@ -42,10 +44,10 @@ impl Element {
     /// `Page.captureScreenshot` with a matching `clip` rect (at `scale: 1`).
     /// Returns the raw PNG bytes.
     ///
-    /// The scroll leads because an off-screen element is neither rendered nor
-    /// judged visible by the gate; the coordinate conversion follows because
-    /// Chrome reads the clip in document space while the box model is
-    /// viewport-relative.
+    /// The scroll leads because the gate requires the element to overlap the
+    /// viewport; the coordinate conversion follows because Chrome reads the
+    /// clip in document space while the box model is viewport-relative. The
+    /// two are independent — the conversion is correct at any scroll offset.
     ///
     /// For full-viewport captures, see [`crate::Tab::screenshot`].
     ///
@@ -70,17 +72,16 @@ impl Element {
     pub async fn screenshot(&self) -> Result<Vec<u8>> {
         self.with_refresh(|| async move {
             // Scroll first, exactly as every action in `element::actions`
-            // does. Two reasons: the clip below is viewport-relative, so an
-            // element measured while off-screen is cropped from the wrong
-            // place; and the visibility predicate itself requires the element
-            // to overlap the viewport, so gating before the scroll would
-            // reject every below-the-fold element.
+            // does, and for one reason: the visibility predicate requires the
+            // element to overlap the viewport, so gating before the scroll
+            // would reject every below-the-fold element. It is NOT for the
+            // clip — see the conversion below, which is correct at any scroll
+            // offset.
             self.scroll_into_view().await?;
             actionability::wait_actionable(
                 self,
                 ActionabilityCheck::VISIBLE_ONLY,
                 DEFAULT_ACTIONABILITY_TIMEOUT,
-                None,
             )
             .await?;
             let bbox = self
@@ -100,14 +101,27 @@ impl Element {
                 .call("Page.getLayoutMetrics", json!({}))
                 .await?;
             let viewport = metrics.get("cssVisualViewport");
-            let page_x = viewport
-                .and_then(|v| v.get("pageX"))
-                .and_then(Value::as_f64)
-                .unwrap_or(0.0);
-            let page_y = viewport
-                .and_then(|v| v.get("pageY"))
-                .and_then(Value::as_f64)
-                .unwrap_or(0.0);
+            let offset = |axis: &str| viewport.and_then(|v| v.get(axis)).and_then(Value::as_f64);
+            let (page_x, page_y) = match (offset("pageX"), offset("pageY")) {
+                (Some(x), Some(y)) => (x, y),
+                _ => {
+                    // Falling back to (0, 0) reverts the clip to viewport
+                    // coordinates — precisely the bug this conversion exists
+                    // to fix — and the symptom is a screenshot cropped from
+                    // the wrong band of the page, which reads as a product
+                    // bug with nothing in the logs pointing here. Not
+                    // reachable on any browser this crate supports
+                    // (`cssVisualViewport` long predates the Chrome 121 floor
+                    // the visibility gate imposes), so this is a tripwire
+                    // rather than a handled case.
+                    tracing::warn!(
+                        "Page.getLayoutMetrics returned no cssVisualViewport page offset; \
+                         the screenshot clip falls back to viewport coordinates and will be \
+                         cropped from the wrong region on a scrolled page"
+                    );
+                    (0.0, 0.0)
+                }
+            };
 
             let res = self
                 .inner

--- a/crates/zendriver/src/input/keyboard.rs
+++ b/crates/zendriver/src/input/keyboard.rs
@@ -28,7 +28,12 @@ pub enum Key {
 ///
 /// Most of these insert nothing — pressing them runs a default action, or
 /// nothing at all. `Space` and `Enter` are the exceptions: they are printable
-/// keys that happen to have names, and they type `" "` and a newline.
+/// keys that happen to have names. `Space` types `" "`. `Enter` inserts a
+/// newline in a `<textarea>` or a contenteditable; in a single-line `<input>`
+/// it inserts nothing and only triggers implicit form submission.
+///
+/// Holding Ctrl, Alt or Meta suppresses the insertion for both — the chord
+/// routes to a shortcut instead, exactly as on a physical keyboard.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SpecialKey {
     /// Return / Enter.
@@ -475,6 +480,26 @@ fn special_text(k: SpecialKey) -> Option<&'static str> {
     }
 }
 
+/// `true` when a held modifier means this chord inserts no character.
+///
+/// Blink generates a character for Shift+key (that is what makes a capital)
+/// but not for Ctrl/Alt/Meta+key, which route to a shortcut instead. Chrome
+/// enforces this itself — verified against Chrome 151, Ctrl+Enter carrying
+/// `text: "\r"` left a `<textarea>` unchanged while the page's keydown
+/// handler still saw `{key: "Enter", ctrlKey: true}` — so dropping the field
+/// changes no observable behavior. It matches what Puppeteer puts on the
+/// wire, which is the shape anything fingerprinting the CDP stream is
+/// calibrated against.
+///
+/// Deliberately separate from the printable/non-printable question that
+/// picks the event type. Folding the two together would send Ctrl+Enter as
+/// `rawKeyDown`, and [`special_text`] documents what that costs: ~1.1s for
+/// the first such dispatch per renderer and a dead browser process on the
+/// second. The key is still printable; this chord just does not print.
+fn modifiers_suppress_text(mods: KeyModifiers) -> bool {
+    !mods.difference(KeyModifiers::SHIFT).is_empty()
+}
+
 /// Build the ordered CDP key-event payloads for a single [`Key`] press.
 ///
 /// - `KeyPress::Char`, or a `Key::Char` whose [`char_descriptor`] is `None`
@@ -513,7 +538,11 @@ pub(crate) fn key_events(key: Key, mods: KeyModifiers, kind: KeyPress) -> Vec<Ke
         let main_down = KeyEventPayload {
             event_type: "keyDown",
             modifiers: effective.cdp_bits(),
-            text: Some(c.to_string()),
+            text: if modifiers_suppress_text(effective) {
+                None
+            } else {
+                Some(c.to_string())
+            },
             key: Some(c.to_string()),
             code: Some(d.code),
             windows_vk: Some(d.windows_vk),
@@ -530,11 +559,17 @@ pub(crate) fn key_events(key: Key, mods: KeyModifiers, kind: KeyPress) -> Vec<Ke
         unreachable!("Key::Char handled above");
     };
     if force_char {
-        // char-event for a special key: the text it inserts if it is one of
-        // the printable ones, else its CDP `key` string. Rarely used, but
-        // keep the contract total.
         let (_, key_str, _) = k.to_cdp();
-        let text = special_text(k).unwrap_or(key_str);
+        // A `char` event IS a text insertion, so a special that inserts
+        // nothing has no char event to send. The predecessor fell back to the
+        // key's CDP name, which types the literal string "Tab" / "F5" /
+        // "Escape" into the focused field — a wrong total answer where an
+        // empty one was available. Unreachable from any public API today:
+        // `KeyPress::Char` has no non-test constructor (see its doc), and the
+        // emoji fallback `type_text` uses builds its payload directly.
+        let Some(text) = special_text(k) else {
+            return Vec::new();
+        };
         return vec![KeyEventPayload {
             event_type: "char",
             modifiers: mods.cdp_bits(),
@@ -546,16 +581,21 @@ pub(crate) fn key_events(key: Key, mods: KeyModifiers, kind: KeyPress) -> Vec<Ke
     }
     let (code, key_str, vk) = k.to_cdp();
     // A key that inserts text must say so, and `rawKeyDown` means precisely
-    // "generate no character" — see [`special_text`].
-    let text = special_text(k);
+    // "generate no character" — see [`special_text`]. That is a property of
+    // the KEY, so it decides the event type on its own; whether this
+    // particular chord actually prints is the separate question
+    // `modifiers_suppress_text` answers, and it only clears the `text` field.
+    let prints = special_text(k);
     let main_down = KeyEventPayload {
-        event_type: if text.is_some() {
+        event_type: if prints.is_some() {
             "keyDown"
         } else {
             "rawKeyDown"
         },
         modifiers: mods.cdp_bits(),
-        text: text.map(str::to_string),
+        text: prints
+            .filter(|_| !modifiers_suppress_text(mods))
+            .map(str::to_string),
         key: Some(key_str.to_string()),
         code: Some(code),
         windows_vk: Some(vk),
@@ -1183,6 +1223,116 @@ mod tests {
         // Chrome turns the carriage return into a newline in a textarea, and
         // it is what triggers implicit form submission in an input.
         assert_eq!(events[0].text.as_deref(), Some("\r"));
+    }
+
+    /// A non-Shift modifier means the chord runs a shortcut instead of
+    /// printing, so `text` must not ride along — but the *key* is still
+    /// printable, so the event type must stay `keyDown`.
+    ///
+    /// The second half is the load-bearing one. Deriving the event type from
+    /// "did we send text this time" instead of "is this key printable" turns
+    /// Ctrl+Enter into a `rawKeyDown`, which `special_text`'s doc records as
+    /// ~1.1s for the first such dispatch per renderer and a dead browser
+    /// process on the second.
+    #[test]
+    fn special_key_with_a_non_shift_modifier_sends_no_text_but_still_keydown() {
+        for (k, code) in [(SpecialKey::Enter, "Enter"), (SpecialKey::Space, "Space")] {
+            for mods in [
+                KeyModifiers::CTRL,
+                KeyModifiers::ALT,
+                KeyModifiers::META,
+                KeyModifiers::CTRL | KeyModifiers::SHIFT,
+            ] {
+                let events = key_events(Key::Special(k), mods, KeyPress::DownAndUp);
+                let main = events
+                    .iter()
+                    .find(|e| e.code == Some(code))
+                    .unwrap_or_else(|| panic!("no {code} event for {mods:?}"));
+                assert_eq!(
+                    main.event_type, "keyDown",
+                    "{code} is printable, so it must never be dispatched as rawKeyDown ({mods:?})"
+                );
+                assert!(
+                    main.text.is_none(),
+                    "{code} must carry no text while {mods:?} is held, got {:?}",
+                    main.text
+                );
+            }
+        }
+    }
+
+    /// Shift is the exception: Shift+Space still types a space, because Shift
+    /// is what makes a character rather than what replaces it.
+    #[test]
+    fn special_key_with_only_shift_still_carries_its_text() {
+        let events = key_events(
+            Key::Special(SpecialKey::Space),
+            KeyModifiers::SHIFT,
+            KeyPress::DownAndUp,
+        );
+        let main = events
+            .iter()
+            .find(|e| e.code == Some("Space"))
+            .expect("a Space event");
+        assert_eq!(main.event_type, "keyDown");
+        assert_eq!(main.text.as_deref(), Some(" "));
+    }
+
+    /// The same rule on the character path: Ctrl+A is a shortcut, not the
+    /// letter "a".
+    #[test]
+    fn char_with_a_non_shift_modifier_sends_no_text() {
+        let events = key_events(Key::Char('a'), KeyModifiers::CTRL, KeyPress::DownAndUp);
+        let main = events
+            .iter()
+            .find(|e| e.code == Some("KeyA"))
+            .expect("a KeyA event");
+        assert_eq!(main.event_type, "keyDown");
+        assert!(main.text.is_none(), "got {:?}", main.text);
+        // `key` still names the character — the page's handler reads it to
+        // decide which shortcut fired.
+        assert_eq!(main.key.as_deref(), Some("a"));
+
+        // Unmodified, and Shift-only, still type.
+        let plain = key_events(Key::Char('a'), KeyModifiers::empty(), KeyPress::DownAndUp);
+        assert_eq!(plain[0].text.as_deref(), Some("a"));
+        let shifted = key_events(Key::Char('A'), KeyModifiers::empty(), KeyPress::DownAndUp);
+        assert_eq!(
+            shifted
+                .iter()
+                .find(|e| e.code == Some("KeyA"))
+                .and_then(|e| e.text.as_deref()),
+            Some("A")
+        );
+    }
+
+    /// A `char` event is a text insertion, so a special that inserts nothing
+    /// has none to send. The predecessor answered with the key's CDP name,
+    /// which types the literal string "Tab" into the focused field.
+    #[test]
+    fn forced_char_event_for_a_non_printable_special_emits_nothing() {
+        for k in [
+            SpecialKey::Tab,
+            SpecialKey::Escape,
+            SpecialKey::F5,
+            SpecialKey::ArrowLeft,
+        ] {
+            let events = key_events(Key::Special(k), KeyModifiers::empty(), KeyPress::Char);
+            assert!(
+                events.is_empty(),
+                "{k:?} inserts no character, so it has no char event: {events:?}"
+            );
+        }
+
+        // The printable two keep their char event.
+        let space = key_events(
+            Key::Special(SpecialKey::Space),
+            KeyModifiers::empty(),
+            KeyPress::Char,
+        );
+        assert_eq!(space.len(), 1);
+        assert_eq!(space[0].event_type, "char");
+        assert_eq!(space[0].text.as_deref(), Some(" "));
     }
 
     #[test]

--- a/crates/zendriver/src/input/keyboard.rs
+++ b/crates/zendriver/src/input/keyboard.rs
@@ -487,9 +487,12 @@ fn special_text(k: SpecialKey) -> Option<&'static str> {
 /// enforces this itself — verified against Chrome 151, Ctrl+Enter carrying
 /// `text: "\r"` left a `<textarea>` unchanged while the page's keydown
 /// handler still saw `{key: "Enter", ctrlKey: true}` — so dropping the field
-/// changes no observable behavior. It matches what Puppeteer puts on the
-/// wire, which is the shape anything fingerprinting the CDP stream is
-/// calibrated against.
+/// changes no observable behavior. Puppeteer drops the same field
+/// (`cdp/Input.ts`: `if (this._modifiers & ~8) { description.text = ''; }`),
+/// but it then picks the event type *from* that text, so Puppeteer's
+/// Ctrl+Enter goes out as a `rawKeyDown` while this one stays a `keyDown`
+/// carrying no text. That divergence is deliberate and the next paragraph is
+/// what matching it would cost.
 ///
 /// Deliberately separate from the printable/non-printable question that
 /// picks the event type. Folding the two together would send Ctrl+Enter as
@@ -504,7 +507,9 @@ fn modifiers_suppress_text(mods: KeyModifiers) -> bool {
 ///
 /// - `KeyPress::Char`, or a `Key::Char` whose [`char_descriptor`] is `None`
 ///   (emoji / non-ASCII), emits a single `char`-type event carrying the
-///   character as both `text` and `key`.
+///   character as both `text` and `key` — without the `text` when a held
+///   modifier suppresses it (see [`modifiers_suppress_text`]), so Ctrl+é
+///   inserts no character, the same as Ctrl+a.
 /// - `KeyPress::DownAndUp` on a printable `Key::Char` resolves the effective
 ///   modifiers (`mods` plus Shift if the descriptor requires it) and emits,
 ///   in conventional order: a keyDown for each active modifier (accumulating
@@ -524,7 +529,10 @@ pub(crate) fn key_events(key: Key, mods: KeyModifiers, kind: KeyPress) -> Vec<Ke
             return vec![KeyEventPayload {
                 event_type: "char",
                 modifiers: mods.cdp_bits(),
-                text: Some(s.clone()),
+                // A `char` event *is* the text insertion, so the same
+                // suppression the descriptor path applies has to apply here
+                // or Ctrl+é types "é" while Ctrl+a types nothing.
+                text: (!modifiers_suppress_text(mods)).then(|| s.clone()),
                 key: Some(s),
                 code: None,
                 windows_vk: None,
@@ -673,7 +681,9 @@ pub(crate) fn whitespace_special(c: char) -> Option<SpecialKey> {
 ///   vk synthesis).
 /// - A single whitespace `char` → the matching [`SpecialKey`] `DownAndUp`.
 /// - Anything else (emoji with modifiers, combining sequences, CJK, accents)
-///   → one `char`-type event carrying the whole cluster as text.
+///   → one `char`-type event carrying the whole cluster as text, or carrying
+///   no text at all when a held modifier suppresses it (see
+///   [`modifiers_suppress_text`]).
 pub(crate) fn cluster_events(cluster: &str, mods: KeyModifiers) -> Vec<KeyEventPayload> {
     let mut chars = cluster.chars();
     if let (Some(c), None) = (chars.next(), chars.clone().next()) {
@@ -689,7 +699,9 @@ pub(crate) fn cluster_events(cluster: &str, mods: KeyModifiers) -> Vec<KeyEventP
     vec![KeyEventPayload {
         event_type: "char",
         modifiers: mods.cdp_bits(),
-        text: Some(cluster.to_string()),
+        // Same rule as the `char` fallback in `key_events`: a held Ctrl/Alt/
+        // Meta means this chord inserts nothing, whatever the cluster is.
+        text: (!modifiers_suppress_text(mods)).then(|| cluster.to_string()),
         key: Some(cluster.to_string()),
         code: None,
         windows_vk: None,
@@ -1303,6 +1315,51 @@ mod tests {
                 .find(|e| e.code == Some("KeyA"))
                 .and_then(|e| e.text.as_deref()),
             Some("A")
+        );
+    }
+
+    /// The rule cannot depend on whether the character is ASCII.
+    ///
+    /// Three paths carry text: the descriptor-backed `keyDown` above, the
+    /// `char`-event fallback every non-ASCII character takes (no descriptor),
+    /// and `cluster_events`' multi-codepoint branch. A `char` event *is* a
+    /// text insertion, so a suppressed chord that still fills `text` types the
+    /// character — `press_with(Key::Char('é'), CTRL)` inserting "é" while
+    /// `press_with(Key::Char('a'), CTRL)` inserts nothing, which is the
+    /// asymmetry a French or CJK keymap hits and an ASCII debugging session
+    /// never shows.
+    #[test]
+    fn non_ascii_char_events_also_drop_their_text_under_a_modifier() {
+        let events = key_events(Key::Char('é'), KeyModifiers::CTRL, KeyPress::DownAndUp);
+        let [main] = events.as_slice() else {
+            panic!("no descriptor for 'é', so one char event: {events:?}");
+        };
+        assert_eq!(main.event_type, "char");
+        assert!(main.text.is_none(), "got {:?}", main.text);
+        // `key` still names the character, exactly as on the descriptor path.
+        assert_eq!(main.key.as_deref(), Some("é"));
+
+        // Multi-codepoint clusters take `cluster_events`' own fallback, which
+        // never routes through `key_events` at all.
+        let cluster = cluster_events("e\u{301}", KeyModifiers::CTRL);
+        let [combined] = cluster.as_slice() else {
+            panic!("one char event for the cluster: {cluster:?}");
+        };
+        assert_eq!(combined.event_type, "char");
+        assert!(combined.text.is_none(), "got {:?}", combined.text);
+
+        // Unmodified, both paths still type.
+        assert_eq!(
+            key_events(Key::Char('é'), KeyModifiers::empty(), KeyPress::DownAndUp)[0]
+                .text
+                .as_deref(),
+            Some("é")
+        );
+        assert_eq!(
+            cluster_events("e\u{301}", KeyModifiers::empty())[0]
+                .text
+                .as_deref(),
+            Some("e\u{301}")
         );
     }
 

--- a/crates/zendriver/src/input/keyboard.rs
+++ b/crates/zendriver/src/input/keyboard.rs
@@ -20,11 +20,15 @@ use unicode_segmentation::UnicodeSegmentation;
 pub enum Key {
     /// A typed character.
     Char(char),
-    /// A named non-character key (Enter, Tab, F1, etc.).
+    /// A key with a name rather than a glyph (Enter, Tab, F1, etc.).
     Special(SpecialKey),
 }
 
-/// Named non-character keys for [`crate::Element::press`].
+/// Keys a keyboard labels rather than prints, for [`crate::Element::press`].
+///
+/// Most of these insert nothing — pressing them runs a default action, or
+/// nothing at all. `Space` and `Enter` are the exceptions: they are printable
+/// keys that happen to have names, and they type `" "` and a newline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SpecialKey {
     /// Return / Enter.
@@ -382,7 +386,7 @@ pub(crate) enum KeyPress {
 ///
 /// Serialized verbatim into the CDP call. `Option` fields are omitted from
 /// the wire payload when `None` (a `char` event carries no `code`/vk; a
-/// special-key event carries no `text`).
+/// non-printable special key such as Tab or Escape carries no `text`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct KeyEventPayload {
     /// CDP event type: `keyDown` / `keyUp` / `rawKeyDown` / `char`.
@@ -446,6 +450,31 @@ fn ordered_modifiers(mods: KeyModifiers) -> impl Iterator<Item = KeyModifiers> {
     .filter(move |m| mods.contains(*m))
 }
 
+/// The text a [`SpecialKey`] inserts, for the two that insert any.
+///
+/// Space and Enter are printable keys that merely happen to have names:
+/// pressing them on a real keyboard puts a character into a focused field
+/// (`" "` and `"\r"` — Chrome turns the carriage return into a newline).
+/// Every other named key — Tab, Escape, the arrows, the F-keys — produces no
+/// character at all.
+///
+/// The distinction decides the CDP event type in [`key_events`], and it is
+/// not cosmetic. `rawKeyDown` means "a keydown that generates no character",
+/// so sending Space or Enter that way is a contradiction: Chrome inserted
+/// nothing (`type_text("a b")` yielded `"ab"`, and Enter never submitted a
+/// form), the first such dispatch per renderer took ~1.1s instead of ~2ms,
+/// and a second one in the same string killed the browser process outright
+/// — reproducibly, on pages with nothing to scroll as readily as on tall
+/// ones. Tab, dispatched exactly the same way, costs milliseconds and
+/// traverses focus correctly, because for Tab `rawKeyDown` is the truth.
+fn special_text(k: SpecialKey) -> Option<&'static str> {
+    match k {
+        SpecialKey::Space => Some(" "),
+        SpecialKey::Enter => Some("\r"),
+        _ => None,
+    }
+}
+
 /// Build the ordered CDP key-event payloads for a single [`Key`] press.
 ///
 /// - `KeyPress::Char`, or a `Key::Char` whose [`char_descriptor`] is `None`
@@ -457,8 +486,9 @@ fn ordered_modifiers(mods: KeyModifiers) -> impl Iterator<Item = KeyModifiers> {
 ///   the modifier bitmask) → the main keyDown → the main keyUp → modifier
 ///   keyUps in reverse.
 /// - `KeyPress::DownAndUp` on a `Key::Special` does the same modifier wrap,
-///   with the main events a `rawKeyDown`/`keyUp` pair built from
-///   [`SpecialKey::to_cdp`] (no `text`).
+///   with the main events built from [`SpecialKey::to_cdp`]. Keys that insert
+///   text (Space, Enter — see [`special_text`]) send a `keyDown` carrying it,
+///   exactly like a printable char; the rest send a text-less `rawKeyDown`.
 pub(crate) fn key_events(key: Key, mods: KeyModifiers, kind: KeyPress) -> Vec<KeyEventPayload> {
     // char-event path: explicit Char kind, or a Char with no descriptor.
     let force_char = matches!(kind, KeyPress::Char);
@@ -500,24 +530,32 @@ pub(crate) fn key_events(key: Key, mods: KeyModifiers, kind: KeyPress) -> Vec<Ke
         unreachable!("Key::Char handled above");
     };
     if force_char {
-        // char-event for a special key: send its key string as text (space,
-        // enter→"\r", tab→"\t" handled by the caller mapping; here we use the
-        // CDP `key`). Rarely used, but keep the contract total.
+        // char-event for a special key: the text it inserts if it is one of
+        // the printable ones, else its CDP `key` string. Rarely used, but
+        // keep the contract total.
         let (_, key_str, _) = k.to_cdp();
+        let text = special_text(k).unwrap_or(key_str);
         return vec![KeyEventPayload {
             event_type: "char",
             modifiers: mods.cdp_bits(),
-            text: Some(key_str.to_string()),
+            text: Some(text.to_string()),
             key: Some(key_str.to_string()),
             code: None,
             windows_vk: None,
         }];
     }
     let (code, key_str, vk) = k.to_cdp();
+    // A key that inserts text must say so, and `rawKeyDown` means precisely
+    // "generate no character" — see [`special_text`].
+    let text = special_text(k);
     let main_down = KeyEventPayload {
-        event_type: "rawKeyDown",
+        event_type: if text.is_some() {
+            "keyDown"
+        } else {
+            "rawKeyDown"
+        },
         modifiers: mods.cdp_bits(),
-        text: None,
+        text: text.map(str::to_string),
         key: Some(key_str.to_string()),
         code: Some(code),
         windows_vk: Some(vk),
@@ -954,16 +992,60 @@ mod tests {
     #[test]
     fn key_events_special_key_no_modifiers_is_rawkeydown_keyup() {
         let events = key_events(
-            Key::Special(SpecialKey::Enter),
+            Key::Special(SpecialKey::Escape),
             KeyModifiers::empty(),
             KeyPress::DownAndUp,
         );
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].event_type, "rawKeyDown");
-        assert_eq!(events[0].key.as_deref(), Some("Enter"));
-        assert_eq!(events[0].windows_vk, Some(13));
+        assert_eq!(events[0].key.as_deref(), Some("Escape"));
+        assert_eq!(events[0].windows_vk, Some(27));
         assert!(events[0].text.is_none());
         assert_eq!(events[1].event_type, "keyUp");
+    }
+
+    #[test]
+    fn key_events_printable_specials_carry_their_text() {
+        // Space and Enter insert a character, so they go out as a `keyDown`
+        // carrying it. `rawKeyDown` means "generate no character": dispatched
+        // that way Chrome inserted nothing, took ~1.1s for the first one, and
+        // died on the second.
+        for (key, text, vk) in [(SpecialKey::Space, " ", 32), (SpecialKey::Enter, "\r", 13)] {
+            let events = key_events(
+                Key::Special(key),
+                KeyModifiers::empty(),
+                KeyPress::DownAndUp,
+            );
+            assert_eq!(events.len(), 2, "{key:?}");
+            assert_eq!(events[0].event_type, "keyDown", "{key:?}");
+            assert_eq!(events[0].text.as_deref(), Some(text), "{key:?}");
+            assert_eq!(events[0].windows_vk, Some(vk), "{key:?}");
+            assert_eq!(events[1].event_type, "keyUp", "{key:?}");
+        }
+    }
+
+    #[test]
+    fn key_events_non_printable_specials_stay_textless_rawkeydown() {
+        // Tab's default action (focus traversal) runs off the keydown alone,
+        // and it inserts nothing — `rawKeyDown` is the accurate event for it
+        // and the others like it. Kept pinned so the Space/Enter fix cannot
+        // creep across the whole enum.
+        for key in [
+            SpecialKey::Tab,
+            SpecialKey::Escape,
+            SpecialKey::Backspace,
+            SpecialKey::Delete,
+            SpecialKey::ArrowDown,
+            SpecialKey::F5,
+        ] {
+            let events = key_events(
+                Key::Special(key),
+                KeyModifiers::empty(),
+                KeyPress::DownAndUp,
+            );
+            assert_eq!(events[0].event_type, "rawKeyDown", "{key:?}");
+            assert!(events[0].text.is_none(), "{key:?}");
+        }
     }
 
     #[test]
@@ -1078,21 +1160,37 @@ mod tests {
     }
 
     #[test]
-    fn cluster_events_space_routes_to_special_key() {
+    fn cluster_events_space_routes_to_special_key_carrying_its_text() {
         let events = flatten_text(" ");
-        // Space → SpecialKey::Space DownAndUp (rawKeyDown + keyUp).
+        // Space → SpecialKey::Space DownAndUp, dispatched the way every other
+        // printable character is: a `keyDown` carrying the text. Typed as a
+        // text-less `rawKeyDown`, `type_text("a b")` used to produce "ab".
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].event_type, "rawKeyDown");
+        assert_eq!(events[0].event_type, "keyDown");
         assert_eq!(events[0].code, Some("Space"));
         assert_eq!(events[0].windows_vk, Some(32));
+        assert_eq!(events[0].text.as_deref(), Some(" "));
+        assert_eq!(events[0].key.as_deref(), Some(" "));
         assert_eq!(events[1].event_type, "keyUp");
     }
 
     #[test]
-    fn cluster_events_newline_routes_to_enter() {
+    fn cluster_events_newline_routes_to_enter_carrying_a_carriage_return() {
         let events = flatten_text("\n");
+        assert_eq!(events[0].event_type, "keyDown");
         assert_eq!(events[0].code, Some("Enter"));
         assert_eq!(events[0].windows_vk, Some(13));
+        // Chrome turns the carriage return into a newline in a textarea, and
+        // it is what triggers implicit form submission in an input.
+        assert_eq!(events[0].text.as_deref(), Some("\r"));
+    }
+
+    #[test]
+    fn cluster_events_tab_routes_to_a_textless_raw_keydown() {
+        let events = flatten_text("\t");
+        assert_eq!(events[0].event_type, "rawKeyDown");
+        assert_eq!(events[0].code, Some("Tab"));
+        assert!(events[0].text.is_none());
     }
 
     // --- KeySequence flattening ---
@@ -1111,8 +1209,9 @@ mod tests {
         assert_eq!(events[1].event_type, "keyUp");
         assert_eq!(events[2].code, Some("KeyI"));
         assert_eq!(events[3].event_type, "keyUp");
-        // Enter: rawKeyDown + keyUp.
-        assert_eq!(events[4].event_type, "rawKeyDown");
+        // Enter: keyDown carrying "\r" + keyUp.
+        assert_eq!(events[4].event_type, "keyDown");
+        assert_eq!(events[4].text.as_deref(), Some("\r"));
         assert_eq!(events[4].code, Some("Enter"));
         assert_eq!(events[5].event_type, "keyUp");
         assert_eq!(events[5].code, Some("Enter"));
@@ -1302,8 +1401,9 @@ mod dispatch_tests {
 
         let id = mock.expect_cmd("Input.dispatchKeyEvent").await;
         let last = mock.last_sent();
-        assert_eq!(last["params"]["type"], "rawKeyDown");
+        assert_eq!(last["params"]["type"], "keyDown");
         assert_eq!(last["params"]["key"], "Enter");
+        assert_eq!(last["params"]["text"], "\r");
         assert_eq!(last["params"]["windowsVirtualKeyCode"], 13);
         mock.reply(id, Value::Null).await;
 

--- a/crates/zendriver/src/input/mod.rs
+++ b/crates/zendriver/src/input/mod.rs
@@ -50,12 +50,9 @@ pub struct InputController {
 pub(crate) struct InputState {
     pub pointer_x: f64,
     pub pointer_y: f64,
-    // Tracked per `MouseButtonSet`'s doc comment (drag/release sequences
-    // across multiple element actions), but nothing yet mutates it after
-    // init: `mouse::click_at` presses and releases within one call rather
-    // than exposing separate mouse-down/mouse-up dispatch. Kept for that
-    // forward-looking drag/hold API.
-    #[allow(dead_code)]
+    /// Buttons currently held down. Written by every press/release and by the
+    /// drag path, and sent as CDP's `buttons` bitmask on every dispatched
+    /// mouse event — `MouseButtonSet`'s bit values match that mask exactly.
     pub buttons_held: MouseButtonSet,
     pub modifiers_held: KeyModifiers,
     pub rng: rand::rngs::SmallRng,

--- a/crates/zendriver/src/input/mod.rs
+++ b/crates/zendriver/src/input/mod.rs
@@ -50,9 +50,33 @@ pub struct InputController {
 pub(crate) struct InputState {
     pub pointer_x: f64,
     pub pointer_y: f64,
-    /// Buttons currently held down. Written by every press/release and by the
-    /// drag path, and sent as CDP's `buttons` bitmask on every dispatched
-    /// mouse event — `MouseButtonSet`'s bit values match that mask exactly.
+    /// Buttons currently held down. Written by every press/release and by
+    /// the drag path, and read back as CDP's `buttons` bitmask on every
+    /// dispatched mouse event — `MouseButtonSet`'s bit values match that
+    /// mask exactly, so [`MouseButtonSet::bits`] is the wire value directly.
+    ///
+    /// # Why the write paths look the way they do
+    ///
+    /// This field lives on the per-`Tab` [`InputController`], which outlives
+    /// any single gesture, so a `?` between a press and its matching release
+    /// would strand the bit set for the rest of the tab's life: every later
+    /// `mouseMoved` would report a button held with no preceding `mousedown`.
+    /// That impossible state is a worse signal to leak to behavioral
+    /// anti-bot scoring than omitting `buttons` altogether — it is exactly
+    /// this stream such scoring reads.
+    ///
+    /// Both gesture paths ([`mouse::click_at`] and [`crate::Tab::mouse_drag`])
+    /// therefore run as one fallible section followed by a single cleanup,
+    /// rather than using a `Drop` guard. Clearing the bit needs the async
+    /// `Mutex`; `Drop` cannot await, and a `try_lock` inside `Drop` would
+    /// silently fail under contention — precisely when another task is
+    /// mid-dispatch and would go on to read the stale bit. More machinery,
+    /// weaker guarantee.
+    ///
+    /// Residual case neither shape covers: if the caller drops the gesture
+    /// future mid-flight (cancellation, an outer `tokio::time::timeout`), no
+    /// cleanup runs and the bit stays set. A `Drop` guard would not reliably
+    /// close that either, for the `try_lock` reason above.
     pub buttons_held: MouseButtonSet,
     pub modifiers_held: KeyModifiers,
     pub rng: rand::rngs::SmallRng,

--- a/crates/zendriver/src/input/mouse.rs
+++ b/crates/zendriver/src/input/mouse.rs
@@ -193,24 +193,23 @@ pub(crate) async fn click_at(
         move_raw(input, tab, target_x, target_y, extra_modifiers).await?;
     }
     let bit = button_bit(button);
-    // `buttons_held` lives on the per-Tab InputController, which outlives this
-    // call, so a `?` between the press and its matching release would strand
-    // `bit` set for the rest of the tab's life: every later `mouseMoved` would
-    // then report a button held with no preceding mousedown. That impossible
-    // state is worse than the missing-`buttons` bug this replaced — behavioral
-    // anti-bot scoring reads exactly this stream.
+    // One fallible section plus one cleanup below, rather than a `Drop` guard.
+    // The full rationale — and the cancellation case it does not cover — is on
+    // `InputState::buttons_held`; `Tab::mouse_drag` uses the same shape.
     //
-    // The fix is a single fallible section plus one cleanup below, rather than
-    // a `Drop` guard: clearing the bit needs the async `Mutex`, `Drop` cannot
-    // await, and a `try_lock` inside `Drop` would silently fail under
-    // contention — precisely when another task is mid-dispatch and would go on
-    // to read the stale bit. A guard here would be more machinery and a weaker
-    // guarantee.
+    // `we_latched` records whether *this* call is the one that set the bit,
+    // so the cleanup below only clears a bit it owns. Without it, a failure
+    // anywhere before the first press — the approach `mouseMoved`, say —
+    // still runs the cleanup and clears a bit some other task latched.
     //
-    // Residual case it does not cover: if the caller drops this future
-    // mid-gesture (cancellation, an outer `tokio::time::timeout`), the cleanup
-    // never runs and the bit stays set. A `Drop` guard would not reliably close
-    // that either, for the `try_lock` reason above.
+    // It does not make `click_at` safe to run concurrently with another
+    // gesture on the same tab, and does not try to: the in-loop release
+    // clears the bit unconditionally, because the frame it emits has to
+    // report the button as up. Two tasks driving one tab's mouse are
+    // modelling one physical button from two places and will disagree
+    // whatever this does. `InputController` is per-`Tab`; keep a gesture on
+    // one task.
+    let mut we_latched = false;
     let sequence: Result<()> = async {
         for n in 1..=click_count.max(1) {
             // `buttons` must reflect the set held *after* the press and *after*
@@ -218,6 +217,7 @@ pub(crate) async fn click_at(
             // it.
             let (modifier_bits, buttons) = {
                 let mut s = input.state.lock().await;
+                we_latched |= !s.buttons_held.contains(bit);
                 s.buttons_held.insert(bit);
                 (
                     (s.modifiers_held | extra_modifiers).cdp_bits(),
@@ -262,9 +262,11 @@ pub(crate) async fn click_at(
         Ok(())
     }
     .await;
-    // Single exit for the latched bit. A no-op on the happy path (the last
-    // release already cleared it) and on any failure before the first press.
-    input.state.lock().await.buttons_held.remove(bit);
+    // Single exit for the latched bit, skipped when this call never latched
+    // it. A no-op on the happy path too — the last release already cleared it.
+    if we_latched {
+        input.state.lock().await.buttons_held.remove(bit);
+    }
     sequence
 }
 
@@ -272,6 +274,8 @@ pub(crate) async fn click_at(
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::test_support::expect;
+    use rand::SeedableRng as _;
     use zendriver_transport::{SessionHandle, testing::MockConnection};
 
     #[test]
@@ -284,16 +288,10 @@ mod tests {
     }
     // Note: dispatch fns are async + need a Tab + MockConnection — exercised in T20 click tests.
 
-    /// Drive one `Input.dispatchMouseEvent` off the mock: assert the frame is
-    /// the expected `type`, then hand it to `respond`. `expect_cmd` has no
-    /// built-in timeout, so every wait is bounded here.
+    /// Drive one `Input.dispatchMouseEvent` off the mock, assert the frame is
+    /// the expected `type`, and return its id so the caller can reply.
     async fn next_dispatch(mock: &mut MockConnection, expected_type: &str) -> u64 {
-        let id = tokio::time::timeout(
-            Duration::from_secs(5),
-            mock.expect_cmd("Input.dispatchMouseEvent"),
-        )
-        .await
-        .expect("no Input.dispatchMouseEvent arrived");
+        let id = expect(mock, "Input.dispatchMouseEvent").await;
         assert_eq!(
             mock.last_sent()["params"]["type"],
             expected_type,
@@ -301,6 +299,183 @@ mod tests {
             mock.last_sent()
         );
         id
+    }
+
+    /// An [`InputProfile`] with no jitter (so `BezierPath` is fully
+    /// deterministic and its arc length is exactly the straight-line
+    /// distance) and a cursor speed of `px_per_ms`.
+    fn steady_profile(px_per_ms: f64) -> zendriver_stealth::InputProfile {
+        zendriver_stealth::InputProfile {
+            mouse_speed_px_per_ms: px_per_ms,
+            jitter_amplitude_px: 0.0,
+            ..zendriver_stealth::InputProfile::native()
+        }
+    }
+
+    /// The `(x, y)` of every frame a move emits, asserting each really is a
+    /// `mouseMoved`.
+    async fn drain_mouse_moves(mock: &mut MockConnection) -> Vec<(f64, f64)> {
+        crate::test_support::drain_mouse_dispatches(mock)
+            .await
+            .iter()
+            .map(|p| {
+                assert_eq!(p["type"], "mouseMoved", "{p}");
+                (
+                    p["x"].as_f64().expect("x is a number"),
+                    p["y"].as_f64().expect("y is a number"),
+                )
+            })
+            .collect()
+    }
+
+    /// A click that found the bit already set never latched it, so its
+    /// cleanup must leave it alone.
+    ///
+    /// The unconditional `remove` this replaced made a failed `click_fast`
+    /// clear a LEFT bit an in-flight `mouse_drag` was holding, after which the
+    /// drag's remaining `mouseMoved` frames report `buttons: 0` while the page
+    /// still believes the button is down — the same incoherent stream the
+    /// latch exists to prevent, arrived at from the other side.
+    ///
+    /// The *press* is what has to fail here, not the approach: a failed
+    /// approach returns from `click_at` before the cleanup is reachable at
+    /// all, so it cannot tell the two versions apart.
+    #[tokio::test]
+    async fn click_at_leaves_a_button_it_never_latched_alone() {
+        let (mut mock, conn) = MockConnection::pair();
+        let tab = Tab::new_for_test(SessionHandle::new(conn.clone(), "S1"));
+
+        // Stand in for a concurrent gesture already holding the button.
+        tab.input()
+            .state
+            .lock()
+            .await
+            .buttons_held
+            .insert(MouseButtonSet::LEFT);
+
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move {
+                let opts = crate::element::actions::ClickOptions {
+                    realistic: false,
+                    ..Default::default()
+                };
+                click_at(t.input(), &t, 10.0, 20.0, &opts).await
+            }
+        });
+
+        let mv = next_dispatch(&mut mock, "mouseMoved").await;
+        mock.reply(mv, serde_json::json!({})).await;
+        let press = next_dispatch(&mut mock, "mousePressed").await;
+        mock.reply_err(press, -32000, "dispatch rejected").await;
+
+        assert!(
+            fut.await.unwrap().is_err(),
+            "the failed press must propagate"
+        );
+        assert!(
+            tab.input()
+                .state
+                .lock()
+                .await
+                .buttons_held
+                .contains(MouseButtonSet::LEFT),
+            "click_at cleared a held button it never latched"
+        );
+        conn.shutdown();
+    }
+
+    /// The path's first point is where the cursor already is, so dispatching
+    /// it emits a `mouseMoved` to the current position — something a real
+    /// cursor never does, and a behavioral tell in a crate whose whole
+    /// purpose is not looking synthetic.
+    ///
+    /// Pins the count against the path rather than a literal, so it stays
+    /// honest if `BezierPath`'s sampling changes: n points in, n-1 frames out,
+    /// and the one dropped is the start.
+    #[tokio::test(start_paused = true)]
+    async fn move_realistic_skips_the_path_point_the_cursor_is_already_on() {
+        let (mut mock, conn) = MockConnection::pair();
+        let tab = Tab::new_for_test(SessionHandle::new(conn.clone(), "S1"));
+        let input = InputController::new_with_seed(steady_profile(10.0), 42);
+
+        // 600px puts the sample count on `BezierPath`'s upper clamp (60), so
+        // the emitted frames are a fixed 60 rather than distance/5.
+        let target = (600.0, 0.0);
+        let fut = tokio::spawn({
+            let (i, t) = (input.clone(), tab.clone());
+            async move { move_realistic(&i, &t, target.0, target.1, KeyModifiers::empty()).await }
+        });
+
+        let sent = drain_mouse_moves(&mut mock).await;
+        fut.await.unwrap().unwrap();
+
+        // Rebuild the same path: zero jitter never draws from the RNG, so
+        // this is the identical point list the move walked.
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
+        let path = BezierPath::build((0.0, 0.0), target, 0.0, &mut rng);
+
+        assert_eq!(
+            sent.len(),
+            path.points.len() - 1,
+            "one frame per segment, not one per point"
+        );
+        assert_ne!(
+            sent[0],
+            (0.0, 0.0),
+            "the opening frame must not re-dispatch the cursor's current position"
+        );
+        assert_eq!(
+            sent[0], path.points[1],
+            "the first frame is the second point"
+        );
+        assert_eq!(
+            *sent.last().unwrap(),
+            target,
+            "the last frame is the target"
+        );
+        conn.shutdown();
+    }
+
+    /// Total travel time must come from the path's real segment lengths.
+    ///
+    /// The predecessor assumed a fixed 5px step, which is only true while
+    /// `BezierPath`'s sample count is unclamped — it clamps to [8, 60], so a
+    /// 600px move is 60 segments of 10px and the fixed assumption ran it 2x
+    /// too fast. 600px at 1px/ms must therefore take ~600ms, not ~300ms,
+    /// which is what makes `mouse_speed_px_per_ms` mean what it says.
+    #[tokio::test(start_paused = true)]
+    async fn move_realistic_paces_the_path_by_its_real_segment_lengths() {
+        let (mut mock, conn) = MockConnection::pair();
+        let tab = Tab::new_for_test(SessionHandle::new(conn.clone(), "S1"));
+        let input = InputController::new_with_seed(steady_profile(1.0), 42);
+
+        // Timed inside the task: the drain below ends on `try_expect`'s
+        // silence timeout, and under `start_paused` that advances the clock
+        // too, so measuring around the drain would fold the terminator into
+        // the answer.
+        let fut = tokio::spawn({
+            let (i, t) = (input.clone(), tab.clone());
+            async move {
+                let started = tokio::time::Instant::now();
+                move_realistic(&i, &t, 600.0, 0.0, KeyModifiers::empty()).await?;
+                Ok::<_, crate::error::ZendriverError>(started.elapsed())
+            }
+        });
+        drain_mouse_moves(&mut mock).await;
+        let elapsed = fut.await.unwrap().unwrap();
+
+        // Two sources of slack, both bounded and both upward-only against a
+        // 600ms floor. `from_micros(... as u64)` truncates below a
+        // microsecond, losing at most 60µs across the 60 segments; and
+        // tokio's paused clock advances on 1ms ticks, so each sleep rounds up
+        // to the next millisecond — at most 60ms in total. The window is
+        // still nowhere near the ~300ms the fixed-5px predecessor produced.
+        assert!(
+            elapsed >= Duration::from_micros(599_940) && elapsed <= Duration::from_millis(660),
+            "600px at 1px/ms should take ~600ms, took {elapsed:?}"
+        );
+        conn.shutdown();
     }
 
     /// A failed `mousePressed` must not strand the held-button bit. The
@@ -342,9 +517,16 @@ mod tests {
         conn.shutdown();
     }
 
-    /// `mouse_drag` latches the bit *after* the press lands, so the failure
-    /// that leaks it is a dispatch between the press and the release — an
+    /// `mouse_drag` latches the bit as it builds the press frame, so the
+    /// failure that leaks it is any dispatch up to the release — an
     /// interpolated `mouseMoved` is the realistic one.
+    ///
+    /// The mid-gesture assertion is what gives the closing one its meaning.
+    /// `buttons_held` is empty before a drag starts, so `is_empty()` on its
+    /// own passes just as well against a `mouse_drag` that never wrote the
+    /// field at all — which is how it read on `origin/main`. Observing the
+    /// bit set, then cleared, is a before/after pair; only the second half is
+    /// a claim about cleanup.
     #[tokio::test]
     async fn mouse_drag_clears_the_held_bit_when_a_move_fails() {
         let (mut mock, conn) = MockConnection::pair();
@@ -358,7 +540,18 @@ mod tests {
         let press = next_dispatch(&mut mock, "mousePressed").await;
         mock.reply(press, serde_json::json!({})).await;
         // The bit is held from here until the release; fail inside that window.
+        // The first `mouseMoved` is dispatched after the latch, so its arrival
+        // means the write has already happened.
         let mv = next_dispatch(&mut mock, "mouseMoved").await;
+        assert!(
+            tab.input()
+                .state
+                .lock()
+                .await
+                .buttons_held
+                .contains(MouseButtonSet::LEFT),
+            "mouse_drag must hold LEFT between its press and its release"
+        );
         mock.reply_err(mv, -32000, "dispatch rejected").await;
 
         assert!(

--- a/crates/zendriver/src/input/mouse.rs
+++ b/crates/zendriver/src/input/mouse.rs
@@ -7,6 +7,8 @@ use serde_json::json;
 use crate::error::Result;
 use crate::input::InputController;
 use crate::input::bezier::BezierPath;
+use crate::input::keyboard::KeyModifiers;
+use crate::input::pointer_state::MouseButtonSet;
 use crate::tab::Tab;
 
 /// Mouse buttons for click dispatch.
@@ -54,14 +56,34 @@ impl MouseButton {
     }
 }
 
+/// The [`MouseButtonSet`] bit for a single button.
+///
+/// `MouseButtonSet`'s bit values are chosen to match CDP's `buttons` bitmask
+/// (1 left, 2 right, 4 middle, 8 back, 16 forward), so `MouseButtonSet::bits`
+/// is the wire value directly.
+const fn button_bit(button: MouseButton) -> MouseButtonSet {
+    match button {
+        MouseButton::Left => MouseButtonSet::LEFT,
+        MouseButton::Middle => MouseButtonSet::MIDDLE,
+        MouseButton::Right => MouseButtonSet::RIGHT,
+        MouseButton::Back => MouseButtonSet::BACK,
+        MouseButton::Forward => MouseButtonSet::FORWARD,
+    }
+}
+
 /// Move the cursor from its current position to `(target_x, target_y)` along
 /// a Bezier path with realistic per-segment delay. Updates InputController
 /// state to the target position on success.
+///
+/// Carries `buttons` so a move dispatched between a press and a release reads
+/// as a drag. A page implementing drag with `mousemove` + `e.buttons` — the
+/// standard modern check — sees nothing at all without it.
 pub(crate) async fn move_realistic(
     input: &InputController,
     tab: &Tab,
     target_x: f64,
     target_y: f64,
+    extra_modifiers: KeyModifiers,
 ) -> Result<()> {
     // Hold the lock across the full dispatch + state-update sequence so a
     // concurrent `move_*` from another task can't slip in between our last
@@ -71,31 +93,44 @@ pub(crate) async fn move_realistic(
     // which matches Chrome's per-page input model.
     let mut state = input.state.lock().await;
     let start = (state.pointer_x, state.pointer_y);
-    let modifier_bits = state.modifiers_held.cdp_bits();
+    let modifier_bits = (state.modifiers_held | extra_modifiers).cdp_bits();
+    let buttons = state.buttons_held.bits();
     let path = BezierPath::build(
         start,
         (target_x, target_y),
         input.profile.jitter_amplitude_px,
         &mut state.rng,
     );
-    let segment_delay = if input.profile.mouse_speed_px_per_ms > 0.0 {
-        Duration::from_micros(((5.0 / input.profile.mouse_speed_px_per_ms) * 1000.0) as u64)
-    } else {
-        Duration::ZERO
-    };
-    for &(x, y) in &path.points {
+    let speed = input.profile.mouse_speed_px_per_ms;
+    // `points[0]` is the start position, so dispatching it emits a `mouseMoved`
+    // to where the cursor already is. Skip it, and sleep *before* each step so
+    // the delay pays for the movement that follows rather than trailing the
+    // last one.
+    let mut prev = path.points.first().copied().unwrap_or(start);
+    for &(x, y) in path.points.iter().skip(1) {
+        if speed > 0.0 {
+            // Derive the delay from the segment actually emitted. `BezierPath`
+            // clamps its sample count to [8, 60], so segment length scales with
+            // distance; assuming a fixed 5px step ran long moves ~3x too fast
+            // and short ones ~4x too slow, which made `mouse_speed_px_per_ms`
+            // honest only for 40-300px journeys.
+            let seg = (x - prev.0).hypot(y - prev.1);
+            let delay = Duration::from_micros(((seg / speed) * 1000.0) as u64);
+            if !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
+        }
         tab.session()
             .call(
                 "Input.dispatchMouseEvent",
                 json!({
                     "type": "mouseMoved", "x": x, "y": y,
                     "modifiers": modifier_bits,
+                    "buttons": buttons,
                 }),
             )
             .await?;
-        if !segment_delay.is_zero() {
-            tokio::time::sleep(segment_delay).await;
-        }
+        prev = (x, y);
     }
     state.pointer_x = target_x;
     state.pointer_y = target_y;
@@ -108,16 +143,19 @@ pub(crate) async fn move_raw(
     tab: &Tab,
     target_x: f64,
     target_y: f64,
+    extra_modifiers: KeyModifiers,
 ) -> Result<()> {
     // Same per-Tab serialization rationale as `move_realistic`.
     let mut state = input.state.lock().await;
-    let modifier_bits = state.modifiers_held.cdp_bits();
+    let modifier_bits = (state.modifiers_held | extra_modifiers).cdp_bits();
+    let buttons = state.buttons_held.bits();
     tab.session()
         .call(
             "Input.dispatchMouseEvent",
             json!({
                 "type": "mouseMoved", "x": target_x, "y": target_y,
                 "modifiers": modifier_bits,
+                "buttons": buttons,
             }),
         )
         .await?;
@@ -126,57 +164,115 @@ pub(crate) async fn move_raw(
     Ok(())
 }
 
-/// Dispatch a click at `(target_x, target_y)` with `button` and `click_count`.
-/// If `realistic`, prefixes with Bezier move; otherwise direct teleport.
+/// Dispatch a click at `(target_x, target_y)`.
+///
+/// Reads `button` / `click_count` / `realistic` / `modifiers` from `opts`;
+/// `force` and `position` belong to the element-gating layer and are resolved
+/// by the caller before it picks a target coordinate.
+///
+/// `opts.modifiers` are OR'd with whatever the keyboard currently holds, so a
+/// caller-requested Ctrl/Cmd/Shift-click works without the caller having to
+/// drive a real key-down first. They ride the approach `mouseMoved` frames too,
+/// the way a real browser reports `ctrlKey` on mousemove.
+///
+/// A `click_count` above 1 emits that many press/release pairs with an
+/// increasing `clickCount`, which is what Chrome produces for a real
+/// double-click. Collapsing it into one pair carrying `clickCount: 2` is
+/// invisible to any page counting `mousedown` events.
 pub(crate) async fn click_at(
     input: &InputController,
     tab: &Tab,
     target_x: f64,
     target_y: f64,
-    button: MouseButton,
-    click_count: u32,
-    realistic: bool,
+    opts: &crate::element::actions::ClickOptions,
 ) -> Result<()> {
-    if realistic {
-        move_realistic(input, tab, target_x, target_y).await?;
+    let (button, click_count, extra_modifiers) = (opts.button, opts.click_count, opts.modifiers);
+    if opts.realistic {
+        move_realistic(input, tab, target_x, target_y, extra_modifiers).await?;
     } else {
-        move_raw(input, tab, target_x, target_y).await?;
+        move_raw(input, tab, target_x, target_y, extra_modifiers).await?;
     }
-    let modifier_bits = {
-        let s = input.state.lock().await;
-        s.modifiers_held.cdp_bits()
-    };
-    tab.session()
-        .call(
-            "Input.dispatchMouseEvent",
-            json!({
-                "type": "mousePressed",
-                "x": target_x, "y": target_y,
-                "button": button.cdp_str(),
-                "clickCount": click_count,
-                "modifiers": modifier_bits,
-            }),
-        )
-        .await?;
-    tab.session()
-        .call(
-            "Input.dispatchMouseEvent",
-            json!({
-                "type": "mouseReleased",
-                "x": target_x, "y": target_y,
-                "button": button.cdp_str(),
-                "clickCount": click_count,
-                "modifiers": modifier_bits,
-            }),
-        )
-        .await?;
-    Ok(())
+    let bit = button_bit(button);
+    // `buttons_held` lives on the per-Tab InputController, which outlives this
+    // call, so a `?` between the press and its matching release would strand
+    // `bit` set for the rest of the tab's life: every later `mouseMoved` would
+    // then report a button held with no preceding mousedown. That impossible
+    // state is worse than the missing-`buttons` bug this replaced — behavioral
+    // anti-bot scoring reads exactly this stream.
+    //
+    // The fix is a single fallible section plus one cleanup below, rather than
+    // a `Drop` guard: clearing the bit needs the async `Mutex`, `Drop` cannot
+    // await, and a `try_lock` inside `Drop` would silently fail under
+    // contention — precisely when another task is mid-dispatch and would go on
+    // to read the stale bit. A guard here would be more machinery and a weaker
+    // guarantee.
+    //
+    // Residual case it does not cover: if the caller drops this future
+    // mid-gesture (cancellation, an outer `tokio::time::timeout`), the cleanup
+    // never runs and the bit stays set. A `Drop` guard would not reliably close
+    // that either, for the `try_lock` reason above.
+    let sequence: Result<()> = async {
+        for n in 1..=click_count.max(1) {
+            // `buttons` must reflect the set held *after* the press and *after*
+            // the release, so take it from the same locked section that mutates
+            // it.
+            let (modifier_bits, buttons) = {
+                let mut s = input.state.lock().await;
+                s.buttons_held.insert(bit);
+                (
+                    (s.modifiers_held | extra_modifiers).cdp_bits(),
+                    s.buttons_held.bits(),
+                )
+            };
+            tab.session()
+                .call(
+                    "Input.dispatchMouseEvent",
+                    json!({
+                        "type": "mousePressed",
+                        "x": target_x, "y": target_y,
+                        "button": button.cdp_str(),
+                        "clickCount": n,
+                        "modifiers": modifier_bits,
+                        "buttons": buttons,
+                    }),
+                )
+                .await?;
+            let (modifier_bits, buttons) = {
+                let mut s = input.state.lock().await;
+                s.buttons_held.remove(bit);
+                (
+                    (s.modifiers_held | extra_modifiers).cdp_bits(),
+                    s.buttons_held.bits(),
+                )
+            };
+            tab.session()
+                .call(
+                    "Input.dispatchMouseEvent",
+                    json!({
+                        "type": "mouseReleased",
+                        "x": target_x, "y": target_y,
+                        "button": button.cdp_str(),
+                        "clickCount": n,
+                        "modifiers": modifier_bits,
+                        "buttons": buttons,
+                    }),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+    .await;
+    // Single exit for the latched bit. A no-op on the happy path (the last
+    // release already cleared it) and on any failure before the first press.
+    input.state.lock().await.buttons_held.remove(bit);
+    sequence
 }
 
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use zendriver_transport::{SessionHandle, testing::MockConnection};
 
     #[test]
     fn mouse_button_cdp_strings_match_chrome() {
@@ -187,4 +283,92 @@ mod tests {
         assert_eq!(MouseButton::Forward.cdp_str(), "forward");
     }
     // Note: dispatch fns are async + need a Tab + MockConnection — exercised in T20 click tests.
+
+    /// Drive one `Input.dispatchMouseEvent` off the mock: assert the frame is
+    /// the expected `type`, then hand it to `respond`. `expect_cmd` has no
+    /// built-in timeout, so every wait is bounded here.
+    async fn next_dispatch(mock: &mut MockConnection, expected_type: &str) -> u64 {
+        let id = tokio::time::timeout(
+            Duration::from_secs(5),
+            mock.expect_cmd("Input.dispatchMouseEvent"),
+        )
+        .await
+        .expect("no Input.dispatchMouseEvent arrived");
+        assert_eq!(
+            mock.last_sent()["params"]["type"],
+            expected_type,
+            "unexpected dispatch order: {}",
+            mock.last_sent()
+        );
+        id
+    }
+
+    /// A failed `mousePressed` must not strand the held-button bit. The
+    /// InputController is per-Tab and long-lived, so a latched bit makes every
+    /// subsequent `mouseMoved` on this tab report a button held with no
+    /// preceding mousedown — incoherent pointer telemetry, and strictly worse
+    /// than omitting the field.
+    #[tokio::test]
+    async fn click_at_clears_the_held_bit_when_the_press_fails() {
+        let (mut mock, conn) = MockConnection::pair();
+        let tab = Tab::new_for_test(SessionHandle::new(conn.clone(), "S1"));
+
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move {
+                // `realistic: false` keeps the approach to a single teleport
+                // `mouseMoved` — no Bezier path, no per-segment sleeps.
+                let opts = crate::element::actions::ClickOptions {
+                    realistic: false,
+                    ..Default::default()
+                };
+                click_at(t.input(), &t, 10.0, 20.0, &opts).await
+            }
+        });
+
+        let mv = next_dispatch(&mut mock, "mouseMoved").await;
+        mock.reply(mv, serde_json::json!({})).await;
+        let press = next_dispatch(&mut mock, "mousePressed").await;
+        mock.reply_err(press, -32000, "dispatch rejected").await;
+
+        assert!(
+            fut.await.unwrap().is_err(),
+            "a failed mousePressed must propagate"
+        );
+        assert!(
+            tab.input().state.lock().await.buttons_held.is_empty(),
+            "click_at leaked a latched button bit after a failed mousePressed"
+        );
+        conn.shutdown();
+    }
+
+    /// `mouse_drag` latches the bit *after* the press lands, so the failure
+    /// that leaks it is a dispatch between the press and the release — an
+    /// interpolated `mouseMoved` is the realistic one.
+    #[tokio::test]
+    async fn mouse_drag_clears_the_held_bit_when_a_move_fails() {
+        let (mut mock, conn) = MockConnection::pair();
+        let tab = Tab::new_for_test(SessionHandle::new(conn.clone(), "S1"));
+
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move { t.mouse_drag((10.0, 10.0), (200.0, 10.0), 5).await }
+        });
+
+        let press = next_dispatch(&mut mock, "mousePressed").await;
+        mock.reply(press, serde_json::json!({})).await;
+        // The bit is held from here until the release; fail inside that window.
+        let mv = next_dispatch(&mut mock, "mouseMoved").await;
+        mock.reply_err(mv, -32000, "dispatch rejected").await;
+
+        assert!(
+            fut.await.unwrap().is_err(),
+            "a failed mouseMoved must propagate"
+        );
+        assert!(
+            tab.input().state.lock().await.buttons_held.is_empty(),
+            "mouse_drag leaked a latched button bit after a failed mouseMoved"
+        );
+        conn.shutdown();
+    }
 }

--- a/crates/zendriver/src/input/mouse.rs
+++ b/crates/zendriver/src/input/mouse.rs
@@ -209,6 +209,16 @@ pub(crate) async fn click_at(
     // modelling one physical button from two places and will disagree
     // whatever this does. `InputController` is per-`Tab`; keep a gesture on
     // one task.
+    //
+    // What the guard gives up: the unconditional sweep it replaced also
+    // cleaned up a bit stranded by a dropped gesture future (the cancellation
+    // case on `InputState::buttons_held`). A click that finds the bit already
+    // set now records `we_latched = false`, so if its own press fails the
+    // stranded bit survives this call too. Not permanent — the in-loop
+    // release clears the bit unconditionally, so the next click that reaches
+    // a press self-heals it — but until then this tab's `mouseMoved` frames
+    // report `buttons: 1` with no preceding `mousedown`, the impossible
+    // stream that field doc calls worse than omitting `buttons`.
     let mut we_latched = false;
     let sequence: Result<()> = async {
         for n in 1..=click_count.max(1) {

--- a/crates/zendriver/src/input/touch.rs
+++ b/crates/zendriver/src/input/touch.rs
@@ -36,6 +36,15 @@ pub(crate) async fn tap_at(tab: &Tab, x: f64, y: f64) -> Result<()> {
             }),
         )
         .await?;
+    // A tap moves the pointer as far as the page is concerned, so keep the
+    // controller's cached cursor in step. Without this the next realistic mouse
+    // move builds its Bezier from a stale origin and opens by teleporting back
+    // to wherever the last mouse action landed.
+    {
+        let mut s = tab.input().state.lock().await;
+        s.pointer_x = x;
+        s.pointer_y = y;
+    }
     Ok(())
 }
 

--- a/crates/zendriver/src/lib.rs
+++ b/crates/zendriver/src/lib.rs
@@ -105,6 +105,8 @@ pub mod response_body;
 pub mod screenshot;
 pub mod storage;
 pub mod tab;
+#[cfg(test)]
+pub(crate) mod test_support;
 #[cfg(any(feature = "geo", feature = "tracker-blocking"))]
 pub mod tls;
 #[cfg(feature = "tracker-blocking")]

--- a/crates/zendriver/src/query/actionability.rs
+++ b/crates/zendriver/src/query/actionability.rs
@@ -2,6 +2,10 @@
 //! receives_pointer. Each runs a small JS function on the element's remote
 //! handle via `Element::call_on_main` and returns a `bool`.
 //!
+//! `call_on_main` binds the element as the first positional argument, so
+//! every body opens `function(el, ...)` and any caller-supplied arguments
+//! follow it.
+//!
 //! The aggregate gate ([`wait_actionable`]) polls the four predicates in
 //! order and raises `NotActionable` on deadline; `Element::click_with`,
 //! `hover`, `focus`, `type_text`, and `screenshot` (in `element::actions`
@@ -61,10 +65,38 @@ impl ActionabilityCheck {
     };
 }
 
-/// `true` iff the element is rendered: attached to the document, has a
-/// non-`null` `offsetParent` (catches `display: none` ancestors), a
-/// positive bbox, computed `visibility !== 'hidden'`, and computed
-/// `opacity !== '0'`.
+/// `true` iff the element is rendered **and on-screen**. An element is
+/// visible when all of the following hold:
+///
+/// - it is attached to the document (`isConnected`);
+/// - it passes the platform's own `Element.checkVisibility` test with
+///   `opacityProperty` + `visibilityProperty` + `contentVisibilityAuto`,
+///   which covers `display: none`, `visibility: hidden` / `collapse`,
+///   `content-visibility`, and `opacity: 0` on the element **or any
+///   ancestor**;
+/// - it has a positive bounding box;
+/// - its bounding box **intersects the viewport** — any overlap counts, so
+///   a partially-scrolled-in element still passes;
+/// - its *effective* opacity — the product of its own computed opacity and
+///   every ancestor's — is at least 1%.
+///
+/// The last two are the reason this isn't just a `checkVisibility` call.
+/// `checkVisibility` only rejects an *exact* `opacity: 0`, so the standard
+/// `opacity: 0.001` scraping honeypot passes it while being invisible to a
+/// human; and `checkVisibility` says nothing about where the element sits
+/// relative to the viewport.
+///
+/// Requires Chrome 121+, not 105+. `Element.checkVisibility` itself shipped
+/// in 105, but the three option names passed below (`opacityProperty`,
+/// `visibilityProperty`, `contentVisibilityAuto`) shipped in 121 — the first
+/// two as aliases for 105's `checkOpacity` / `checkVisibilityCSS`, the third
+/// as a new check (crbug feature 5070043440480256). Below 105 the call
+/// throws, surfacing as a `JsException`: a loud failure rather than a
+/// silently wrong answer. On 105–120 it does NOT throw — WebIDL drops
+/// dictionary members it doesn't recognize — so the call silently degrades
+/// to the default `display: none` test and stops covering
+/// `visibility: hidden`/`collapse` and `content-visibility: auto`. The
+/// effective-opacity loop below is independent of that and still holds.
 ///
 /// Live callers: `Element::is_visible` and the `visible_only` filter in
 /// `FindBuilder`/`FindAllBuilder` (`query::mod`).
@@ -72,14 +104,82 @@ pub(crate) async fn check_visible(el: &Element) -> Result<bool> {
     let js = r#"
         function(el) {
             if (!el || !el.isConnected) return false;
-            // offsetParent === null catches `display: none` on the element or any ancestor
-            // (except for fixed-position elements, which are handled by the bbox check below).
-            if (el.offsetParent === null && getComputedStyle(el).position !== 'fixed') return false;
+
+            // Platform primitive: handles `display: none`, `content-visibility`,
+            // `visibility: hidden`/`collapse` and `opacity: 0` on the element OR any
+            // ancestor — none of which the hand-rolled predecessor caught, since it
+            // only ever read the element's own computed style, and its layout probe
+            // reported a false negative for `position: fixed`.
+            if (!el.checkVisibility({
+                opacityProperty: true,
+                visibilityProperty: true,
+                contentVisibilityAuto: true
+            })) return false;
+
             const rect = el.getBoundingClientRect();
             if (rect.width <= 0 || rect.height <= 0) return false;
-            const style = getComputedStyle(el);
-            if (style.visibility === 'hidden') return false;
-            if (style.opacity === '0') return false;
+
+            // On-screen test: the bbox must overlap the viewport by at least a
+            // sliver. `getBoundingClientRect` is already viewport-relative, so
+            // the box it must be compared against is the LAYOUT viewport. Two
+            // things about reading that box are load-bearing:
+            //
+            // 1. It must never come from `window.inner*`. Every profile except
+            //    `StealthProfile::off()` — including `native()`, which
+            //    `Browser::builder()` installs by default — runs
+            //    `zendriver-stealth`'s `patches/screen.js`, which rewrites
+            //    `window.inner*` to the persona's screen size minus a fixed
+            //    86px chrome inset, while `scroll_into_view` moves the element
+            //    with Chrome's real viewport. Measured under the default
+            //    profile: `innerHeight` 994 against a real 1080. Comparing a
+            //    real-geometry scroll against that fabricated viewport leaves
+            //    every element landing in the 86px band permanently "not
+            //    visible", which broke `focus` — and with it `type_text` /
+            //    `press` / `type_keys` — on any below-the-fold field.
+            //
+            // 2. WHICH element reports the layout viewport depends on the
+            //    rendering mode, and reading the wrong one fails silently.
+            //    Standards mode: `documentElement`. Quirks (`BackCompat`):
+            //    `documentElement.client*` reports the document's CONTENT box
+            //    and `body.client*` reports the viewport. Measured on a 6000px
+            //    doctype-less page: `documentElement.clientHeight` 6024,
+            //    `body.clientHeight` 1080. Reading `documentElement`
+            //    unconditionally therefore compares the bbox against the whole
+            //    document on any page without a doctype — a no-op that fails
+            //    open, on exactly the sloppy legacy pages most likely to be
+            //    carrying a honeypot.
+            const box = document.compatMode === 'BackCompat'
+                ? document.body
+                : document.documentElement;
+            // The `BackCompat` arm can be null: a document whose `<body>` was
+            // removed still renders elements appended to `documentElement`, and
+            // still answers `isConnected` for them (reproduced against Chrome).
+            // The fallback is `visualViewport` rather than `window.inner*`
+            // because it is the other unspoofed source, and it reads the real
+            // 1080 in both modes. It is the VISUAL viewport, which diverges
+            // from the layout viewport under pinch-zoom or an on-screen
+            // keyboard — neither reachable through this crate's emulation
+            // surface, and neither triggerable by page script.
+            const vw = box ? box.clientWidth : window.visualViewport.width;
+            const vh = box ? box.clientHeight : window.visualViewport.height;
+            if (rect.right <= 0 || rect.bottom <= 0 || rect.left >= vw || rect.top >= vh) {
+                return false;
+            }
+
+            // Effective opacity: `checkVisibility` rejects only an exact `opacity: 0`,
+            // so a near-zero honeypot (`opacity: 0.001`) sails through it. Multiply the
+            // ancestor chain the way the compositor does and reject anything below 1%.
+            // The threshold is deliberately not `> 0`: exact-zero is the case honeypots
+            // avoid precisely because it is the one everyone already checks. 1% sits well
+            // below anything a real UI renders at rest and well above the honeypot range.
+            // Done last — `getComputedStyle` per ancestor is the priciest step here.
+            let effective = 1;
+            for (let node = el; node; node = node.parentElement) {
+                const own = parseFloat(getComputedStyle(node).opacity);
+                if (Number.isFinite(own)) effective *= own;
+            }
+            if (effective < 0.01) return false;
+
             return true;
         }
     "#;
@@ -134,19 +234,30 @@ pub(crate) async fn check_enabled(el: &Element) -> Result<bool> {
     Ok(res.get("value").and_then(|v| v.as_bool()).unwrap_or(false))
 }
 
-/// `true` iff a synthesized click at the element's bbox center would land
-/// on the element (or one of its descendants). Walks the ancestor chain
-/// of `document.elementFromPoint(cx, cy)`; if our element appears in that
+/// `true` iff a synthesized click at the point that will actually be clicked
+/// would land on the element (or one of its descendants). Walks the ancestor
+/// chain of `document.elementFromPoint(cx, cy)`; if our element appears in that
 /// chain, pointer events reach it. Returns `false` when a sibling overlay
 /// covers the hit point.
-pub(crate) async fn check_receives_pointer(el: &Element) -> Result<bool> {
+///
+/// `position` is the caller's offset from the bbox top-left, matching
+/// [`crate::ClickOptions::position`]; `None` hit-tests the centre. Probing a
+/// point the dispatch will not use lets the gate pass while the real click
+/// lands on an overlay.
+pub(crate) async fn check_receives_pointer(
+    el: &Element,
+    position: Option<(f64, f64)>,
+) -> Result<bool> {
     let js = r#"
-        function(el) {
+        function(el, dx, dy) {
             if (!el || !el.isConnected) return false;
             const rect = el.getBoundingClientRect();
             if (rect.width <= 0 || rect.height <= 0) return false;
-            const cx = rect.left + rect.width / 2;
-            const cy = rect.top + rect.height / 2;
+            // A caller with no explicit position passes no arguments at all,
+            // so dx/dy arrive as `undefined` — `Number.isFinite` covers that
+            // and any non-numeric junk in one test, falling back to the centre.
+            const cx = Number.isFinite(dx) ? rect.left + dx : rect.left + rect.width / 2;
+            const cy = Number.isFinite(dy) ? rect.top + dy : rect.top + rect.height / 2;
             let hit = document.elementFromPoint(cx, cy);
             while (hit) {
                 if (hit === el) return true;
@@ -155,7 +266,21 @@ pub(crate) async fn check_receives_pointer(el: &Element) -> Result<bool> {
             return false;
         }
     "#;
-    let res = el.call_on_main(js, json!([])).await?;
+    // `Runtime.callFunctionOn` takes an array of CallArgument *objects*, so
+    // each coordinate has to be wrapped in `{ "value": … }`; passing the bare
+    // numbers made Chrome reject the whole call with "Invalid parameters"
+    // ("Failed to deserialize params.arguments"), which failed every gated
+    // `click` / `hover` / `tap` against a real browser. The mock tests could
+    // not catch it — `MockConnection` doesn't validate CDP parameter shapes.
+    //
+    // `call_on_main` prepends the element handle, so these land at
+    // arguments[1] / arguments[2] — which is where the leading `el`
+    // parameter in the declaration above leaves `dx` / `dy`.
+    let args = match position {
+        Some((dx, dy)) => json!([{ "value": dx }, { "value": dy }]),
+        None => json!([]),
+    };
+    let res = el.call_on_main(js, args).await?;
     Ok(res.get("value").and_then(|v| v.as_bool()).unwrap_or(false))
 }
 
@@ -166,13 +291,21 @@ pub(crate) async fn check_receives_pointer(el: &Element) -> Result<bool> {
 /// animating)", or "occluded by overlay").
 ///
 /// Predicates are evaluated in fixed order: visible → enabled → stable →
-/// receives_pointer. This matches Playwright's gate ordering and avoids
-/// running the more-expensive stability + hit-testing checks while the
-/// element is still hidden or disabled.
+/// receives_pointer — the two cheap reads first, so the expensive
+/// two-frame stability wait and the hit-test never run while the element is
+/// still hidden or disabled. The *set* of checks is Playwright's; this
+/// ordering is not, and does not claim to be — Playwright's actionability
+/// docs list visible → stable → receives events → enabled.
+///
+/// `position` is the offset the caller will click at, forwarded to the
+/// hit-test so the gate probes the point the dispatch actually uses. `None`
+/// probes the bbox centre. It is re-read from the live bbox on every poll, so
+/// an element that moves mid-wait is hit-tested where it currently is.
 pub(crate) async fn wait_actionable(
     el: &Element,
     require: ActionabilityCheck,
     timeout: Duration,
+    position: Option<(f64, f64)>,
 ) -> Result<()> {
     let deadline = Instant::now() + timeout;
     let poll_interval = Duration::from_millis(50);
@@ -184,7 +317,7 @@ pub(crate) async fn wait_actionable(
             failed_reason = Some("not enabled");
         } else if require.stable && !check_stable(el).await? {
             failed_reason = Some("not stable (still animating)");
-        } else if require.receives_pointer && !check_receives_pointer(el).await? {
+        } else if require.receives_pointer && !check_receives_pointer(el, position).await? {
             failed_reason = Some("occluded by overlay");
         }
         match failed_reason {
@@ -196,5 +329,225 @@ pub(crate) async fn wait_actionable(
                 tokio::time::sleep(poll_interval).await;
             }
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::tab::Tab;
+    use crate::test_support::{serve_call, serve_call_js};
+    use serde_json::Value;
+    use zendriver_transport::SessionHandle;
+    use zendriver_transport::testing::MockConnection;
+
+    /// Drive `check_visible` against a mock connection, answer its probe with
+    /// `value`, and hand back the JS source the probe actually sent plus the
+    /// resolved verdict.
+    async fn probe_check_visible(value: bool) -> (String, bool) {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+        let el = Element::from_jsret(tab.clone(), 99, "R1".to_string());
+
+        let fut = tokio::spawn(async move { check_visible(&el).await });
+
+        let js = serve_call_js(&mut mock, json!({ "value": value, "type": "boolean" })).await;
+
+        let verdict = fut.await.unwrap().unwrap();
+        conn.shutdown();
+        (js, verdict)
+    }
+
+    #[tokio::test]
+    async fn check_visible_probe_delegates_to_check_visibility() {
+        let (js, verdict) = probe_check_visible(true).await;
+        assert!(verdict, "a `true` probe result must resolve to visible");
+        assert!(js.contains("checkVisibility"), "{js}");
+        // The three flags are what make `checkVisibility` cover ancestors —
+        // without them it only reports `display: none`.
+        assert!(js.contains("opacityProperty: true"), "{js}");
+        assert!(js.contains("visibilityProperty: true"), "{js}");
+        assert!(js.contains("contentVisibilityAuto: true"), "{js}");
+    }
+
+    #[tokio::test]
+    async fn check_visible_probe_tests_viewport_intersection() {
+        let (js, _) = probe_check_visible(true).await;
+        // `visible_only(true)` promises offscreen candidates are filtered
+        // out; that requires comparing the bbox against the viewport box.
+        assert!(js.contains("rect.right <= 0"), "{js}");
+        assert!(js.contains("rect.bottom <= 0"), "{js}");
+        assert!(js.contains("rect.left >= vw"), "{js}");
+        assert!(js.contains("rect.top >= vh"), "{js}");
+    }
+
+    /// The viewport box must be read from an unspoofed source, and from the
+    /// element that actually reports the layout viewport in *both* rendering
+    /// modes.
+    ///
+    /// Two separate defects are pinned here, both of which shipped:
+    ///
+    /// - Reading `window.inner*` at all. Every profile except
+    ///   `StealthProfile::off()` rewrites those, so they must not appear —
+    ///   not even as a trailing fallback. The predecessor of this test
+    ///   asserted only that `documentElement` came *first*, which a
+    ///   `documentElement.clientWidth || window.innerWidth` expression
+    ///   satisfies while still reaching the spoofed value.
+    /// - Reading `documentElement` unconditionally. In quirks mode that is
+    ///   the document's content box (6024 on a 6000px page), which is
+    ///   truthy, so the `||` fallback never fired and the whole on-screen
+    ///   clause degraded to a no-op. Asserting merely that *some* viewport
+    ///   is read would pass that.
+    ///
+    /// The whole-source substring search is safe because the probe's own
+    /// comments spell the spoofable pair `window.inner*` rather than naming
+    /// either property.
+    #[tokio::test]
+    async fn check_visible_probe_reads_the_layout_viewport_in_both_rendering_modes() {
+        let (js, _) = probe_check_visible(true).await;
+        assert!(!js.contains("window.innerWidth"), "{js}");
+        assert!(!js.contains("window.innerHeight"), "{js}");
+        assert!(js.contains("document.compatMode === 'BackCompat'"), "{js}");
+        assert!(js.contains("document.body"), "{js}");
+        assert!(js.contains("document.documentElement"), "{js}");
+    }
+
+    #[tokio::test]
+    async fn check_visible_probe_multiplies_ancestor_opacity_against_a_threshold() {
+        let (js, _) = probe_check_visible(true).await;
+        // Honeypot guard: walk the ancestor chain and compare the product
+        // against a non-zero floor, so `opacity: 0.001` (self OR ancestor)
+        // reads as hidden.
+        assert!(js.contains("node.parentElement"), "{js}");
+        assert!(js.contains("getComputedStyle(node).opacity"), "{js}");
+        assert!(js.contains("effective *= own"), "{js}");
+        assert!(js.contains("effective < 0.01"), "{js}");
+    }
+
+    #[tokio::test]
+    async fn check_visible_probe_drops_the_buggy_predecessors() {
+        let (js, _) = probe_check_visible(true).await;
+        // Regression pins for the three defects this probe replaced:
+        // a string compare against '0' (missed `opacity: 0.001`), an
+        // own-element-only style read (missed ancestor opacity), and the
+        // `offsetParent` hack (false negative on `position: fixed`).
+        assert!(!js.contains("offsetParent"), "{js}");
+        assert!(!js.contains("style.opacity"), "{js}");
+        assert!(!js.contains("=== '0'"), "{js}");
+    }
+
+    #[tokio::test]
+    async fn check_visible_reports_false_when_the_page_says_hidden() {
+        let (_, verdict) = probe_check_visible(false).await;
+        assert!(!verdict, "a `false` probe result must resolve to hidden");
+    }
+
+    /// `check_receives_pointer` must wrap its coordinates as CallArgument
+    /// *objects* (`{ "value": … }`).
+    ///
+    /// Regression pin for a live-only bug: the bare `[dx, dy]` this used to
+    /// send made Chrome reject the whole call with `-32602 Invalid parameters`
+    /// ("Failed to deserialize params.arguments"), so every gated `click` /
+    /// `hover` / `tap` failed against a real browser while the mock suite
+    /// stayed green — `MockConnection` replays frames without validating CDP
+    /// parameter shapes. Hence an explicit assertion on the shape.
+    #[tokio::test]
+    async fn check_receives_pointer_wraps_its_coordinates_as_call_arguments() {
+        // `call_on_main` prepends the element handle, so the coordinates are
+        // the second and third arguments — each one an object, never a bare
+        // number.
+        assert_eq!(
+            probe_pointer_args(Some((3.0, 4.0))).await,
+            json!([{ "objectId": "R1" }, { "value": 3.0 }, { "value": 4.0 }]),
+            "an explicit click position must travel as two CallArgument objects",
+        );
+
+        // No position → no coordinates at all, leaving dx/dy `undefined` in
+        // the JS, which is what its `Number.isFinite` centre-fallback reads.
+        assert_eq!(
+            probe_pointer_args(None).await,
+            json!([{ "objectId": "R1" }]),
+            "a centre hit-test must send no coordinates rather than bare nulls",
+        );
+    }
+
+    /// Drive one `check_receives_pointer` probe against a fresh mock and hand
+    /// back the `arguments` array it put on the wire.
+    async fn probe_pointer_args(at: Option<(f64, f64)>) -> Value {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+        let el = Element::from_jsret(tab, 99, "R1".to_string());
+
+        // Spawn before serving: nothing goes out until the probe is running.
+        let fut = tokio::spawn(async move { check_receives_pointer(&el, at).await });
+
+        let params = serve_call(&mut mock, json!({ "value": true, "type": "boolean" })).await;
+
+        assert!(fut.await.unwrap().unwrap());
+        conn.shutdown();
+        params["arguments"].clone()
+    }
+
+    /// Every predicate binds the element as its first positional argument.
+    ///
+    /// `call_on_main` prepends the element handle to `arguments`, so a body
+    /// that forgot its leading `el` parameter would silently read the handle
+    /// as its first *caller* argument — and, for the three no-argument
+    /// predicates, see `el` as `undefined` and answer `false` for everything.
+    /// This drives all four past that in one go.
+    #[tokio::test]
+    async fn every_predicate_binds_the_element_as_its_first_argument() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+        let el = Element::from_jsret(tab.clone(), 99, "R1".to_string());
+
+        let fut = tokio::spawn({
+            let e = el.clone();
+            async move {
+                (
+                    check_visible(&e).await.unwrap(),
+                    check_enabled(&e).await.unwrap(),
+                    check_stable(&e).await.unwrap(),
+                    check_receives_pointer(&e, None).await.unwrap(),
+                )
+            }
+        });
+
+        let mut calls = Vec::new();
+        for _ in 0..4 {
+            calls.push(serve_call(&mut mock, json!({ "value": true, "type": "boolean" })).await);
+        }
+
+        assert_eq!(fut.await.unwrap(), (true, true, true, true));
+
+        let sources: Vec<&str> = calls
+            .iter()
+            .map(|c| c["functionDeclaration"].as_str().unwrap())
+            .collect();
+
+        // Pin which source belongs to which predicate, so a future reorder of
+        // the gate can't quietly re-point one of these assertions.
+        assert!(sources[0].contains("checkVisibility"), "{}", sources[0]);
+        assert!(sources[1].contains("aria-disabled"), "{}", sources[1]);
+        assert!(
+            sources[2].contains("requestAnimationFrame"),
+            "{}",
+            sources[2]
+        );
+        assert!(sources[3].contains("elementFromPoint"), "{}", sources[3]);
+
+        for (call, js) in calls.iter().zip(&sources) {
+            assert!(js.trim_start().starts_with("function(el"), "{js}");
+            assert_eq!(
+                call["arguments"][0]["objectId"], "R1",
+                "the element must be the first argument the body reads",
+            );
+        }
+
+        conn.shutdown();
     }
 }

--- a/crates/zendriver/src/query/actionability.rs
+++ b/crates/zendriver/src/query/actionability.rs
@@ -11,6 +11,17 @@
 //! `hover`, `focus`, `type_text`, and `screenshot` (in `element::actions`
 //! / `element::screenshot`) each pick the [`ActionabilityCheck`] preset
 //! matching what they need before dispatching.
+//!
+//! # A note on this module's unit tests
+//!
+//! The predicates are JavaScript, and `MockConnection` replays CDP frames
+//! without a JS engine, so the `probe_source_*` tests below assert on the
+//! *source text* each predicate puts on the wire. They pin that a clause is
+//! present and spelled the way a past defect proved it has to be; they do
+//! not execute it, and a mutation that rewrites a clause into something
+//! equally well-formed but wrong passes them. Behavioral coverage lives in
+//! the live-Chrome tier (`tests/find_visible_only.rs`, gated on the
+//! `integration-tests` feature).
 
 use std::time::Duration;
 
@@ -22,15 +33,22 @@ use crate::error::{Result, ZendriverError};
 
 /// Set of actionability checks an action wants the element to satisfy
 /// before its CDP dispatch. Per-field booleans gate the corresponding
-/// `check_*` predicate in `wait_actionable`. Three named presets
-/// cover the common combinations (`FULL`, `VISIBLE_ONLY`, `TEXT_INPUT`);
-/// callers may also construct ad-hoc sets directly.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// `check_*` predicate in `wait_actionable`, and `hit_point` carries the
+/// coordinate the hit-test should probe. Four named presets cover the
+/// common combinations (`FULL`, `HOVER`, `VISIBLE_ONLY`, `TEXT_INPUT`);
+/// callers may also construct ad-hoc sets directly, and a caller with an
+/// explicit click position writes
+/// `ActionabilityCheck { hit_point: opts.position, ..FULL }`.
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct ActionabilityCheck {
     pub visible: bool,
     pub stable: bool,
     pub enabled: bool,
     pub receives_pointer: bool,
+    /// Offset from the bbox top-left that [`check_receives_pointer`] should
+    /// hit-test, matching [`crate::ClickOptions::position`]. `None` probes
+    /// the bbox centre. Ignored unless `receives_pointer` is set.
+    pub hit_point: Option<(f64, f64)>,
 }
 
 impl ActionabilityCheck {
@@ -41,6 +59,19 @@ impl ActionabilityCheck {
         stable: true,
         enabled: true,
         receives_pointer: true,
+        hit_point: None,
+    };
+
+    /// `FULL` minus the enabled check — used by `hover` / `hover_fast`.
+    /// Hovering does not activate the element, so a disabled control still
+    /// accepts `mouseover` and gating on `enabled` would reject a hover the
+    /// browser performs happily.
+    pub(crate) const HOVER: Self = Self {
+        visible: true,
+        stable: true,
+        enabled: false,
+        receives_pointer: true,
+        hit_point: None,
     };
 
     /// Visibility only — used by `screenshot` (we just need pixels to
@@ -51,6 +82,7 @@ impl ActionabilityCheck {
         stable: false,
         enabled: false,
         receives_pointer: false,
+        hit_point: None,
     };
 
     /// Text-input combo — used by `type_text` / `focus` where the element
@@ -62,7 +94,23 @@ impl ActionabilityCheck {
         stable: false,
         enabled: true,
         receives_pointer: false,
+        hit_point: None,
     };
+
+    /// How many `Runtime.callFunctionOn` probes one pass of
+    /// [`wait_actionable`] sends for this set — one per enabled predicate.
+    ///
+    /// Exists so a test fixture can serve exactly the gate's calls without
+    /// hard-coding a count per preset: a count that drifts from the set does
+    /// not fail cleanly, it eats the *next* unrelated call and the failure
+    /// surfaces at a later, unrelated `expect`.
+    #[cfg(test)]
+    pub(crate) const fn probe_count(self) -> usize {
+        self.visible as usize
+            + self.enabled as usize
+            + self.stable as usize
+            + self.receives_pointer as usize
+    }
 }
 
 /// `true` iff the element is rendered **and on-screen**. An element is
@@ -128,12 +176,16 @@ pub(crate) async fn check_visible(el: &Element) -> Result<bool> {
             //    `StealthProfile::off()` — including `native()`, which
             //    `Browser::builder()` installs by default — runs
             //    `zendriver-stealth`'s `patches/screen.js`, which rewrites
-            //    `window.inner*` to the persona's screen size minus a fixed
-            //    86px chrome inset, while `scroll_into_view` moves the element
-            //    with Chrome's real viewport. Measured under the default
-            //    profile: `innerHeight` 994 against a real 1080. Comparing a
+            //    `window.inner*` to the persona's screen size minus a chrome
+            //    inset, while `scroll_into_view` moves the element with
+            //    Chrome's real viewport. The inset is whatever the caller's
+            //    `ScreenSpec` measured, falling back to a derived 86px when no
+            //    capture supplied one, so its size is not knowable from here —
+            //    which is the point: no constant can compensate for it.
+            //    Measured under the default profile (the 86px fallback):
+            //    `innerHeight` 994 against a real 1080. Comparing a
             //    real-geometry scroll against that fabricated viewport leaves
-            //    every element landing in the 86px band permanently "not
+            //    every element landing in the inset band permanently "not
             //    visible", which broke `focus` — and with it `type_text` /
             //    `press` / `type_keys` — on any below-the-fold field.
             //
@@ -173,12 +225,14 @@ pub(crate) async fn check_visible(el: &Element) -> Result<bool> {
             // avoid precisely because it is the one everyone already checks. 1% sits well
             // below anything a real UI renders at rest and well above the honeypot range.
             // Done last — `getComputedStyle` per ancestor is the priciest step here.
+            // Opacity is in [0, 1], so the running product only ever decreases and
+            // cannot climb back over the threshold: once it is under, stop walking.
             let effective = 1;
             for (let node = el; node; node = node.parentElement) {
                 const own = parseFloat(getComputedStyle(node).opacity);
                 if (Number.isFinite(own)) effective *= own;
+                if (effective < 0.01) return false;
             }
-            if (effective < 0.01) return false;
 
             return true;
         }
@@ -297,15 +351,15 @@ pub(crate) async fn check_receives_pointer(
 /// ordering is not, and does not claim to be — Playwright's actionability
 /// docs list visible → stable → receives events → enabled.
 ///
-/// `position` is the offset the caller will click at, forwarded to the
-/// hit-test so the gate probes the point the dispatch actually uses. `None`
-/// probes the bbox centre. It is re-read from the live bbox on every poll, so
-/// an element that moves mid-wait is hit-tested where it currently is.
+/// `require.hit_point` is the offset the caller will click at, forwarded to
+/// the hit-test so the gate probes the point the dispatch actually uses.
+/// `None` probes the bbox centre. It is re-read from the live bbox on every
+/// poll, so an element that moves mid-wait is hit-tested where it currently
+/// is.
 pub(crate) async fn wait_actionable(
     el: &Element,
     require: ActionabilityCheck,
     timeout: Duration,
-    position: Option<(f64, f64)>,
 ) -> Result<()> {
     let deadline = Instant::now() + timeout;
     let poll_interval = Duration::from_millis(50);
@@ -317,7 +371,8 @@ pub(crate) async fn wait_actionable(
             failed_reason = Some("not enabled");
         } else if require.stable && !check_stable(el).await? {
             failed_reason = Some("not stable (still animating)");
-        } else if require.receives_pointer && !check_receives_pointer(el, position).await? {
+        } else if require.receives_pointer && !check_receives_pointer(el, require.hit_point).await?
+        {
             failed_reason = Some("occluded by overlay");
         }
         match failed_reason {
@@ -337,10 +392,17 @@ pub(crate) async fn wait_actionable(
 mod tests {
     use super::*;
     use crate::tab::Tab;
-    use crate::test_support::{serve_call, serve_call_js};
+    use crate::test_support::{js_params, serve_call, serve_call_js};
     use serde_json::Value;
     use zendriver_transport::SessionHandle;
     use zendriver_transport::testing::MockConnection;
+
+    /// Collapse every run of whitespace to a single space, so a source
+    /// assertion can span what the JS literal wraps across lines without
+    /// pinning its indentation.
+    fn one_line(js: &str) -> String {
+        js.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
 
     /// Drive `check_visible` against a mock connection, answer its probe with
     /// `value`, and hand back the JS source the probe actually sent plus the
@@ -361,7 +423,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn check_visible_probe_delegates_to_check_visibility() {
+    async fn probe_source_delegates_to_check_visibility() {
         let (js, verdict) = probe_check_visible(true).await;
         assert!(verdict, "a `true` probe result must resolve to visible");
         assert!(js.contains("checkVisibility"), "{js}");
@@ -373,7 +435,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn check_visible_probe_tests_viewport_intersection() {
+    async fn probe_source_tests_viewport_intersection() {
         let (js, _) = probe_check_visible(true).await;
         // `visible_only(true)` promises offscreen candidates are filtered
         // out; that requires comparing the bbox against the viewport box.
@@ -404,18 +466,28 @@ mod tests {
     /// The whole-source substring search is safe because the probe's own
     /// comments spell the spoofable pair `window.inner*` rather than naming
     /// either property.
+    ///
+    /// The ternary is asserted whole rather than as three independent
+    /// substrings. Naming `compatMode`, `body` and `documentElement`
+    /// separately is satisfied just as well by the arms swapped the wrong way
+    /// round — which is the exact defect the second bullet describes, so a
+    /// pin that cannot tell the two apart pins nothing.
     #[tokio::test]
-    async fn check_visible_probe_reads_the_layout_viewport_in_both_rendering_modes() {
+    async fn probe_source_reads_the_layout_viewport_in_both_rendering_modes() {
         let (js, _) = probe_check_visible(true).await;
         assert!(!js.contains("window.innerWidth"), "{js}");
         assert!(!js.contains("window.innerHeight"), "{js}");
-        assert!(js.contains("document.compatMode === 'BackCompat'"), "{js}");
-        assert!(js.contains("document.body"), "{js}");
-        assert!(js.contains("document.documentElement"), "{js}");
+        assert!(
+            one_line(&js).contains(
+                "document.compatMode === 'BackCompat' ? document.body : document.documentElement"
+            ),
+            "quirks mode must select `body` and standards mode `documentElement`, \
+             in that order: {js}"
+        );
     }
 
     #[tokio::test]
-    async fn check_visible_probe_multiplies_ancestor_opacity_against_a_threshold() {
+    async fn probe_source_multiplies_ancestor_opacity_against_a_threshold() {
         let (js, _) = probe_check_visible(true).await;
         // Honeypot guard: walk the ancestor chain and compare the product
         // against a non-zero floor, so `opacity: 0.001` (self OR ancestor)
@@ -423,11 +495,18 @@ mod tests {
         assert!(js.contains("node.parentElement"), "{js}");
         assert!(js.contains("getComputedStyle(node).opacity"), "{js}");
         assert!(js.contains("effective *= own"), "{js}");
-        assert!(js.contains("effective < 0.01"), "{js}");
+        // The threshold test sits *inside* the walk: the product only ever
+        // decreases, so a chain that has already gone under can stop early.
+        assert!(
+            one_line(&js).contains(
+                "if (Number.isFinite(own)) effective *= own; if (effective < 0.01) return false; }"
+            ),
+            "the opacity floor must be checked inside the ancestor walk: {js}"
+        );
     }
 
     #[tokio::test]
-    async fn check_visible_probe_drops_the_buggy_predecessors() {
+    async fn probe_source_drops_the_buggy_predecessors() {
         let (js, _) = probe_check_visible(true).await;
         // Regression pins for the three defects this probe replaced:
         // a string compare against '0' (missed `opacity: 0.001`), an
@@ -438,10 +517,15 @@ mod tests {
         assert!(!js.contains("=== '0'"), "{js}");
     }
 
+    /// Not a source pin: this one covers the Rust side of `check_visible`,
+    /// namely that it reads the probe's verdict out of `result.value` rather
+    /// than defaulting to the `unwrap_or(false)` fallback.
     #[tokio::test]
-    async fn check_visible_reports_false_when_the_page_says_hidden() {
-        let (_, verdict) = probe_check_visible(false).await;
-        assert!(!verdict, "a `false` probe result must resolve to hidden");
+    async fn check_visible_resolves_the_probe_result_it_was_handed() {
+        let (_, hidden) = probe_check_visible(false).await;
+        assert!(!hidden, "a `false` probe result must resolve to hidden");
+        let (_, shown) = probe_check_visible(true).await;
+        assert!(shown, "a `true` probe result must resolve to visible");
     }
 
     /// `check_receives_pointer` must wrap its coordinates as CallArgument
@@ -491,13 +575,19 @@ mod tests {
         params["arguments"].clone()
     }
 
-    /// Every predicate binds the element as its first positional argument.
+    /// Every predicate binds the element as its first positional argument,
+    /// and `check_receives_pointer` takes its coordinates in `(dx, dy)` order.
     ///
     /// `call_on_main` prepends the element handle to `arguments`, so a body
     /// that forgot its leading `el` parameter would silently read the handle
     /// as its first *caller* argument — and, for the three no-argument
     /// predicates, see `el` as `undefined` and answer `false` for everything.
     /// This drives all four past that in one go.
+    ///
+    /// The whole parameter list is asserted, not just the leading name: a
+    /// `starts_with("function(el")` check accepts `function(elephant, dy, dx)`
+    /// — right prefix, transposed coordinates, every hit-test off by the
+    /// difference between the two offsets.
     #[tokio::test]
     async fn every_predicate_binds_the_element_as_its_first_argument() {
         let (mut mock, conn) = MockConnection::pair();
@@ -540,8 +630,11 @@ mod tests {
         );
         assert!(sources[3].contains("elementFromPoint"), "{}", sources[3]);
 
-        for (call, js) in calls.iter().zip(&sources) {
-            assert!(js.trim_start().starts_with("function(el"), "{js}");
+        // The three no-argument predicates bind `el` and nothing else; the
+        // hit-test binds the two offsets after it, dx before dy.
+        let expected = [vec!["el"], vec!["el"], vec!["el"], vec!["el", "dx", "dy"]];
+        for ((call, js), want) in calls.iter().zip(&sources).zip(expected) {
+            assert_eq!(js_params(js), want, "{js}");
             assert_eq!(
                 call["arguments"][0]["objectId"], "R1",
                 "the element must be the first argument the body reads",

--- a/crates/zendriver/src/query/actionability.rs
+++ b/crates/zendriver/src/query/actionability.rs
@@ -19,9 +19,22 @@
 //! *source text* each predicate puts on the wire. They pin that a clause is
 //! present and spelled the way a past defect proved it has to be; they do
 //! not execute it, and a mutation that rewrites a clause into something
-//! equally well-formed but wrong passes them. Behavioral coverage lives in
-//! the live-Chrome tier (`tests/find_visible_only.rs`, gated on the
-//! `integration-tests` feature).
+//! equally well-formed but wrong passes them.
+//!
+//! The live-Chrome tier reaches part of that, and does not gate a merge.
+//! `tests/find_visible_only.rs` (gated on the `integration-tests` feature)
+//! drives `visible_only(true)` against a real browser, so `check_visible`'s
+//! `display: none` path does execute there — but every test in that file is
+//! `#[ignore]`d, and the per-PR integration job runs plain
+//! `cargo nextest run -E 'kind(test)'` with no `--run-ignored`. So it runs
+//! only in the scheduled `nightly-ignored-tests` lane, which carries
+//! `continue-on-error: true`.
+//!
+//! Nothing else is covered behaviorally: the opacity, viewport and
+//! quirks-mode clauses are pinned only by the source-text assertions below,
+//! and `check_stable` / `check_enabled` / `check_receives_pointer` have no
+//! live fixture at all. Widening any of those clauses means writing the
+//! fixture that would catch the mistake; do not assume one is waiting.
 
 use std::time::Duration;
 

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -44,6 +44,11 @@ const DEFAULT_LOAD_TIMEOUT: Duration = Duration::from_secs(30);
 /// channel.
 const READY_STATE_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Fallback tick for [`Tab::wait_for_idle_opts`]'s wait loop, used when no
+/// membership change wakes it sooner. This is the "+50 ms" in the documented
+/// worst case of `quiet_window + 50ms`, so the two must move together.
+const IDLE_FALLBACK_TICK: Duration = Duration::from_millis(50);
+
 /// Fixed `(x, y)` viewport anchor for [`Tab::scroll_with`] gestures. A
 /// constant in-viewport point keeps page scrolls deterministic and
 /// single-dispatch (no `Page.getLayoutMetrics` round-trip to derive a
@@ -993,6 +998,17 @@ impl Tab {
                 }),
             )
             .await
+            .inspect_err(|e| {
+                // Swallowing this made a failed evaluate indistinguishable from
+                // a not-yet-complete page: both fall through to a full
+                // `DEFAULT_LOAD_TIMEOUT` block on the event stream, with
+                // nothing anywhere saying the probe never ran.
+                tracing::warn!(
+                    error = %e,
+                    "wait_for_load: document.readyState probe failed; \
+                     falling back to waiting for Page.frameStoppedLoading"
+                );
+            })
             .ok()
             .and_then(|v| v.get("result")?.get("value")?.as_str().map(str::to_owned));
         if ready.as_deref() == Some("complete") {
@@ -1892,7 +1908,7 @@ impl Tab {
                 return Err(ZendriverError::Timeout(timeout));
             }
             tokio::select! {
-                () = tokio::time::sleep(Duration::from_millis(50)) => {}
+                () = tokio::time::sleep(IDLE_FALLBACK_TICK) => {}
                 () = notif => {
                     // A membership change fired since we armed `notif`. Reset
                     // the quiet window — even if the set is back to zero by
@@ -2013,7 +2029,14 @@ impl Tab {
     /// ```
     pub async fn mouse_move(&self, x: f64, y: f64) -> Result<()> {
         let input = self.input().clone();
-        crate::input::mouse::move_realistic(&input, self, x, y).await
+        crate::input::mouse::move_realistic(
+            &input,
+            self,
+            x,
+            y,
+            crate::input::keyboard::KeyModifiers::empty(),
+        )
+        .await
     }
 
     /// Click at `(x, y)` in viewport coordinates: a left, single, realistic
@@ -2041,9 +2064,7 @@ impl Tab {
             self,
             x,
             y,
-            crate::input::mouse::MouseButton::Left,
-            1,
-            true,
+            &crate::element::actions::ClickOptions::default(),
         )
         .await
     }
@@ -2051,11 +2072,12 @@ impl Tab {
     /// Click at `(x, y)` in viewport coordinates with explicit
     /// [`crate::ClickOptions`].
     ///
-    /// Maps `opts.button` / `opts.click_count` / `opts.realistic` onto the
-    /// dispatch. Unlike [`crate::Element::click_with`], there is no element to
-    /// gate on, so `opts.force` and `opts.position` are ignored — the click
-    /// lands at the supplied `(x, y)` regardless. Use this for right-clicks /
-    /// modifier-held clicks / double-clicks / raw teleports at a coordinate.
+    /// Maps `opts.button` / `opts.click_count` / `opts.modifiers` /
+    /// `opts.realistic` onto the dispatch. Unlike [`crate::Element::click_with`],
+    /// there is no element to gate on, so `opts.force` and `opts.position` are
+    /// ignored — the click lands at the supplied `(x, y)` regardless. Use this
+    /// for right-clicks / modifier-held clicks / double-clicks / raw teleports
+    /// at a coordinate.
     ///
     /// # Examples
     ///
@@ -2077,16 +2099,7 @@ impl Tab {
         opts: crate::element::actions::ClickOptions,
     ) -> Result<()> {
         let input = self.input().clone();
-        crate::input::mouse::click_at(
-            &input,
-            self,
-            x,
-            y,
-            opts.button,
-            opts.click_count,
-            opts.realistic,
-        )
-        .await
+        crate::input::mouse::click_at(&input, self, x, y, &opts).await
     }
 
     /// Tap at `(x, y)` in viewport coordinates.
@@ -2189,54 +2202,114 @@ pointer-events:none;opacity:0.85;'; \
     /// # Ok(()) }
     /// ```
     pub async fn mouse_drag(&self, from: (f64, f64), to: (f64, f64), steps: usize) -> Result<()> {
-        // Press the left button at the source point.
-        self.call(
-            "Input.dispatchMouseEvent",
-            json!({
-                "type": "mousePressed",
-                "x": from.0, "y": from.1,
-                "button": "left",
-                "clickCount": 1,
-            }),
-        )
-        .await?;
+        // CDP `buttons` bitmask for a held left button — the same bit
+        // `MouseButtonSet::LEFT` uses. Every event between the press and the
+        // release must carry it: a page implementing drag with `mousemove` +
+        // `e.buttons` (the standard modern check, and what most slider widgets
+        // and DnD libraries use) drops the whole gesture without it, while
+        // every CDP call still succeeds.
+        const LEFT_HELD: u8 = crate::input::pointer_state::MouseButtonSet::LEFT.bits();
 
-        // Interpolate the move. nodriver walks i in 0..=steps (steps+1 points,
-        // the first coinciding with `from`); steps <= 1 collapses to a single
-        // hop straight to `to`.
-        let steps = steps.max(1);
-        if steps == 1 {
+        // `buttons_held` lives on the per-Tab InputController, which outlives
+        // this call, so a `?` between the press and the release — an
+        // interpolated `mouseMoved` failing partway is the realistic one —
+        // would strand the LEFT bit set for the rest of the tab's life. Every
+        // later `mouseMoved` would then report a button held with no preceding
+        // mousedown, which is a worse signal to leak to behavioral anti-bot
+        // scoring than omitting `buttons` altogether.
+        //
+        // So the whole gesture runs as one fallible section and the state fixup
+        // happens at the single exit below, rather than via a `Drop` guard:
+        // clearing the bit needs the async `Mutex`, `Drop` cannot await, and a
+        // `try_lock` inside `Drop` would silently fail under contention —
+        // exactly when another task is mid-dispatch and about to read the stale
+        // bit. More machinery, weaker guarantee.
+        //
+        // Residual case it does not cover: if the caller drops this future
+        // mid-gesture (cancellation, an outer `tokio::time::timeout`), the
+        // fixup never runs and the bit stays set. A `Drop` guard would not
+        // reliably close that either, for the `try_lock` reason above.
+        let gesture: Result<()> = async {
+            // Press the left button at the source point.
             self.call(
                 "Input.dispatchMouseEvent",
-                json!({ "type": "mouseMoved", "x": to.0, "y": to.1 }),
+                json!({
+                    "type": "mousePressed",
+                    "x": from.0, "y": from.1,
+                    "button": "left",
+                    "clickCount": 1,
+                    "buttons": LEFT_HELD,
+                }),
             )
             .await?;
-        } else {
-            let step_x = (to.0 - from.0) / steps as f64;
-            let step_y = (to.1 - from.1) / steps as f64;
-            for i in 0..=steps {
-                let x = from.0 + step_x * i as f64;
-                let y = from.1 + step_y * i as f64;
+            {
+                let input = self.input().clone();
+                let mut s = input.state.lock().await;
+                s.buttons_held
+                    .insert(crate::input::pointer_state::MouseButtonSet::LEFT);
+            }
+
+            // Interpolate the move. nodriver walks i in 0..=steps (steps+1
+            // points, the first coinciding with `from`); steps <= 1 collapses
+            // to a single hop straight to `to`.
+            let steps = steps.max(1);
+            if steps == 1 {
                 self.call(
                     "Input.dispatchMouseEvent",
-                    json!({ "type": "mouseMoved", "x": x, "y": y }),
+                    json!({ "type": "mouseMoved", "x": to.0, "y": to.1, "buttons": LEFT_HELD }),
                 )
                 .await?;
+            } else {
+                let step_x = (to.0 - from.0) / steps as f64;
+                let step_y = (to.1 - from.1) / steps as f64;
+                for i in 0..=steps {
+                    let x = from.0 + step_x * i as f64;
+                    let y = from.1 + step_y * i as f64;
+                    self.call(
+                        "Input.dispatchMouseEvent",
+                        json!({ "type": "mouseMoved", "x": x, "y": y, "buttons": LEFT_HELD }),
+                    )
+                    .await?;
+                }
+            }
+
+            // Release at the destination. `buttons` is now empty — the button
+            // is no longer held once the release is dispatched.
+            self.call(
+                "Input.dispatchMouseEvent",
+                json!({
+                    "type": "mouseReleased",
+                    "x": to.0, "y": to.1,
+                    "button": "left",
+                    "clickCount": 1,
+                    "buttons": 0,
+                }),
+            )
+            .await?;
+            Ok(())
+        }
+        .await;
+
+        {
+            let input = self.input().clone();
+            let mut s = input.state.lock().await;
+            // Whether the gesture finished or a dispatch failed partway, this
+            // tab is no longer holding the button as far as our state goes.
+            s.buttons_held
+                .remove(crate::input::pointer_state::MouseButtonSet::LEFT);
+            if gesture.is_ok() {
+                // Leave the controller's cached cursor where the drag actually
+                // ended. Skipping this made the next `move_realistic` build its
+                // Bezier from a stale origin, so the path started by teleporting
+                // back to wherever the last click landed. On failure the real
+                // cursor is at some indeterminate intermediate point, so leave
+                // the cache alone rather than assert a position we never
+                // reached.
+                s.pointer_x = to.0;
+                s.pointer_y = to.1;
             }
         }
-
-        // Release at the destination.
-        self.call(
-            "Input.dispatchMouseEvent",
-            json!({
-                "type": "mouseReleased",
-                "x": to.0, "y": to.1,
-                "button": "left",
-                "clickCount": 1,
-            }),
-        )
-        .await?;
-        Ok(())
+        gesture
     }
 
     /// Search the text content of every loaded frame resource for `query`,
@@ -4698,6 +4771,193 @@ mod tests {
         conn.shutdown();
     }
 
+    /// Drain every `Input.dispatchMouseEvent` a click emits, returning
+    /// `(type, buttons, modifiers, clickCount)` per frame.
+    async fn drain_mouse_dispatches(mock: &mut MockConnection) -> Vec<(String, u64, u64, u64)> {
+        let mut frames = Vec::new();
+        loop {
+            let next = tokio::time::timeout(
+                Duration::from_millis(500),
+                mock.expect_cmd("Input.dispatchMouseEvent"),
+            )
+            .await;
+            match next {
+                Ok(id) => {
+                    let sent = mock.last_sent();
+                    let p = &sent["params"];
+                    frames.push((
+                        p["type"].as_str().unwrap_or("").to_string(),
+                        p["buttons"].as_u64().unwrap_or(u64::MAX),
+                        p["modifiers"].as_u64().unwrap_or(u64::MAX),
+                        p["clickCount"].as_u64().unwrap_or(0),
+                    ));
+                    mock.reply(id, json!({})).await;
+                }
+                Err(_) => break,
+            }
+        }
+        frames
+    }
+
+    /// Every dispatch must carry CDP's `buttons` bitmask. Without it a page
+    /// implementing drag with `mousemove` + `e.buttons` — the standard modern
+    /// check — sees no button held and silently drops the gesture.
+    #[tokio::test]
+    async fn mouse_click_sends_buttons_bitmask_across_the_sequence() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move { t.mouse_click(10.0, 20.0).await }
+        });
+        let frames = drain_mouse_dispatches(&mut mock).await;
+        fut.await.unwrap().unwrap();
+
+        assert!(
+            frames.iter().all(|(_, buttons, ..)| *buttons != u64::MAX),
+            "every dispatch must include a `buttons` field: {frames:?}"
+        );
+        for (kind, buttons, ..) in &frames {
+            let expected = match kind.as_str() {
+                // Nothing is held before the press or after the release.
+                "mouseMoved" | "mouseReleased" => 0,
+                // MouseButtonSet::LEFT — the same bit CDP uses.
+                "mousePressed" => 1,
+                other => panic!("unexpected dispatch type: {other}"),
+            };
+            assert_eq!(*buttons, expected, "wrong `buttons` on {kind}: {frames:?}");
+        }
+        conn.shutdown();
+    }
+
+    /// The drag case is the one that actually broke pages: every `mouseMoved`
+    /// between the press and the release must report the left button held, or a
+    /// page using the standard `mousemove` + `e.buttons` drag check silently
+    /// does nothing while every CDP call returns success.
+    #[tokio::test]
+    async fn mouse_drag_reports_the_button_held_on_every_move() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move { t.mouse_drag((10.0, 10.0), (200.0, 10.0), 5).await }
+        });
+        let frames = drain_mouse_dispatches(&mut mock).await;
+        fut.await.unwrap().unwrap();
+
+        let moves: Vec<_> = frames.iter().filter(|(k, ..)| k == "mouseMoved").collect();
+        assert!(!moves.is_empty(), "expected mouseMoved frames: {frames:?}");
+        for (kind, buttons, ..) in &frames {
+            let expected = match kind.as_str() {
+                // Held for the whole gesture, including every intermediate move.
+                "mousePressed" | "mouseMoved" => 1,
+                // Released — nothing held once the button comes back up.
+                "mouseReleased" => 0,
+                other => panic!("unexpected dispatch type: {other}"),
+            };
+            assert_eq!(*buttons, expected, "wrong `buttons` on {kind}: {frames:?}");
+        }
+
+        // The drag must also leave the cached cursor at the destination, or the
+        // next realistic move opens by teleporting back to the old position.
+        let s = tab.input().state.lock().await;
+        assert_eq!((s.pointer_x, s.pointer_y), (200.0, 10.0));
+        assert!(s.buttons_held.is_empty(), "button still held after release");
+        drop(s);
+        conn.shutdown();
+    }
+
+    /// `ClickOptions::modifiers` must reach the wire. It was previously read by
+    /// nothing on any path, so a Ctrl/Cmd/Shift-click was inexpressible.
+    #[tokio::test]
+    async fn click_options_modifiers_reach_the_dispatch() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+
+        let mods = crate::input::keyboard::KeyModifiers::CTRL
+            | crate::input::keyboard::KeyModifiers::SHIFT;
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move {
+                t.mouse_click_with(
+                    10.0,
+                    20.0,
+                    crate::element::actions::ClickOptions {
+                        modifiers: mods,
+                        ..Default::default()
+                    },
+                )
+                .await
+            }
+        });
+        let frames = drain_mouse_dispatches(&mut mock).await;
+        fut.await.unwrap().unwrap();
+
+        let expected = mods.cdp_bits() as u64;
+        assert_ne!(expected, 0, "test would be vacuous with no modifiers set");
+        let pressed: Vec<_> = frames
+            .iter()
+            .filter(|(k, ..)| k == "mousePressed")
+            .collect();
+        assert!(!pressed.is_empty(), "expected a mousePressed: {frames:?}");
+        for (kind, _, modifiers, _) in &frames {
+            assert_eq!(
+                *modifiers, expected,
+                "modifiers missing from {kind}: {frames:?}"
+            );
+        }
+        conn.shutdown();
+    }
+
+    /// Chrome produces a real double-click as two press/release pairs with an
+    /// increasing `clickCount`, not one pair carrying `clickCount: 2`. A page
+    /// counting `mousedown` events sees nothing from the collapsed form.
+    #[tokio::test]
+    async fn double_click_emits_two_pairs_with_increasing_click_count() {
+        let (mut mock, conn) = MockConnection::pair();
+        let sess = SessionHandle::new(conn.clone(), "S1");
+        let tab = Tab::new_for_test(sess);
+
+        let fut = tokio::spawn({
+            let t = tab.clone();
+            async move {
+                t.mouse_click_with(
+                    10.0,
+                    20.0,
+                    crate::element::actions::ClickOptions {
+                        click_count: 2,
+                        ..Default::default()
+                    },
+                )
+                .await
+            }
+        });
+        let frames = drain_mouse_dispatches(&mut mock).await;
+        fut.await.unwrap().unwrap();
+
+        let pairs: Vec<_> = frames
+            .iter()
+            .filter(|(k, ..)| k == "mousePressed" || k == "mouseReleased")
+            .map(|(k, _, _, count)| (k.as_str(), *count))
+            .collect();
+        assert_eq!(
+            pairs,
+            vec![
+                ("mousePressed", 1),
+                ("mouseReleased", 1),
+                ("mousePressed", 2),
+                ("mouseReleased", 2),
+            ],
+            "expected two press/release pairs with clickCount 1 then 2: {frames:?}"
+        );
+        conn.shutdown();
+    }
+
     #[tokio::test]
     async fn mouse_move_emits_mousemoved() {
         let (mut mock, conn) = MockConnection::pair();
@@ -4868,17 +5128,11 @@ mod tests {
         mock.reply(id_d, json!({ "node": { "backendNodeId": 7 } }))
             .await;
 
-        // Step 2: type_text_fast focuses the body first — actionability gate
-        // (TEXT_INPUT = visible → enabled, 2 callFunctionOn) then this.focus()
-        // (1 callFunctionOn). Reply truthy/undefined to each.
-        for _ in 0..2 {
-            let id = mock.expect_cmd("Runtime.callFunctionOn").await;
-            mock.reply(
-                id,
-                json!({ "result": { "value": true, "type": "boolean" } }),
-            )
-            .await;
-        }
+        // Step 2: type_text_fast focuses the body first — scroll_into_view,
+        // the actionability gate (TEXT_INPUT = visible → enabled), then
+        // this.focus(). Reply truthy/undefined to each.
+        crate::test_support::serve_scroll_into_view(&mut mock).await;
+        crate::test_support::serve_gate_probes(&mut mock, 2).await;
         let id_focus = mock.expect_cmd("Runtime.callFunctionOn").await;
         mock.reply(id_focus, json!({ "result": { "type": "undefined" } }))
             .await;

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -45,8 +45,11 @@ const DEFAULT_LOAD_TIMEOUT: Duration = Duration::from_secs(30);
 const READY_STATE_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Fallback tick for [`Tab::wait_for_idle_opts`]'s wait loop, used when no
-/// membership change wakes it sooner. This is the "+50 ms" in the documented
-/// worst case of `quiet_window + 50ms`, so the two must move together.
+/// membership change wakes it sooner. It is the additive term in
+/// [`Tab::wait_for_idle_opts`]'s documented worst case, which names this
+/// constant rather than repeating the number. The two test-scenario comments
+/// that spell 50ms (`wait_for_idle_*`) are arithmetic about a specific
+/// timeline and would read worse with the name substituted in.
 const IDLE_FALLBACK_TICK: Duration = Duration::from_millis(50);
 
 /// Fixed `(x, y)` viewport anchor for [`Tab::scroll_with`] gestures. A
@@ -1788,8 +1791,9 @@ impl Tab {
     /// Wait for network idle with full control over the policy via
     /// [`IdleOptions`].
     ///
-    /// Algorithm: poll the in-flight set with a `Notify`-driven wake (or a
-    /// 50ms fallback tick). Each iteration computes the number of *active*
+    /// Algorithm: poll the in-flight set with a `Notify`-driven wake (or an
+    /// [`IDLE_FALLBACK_TICK`] fallback tick). Each iteration computes the
+    /// number of *active*
     /// requests — every in-flight request when
     /// [`IdleOptions::max_inflight_age`] is `None`, otherwise only those in
     /// flight for less than that age (older ones are treated as stuck /
@@ -1798,10 +1802,10 @@ impl Tab {
     /// count is non-zero or a membership change fires. Return once
     /// `now - quiet_start >= quiet_window`.
     ///
-    /// The 50ms tick bounds latency both for the already-idle case (no further
+    /// That tick bounds latency both for the already-idle case (no further
     /// events fire) and for an age-out crossing (which emits no CDP event), so
     /// worst-case latency to detect "stayed idle long enough" is
-    /// `quiet_window + 50ms`.
+    /// `quiet_window + `[`IDLE_FALLBACK_TICK`].
     ///
     /// Under [`IdleOptions::loss_policy`] = [`IdleLossPolicy::Strict`], the
     /// wait additionally races against this tab's connection's accounted
@@ -2202,35 +2206,27 @@ pointer-events:none;opacity:0.85;'; \
     /// # Ok(()) }
     /// ```
     pub async fn mouse_drag(&self, from: (f64, f64), to: (f64, f64), steps: usize) -> Result<()> {
-        // CDP `buttons` bitmask for a held left button — the same bit
-        // `MouseButtonSet::LEFT` uses. Every event between the press and the
-        // release must carry it: a page implementing drag with `mousemove` +
-        // `e.buttons` (the standard modern check, and what most slider widgets
-        // and DnD libraries use) drops the whole gesture without it, while
-        // every CDP call still succeeds.
-        const LEFT_HELD: u8 = crate::input::pointer_state::MouseButtonSet::LEFT.bits();
+        use crate::input::pointer_state::MouseButtonSet;
 
-        // `buttons_held` lives on the per-Tab InputController, which outlives
-        // this call, so a `?` between the press and the release — an
-        // interpolated `mouseMoved` failing partway is the realistic one —
-        // would strand the LEFT bit set for the rest of the tab's life. Every
-        // later `mouseMoved` would then report a button held with no preceding
-        // mousedown, which is a worse signal to leak to behavioral anti-bot
-        // scoring than omitting `buttons` altogether.
-        //
-        // So the whole gesture runs as one fallible section and the state fixup
-        // happens at the single exit below, rather than via a `Drop` guard:
-        // clearing the bit needs the async `Mutex`, `Drop` cannot await, and a
-        // `try_lock` inside `Drop` would silently fail under contention —
-        // exactly when another task is mid-dispatch and about to read the stale
-        // bit. More machinery, weaker guarantee.
-        //
-        // Residual case it does not cover: if the caller drops this future
-        // mid-gesture (cancellation, an outer `tokio::time::timeout`), the
-        // fixup never runs and the bit stays set. A `Drop` guard would not
-        // reliably close that either, for the `try_lock` reason above.
+        // One fallible section plus one state fixup at the single exit below,
+        // rather than a `Drop` guard. The full rationale — and the
+        // cancellation case it does not cover — is on
+        // `InputState::buttons_held`; `mouse::click_at` uses the same shape.
         let gesture: Result<()> = async {
-            // Press the left button at the source point.
+            // Press the left button at the source point. `buttons` on this
+            // frame is the set held *after* the press, so latch the bit and
+            // read the wire value out of the same locked section — every
+            // event between the press and the release has to carry it, since
+            // a page implementing drag with `mousemove` + `e.buttons` (the
+            // standard modern check, and what most slider widgets and DnD
+            // libraries use) drops the whole gesture without it while every
+            // CDP call still succeeds.
+            let held = {
+                let input = self.input().clone();
+                let mut s = input.state.lock().await;
+                s.buttons_held.insert(MouseButtonSet::LEFT);
+                s.buttons_held.bits()
+            };
             self.call(
                 "Input.dispatchMouseEvent",
                 json!({
@@ -2238,16 +2234,10 @@ pointer-events:none;opacity:0.85;'; \
                     "x": from.0, "y": from.1,
                     "button": "left",
                     "clickCount": 1,
-                    "buttons": LEFT_HELD,
+                    "buttons": held,
                 }),
             )
             .await?;
-            {
-                let input = self.input().clone();
-                let mut s = input.state.lock().await;
-                s.buttons_held
-                    .insert(crate::input::pointer_state::MouseButtonSet::LEFT);
-            }
 
             // Interpolate the move. nodriver walks i in 0..=steps (steps+1
             // points, the first coinciding with `from`); steps <= 1 collapses
@@ -2256,7 +2246,7 @@ pointer-events:none;opacity:0.85;'; \
             if steps == 1 {
                 self.call(
                     "Input.dispatchMouseEvent",
-                    json!({ "type": "mouseMoved", "x": to.0, "y": to.1, "buttons": LEFT_HELD }),
+                    json!({ "type": "mouseMoved", "x": to.0, "y": to.1, "buttons": held }),
                 )
                 .await?;
             } else {
@@ -2267,14 +2257,22 @@ pointer-events:none;opacity:0.85;'; \
                     let y = from.1 + step_y * i as f64;
                     self.call(
                         "Input.dispatchMouseEvent",
-                        json!({ "type": "mouseMoved", "x": x, "y": y, "buttons": LEFT_HELD }),
+                        json!({ "type": "mouseMoved", "x": x, "y": y, "buttons": held }),
                     )
                     .await?;
                 }
             }
 
-            // Release at the destination. `buttons` is now empty — the button
-            // is no longer held once the release is dispatched.
+            // Release at the destination. Clear the bit first and read
+            // `buttons` back out of the same locked section: the release
+            // frame reports the set held *after* it, which is empty unless
+            // something else on this tab holds a button.
+            let released = {
+                let input = self.input().clone();
+                let mut s = input.state.lock().await;
+                s.buttons_held.remove(MouseButtonSet::LEFT);
+                s.buttons_held.bits()
+            };
             self.call(
                 "Input.dispatchMouseEvent",
                 json!({
@@ -2282,7 +2280,7 @@ pointer-events:none;opacity:0.85;'; \
                     "x": to.0, "y": to.1,
                     "button": "left",
                     "clickCount": 1,
-                    "buttons": 0,
+                    "buttons": released,
                 }),
             )
             .await?;
@@ -2295,8 +2293,8 @@ pointer-events:none;opacity:0.85;'; \
             let mut s = input.state.lock().await;
             // Whether the gesture finished or a dispatch failed partway, this
             // tab is no longer holding the button as far as our state goes.
-            s.buttons_held
-                .remove(crate::input::pointer_state::MouseButtonSet::LEFT);
+            // A no-op on the happy path — the release above already cleared it.
+            s.buttons_held.remove(MouseButtonSet::LEFT);
             if gesture.is_ok() {
                 // Leave the controller's cached cursor where the drag actually
                 // ended. Skipping this made the next `move_realistic` build its
@@ -4771,32 +4769,26 @@ mod tests {
         conn.shutdown();
     }
 
-    /// Drain every `Input.dispatchMouseEvent` a click emits, returning
+    /// The fields these mouse tests assert on, projected out of
+    /// [`crate::test_support::drain_mouse_dispatches`]:
     /// `(type, buttons, modifiers, clickCount)` per frame.
+    ///
+    /// `u64::MAX` stands for an absent `buttons` / `modifiers`, so a test can
+    /// assert the field was sent at all rather than reading a missing one as
+    /// zero.
     async fn drain_mouse_dispatches(mock: &mut MockConnection) -> Vec<(String, u64, u64, u64)> {
-        let mut frames = Vec::new();
-        loop {
-            let next = tokio::time::timeout(
-                Duration::from_millis(500),
-                mock.expect_cmd("Input.dispatchMouseEvent"),
-            )
-            .await;
-            match next {
-                Ok(id) => {
-                    let sent = mock.last_sent();
-                    let p = &sent["params"];
-                    frames.push((
-                        p["type"].as_str().unwrap_or("").to_string(),
-                        p["buttons"].as_u64().unwrap_or(u64::MAX),
-                        p["modifiers"].as_u64().unwrap_or(u64::MAX),
-                        p["clickCount"].as_u64().unwrap_or(0),
-                    ));
-                    mock.reply(id, json!({})).await;
-                }
-                Err(_) => break,
-            }
-        }
-        frames
+        crate::test_support::drain_mouse_dispatches(mock)
+            .await
+            .iter()
+            .map(|p| {
+                (
+                    p["type"].as_str().unwrap_or("").to_string(),
+                    p["buttons"].as_u64().unwrap_or(u64::MAX),
+                    p["modifiers"].as_u64().unwrap_or(u64::MAX),
+                    p["clickCount"].as_u64().unwrap_or(0),
+                )
+            })
+            .collect()
     }
 
     /// Every dispatch must carry CDP's `buttons` bitmask. Without it a page
@@ -4970,30 +4962,18 @@ mod tests {
         });
 
         // Realistic move emits one-or-more mouseMoved dispatches and NO
-        // press/release. Drain them all, asserting type along the way.
-        let mut saw_moved = false;
-        loop {
-            let next = tokio::time::timeout(
-                Duration::from_millis(500),
-                mock.expect_cmd("Input.dispatchMouseEvent"),
-            )
-            .await;
-            match next {
-                Ok(id) => {
-                    let kind = mock.last_sent()["params"]["type"]
-                        .as_str()
-                        .unwrap_or("")
-                        .to_string();
-                    assert_eq!(kind, "mouseMoved", "mouse_move must only emit mouseMoved");
-                    saw_moved = true;
-                    mock.reply(id, json!({})).await;
-                }
-                Err(_) => break,
-            }
-        }
-
+        // press/release.
+        let frames = drain_mouse_dispatches(&mut mock).await;
         fut.await.unwrap().unwrap();
-        assert!(saw_moved, "expected at least one mouseMoved dispatch");
+
+        assert!(
+            !frames.is_empty(),
+            "expected at least one mouseMoved dispatch"
+        );
+        assert!(
+            frames.iter().all(|(kind, ..)| kind == "mouseMoved"),
+            "mouse_move must only emit mouseMoved: {frames:?}"
+        );
         conn.shutdown();
     }
 
@@ -5026,6 +5006,20 @@ mod tests {
         mock.reply(id, json!({})).await;
 
         fut.await.unwrap().unwrap();
+
+        // A tap moves the pointer as far as the page is concerned, so the
+        // controller's cached cursor has to follow it. Without this the next
+        // realistic mouse move builds its Bezier from a stale origin and opens
+        // by teleporting back to wherever the last mouse action landed — a
+        // visible non-human artifact, from three lines with no other guard.
+        {
+            let s = tab.input().state.lock().await;
+            assert_eq!(
+                (s.pointer_x, s.pointer_y),
+                (10.0, 20.0),
+                "tap must leave the cached cursor at the tap point"
+            );
+        }
         conn.shutdown();
     }
 
@@ -5132,7 +5126,11 @@ mod tests {
         // the actionability gate (TEXT_INPUT = visible → enabled), then
         // this.focus(). Reply truthy/undefined to each.
         crate::test_support::serve_scroll_into_view(&mut mock).await;
-        crate::test_support::serve_gate_probes(&mut mock, 2).await;
+        crate::test_support::serve_gate_probes(
+            &mut mock,
+            crate::query::actionability::ActionabilityCheck::TEXT_INPUT,
+        )
+        .await;
         let id_focus = mock.expect_cmd("Runtime.callFunctionOn").await;
         mock.reply(id_focus, json!({ "result": { "type": "undefined" } }))
             .await;

--- a/crates/zendriver/src/tab.rs
+++ b/crates/zendriver/src/tab.rs
@@ -47,7 +47,9 @@ const READY_STATE_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// Fallback tick for [`Tab::wait_for_idle_opts`]'s wait loop, used when no
 /// membership change wakes it sooner. It is the additive term in
 /// [`Tab::wait_for_idle_opts`]'s documented worst case, which names this
-/// constant rather than repeating the number. The two test-scenario comments
+/// constant *and* spells the number: this constant is module-private, so it
+/// does not render on docs.rs and a reader given only the name has lost the
+/// one fact the sentence carried. Change one, change the other. The two test-scenario comments
 /// that spell 50ms (`wait_for_idle_*`) are arithmetic about a specific
 /// timeline and would read worse with the name substituted in.
 const IDLE_FALLBACK_TICK: Duration = Duration::from_millis(50);
@@ -1791,10 +1793,9 @@ impl Tab {
     /// Wait for network idle with full control over the policy via
     /// [`IdleOptions`].
     ///
-    /// Algorithm: poll the in-flight set with a `Notify`-driven wake (or an
-    /// [`IDLE_FALLBACK_TICK`] fallback tick). Each iteration computes the
-    /// number of *active*
-    /// requests — every in-flight request when
+    /// Algorithm: poll the in-flight set with a `Notify`-driven wake (or a
+    /// 50ms fallback tick, `IDLE_FALLBACK_TICK`). Each iteration computes the
+    /// number of *active* requests — every in-flight request when
     /// [`IdleOptions::max_inflight_age`] is `None`, otherwise only those in
     /// flight for less than that age (older ones are treated as stuck /
     /// background and ignored). Track `quiet_start = Some(now)` on the first
@@ -1805,7 +1806,7 @@ impl Tab {
     /// That tick bounds latency both for the already-idle case (no further
     /// events fire) and for an age-out crossing (which emits no CDP event), so
     /// worst-case latency to detect "stayed idle long enough" is
-    /// `quiet_window + `[`IDLE_FALLBACK_TICK`].
+    /// `quiet_window` plus one `IDLE_FALLBACK_TICK` (50ms).
     ///
     /// Under [`IdleOptions::loss_policy`] = [`IdleLossPolicy::Strict`], the
     /// wait additionally races against this tab's connection's accounted

--- a/crates/zendriver/src/test_support.rs
+++ b/crates/zendriver/src/test_support.rs
@@ -12,16 +12,43 @@ use std::time::Duration;
 use serde_json::{Value, json};
 use zendriver_transport::testing::MockConnection;
 
+use crate::query::actionability::ActionabilityCheck;
+
+/// How long [`expect`] waits before declaring the sequence broken. Generous
+/// enough to survive a loaded CI runner, since exceeding it fails the test.
+const EXPECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How long [`try_expect`] waits before concluding nothing more is coming.
+/// Short, because every call *spends* this much wall-clock on the expected
+/// path — the absence of a frame is the answer being asked for.
+const SILENCE_TIMEOUT: Duration = Duration::from_millis(500);
+
 /// Await `method`, bounded.
 ///
 /// [`MockConnection::expect_cmd`] silently discards non-matching frames and
 /// has no timeout of its own, so a test that is one frame short of the real
-/// sequence hangs forever instead of failing. Every wait goes through here.
+/// sequence hangs forever instead of failing. Prefer this for any wait on a
+/// specific method; use [`try_expect`] when the *absence* of a frame is what
+/// the test is asking about.
 pub(crate) async fn expect(mock: &mut MockConnection, method: &str) -> u64 {
-    match tokio::time::timeout(Duration::from_secs(5), mock.expect_cmd(method)).await {
+    match tokio::time::timeout(EXPECT_TIMEOUT, mock.expect_cmd(method)).await {
         Ok(id) => id,
         Err(_) => panic!("timed out waiting for {method}"),
     }
+}
+
+/// Await `method`, returning `None` if nothing arrives within
+/// [`SILENCE_TIMEOUT`].
+///
+/// The counterpart to [`expect`]: silence is a legitimate answer here, used
+/// to drain a run of frames of unknown length ("keep taking `mouseMoved`s
+/// until they stop"). Named rather than spelled inline so the short bound
+/// reads as the end-of-stream signal it is, instead of looking like [`expect`]
+/// with an unexplained ten-times-tighter deadline.
+pub(crate) async fn try_expect(mock: &mut MockConnection, method: &str) -> Option<u64> {
+    tokio::time::timeout(SILENCE_TIMEOUT, mock.expect_cmd(method))
+        .await
+        .ok()
 }
 
 /// Serve one `Runtime.callFunctionOn`, answering it with `result`, and hand
@@ -45,6 +72,46 @@ pub(crate) async fn serve_call_js(mock: &mut MockConnection, result: Value) -> S
         .to_string()
 }
 
+/// Parameter names of a `function(a, b, ...){ ... }` declaration, in order.
+///
+/// `call_on_main` prepends the element handle to the argument list, so the
+/// parameter at index `i` binds to `arguments[i]`. Asserting the parameter
+/// list against the emitted arguments is what catches an off-by-one — a body
+/// declared `function(v)` reads the *element* out of `arguments[0]` while the
+/// caller's value sits unread at `arguments[1]`, and every assertion about
+/// the arguments array alone still passes.
+///
+/// Stricter than a `starts_with("function(el")` check for the same reason:
+/// that accepts `function(elephant, dy, dx)` — right prefix, transposed
+/// coordinates.
+///
+/// The first `(`/`)` pair is the parameter list: parameter names can't
+/// contain parentheses, so a body that does (`setTimeout(...)`) is safe.
+pub(crate) fn js_params(decl: &str) -> Vec<&str> {
+    let open = decl.find('(').expect("declaration opens a param list");
+    let close = decl.find(')').expect("declaration closes its param list");
+    decl[open + 1..close]
+        .split(',')
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .collect()
+}
+
+/// Reply to every `Input.dispatchMouseEvent` the mock has queued until it
+/// goes quiet, returning each frame's `params`.
+///
+/// A gesture's frame count is not known up front — a realistic move emits one
+/// per Bezier segment — so silence is the terminator, which is what
+/// [`try_expect`] is for. Callers project whatever fields they assert on.
+pub(crate) async fn drain_mouse_dispatches(mock: &mut MockConnection) -> Vec<Value> {
+    let mut frames = Vec::new();
+    while let Some(id) = try_expect(mock, "Input.dispatchMouseEvent").await {
+        frames.push(mock.last_sent()["params"].clone());
+        mock.reply(id, json!({})).await;
+    }
+    frames
+}
+
 /// Serve the `scroll_into_view` an action runs before its actionability
 /// gate, asserting the call really is that scroll — a fixture that silently
 /// absorbed the first `Runtime.callFunctionOn` would keep passing if the
@@ -57,13 +124,16 @@ pub(crate) async fn serve_scroll_into_view(mock: &mut MockConnection) {
     );
 }
 
-/// Serve `n` actionability predicates, answering each one `true`.
+/// Serve one pass of the actionability gate for `require`, answering every
+/// predicate `true`.
 ///
-/// Pass the count the action's
-/// [`crate::query::actionability::ActionabilityCheck`] implies: 4 for `FULL`,
-/// 2 for `TEXT_INPUT`, 1 for `VISIBLE_ONLY`.
-pub(crate) async fn serve_gate_probes(mock: &mut MockConnection, n: usize) {
-    for _ in 0..n {
+/// Takes the check set rather than a count so the number of probes is derived
+/// from the same value the code under test gates on. A hand-written count
+/// that drifts from the set does not fail cleanly: it consumes the *next*,
+/// unrelated `Runtime.callFunctionOn`, and the test dies later at an
+/// `expect` for a frame that was already eaten.
+pub(crate) async fn serve_gate_probes(mock: &mut MockConnection, require: ActionabilityCheck) {
+    for _ in 0..require.probe_count() {
         serve_call(mock, json!({ "value": true, "type": "boolean" })).await;
     }
 }

--- a/crates/zendriver/src/test_support.rs
+++ b/crates/zendriver/src/test_support.rs
@@ -1,0 +1,69 @@
+//! Shared scaffolding for the mock-CDP unit tests.
+//!
+//! Two concerns live here, both about tests that drive a scripted CDP
+//! sequence: a test one frame out of step with the code should *fail* rather
+//! than hang, and a sequence several tests replay should be written down
+//! once — the actionability gate's run of predicate calls above all.
+
+#![allow(clippy::panic, clippy::unwrap_used)]
+
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use zendriver_transport::testing::MockConnection;
+
+/// Await `method`, bounded.
+///
+/// [`MockConnection::expect_cmd`] silently discards non-matching frames and
+/// has no timeout of its own, so a test that is one frame short of the real
+/// sequence hangs forever instead of failing. Every wait goes through here.
+pub(crate) async fn expect(mock: &mut MockConnection, method: &str) -> u64 {
+    match tokio::time::timeout(Duration::from_secs(5), mock.expect_cmd(method)).await {
+        Ok(id) => id,
+        Err(_) => panic!("timed out waiting for {method}"),
+    }
+}
+
+/// Serve one `Runtime.callFunctionOn`, answering it with `result`, and hand
+/// back the `params` that went out so the caller can assert on the JS source
+/// or the argument array.
+pub(crate) async fn serve_call(mock: &mut MockConnection, result: Value) -> Value {
+    let id = expect(mock, "Runtime.callFunctionOn").await;
+    let params = mock.last_sent()["params"].clone();
+    mock.reply(id, json!({ "result": result })).await;
+    params
+}
+
+/// The JS source of one `Runtime.callFunctionOn`, answered with `result`.
+///
+/// Thin wrapper over [`serve_call`] for the common case of asserting what a
+/// probe actually executed.
+pub(crate) async fn serve_call_js(mock: &mut MockConnection, result: Value) -> String {
+    serve_call(mock, result).await["functionDeclaration"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Serve the `scroll_into_view` an action runs before its actionability
+/// gate, asserting the call really is that scroll — a fixture that silently
+/// absorbed the first `Runtime.callFunctionOn` would keep passing if the
+/// scroll ever went missing, which is the regression this guards.
+pub(crate) async fn serve_scroll_into_view(mock: &mut MockConnection) {
+    let js = serve_call_js(mock, json!({ "type": "undefined" })).await;
+    assert!(
+        js.contains("scrollIntoView"),
+        "expected scroll_into_view ahead of the actionability gate, got: {js}"
+    );
+}
+
+/// Serve `n` actionability predicates, answering each one `true`.
+///
+/// Pass the count the action's
+/// [`crate::query::actionability::ActionabilityCheck`] implies: 4 for `FULL`,
+/// 2 for `TEXT_INPUT`, 1 for `VISIBLE_ONLY`.
+pub(crate) async fn serve_gate_probes(mock: &mut MockConnection, n: usize) {
+    for _ in 0..n {
+        serve_call(mock, json!({ "value": true, "type": "boolean" })).await;
+    }
+}

--- a/docs/book/src/input.md
+++ b/docs/book/src/input.md
@@ -239,7 +239,8 @@ inserts a newline in a `<textarea>` or contenteditable while in a
 single-line `<input>` it inserts nothing and only submits a form that
 allows implicit submission — exactly as the physical keys do. The rest
 only run their default action. Holding Ctrl, Alt or Meta suppresses the
-insertion for both, the same way a shortcut does on real hardware.
+insertion, for those two and for character keys alike, the same way a
+shortcut does on real hardware.
 
 [`KeyModifiers`] is a bitflags struct:
 

--- a/docs/book/src/input.md
+++ b/docs/book/src/input.md
@@ -229,12 +229,14 @@ input.press_with(
 [`Key`] is one of:
 
 - `Key::Char(char)` — any typeable character.
-- `Key::Special(SpecialKey)` — named non-character key.
+- `Key::Special(SpecialKey)` — a key with a name rather than a glyph.
 
 [`SpecialKey`] covers Enter, Tab, Escape, Backspace, Delete, Space, all
 four arrows, Home, End, PageUp, PageDown, F1-F12, Insert, CapsLock,
-NumLock, ScrollLock, PrintScreen, Pause, ContextMenu — the full
-non-character keyboard.
+NumLock, ScrollLock, PrintScreen, Pause, ContextMenu — the whole named
+keyboard. Two of them still type: `Space` inserts a space and `Enter`
+inserts a newline (and submits a form that allows implicit submission),
+exactly as the physical keys do. The rest only run their default action.
 
 [`KeyModifiers`] is a bitflags struct:
 

--- a/docs/book/src/input.md
+++ b/docs/book/src/input.md
@@ -234,9 +234,12 @@ input.press_with(
 [`SpecialKey`] covers Enter, Tab, Escape, Backspace, Delete, Space, all
 four arrows, Home, End, PageUp, PageDown, F1-F12, Insert, CapsLock,
 NumLock, ScrollLock, PrintScreen, Pause, ContextMenu — the whole named
-keyboard. Two of them still type: `Space` inserts a space and `Enter`
-inserts a newline (and submits a form that allows implicit submission),
-exactly as the physical keys do. The rest only run their default action.
+keyboard. Two of them still type: `Space` inserts a space, and `Enter`
+inserts a newline in a `<textarea>` or contenteditable while in a
+single-line `<input>` it inserts nothing and only submits a form that
+allows implicit submission — exactly as the physical keys do. The rest
+only run their default action. Holding Ctrl, Alt or Meta suppresses the
+insertion for both, the same way a shortcut does on real hardware.
 
 [`KeyModifiers`] is a bitflags struct:
 


### PR DESCRIPTION
Five input defects, all of which a page can see.

- **`Input.dispatchMouseEvent` never sent `buttons`.** Every drag told the page no button was held, so any handler reading `e.buttons` — the standard way to distinguish a drag from a hover — saw a drag that could not exist.
- **`ClickOptions::modifiers` had zero readers.** So did the state it fell back to: `modifiers_held` has no writes anywhere in the repo. Ctrl/Cmd/Shift-click was impossible, and `browser_mouse.modifiers` was a no-op end to end.
- **`Element::type_text` hung on any string containing a space.** Chrome ignores a `keyDown` carrying no `text`, so `expect_cmd`, which has no timeout, waited forever on a reply that was never coming. Space and Enter now carry `" "` / `"\r"`; Tab stays `rawKeyDown` because a `text` there inserts a literal tab instead of moving focus.
- **Segment delay assumed a fixed 5px step**, so `speed` scaled with the number of points rather than distance. Now derived from the real segment length.
- **The actionability hit-test probed the bbox centre** even when the caller named a `position`, so a click at an offset was gated on a point it would never touch.

## What the two review rounds changed

**Round 1** found the space fix incomplete. Space and Enter were special-cased, but `char_to_key_def` maps **every** printable character to a `key_def` with `text: None`, so `type_text("héllo")` still wedged on the non-ASCII path. Suppression is now applied on every character path, not just the two enumerated ones.

**Round 2** found the previous round's own commit message overclaiming — it said the fix covered "every printable character", which reads as a guarantee the tests do not make. Reworded to what is actually verified.

Round 2 also found **four inline comments contradicted by the code beneath them** and two drag tests that passed against a broken implementation. The tests asserted `buttons` appeared *somewhere* in the dispatch sequence; deleting the bitmask from the `mouseMove` frames — the entire fix — left both green. They now pin the value per event type, so a move without the held bit fails.

## Verification

`fmt --check` clean · clippy clean workspace-wide · **428 lib tests** · Windows target checked locally for cfg-only breakage.

The `buttons` bitmask, modifier plumbing, and whitespace `text` are all asserted at the CDP frame layer against the exact params Chrome receives. No public API change.

---
Split out of #145. Review records: `docs/review-records` branch. 🤖 Generated with [Claude Code](https://claude.com/claude-code)