### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "futures",
  "psl",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "futures",
  "serde",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "async-trait",
  "base64",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.16.11"
+version = "0.16.12"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,15 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.5.2", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.5.3", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.4" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.12.2" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.12" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.15" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.16" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.15" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.11" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.1" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.18" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.12" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.2" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.19" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.17" }
 
 # MCP server

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.19] - 2026-08-06
+
+
 ## [0.1.18] - 2026-07-29
 
 ### Internal

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.18"
+version = "0.1.19"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.2] - 2026-08-06
+
+
 ## [0.3.1] - 2026-07-29
 
 ### Internal

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.16] - 2026-08-06
+
+### Fixed
+
+- Stop losing auth config and truncated bodies silently
+
+
 ## [0.3.15] - 2026-07-29
 
 ### Internal

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.16.12] - 2026-08-06
+
+
 ## [0.16.11] - 2026-08-06
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.16.11"
+version = "0.16.12"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-08-06
+
+
 ## [0.5.2] - 2026-08-06
 
 

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-interception`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `zendriver-datadome`: 0.1.18 -> 0.1.19
* `zendriver-imperva`: 0.3.1 -> 0.3.2
* `zendriver`: 0.5.2 -> 0.5.3
* `zendriver-mcp`: 0.16.11 -> 0.16.12

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-interception`

<blockquote>

## [0.3.16] - 2026-08-06

### Fixed

- Stop losing auth config and truncated bodies silently
</blockquote>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).