### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.16.10"
+version = "0.16.11"
 dependencies = [
  "async-trait",
  "axum",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.5.1", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.5.2", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.4" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.12.1" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.12.2" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.12" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.15" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.15" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.10" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.11" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.1" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.18" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.16" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.17" }
 
 # MCP server
 # Pinned exactly, matching proxybroker-rs: rmcp's macro and transport surface moves across

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.17] - 2026-08-06
+
+
 ## [0.3.16] - 2026-08-06
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.3.16"
+version = "0.3.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.16.11] - 2026-08-06
+
+
 ## [0.16.10] - 2026-08-06
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.16.10"
+version = "0.16.11"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.12.2] - 2026-08-06
+
+### Fixed
+
+- Stop fabricating 8 GB when the memory probe fails
+
+
 ## [0.12.1] - 2026-08-06
 
 ### Fixed

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.12.1"
+version = "0.12.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-08-06
+
+
 ## [0.5.1] - 2026-08-06
 
 

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.12.1 -> 0.12.2 (✓ API compatible changes)
* `zendriver`: 0.5.1 -> 0.5.2
* `zendriver-fingerprints`: 0.3.16 -> 0.3.17
* `zendriver-mcp`: 0.16.10 -> 0.16.11

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-stealth`

<blockquote>

## [0.12.2] - 2026-08-06

### Fixed

- Stop fabricating 8 GB when the memory probe fails
</blockquote>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).