### PR TITLE
feat(fetcher): multi-distribution downloads (ungoogled-chromium, Chromium snapshots) + a zendriver-fetch CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,44 @@ jobs:
           Write-Host "Using preinstalled Chrome $version at $chrome"
       - run: cargo nextest run --workspace --features integration-tests --locked --profile ci-integration -E '${{ matrix.filter }}'
 
+  # `zendriver-fetcher` is the one crate whose unit tests encode OS-specific
+  # *path* semantics rather than browser behaviour, and until now none of them
+  # ran on Windows: `test-unit` is ubuntu-only, and the Windows leg of
+  # `test-integration` is filtered to a single `zendriver` binary.
+  #
+  # Two fixes shipped on reasoning alone because of that gap, both invisible
+  # from Linux or macOS by construction:
+  #  - `resolve_target` in `extract.rs` is reachable only from the
+  #    `#[cfg(unix)]` symlink arm, so on Windows it is an unreferenced function
+  #    and the workspace's `-D warnings` turned that into a hard build failure.
+  #    It was caught only because `test-integration`'s Windows leg happens to
+  #    compile the crate on the way to a `zendriver` test.
+  #  - Asset names are rejected when they contain `:`, because a
+  #    drive-relative name like `C:evil` has no separator to catch yet
+  #    `Path::join` DISCARDS the base for it on Windows -- the same escape as
+  #    `..`, reached without a `..`.
+  #
+  # No browser is launched here and no Chrome is needed, which is why this is
+  # its own job rather than another leg of `test-integration`: it has no
+  # business inheriting that job's 90-minute budget or its Chrome setup. It is
+  # also NOT the widening of that leg's filter discussed above -- that remains
+  # its own change, for the reasons documented there.
+  test-fetcher-windows:
+    runs-on: windows-latest
+    # One crate and its dependencies, not the workspace, and the tests
+    # themselves are offline and finish in under a second. This budget is
+    # almost entirely a cold compile against an empty rust-cache.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # `--lib --bins` in one invocation: the CLI's argument-contract tests
+      # live in a binary, behind the same non-default `cli` feature. The
+      # workflow-wide `RUSTFLAGS: -D warnings` is what makes this also catch
+      # the dead-code class that only appears once `cfg(unix)` is false.
+      - run: cargo test -p zendriver-fetcher --lib --bins --features cli --locked
+
   # The only check that puts this repo's WebGL/WebGPU spoofing in front of a
   # real browser. Everything else guarding it -- the tier-table unit tests, the
   # `gpu-tier-gen` regeneration diff in `fmt`, the hand-written Node model of
@@ -273,9 +311,13 @@ jobs:
   # requires makes it genuinely blocking today. If it is later added to the
   # ruleset under its own name, drop it from `needs` here so the two do not
   # report the same failure twice.
+  #
+  # `test-fetcher-windows` is folded in on exactly that reasoning — it is the
+  # only job that can observe the fetcher's Windows path handling, so it being
+  # red-but-mergeable would defeat the point of adding it.
   test-integration-gate:
     name: test-integration
-    needs: [test-integration, test-gpu-coherence]
+    needs: [test-integration, test-gpu-coherence, test-fetcher-windows]
     # Not stylistic. Without `always()`, a FAILED leg skips this job, and a
     # skipped check never reports a failure — the gate would fall silent in
     # exactly the case it exists to catch, which is worse than no gate at all.
@@ -287,8 +329,10 @@ jobs:
           set -euo pipefail
           matrix='${{ needs.test-integration.result }}'
           gpu='${{ needs.test-gpu-coherence.result }}'
+          fetcher='${{ needs.test-fetcher-windows.result }}'
           echo "test-integration matrix aggregate result: ${matrix}"
           echo "test-gpu-coherence result: ${gpu}"
+          echo "test-fetcher-windows result: ${fetcher}"
           # For a matrix dependency this is `success` only when EVERY leg
           # succeeded. Treat everything else -- failure, cancelled, and skipped
           # -- as blocking: a leg that silently stops running must not read as
@@ -303,7 +347,11 @@ jobs:
             echo "::error::test-gpu-coherence did not succeed (result=${gpu}) — the spoofed GPU surface disagreed with the committed tier tables in a real browser, or the ANGLE canary drifted"
             failed=1
           fi
-          # Report BOTH before exiting, so one failure does not hide the other.
+          if [ "${fetcher}" != 'success' ]; then
+            echo "::error::test-fetcher-windows did not succeed (result=${fetcher}) — the fetcher's path handling differs on Windows and no other job can see it"
+            failed=1
+          fi
+          # Report ALL of them before exiting, so one failure does not hide another.
           exit "${failed}"
 
   nightly-stealth-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,19 +336,35 @@ jobs:
           # For a matrix dependency this is `success` only when EVERY leg
           # succeeded. Treat everything else -- failure, cancelled, and skipped
           # -- as blocking: a leg that silently stops running must not read as
-          # a pass. Same rule for the GPU coherence job, which is a plain job
-          # rather than a matrix but earns no more leniency for it.
+          # a pass. Same rule for the other jobs, which are plain rather than
+          # matrices but earn no more leniency for it.
+          #
+          # Blocking on all of them is not the same as EXPLAINING all of them
+          # identically. A job that ran and failed has a verdict, and naming the
+          # likely cause is the useful thing to print. A job that was cancelled
+          # or skipped produced no verdict at all, and asserting a cause there
+          # is actively misleading -- "the tier tables disagreed" sent a reader
+          # off to regenerate tables that had never been checked, when the real
+          # story was a GitHub outage cancelling the runner mid-queue.
+          report() {
+            if [ "$2" = 'failure' ]; then
+              echo "::error::$1 failed — $3"
+            else
+              echo "::error::$1 produced no verdict (result=$2) — re-run it. Not running is not a pass, but it is also not evidence that anything is broken."
+            fi
+          }
+
           failed=0
           if [ "${matrix}" != 'success' ]; then
-            echo "::error::integration matrix did not succeed (result=${matrix})"
+            report 'test-integration matrix' "${matrix}" 'a real-Chrome integration test broke on at least one OS'
             failed=1
           fi
           if [ "${gpu}" != 'success' ]; then
-            echo "::error::test-gpu-coherence did not succeed (result=${gpu}) — the spoofed GPU surface disagreed with the committed tier tables in a real browser, or the ANGLE canary drifted"
+            report 'test-gpu-coherence' "${gpu}" 'the spoofed GPU surface disagreed with the committed tier tables in a real browser, or the ANGLE canary drifted'
             failed=1
           fi
           if [ "${fetcher}" != 'success' ]; then
-            echo "::error::test-fetcher-windows did not succeed (result=${fetcher}) — the fetcher's path handling differs on Windows and no other job can see it"
+            report 'test-fetcher-windows' "${fetcher}" "the fetcher's path handling differs on Windows and no other job can see it"
             failed=1
           fi
           # Report ALL of them before exiting, so one failure does not hide another.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
+      # zendriver-fetcher's `cli` feature is off by default (library first),
+      # so the sweep above never compiles the `zendriver-fetch` binary. Lint
+      # it explicitly, or it rots unnoticed.
+      - run: cargo clippy -p zendriver-fetcher --all-targets --features cli --locked -- -D warnings
 
   test-unit:
     runs-on: ubuntu-latest
@@ -49,6 +53,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --lib --locked
+      # `--lib` skips binaries, and the CLI's argument-contract tests live in
+      # one — behind the same non-default `cli` feature.
+      - run: cargo test -p zendriver-fetcher --bins --features cli --locked
 
   test-doc:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ check above.
 | `zendriver-interception` | Network interception via the `Fetch.*` CDP domain. |
 | `zendriver-cloudflare` | Cloudflare Turnstile bypass. |
 | `zendriver-imperva` | Imperva WAF / Incapsula bypass. |
-| `zendriver-fetcher` | Chrome binary downloader. |
+| `zendriver-fetcher` | Chromium binary downloader (Chrome for Testing / ungoogled-chromium / snapshots), plus the `zendriver-fetch` CLI behind the non-default `cli` feature. |
 | `zendriver-mcp` | MCP server exposing the `zendriver` surface as agent tools (see MCP coverage above). |
 
 Capability crates are wired into `zendriver` behind features (`interception` /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,6 +3493,7 @@ dependencies = [
 name = "zendriver-fetcher"
 version = "0.1.15"
 dependencies = [
+ "clap",
  "dirs",
  "futures",
  "reqwest",

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ More working examples in [`crates/zendriver/examples/`](crates/zendriver/example
 | `monitor`      | no       | Passive network monitor — buffered HTTP / WebSocket / SSE events via `tab.monitor()`, plus opt-in incremental body streaming | (in-tree, no extra crate)             |
 | `geo`          | no       | Country code → coherent `locale` + `languages` (Accept-Language) + representative `timezone` persona overlay, plus opt-in `geo_auto()` exit-IP auto-resolution (exact probe timezone, not just representative) | `reqwest` (via `zendriver-stealth`) |
 | `tracker-blocking` | no   | Opt-in third-party tracker / fingerprinter host blocklist (curated bundled list + BYO file / URL) | `reqwest` + `dirs`         |
-| `fetcher`      | no       | Auto-download a pinned Chrome for Testing build               | `zendriver-fetcher` + `reqwest`/`zip` |
+| `fetcher`      | no       | Auto-download a pinned Chromium build — Chrome for Testing (default), ungoogled-chromium, or a Chromium snapshot | `zendriver-fetcher` + `reqwest`/`zip` |
 
 Separate binary crate (not a feature on `zendriver`):
 

--- a/crates/zendriver-fetcher/Cargo.toml
+++ b/crates/zendriver-fetcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-fetcher"
-description = "Chrome binary downloader for zendriver"
+description = "Chromium binary downloader for zendriver — Chrome for Testing, ungoogled-chromium and Chromium snapshots"
 version = "0.1.15"
 edition.workspace = true
 rust-version.workspace = true
@@ -19,6 +19,18 @@ rustdoc-args = ["--cfg", "docsrs"]
 [lints]
 workspace = true
 
+# Library first: the CLI is opt-in, so `clap` never lands in the dependency
+# graph of a crate that only wants to download a browser.
+#   cargo install zendriver-fetcher --features cli
+[features]
+default = []
+cli = ["dep:clap"]
+
+[[bin]]
+name              = "zendriver-fetch"
+path              = "src/bin/zendriver-fetch.rs"
+required-features = ["cli"]
+
 [dependencies]
 tokio.workspace      = true
 reqwest.workspace    = true
@@ -31,6 +43,9 @@ serde_json.workspace = true
 thiserror.workspace  = true
 tracing.workspace    = true
 futures.workspace    = true
+
+# CLI only.
+clap = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio-test.workspace = true

--- a/crates/zendriver-fetcher/README.md
+++ b/crates/zendriver-fetcher/README.md
@@ -1,6 +1,32 @@
 # zendriver-fetcher
 
-Chrome binary downloader for zendriver.
+Chromium binary downloader for zendriver. Resolves a version against a
+distribution's index, downloads it, unpacks it, and caches it under a
+per-build directory.
+
+Three distributions, differing only in how a version turns into a URL:
+
+| Distribution | Index | Keyed by |
+|---|---|---|
+| Chrome for Testing (default) | one JSON manifest | version |
+| ungoogled-chromium | three GitHub repos, one per OS | version (tag prefix) |
+| Chromium snapshots | a GCS bucket per platform | revision |
+
+## Command line
+
+```bash
+cargo install zendriver-fetcher --features cli
+
+zendriver-fetch --distribution cft --version 146.0.7680.153 \
+                --platform mac-arm64 --out ./chrome
+```
+
+Given every flag it never prompts and exits non-zero on failure. Leave a flag
+out at a terminal and it lists what the distribution actually publishes for
+your platform; outside a terminal it refuses to prompt and names the missing
+flags rather than hanging a CI job.
+
+The `cli` feature is off by default — this is a library first.
 
 Part of the [zendriver-rs](https://github.com/TurtIeSocks/zendriver-rs) workspace.
 See the [`zendriver`](https://crates.io/crates/zendriver) crate and the

--- a/crates/zendriver-fetcher/src/archive.rs
+++ b/crates/zendriver-fetcher/src/archive.rs
@@ -127,7 +127,7 @@ async fn install_dmg(
 ) -> Result<(), FetcherError> {
     // A private mountpoint beside the staging dir, so two concurrent fetches
     // of different builds cannot collide and nothing lands in /Volumes.
-    let mountpoint = std::path::PathBuf::from(format!("{}.mnt", dest_dir.display()));
+    let mountpoint = crate::cache::with_suffix(dest_dir, ".mnt");
     let _ = tokio::fs::remove_dir_all(&mountpoint).await;
     tokio::fs::create_dir_all(&mountpoint).await?;
 

--- a/crates/zendriver-fetcher/src/archive.rs
+++ b/crates/zendriver-fetcher/src/archive.rs
@@ -1,0 +1,329 @@
+//! What the downloaded file *is*, and how to turn it into a runnable tree.
+//!
+//! Chrome for Testing and the Chromium snapshot bucket ship a zip on every
+//! platform, so for years "unpack" and "unzip" were the same verb.
+//! ungoogled-chromium is built by three independent per-OS repos and each
+//! packages differently:
+//!
+//! | Distribution | Platform | Archive |
+//! |---|---|---|
+//! | Chrome for Testing | all | zip |
+//! | Chromium snapshot | all | zip |
+//! | ungoogled-chromium | Windows | zip |
+//! | ungoogled-chromium | Linux | AppImage |
+//! | ungoogled-chromium | macOS | dmg |
+//!
+//! The Linux and macOS rows are why this module exists.
+//!
+//! **Linux** takes the `.AppImage` rather than the `.tar.xz` published beside
+//! it. An AppImage *is* the executable — install is a move plus a chmod, and
+//! no xz decompressor enters the dependency graph. (It does want FUSE at run
+//! time; `--appimage-extract` is the escape hatch on hosts without it.)
+//!
+//! **macOS** has no zip option at all: ungoogled publishes `.dmg` only. A
+//! disk image is unpacked with `hdiutil`, which exists only on macOS, so that
+//! one combination is host-bound and says so via
+//! [`FetcherError::UnsupportedArchive`].
+
+use std::path::Path;
+
+use crate::error::FetcherError;
+
+/// Packaging of a resolved download, and the instructions for unpacking it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Archive {
+    /// A zip in which every entry lives under one top-level directory.
+    ///
+    /// The prefix is pinned rather than inferred: it rejects a mislabeled or
+    /// tampered archive before anything is written into the cache.
+    Zip {
+        /// Required top-level directory, e.g. `chrome-linux64`.
+        top_dir: String,
+    },
+
+    /// A single self-contained executable (an AppImage). "Unpacking" is a
+    /// move into the staging directory plus the executable bit.
+    Executable {
+        /// Filename to store it under inside the build directory.
+        file_name: String,
+    },
+
+    /// A macOS disk image containing one `.app` bundle.
+    AppBundleDmg {
+        /// Bundle directory expected on the mounted volume, e.g.
+        /// `Chromium.app`.
+        app_dir: String,
+    },
+}
+
+impl Archive {
+    /// Extension for the temporary download file.
+    ///
+    /// `hdiutil` is content-sniffing and does not require `.dmg`, but a
+    /// correctly-named temp file is what makes a half-finished cache
+    /// directory legible when something goes wrong.
+    pub(crate) fn tmp_extension(&self) -> &'static str {
+        match self {
+            Archive::Zip { .. } => "zip",
+            Archive::Executable { .. } => "AppImage",
+            Archive::AppBundleDmg { .. } => "dmg",
+        }
+    }
+}
+
+/// Unpack `downloaded` into the already-created staging directory `dest_dir`.
+///
+/// `dest_dir` is the `<build>.tmp/` sibling the fetcher promotes with a
+/// single atomic rename, so a failure here leaves the published cache
+/// untouched.
+pub(crate) async fn install(
+    archive: &Archive,
+    downloaded: &Path,
+    dest_dir: &Path,
+) -> Result<(), FetcherError> {
+    match archive {
+        Archive::Zip { top_dir } => {
+            crate::extract::extract(downloaded, dest_dir, Some(top_dir)).await
+        }
+        Archive::Executable { file_name } => {
+            install_executable(downloaded, dest_dir, file_name).await
+        }
+        Archive::AppBundleDmg { app_dir } => install_dmg(downloaded, dest_dir, app_dir).await,
+    }
+}
+
+/// Move a single-file executable (AppImage) into place and make it runnable.
+async fn install_executable(
+    downloaded: &Path,
+    dest_dir: &Path,
+    file_name: &str,
+) -> Result<(), FetcherError> {
+    let target = dest_dir.join(file_name);
+    // Rename first (same filesystem: both live under the cache root); fall
+    // back to copy so a cache dir spanning mount points still works.
+    if tokio::fs::rename(downloaded, &target).await.is_err() {
+        tokio::fs::copy(downloaded, &target).await?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut perms = tokio::fs::metadata(&target).await?.permissions();
+        perms.set_mode(perms.mode() | 0o755);
+        tokio::fs::set_permissions(&target, perms).await?;
+    }
+
+    Ok(())
+}
+
+/// Mount a `.dmg`, copy the `.app` bundle out of it, unmount.
+///
+/// macOS only — `hdiutil` ships with the OS and has no portable equivalent.
+#[cfg(target_os = "macos")]
+async fn install_dmg(
+    downloaded: &Path,
+    dest_dir: &Path,
+    app_dir: &str,
+) -> Result<(), FetcherError> {
+    // A private mountpoint beside the staging dir, so two concurrent fetches
+    // of different builds cannot collide and nothing lands in /Volumes.
+    let mountpoint = std::path::PathBuf::from(format!("{}.mnt", dest_dir.display()));
+    let _ = tokio::fs::remove_dir_all(&mountpoint).await;
+    tokio::fs::create_dir_all(&mountpoint).await?;
+
+    // `-nobrowse` keeps it out of Finder; `-noverify` skips the multi-minute
+    // checksum pass (the archive's integrity is the fetcher's own
+    // `expected_sha256` job); `-noautoopen` stops the volume window opening.
+    run(
+        "hdiutil",
+        &[
+            "attach",
+            &downloaded.display().to_string(),
+            "-mountpoint",
+            &mountpoint.display().to_string(),
+            "-nobrowse",
+            "-noverify",
+            "-noautoopen",
+            "-readonly",
+        ],
+    )
+    .await?;
+
+    // Copy inside a closure so the detach below runs on every path out.
+    let copied = copy_app_bundle(&mountpoint, dest_dir, app_dir).await;
+
+    let detached = run(
+        "hdiutil",
+        &["detach", &mountpoint.display().to_string(), "-force"],
+    )
+    .await;
+    let _ = tokio::fs::remove_dir_all(&mountpoint).await;
+
+    copied?;
+    detached?;
+    Ok(())
+}
+
+/// `ditto` the bundle out of the mounted volume, verifying it is the layout
+/// the resolver promised.
+#[cfg(target_os = "macos")]
+async fn copy_app_bundle(
+    mountpoint: &Path,
+    dest_dir: &Path,
+    app_dir: &str,
+) -> Result<(), FetcherError> {
+    let src = mountpoint.join(app_dir);
+    if !src.is_dir() {
+        // Name what *is* there — a renamed bundle upstream should read as a
+        // layout change, not as a mysterious missing file.
+        let found = list_dir_names(mountpoint).await;
+        return Err(FetcherError::Extraction(format!(
+            "expected {app_dir:?} on the mounted image, found {found:?}"
+        )));
+    }
+
+    // `ditto`, not `cp -R`: an app bundle carries symlinked framework
+    // versions and code-signing metadata, and ditto is the tool Apple
+    // documents for copying one intact.
+    run(
+        "ditto",
+        &[
+            &src.display().to_string(),
+            &dest_dir.join(app_dir).display().to_string(),
+        ],
+    )
+    .await
+}
+
+/// Entry names directly inside `dir`, for error messages.
+#[cfg(target_os = "macos")]
+async fn list_dir_names(dir: &Path) -> Vec<String> {
+    let mut names = Vec::new();
+    if let Ok(mut rd) = tokio::fs::read_dir(dir).await {
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            names.push(entry.file_name().to_string_lossy().into_owned());
+        }
+    }
+    names.sort();
+    names
+}
+
+/// Run a command to completion, turning a non-zero exit into an error that
+/// carries stderr.
+#[cfg(target_os = "macos")]
+async fn run(program: &str, args: &[&str]) -> Result<(), FetcherError> {
+    let output = tokio::process::Command::new(program)
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| FetcherError::Extraction(format!("failed to run {program}: {e}")))?;
+
+    if !output.status.success() {
+        return Err(FetcherError::Extraction(format!(
+            "{program} exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+/// Disk images are a macOS packaging format and `hdiutil` is a macOS tool.
+/// Cross-platform fetching still works for every other combination — only
+/// ungoogled-chromium *on* macOS is host-bound.
+#[cfg(not(target_os = "macos"))]
+async fn install_dmg(
+    _downloaded: &Path,
+    _dest_dir: &Path,
+    app_dir: &str,
+) -> Result<(), FetcherError> {
+    Err(FetcherError::UnsupportedArchive(format!(
+        "cannot unpack {app_dir} from a .dmg on this host — disk images need macOS's `hdiutil`. \
+         ungoogled-chromium publishes .dmg only for macOS; fetch it from a Mac, or pick a \
+         different --platform"
+    )))
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tmp_extension_matches_the_packaging() {
+        assert_eq!(
+            Archive::Zip {
+                top_dir: "chrome-linux64".into()
+            }
+            .tmp_extension(),
+            "zip"
+        );
+        assert_eq!(
+            Archive::Executable {
+                file_name: "chrome.AppImage".into()
+            }
+            .tmp_extension(),
+            "AppImage"
+        );
+        assert_eq!(
+            Archive::AppBundleDmg {
+                app_dir: "Chromium.app".into()
+            }
+            .tmp_extension(),
+            "dmg"
+        );
+    }
+
+    #[tokio::test]
+    async fn executable_install_moves_the_file_and_marks_it_runnable() {
+        let root = tempfile::tempdir().unwrap();
+        let downloaded = root.path().join("build.tmp.AppImage");
+        tokio::fs::write(&downloaded, b"#!/bin/sh\necho appimage\n")
+            .await
+            .unwrap();
+        let dest = root.path().join("build.tmp");
+        tokio::fs::create_dir_all(&dest).await.unwrap();
+
+        install(
+            &Archive::Executable {
+                file_name: "chrome.AppImage".into(),
+            },
+            &downloaded,
+            &dest,
+        )
+        .await
+        .unwrap();
+
+        let installed = dest.join("chrome.AppImage");
+        assert_eq!(
+            tokio::fs::read(&installed).await.unwrap(),
+            b"#!/bin/sh\necho appimage\n"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let meta = tokio::fs::metadata(&installed).await.unwrap();
+            assert!(meta.permissions().mode() & 0o111 != 0);
+        }
+    }
+
+    /// On a non-macOS host the dmg path must fail with a message that says
+    /// why and what to do, not with a generic IO error.
+    #[cfg(not(target_os = "macos"))]
+    #[tokio::test]
+    async fn dmg_on_a_non_mac_host_explains_itself() {
+        let root = tempfile::tempdir().unwrap();
+        let err = install(
+            &Archive::AppBundleDmg {
+                app_dir: "Chromium.app".into(),
+            },
+            &root.path().join("x.dmg"),
+            root.path(),
+        )
+        .await
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("hdiutil"), "{msg}");
+        assert!(msg.contains("--platform"), "{msg}");
+    }
+}

--- a/crates/zendriver-fetcher/src/bin/zendriver-fetch.rs
+++ b/crates/zendriver-fetcher/src/bin/zendriver-fetch.rs
@@ -218,7 +218,9 @@ fn prompt_distribution() -> Result<Distribution, String> {
         let line = read_line("distribution [1]: ")?;
         let line = line.trim();
         if line.is_empty() {
-            return Ok(Distribution::ChromeForTesting);
+            // Whatever `1)` printed above — reordering the menu must not leave
+            // the default pointing somewhere else.
+            return Ok(Distribution::ALL[0]);
         }
         if let Some(d) = line
             .parse::<usize>()

--- a/crates/zendriver-fetcher/src/bin/zendriver-fetch.rs
+++ b/crates/zendriver-fetcher/src/bin/zendriver-fetch.rs
@@ -1,0 +1,414 @@
+//! `zendriver-fetch` — download a Chromium build from the command line.
+//!
+//! Two modes, and which one runs is decided by what you passed:
+//!
+//! **Non-interactive.** Give a distribution and a version (or revision) and
+//! the tool never prompts, never blocks on stdin, and exits non-zero on any
+//! failure:
+//!
+//! ```text
+//! zendriver-fetch --distribution cft --version 146.0.7680.153 \
+//!                 --platform mac-arm64 --out ./chrome
+//! ```
+//!
+//! **Interactive.** With those missing, it asks — distribution first, then a
+//! paged menu of the builds that distribution *actually publishes for the
+//! resolved platform*, then a confirmation before anything downloads.
+//!
+//! The two modes meet at a guard rail: if stdin is not a terminal, the
+//! interactive path **refuses to prompt** and instead prints the flags it
+//! needed. A CLI that blocks on stdin inside CI does not fail — it hangs
+//! until the job times out, which is the worst outcome for a tool built to
+//! run unattended.
+//!
+//! The menu is hand-rolled rather than pulled from a prompt crate: it is a
+//! numbered list and a line of stdin, and keeping it in-tree keeps a
+//! dependency out of the graph of a crate whose whole job is to be a small
+//! library.
+
+use std::io::{IsTerminal as _, Write as _};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+use zendriver_fetcher::{
+    Build, Distribution, Fetcher, FetcherPhase, FetcherProgress, Platform, VersionSpec, list_builds,
+};
+
+/// Builds shown per page in the interactive picker. Chrome for Testing lists
+/// thousands of versions; a page has to fit on a terminal.
+const PAGE: usize = 15;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "zendriver-fetch",
+    about = "Download a Chromium build (Chrome for Testing, ungoogled-chromium, or a Chromium snapshot)",
+    // No `version` attribute: `--version` selects the *browser* version here,
+    // which is the whole point of the tool.
+    disable_version_flag = true
+)]
+struct Args {
+    /// Which build to fetch: cft, ungoogled, or snapshot.
+    #[arg(short, long, value_name = "NAME")]
+    distribution: Option<String>,
+
+    /// Browser version, e.g. 146.0.7680.153, or `latest`.
+    ///
+    /// Matched exactly for Chrome for Testing and as a tag prefix for
+    /// ungoogled-chromium. Not accepted for snapshots, which are keyed by
+    /// revision — use --revision there.
+    #[arg(long, value_name = "VERSION")]
+    version: Option<String>,
+
+    /// Chromium revision, e.g. 1674890. Snapshots only.
+    #[arg(long, value_name = "N", conflicts_with = "version")]
+    revision: Option<u64>,
+
+    /// Target platform: linux64, mac-x64, mac-arm64, win32, win64.
+    /// Defaults to this host.
+    #[arg(short, long, value_name = "PLATFORM")]
+    platform: Option<String>,
+
+    /// Directory to cache the build under. Defaults to the OS cache dir.
+    #[arg(short, long, value_name = "DIR")]
+    out: Option<PathBuf>,
+
+    /// Suppress progress output. Errors still go to stderr.
+    #[arg(short, long)]
+    quiet: bool,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let args = Args::parse();
+    let quiet = args.quiet;
+    match run(args).await {
+        Ok(path) => {
+            println!("{}", path.display());
+            ExitCode::SUCCESS
+        }
+        Err(message) => {
+            // Progress is a single rewritten line with no trailing newline,
+            // so close it before the error rather than running into it.
+            if !quiet {
+                eprintln!();
+            }
+            eprintln!("error: {message}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run(args: Args) -> Result<PathBuf, String> {
+    let platform = match &args.platform {
+        Some(name) => Platform::parse(name).ok_or_else(|| {
+            format!(
+                "unknown platform {name:?}; expected one of: {}",
+                Platform::ALL
+                    .iter()
+                    .map(|p| p.as_cft_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?,
+        None => Platform::auto_detect()
+            .ok_or("this host is not a supported platform; pass --platform explicitly")?,
+    };
+
+    let (distribution, spec) = select_build(&args, platform).await?;
+
+    let quiet = args.quiet;
+    if !quiet {
+        eprintln!(
+            "fetching {} for {} ...",
+            distribution.title(),
+            platform.as_cft_str()
+        );
+    }
+
+    let mut fetcher = Fetcher::new()
+        .distribution(distribution)
+        .platform(platform)
+        .version(spec);
+    if let Some(dir) = args.out {
+        fetcher = fetcher.cache_dir(dir);
+    }
+    if !quiet {
+        fetcher = fetcher.on_progress(report_progress);
+    }
+
+    let path = fetcher.ensure_chrome().await.map_err(|e| e.to_string())?;
+    if !quiet {
+        eprintln!();
+    }
+    Ok(path)
+}
+
+/// Work out which build to fetch, prompting only when a flag is missing *and*
+/// there is a human on the other end of stdin.
+async fn select_build(
+    args: &Args,
+    platform: Platform,
+) -> Result<(Distribution, VersionSpec), String> {
+    let distribution = match &args.distribution {
+        Some(name) => Some(Distribution::parse(name).ok_or_else(|| {
+            format!(
+                "unknown distribution {name:?}; expected one of: {}",
+                Distribution::ALL
+                    .iter()
+                    .map(|d| d.slug())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?),
+        None => None,
+    };
+
+    let spec = match (&args.version, args.revision) {
+        (Some(v), _) if v.eq_ignore_ascii_case("latest") => Some(VersionSpec::Latest),
+        (Some(v), _) => Some(VersionSpec::Explicit(v.clone())),
+        (None, Some(rev)) => Some(VersionSpec::Revision(rev)),
+        (None, None) => None,
+    };
+
+    // Fully specified: no prompting, whatever the terminal looks like.
+    if let (Some(distribution), Some(spec)) = (distribution, spec.clone()) {
+        return Ok((distribution, spec));
+    }
+
+    if !std::io::stdin().is_terminal() {
+        return Err(missing_flags_message(
+            distribution.is_none(),
+            spec.is_none(),
+        ));
+    }
+
+    let distribution = match distribution {
+        Some(d) => d,
+        None => prompt_distribution()?,
+    };
+    let spec = match spec {
+        Some(s) => s,
+        None => prompt_build(distribution, platform).await?,
+    };
+    Ok((distribution, spec))
+}
+
+/// The message a non-interactive caller gets instead of a hung prompt.
+fn missing_flags_message(needs_distribution: bool, needs_version: bool) -> String {
+    let mut missing = Vec::new();
+    if needs_distribution {
+        missing.push("--distribution <cft|ungoogled|snapshot>");
+    }
+    if needs_version {
+        missing.push("--version <VERSION|latest> (or --revision <N> for snapshots)");
+    }
+    format!(
+        "stdin is not a terminal, so there is nobody to prompt — pass {} on the command line",
+        missing.join(" and ")
+    )
+}
+
+fn prompt_distribution() -> Result<Distribution, String> {
+    eprintln!("Which distribution?");
+    for (i, d) in Distribution::ALL.iter().enumerate() {
+        eprintln!("  {}) {:<20} [{}]", i + 1, d.title(), d.slug());
+    }
+    loop {
+        let line = read_line("distribution [1]: ")?;
+        let line = line.trim();
+        if line.is_empty() {
+            return Ok(Distribution::ChromeForTesting);
+        }
+        if let Some(d) = line
+            .parse::<usize>()
+            .ok()
+            .filter(|n| (1..=Distribution::ALL.len()).contains(n))
+            .map(|n| Distribution::ALL[n - 1])
+            .or_else(|| Distribution::parse(line))
+        {
+            return Ok(d);
+        }
+        eprintln!("  not one of the options — enter a number or a slug");
+    }
+}
+
+/// Page through the builds this distribution really has for this platform.
+async fn prompt_build(
+    distribution: Distribution,
+    platform: Platform,
+) -> Result<VersionSpec, String> {
+    eprintln!(
+        "Listing {} builds for {} ...",
+        distribution.title(),
+        platform.as_cft_str()
+    );
+    let builds = list_builds(distribution, platform)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if builds.is_empty() {
+        return Err(format!(
+            "{} publishes no builds for {}",
+            distribution.title(),
+            platform.as_cft_str()
+        ));
+    }
+
+    let mut page = 0usize;
+    loop {
+        let start = page * PAGE;
+        let shown = &builds[start..builds.len().min(start + PAGE)];
+        for (offset, build) in shown.iter().enumerate() {
+            eprintln!("  {:>3}) {}", start + offset + 1, build.label);
+        }
+
+        let has_more = start + PAGE < builds.len();
+        let prompt = if has_more {
+            format!(
+                "number, `m` for more ({} of {} shown), or `q`: ",
+                start + shown.len(),
+                builds.len()
+            )
+        } else {
+            "number, or `q`: ".to_string()
+        };
+
+        let line = read_line(&prompt)?;
+        let line = line.trim();
+        match line {
+            "q" | "Q" => return Err("cancelled".to_string()),
+            "m" | "M" if has_more => {
+                page += 1;
+                continue;
+            }
+            _ => {}
+        }
+
+        let Some(build) = line
+            .parse::<usize>()
+            .ok()
+            .filter(|n| (1..=builds.len()).contains(n))
+            .map(|n| &builds[n - 1])
+        else {
+            eprintln!("  enter a listed number");
+            continue;
+        };
+
+        if confirm(build, platform)? {
+            return Ok(build.spec.clone());
+        }
+    }
+}
+
+fn confirm(build: &Build, platform: Platform) -> Result<bool, String> {
+    let answer = read_line(&format!(
+        "Download {} for {}? [y/N]: ",
+        build.label,
+        platform.as_cft_str()
+    ))?;
+    Ok(matches!(answer.trim(), "y" | "Y" | "yes" | "YES"))
+}
+
+fn read_line(prompt: &str) -> Result<String, String> {
+    eprint!("{prompt}");
+    std::io::stderr()
+        .flush()
+        .map_err(|e| format!("stderr: {e}"))?;
+    let mut buf = String::new();
+    match std::io::stdin().read_line(&mut buf) {
+        // EOF: the terminal went away mid-prompt. Bail rather than spin.
+        Ok(0) => Err("stdin closed".to_string()),
+        Ok(_) => Ok(buf),
+        Err(e) => Err(format!("stdin: {e}")),
+    }
+}
+
+/// One rewritten line on stderr, so piping stdout still yields just the path.
+fn report_progress(p: FetcherProgress) {
+    let line = match (p.phase, p.total) {
+        (FetcherPhase::Downloading, Some(total)) if total > 0 => {
+            let pct = (p.downloaded as f64 / total as f64) * 100.0;
+            format!(
+                "downloading {:>5.1}%  ({:.1}/{:.1} MiB)",
+                pct,
+                mib(p.downloaded),
+                mib(total)
+            )
+        }
+        (FetcherPhase::Downloading, _) => {
+            format!("downloading {:.1} MiB", mib(p.downloaded))
+        }
+        (FetcherPhase::Resolving, _) => "resolving".to_string(),
+        (FetcherPhase::Extracting, _) => "unpacking".to_string(),
+        (FetcherPhase::Verifying, _) => "verifying".to_string(),
+        (FetcherPhase::Done, _) => "done".to_string(),
+    };
+    eprint!("\r\x1b[2K{line}");
+    let _ = std::io::stderr().flush();
+}
+
+fn mib(bytes: u64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory as _;
+
+    #[test]
+    fn clap_definition_is_valid() {
+        Args::command().debug_assert();
+    }
+
+    /// The documented non-interactive invocation must parse into a fully
+    /// specified request — nothing left for a prompt to fill in.
+    #[test]
+    fn the_documented_ci_invocation_needs_no_prompting() {
+        let args = Args::parse_from([
+            "zendriver-fetch",
+            "--distribution",
+            "cft",
+            "--version",
+            "146.0.7680.153",
+            "--platform",
+            "mac-arm64",
+            "--out",
+            "/tmp/chrome",
+        ]);
+        assert_eq!(args.distribution.as_deref(), Some("cft"));
+        assert_eq!(args.version.as_deref(), Some("146.0.7680.153"));
+        assert_eq!(args.platform.as_deref(), Some("mac-arm64"));
+        assert_eq!(args.out, Some(PathBuf::from("/tmp/chrome")));
+        assert!(!args.quiet);
+    }
+
+    #[test]
+    fn version_and_revision_are_mutually_exclusive() {
+        let err = Args::try_parse_from([
+            "zendriver-fetch",
+            "--version",
+            "151.0.7922.71",
+            "--revision",
+            "1674890",
+        ])
+        .unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    /// The refusal has to name the flags, or a CI failure tells the operator
+    /// nothing actionable.
+    #[test]
+    fn non_tty_refusal_names_the_missing_flags() {
+        let msg = missing_flags_message(true, true);
+        assert!(msg.contains("--distribution"), "{msg}");
+        assert!(msg.contains("--version"), "{msg}");
+        assert!(msg.contains("--revision"), "{msg}");
+
+        let msg = missing_flags_message(false, true);
+        assert!(!msg.contains("--distribution"), "{msg}");
+        assert!(msg.contains("--version"), "{msg}");
+    }
+}

--- a/crates/zendriver-fetcher/src/cache.rs
+++ b/crates/zendriver-fetcher/src/cache.rs
@@ -1,6 +1,7 @@
 //! Cache directory layout + path resolution.
 //!
-//! The on-disk layout matches the Chrome for Testing zip layout:
+//! Chrome for Testing keeps the layout it has always had, straight under the
+//! cache root:
 //!
 //! ```text
 //! <cache_dir>/
@@ -11,12 +12,29 @@
 //!       Google Chrome for Testing.app/Contents/MacOS/...  (macOS)
 //! ```
 //!
-//! Per-version dirs are written atomically: download + extract land under
-//! a `<version>.tmp/` sibling, then a single rename promotes it.
+//! The distributions added later namespace themselves under their
+//! [`Distribution::slug`]:
+//!
+//! ```text
+//! <cache_dir>/
+//!   ungoogled/151.0.7922.71/...
+//!   snapshot/r1674890/...
+//! ```
+//!
+//! The asymmetry is deliberate and load-bearing in both directions. Chrome
+//! for Testing stays un-prefixed so caches populated by earlier versions of
+//! this crate keep hitting. The others are prefixed because a Chrome version
+//! number is *not* unique across distributions — CfT 151.0.7922.71 and
+//! ungoogled 151.0.7922.71 are different binaries, and sharing a directory
+//! would serve whichever landed first.
+//!
+//! Per-build dirs are written atomically: download + unpack land under a
+//! `<build>.tmp/` sibling, then a single rename promotes it.
 
 use std::env;
 use std::path::{Path, PathBuf};
 
+use crate::distribution::Distribution;
 use crate::platform::Platform;
 
 /// Default cache root: OS cache dir if available, otherwise the temp dir.
@@ -29,20 +47,22 @@ pub(crate) fn default_cache_dir() -> PathBuf {
         .join("zendriver/chrome")
 }
 
-/// Path to the Chrome binary inside the extracted, cached version dir.
+/// Directory holding one unpacked build.
 ///
-/// Matches the Chrome for Testing zip layout — see module docs.
-pub(crate) fn binary_path(cache_dir: &Path, version: &str, platform: Platform) -> PathBuf {
-    cache_dir.join(version).join(binary_subpath(platform))
+/// See the module docs for why Chrome for Testing is the un-prefixed case.
+pub(crate) fn build_dir(cache_dir: &Path, distribution: Distribution, build_id: &str) -> PathBuf {
+    match distribution {
+        Distribution::ChromeForTesting => cache_dir.join(build_id),
+        other => cache_dir.join(other.slug()).join(build_id),
+    }
 }
 
-/// Path to the Chrome binary *relative* to the version directory.
+/// Path to the Chrome for Testing binary *relative* to its build directory.
 ///
-/// Used by both [`binary_path`] (against the published `<cache>/<version>/`
-/// layout) and the fetcher's permission-fix step (against the in-progress
-/// `<cache>/<version>.tmp/` staging dir, so the binary is executable
-/// *before* it is atomically renamed into place).
-pub(crate) fn binary_subpath(platform: Platform) -> PathBuf {
+/// Used against the published `<cache>/<version>/` layout and against the
+/// in-progress `<cache>/<version>.tmp/` staging dir, so the binary can be
+/// made executable *before* it is atomically renamed into place.
+pub(crate) fn cft_binary_subpath(platform: Platform) -> PathBuf {
     match platform {
         Platform::LinuxX64 => PathBuf::from("chrome-linux64").join("chrome"),
         Platform::MacX64 => PathBuf::from("chrome-mac-x64")
@@ -57,6 +77,50 @@ pub(crate) fn binary_subpath(platform: Platform) -> PathBuf {
             .join("Google Chrome for Testing"),
         Platform::Win32 => PathBuf::from("chrome-win32").join("chrome.exe"),
         Platform::Win64 => PathBuf::from("chrome-win64").join("chrome.exe"),
+    }
+}
+
+/// Path to the binary inside an unpacked Chromium snapshot.
+///
+/// Snapshot archives are plain Chromium: the macOS bundle is `Chromium.app`
+/// and the Linux/Windows binary keeps the `chrome` name, all under the
+/// archive's own per-OS top directory (`chrome-mac`, not `chrome-mac-arm64`).
+pub(crate) fn snapshot_binary_subpath(platform: Platform) -> PathBuf {
+    let top = PathBuf::from(platform.snapshot_archive_stem());
+    match platform {
+        Platform::LinuxX64 => top.join("chrome"),
+        Platform::MacX64 | Platform::MacArm64 => top
+            .join("Chromium.app")
+            .join("Contents")
+            .join("MacOS")
+            .join("Chromium"),
+        Platform::Win32 | Platform::Win64 => top.join("chrome.exe"),
+    }
+}
+
+/// Filename an ungoogled AppImage is stored under inside its build dir.
+///
+/// An AppImage is not unpacked, so this is both the stored name and the
+/// executable path.
+pub(crate) const UNGOOGLED_APPIMAGE_NAME: &str = "chrome.AppImage";
+
+/// Bundle directory inside ungoogled-chromium's macOS disk image.
+pub(crate) const UNGOOGLED_APP_BUNDLE: &str = "Chromium.app";
+
+/// Path to the binary inside an unpacked ungoogled-chromium build.
+///
+/// `archive_top` is the zip's top-level directory on Windows — ungoogled
+/// names it after the asset (`ungoogled-chromium_151.0.7922.71-1.1_windows_x64/`),
+/// so unlike every other case here it is not a constant and has to be
+/// threaded through from the resolved asset name.
+pub(crate) fn ungoogled_binary_subpath(platform: Platform, archive_top: &str) -> PathBuf {
+    match platform {
+        Platform::LinuxX64 => PathBuf::from(UNGOOGLED_APPIMAGE_NAME),
+        Platform::MacX64 | Platform::MacArm64 => PathBuf::from(UNGOOGLED_APP_BUNDLE)
+            .join("Contents")
+            .join("MacOS")
+            .join("Chromium"),
+        Platform::Win32 | Platform::Win64 => PathBuf::from(archive_top).join("chrome.exe"),
     }
 }
 
@@ -76,9 +140,10 @@ mod tests {
     }
 
     #[test]
-    fn binary_path_linux_layout() {
+    fn cft_binary_path_linux_layout() {
         let root = Path::new("/tmp/cache");
-        let p = binary_path(root, "120.0.6099.234", Platform::LinuxX64);
+        let p = build_dir(root, Distribution::ChromeForTesting, "120.0.6099.234")
+            .join(cft_binary_subpath(Platform::LinuxX64));
         assert_eq!(
             p,
             Path::new("/tmp/cache/120.0.6099.234/chrome-linux64/chrome")
@@ -86,9 +151,10 @@ mod tests {
     }
 
     #[test]
-    fn binary_path_mac_arm64_layout() {
+    fn cft_binary_path_mac_arm64_layout() {
         let root = Path::new("/tmp/cache");
-        let p = binary_path(root, "120.0.6099.234", Platform::MacArm64);
+        let p = build_dir(root, Distribution::ChromeForTesting, "120.0.6099.234")
+            .join(cft_binary_subpath(Platform::MacArm64));
         assert_eq!(
             p,
             Path::new(
@@ -98,12 +164,81 @@ mod tests {
     }
 
     #[test]
-    fn binary_path_win64_layout() {
+    fn cft_binary_path_win64_layout() {
         let root = Path::new("/tmp/cache");
-        let p = binary_path(root, "120.0.6099.234", Platform::Win64);
+        let p = build_dir(root, Distribution::ChromeForTesting, "120.0.6099.234")
+            .join(cft_binary_subpath(Platform::Win64));
         assert_eq!(
             p,
             Path::new("/tmp/cache/120.0.6099.234/chrome-win64/chrome.exe")
+        );
+    }
+
+    /// Chrome for Testing must keep the un-prefixed layout, or every cache
+    /// populated before the distribution axis existed silently misses.
+    #[test]
+    fn chrome_for_testing_build_dir_is_unprefixed() {
+        let root = Path::new("/tmp/cache");
+        assert_eq!(
+            build_dir(root, Distribution::ChromeForTesting, "120.0.6099.234"),
+            Path::new("/tmp/cache/120.0.6099.234")
+        );
+    }
+
+    /// ...and the others must not be, or two distributions sharing a Chrome
+    /// version would share a directory.
+    #[test]
+    fn other_distributions_namespace_by_slug() {
+        let root = Path::new("/tmp/cache");
+        assert_eq!(
+            build_dir(root, Distribution::UngoogledChromium, "151.0.7922.71"),
+            Path::new("/tmp/cache/ungoogled/151.0.7922.71")
+        );
+        assert_eq!(
+            build_dir(root, Distribution::ChromiumSnapshot, "r1674890"),
+            Path::new("/tmp/cache/snapshot/r1674890")
+        );
+        assert_ne!(
+            build_dir(root, Distribution::ChromeForTesting, "151.0.7922.71"),
+            build_dir(root, Distribution::UngoogledChromium, "151.0.7922.71"),
+        );
+    }
+
+    #[test]
+    fn snapshot_binary_subpaths_use_the_snapshot_top_dir_not_the_cft_one() {
+        assert_eq!(
+            snapshot_binary_subpath(Platform::LinuxX64),
+            Path::new("chrome-linux/chrome")
+        );
+        assert_eq!(
+            snapshot_binary_subpath(Platform::Win64),
+            Path::new("chrome-win/chrome.exe")
+        );
+        assert_eq!(
+            snapshot_binary_subpath(Platform::MacArm64),
+            Path::new("chrome-mac/Chromium.app/Contents/MacOS/Chromium")
+        );
+        // Snapshots are Chromium, not Chrome for Testing — different tree.
+        assert_ne!(
+            snapshot_binary_subpath(Platform::LinuxX64),
+            cft_binary_subpath(Platform::LinuxX64)
+        );
+    }
+
+    #[test]
+    fn ungoogled_binary_subpaths_cover_the_three_packagings() {
+        let win_top = "ungoogled-chromium_151.0.7922.71-1.1_windows_x64";
+        assert_eq!(
+            ungoogled_binary_subpath(Platform::Win64, win_top),
+            Path::new(win_top).join("chrome.exe")
+        );
+        assert_eq!(
+            ungoogled_binary_subpath(Platform::LinuxX64, ""),
+            Path::new("chrome.AppImage")
+        );
+        assert_eq!(
+            ungoogled_binary_subpath(Platform::MacArm64, ""),
+            Path::new("Chromium.app/Contents/MacOS/Chromium")
         );
     }
 }

--- a/crates/zendriver-fetcher/src/cache.rs
+++ b/crates/zendriver-fetcher/src/cache.rs
@@ -76,21 +76,20 @@ pub(crate) fn build_dir(cache_dir: &Path, distribution: Distribution, build_id: 
 /// Used against the published `<cache>/<version>/` layout and against the
 /// in-progress `<cache>/<version>.tmp/` staging dir, so the binary can be
 /// made executable *before* it is atomically renamed into place.
+///
+/// The leading directory comes from [`Platform::cft_top_dir`] — the same value
+/// the extractor pins the archive to, so the two cannot drift into disagreeing
+/// about where the binary landed.
 pub(crate) fn cft_binary_subpath(platform: Platform) -> PathBuf {
+    let top = PathBuf::from(platform.cft_top_dir());
     match platform {
-        Platform::LinuxX64 => PathBuf::from("chrome-linux64").join("chrome"),
-        Platform::MacX64 => PathBuf::from("chrome-mac-x64")
+        Platform::LinuxX64 => top.join("chrome"),
+        Platform::MacX64 | Platform::MacArm64 => top
             .join("Google Chrome for Testing.app")
             .join("Contents")
             .join("MacOS")
             .join("Google Chrome for Testing"),
-        Platform::MacArm64 => PathBuf::from("chrome-mac-arm64")
-            .join("Google Chrome for Testing.app")
-            .join("Contents")
-            .join("MacOS")
-            .join("Google Chrome for Testing"),
-        Platform::Win32 => PathBuf::from("chrome-win32").join("chrome.exe"),
-        Platform::Win64 => PathBuf::from("chrome-win64").join("chrome.exe"),
+        Platform::Win32 | Platform::Win64 => top.join("chrome.exe"),
     }
 }
 

--- a/crates/zendriver-fetcher/src/cache.rs
+++ b/crates/zendriver-fetcher/src/cache.rs
@@ -47,6 +47,20 @@ pub(crate) fn default_cache_dir() -> PathBuf {
         .join("zendriver/chrome")
 }
 
+/// `path` with `suffix` appended to its last component: `<build>` + `.tmp`
+/// becomes the `<build>.tmp` staging sibling.
+///
+/// Appends to the `OsString` rather than going through
+/// `format!("{}", path.display())`, because `display()` substitutes U+FFFD for
+/// bytes that are not valid UTF-8. On a cache directory containing any such
+/// byte that spelling would stage into — and try to promote from — a directory
+/// other than the one intended.
+pub(crate) fn with_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut joined = path.to_path_buf().into_os_string();
+    joined.push(suffix);
+    PathBuf::from(joined)
+}
+
 /// Directory holding one unpacked build.
 ///
 /// See the module docs for why Chrome for Testing is the un-prefixed case.
@@ -136,6 +150,35 @@ mod tests {
             p.ends_with("zendriver/chrome"),
             "expected suffix zendriver/chrome, got {}",
             p.display()
+        );
+    }
+
+    /// The staging sibling has to be exactly the build directory plus a
+    /// suffix — a lossy round-trip through `display()` would promote a
+    /// different directory than the one that was written.
+    #[test]
+    fn with_suffix_appends_to_the_last_component() {
+        assert_eq!(
+            with_suffix(Path::new("/tmp/cache/120.0.6099.234"), ".tmp"),
+            Path::new("/tmp/cache/120.0.6099.234.tmp")
+        );
+        assert_eq!(
+            with_suffix(Path::new("/tmp/cache/ungoogled/151.0.7922.71"), ".tmp.zip"),
+            Path::new("/tmp/cache/ungoogled/151.0.7922.71.tmp.zip")
+        );
+    }
+
+    /// Non-UTF-8 bytes in the cache path must survive verbatim.
+    #[cfg(unix)]
+    #[test]
+    fn with_suffix_preserves_non_utf8_path_bytes() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let base = Path::new(OsStr::from_bytes(b"/tmp/ca\xffche/120.0.6099.234"));
+        assert_eq!(
+            with_suffix(base, ".tmp").as_os_str().as_bytes(),
+            b"/tmp/ca\xffche/120.0.6099.234.tmp"
         );
     }
 

--- a/crates/zendriver-fetcher/src/distribution.rs
+++ b/crates/zendriver-fetcher/src/distribution.rs
@@ -1,0 +1,229 @@
+//! Which *build* of Chromium to fetch.
+//!
+//! The crate started life as a Chrome for Testing downloader, and Chrome for
+//! Testing remains the default — [`Distribution::default()`] is
+//! [`Distribution::ChromeForTesting`], so a caller that never mentions a
+//! distribution gets exactly the behaviour it always had.
+//!
+//! The three distributions differ **only** in how a
+//! [`VersionSpec`](crate::VersionSpec) + [`Platform`] pair turns into a
+//! download URL. Everything downstream — streaming, SHA256 verification,
+//! extraction, the atomic per-build cache — is shared. Resolution is the
+//! whole distribution axis:
+//!
+//! | Distribution | Index | Keyed by |
+//! |---|---|---|
+//! | [`ChromeForTesting`](Distribution::ChromeForTesting) | one JSON manifest for every platform | version |
+//! | [`UngoogledChromium`](Distribution::UngoogledChromium) | three GitHub repos, one per OS | version (tag *prefix*) |
+//! | [`ChromiumSnapshot`](Distribution::ChromiumSnapshot) | a GCS bucket per platform | **revision** |
+//!
+//! That last row is the awkward one and the reason
+//! [`VersionSpec::Revision`](crate::VersionSpec::Revision) exists — see
+//! [`Distribution::ChromiumSnapshot`].
+
+use crate::platform::Platform;
+
+/// Which Chromium build to download.
+///
+/// Defaults to [`Distribution::ChromeForTesting`].
+///
+/// ```
+/// use zendriver_fetcher::Distribution;
+/// assert_eq!(Distribution::default(), Distribution::ChromeForTesting);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum Distribution {
+    /// Google's [Chrome for Testing][cft] builds: one JSON manifest listing
+    /// every version on every platform, with a stable URL scheme and no
+    /// auto-update. The default, and the only distribution that is really
+    /// *Chrome* rather than Chromium.
+    ///
+    /// [cft]: https://googlechromelabs.github.io/chrome-for-testing/
+    #[default]
+    ChromeForTesting,
+
+    /// [ungoogled-chromium][ug]: Chromium with Google integration stripped out.
+    ///
+    /// There is no single manifest. Binaries are built by **three separate
+    /// per-OS repos** under the `ungoogled-software` org, each cutting its own
+    /// releases on its own cadence, so version availability genuinely differs
+    /// per platform — as of 2026-08-06 Windows and Linux were on
+    /// `151.0.7922.71` while macOS was still on `150.0.7871.46`. Resolution
+    /// reports what the *requested* platform actually has; it never assumes
+    /// parity.
+    ///
+    /// The org's main `ungoogled-chromium` repo also tags releases, but they
+    /// carry **zero assets** — it is the source/patches repo. It is
+    /// deliberately not used as a binary source.
+    ///
+    /// [ug]: https://github.com/ungoogled-software/ungoogled-chromium
+    UngoogledChromium,
+
+    /// Per-commit [Chromium continuous-build snapshots][snap] from Google's
+    /// GCS bucket.
+    ///
+    /// **Snapshots are keyed by revision, not by version.** The bucket is laid
+    /// out `<platform>/<revision>/chrome-<os>.zip` and publishes no
+    /// version→revision index, so
+    /// [`VersionSpec::Explicit`](crate::VersionSpec::Explicit) cannot be
+    /// resolved here and is refused rather than silently downgraded to "the
+    /// newest snapshot" — handing back a different browser than the one asked
+    /// for is worse than an error. Pin a build with
+    /// [`VersionSpec::Revision`](crate::VersionSpec::Revision) instead, or take
+    /// the tip with [`VersionSpec::Latest`](crate::VersionSpec::Latest).
+    ///
+    /// [snap]: https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html
+    ChromiumSnapshot,
+}
+
+impl Distribution {
+    /// Every distribution, in menu order. Used by the CLI's interactive
+    /// picker and by tests that assert exhaustive coverage.
+    pub const ALL: &'static [Distribution] = &[
+        Distribution::ChromeForTesting,
+        Distribution::UngoogledChromium,
+        Distribution::ChromiumSnapshot,
+    ];
+
+    /// Short lowercase slug — the value accepted by `--distribution` and used
+    /// as the cache sub-directory name.
+    ///
+    /// ```
+    /// use zendriver_fetcher::Distribution;
+    /// assert_eq!(Distribution::UngoogledChromium.slug(), "ungoogled");
+    /// ```
+    pub fn slug(self) -> &'static str {
+        match self {
+            Distribution::ChromeForTesting => "cft",
+            Distribution::UngoogledChromium => "ungoogled",
+            Distribution::ChromiumSnapshot => "snapshot",
+        }
+    }
+
+    /// Human-readable name, for CLI menus and error messages.
+    pub fn title(self) -> &'static str {
+        match self {
+            Distribution::ChromeForTesting => "Chrome for Testing",
+            Distribution::UngoogledChromium => "ungoogled-chromium",
+            Distribution::ChromiumSnapshot => "Chromium snapshot",
+        }
+    }
+
+    /// Parse a slug. Accepts a few obvious aliases so the CLI is forgiving.
+    ///
+    /// ```
+    /// use zendriver_fetcher::Distribution;
+    /// assert_eq!(
+    ///     Distribution::parse("chrome-for-testing"),
+    ///     Some(Distribution::ChromeForTesting)
+    /// );
+    /// assert_eq!(Distribution::parse("nope"), None);
+    /// ```
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "cft" | "chrome-for-testing" | "chrome_for_testing" | "chrome" => {
+                Some(Distribution::ChromeForTesting)
+            }
+            "ungoogled" | "ungoogled-chromium" | "ungoogled_chromium" => {
+                Some(Distribution::UngoogledChromium)
+            }
+            "snapshot" | "snapshots" | "chromium-snapshot" | "chromium_snapshot" => {
+                Some(Distribution::ChromiumSnapshot)
+            }
+            _ => None,
+        }
+    }
+
+    /// The `owner/name` GitHub repo publishing ungoogled-chromium binaries for
+    /// `platform`.
+    ///
+    /// The three OSes are built by three different repos — that split is the
+    /// entire reason ungoogled needs per-platform resolution rather than one
+    /// manifest lookup.
+    ///
+    /// ```
+    /// use zendriver_fetcher::{Distribution, Platform};
+    /// assert_eq!(
+    ///     Distribution::ungoogled_repo(Platform::MacArm64),
+    ///     "ungoogled-software/ungoogled-chromium-macos"
+    /// );
+    /// ```
+    pub fn ungoogled_repo(platform: Platform) -> &'static str {
+        match platform {
+            Platform::MacX64 | Platform::MacArm64 => "ungoogled-software/ungoogled-chromium-macos",
+            Platform::Win32 | Platform::Win64 => "ungoogled-software/ungoogled-chromium-windows",
+            // "portablelinux" ships relocatable AppImage/tarball builds; the
+            // sibling `ungoogled-chromium-archlinux` / `-debian` repos publish
+            // distro packages, which are not usable as a drop-in binary.
+            Platform::LinuxX64 => "ungoogled-software/ungoogled-chromium-portablelinux",
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_chrome_for_testing_so_existing_callers_are_untouched() {
+        assert_eq!(Distribution::default(), Distribution::ChromeForTesting);
+    }
+
+    #[test]
+    fn slug_round_trips_through_parse_for_every_distribution() {
+        for &d in Distribution::ALL {
+            assert_eq!(Distribution::parse(d.slug()), Some(d), "slug {}", d.slug());
+        }
+    }
+
+    #[test]
+    fn parse_is_case_insensitive_and_rejects_unknown() {
+        assert_eq!(
+            Distribution::parse("  UnGoogled  "),
+            Some(Distribution::UngoogledChromium)
+        );
+        assert_eq!(Distribution::parse("firefox"), None);
+    }
+
+    #[test]
+    fn ungoogled_maps_the_three_oses_to_three_different_repos() {
+        let mac = Distribution::ungoogled_repo(Platform::MacArm64);
+        let win = Distribution::ungoogled_repo(Platform::Win64);
+        let linux = Distribution::ungoogled_repo(Platform::LinuxX64);
+
+        assert_eq!(mac, "ungoogled-software/ungoogled-chromium-macos");
+        assert_eq!(win, "ungoogled-software/ungoogled-chromium-windows");
+        assert_eq!(linux, "ungoogled-software/ungoogled-chromium-portablelinux");
+
+        // The point of the mapping: three OSes, three distinct repos.
+        assert_ne!(mac, win);
+        assert_ne!(win, linux);
+        assert_ne!(mac, linux);
+
+        // Both arches of an OS share that OS's repo.
+        assert_eq!(mac, Distribution::ungoogled_repo(Platform::MacX64));
+        assert_eq!(win, Distribution::ungoogled_repo(Platform::Win32));
+    }
+
+    #[test]
+    fn ungoogled_never_points_at_the_assetless_source_repo() {
+        // `ungoogled-software/ungoogled-chromium` tags releases with zero
+        // assets (it is the patch set, not a build). Resolving against it
+        // would always fail to find a binary.
+        for &p in &[
+            Platform::MacX64,
+            Platform::MacArm64,
+            Platform::Win32,
+            Platform::Win64,
+            Platform::LinuxX64,
+        ] {
+            assert_ne!(
+                Distribution::ungoogled_repo(p),
+                "ungoogled-software/ungoogled-chromium",
+                "{p:?} points at the source-only repo"
+            );
+        }
+    }
+}

--- a/crates/zendriver-fetcher/src/error.rs
+++ b/crates/zendriver-fetcher/src/error.rs
@@ -39,6 +39,64 @@ pub enum FetcherError {
     /// The downloaded zip could not be extracted.
     #[error("extraction: {0}")]
     Extraction(String),
+
+    /// The requested [`crate::VersionSpec`] cannot be honoured by the
+    /// requested [`crate::Distribution`].
+    ///
+    /// Carries the reason *and* the alternative, because every case is "you
+    /// asked for something this index cannot express": an explicit version
+    /// against the revision-keyed snapshot bucket, or a release channel
+    /// against a distribution that has none. Resolving those to "the newest
+    /// build" instead would hand back a browser other than the one requested,
+    /// which is worse than failing.
+    #[error("{distribution} cannot resolve {selector}: {reason}")]
+    UnsupportedSelector {
+        /// Distribution that refused the selector.
+        distribution: &'static str,
+        /// The selector, as a short human-readable phrase.
+        selector: String,
+        /// Why it cannot be honoured, and what to use instead.
+        reason: String,
+    },
+
+    /// The release exists but publishes no asset for the target platform.
+    ///
+    /// Routine for ungoogled-chromium, whose three per-OS repos release on
+    /// independent cadences — a version present on Windows may simply not be
+    /// built for macOS yet.
+    #[error("{repo} release {tag} has no asset for {platform} (expected one ending in {suffix})")]
+    AssetNotFound {
+        /// `owner/name` of the repo searched.
+        repo: String,
+        /// Release tag searched.
+        tag: String,
+        /// Platform whose asset is missing.
+        platform: &'static str,
+        /// Asset filename suffix that was looked for.
+        suffix: &'static str,
+    },
+
+    /// GitHub's API refused the request for rate-limiting reasons.
+    ///
+    /// Unauthenticated `api.github.com` allows 60 requests per hour per IP;
+    /// setting `GITHUB_TOKEN` raises it to 5000. Surfaced as its own variant
+    /// so the fix is in the message instead of buried in an HTTP 403.
+    #[error(
+        "github api rate limit reached (unauthenticated limit is 60 requests/hour{reset_hint}); \
+         set GITHUB_TOKEN to raise it to 5000/hour"
+    )]
+    GitHubRateLimited {
+        /// `", resets at <unix timestamp>"` when GitHub sent an
+        /// `x-ratelimit-reset` header, otherwise empty.
+        reset_hint: String,
+    },
+
+    /// The downloaded archive is in a format this host cannot unpack.
+    ///
+    /// In practice this is ungoogled-chromium's macOS `.dmg`, which is
+    /// unpacked with `hdiutil` and therefore only on a macOS host.
+    #[error("unsupported archive: {0}")]
+    UnsupportedArchive(String),
 }
 
 #[cfg(test)]
@@ -68,5 +126,47 @@ mod tests {
     fn display_unsupported_platform() {
         let e = FetcherError::UnsupportedPlatform;
         assert_eq!(e.to_string(), "unsupported platform");
+    }
+
+    /// The whole point of this variant is that the message says what to do
+    /// instead, so the message is what gets pinned.
+    #[test]
+    fn display_unsupported_selector_names_the_alternative() {
+        let e = FetcherError::UnsupportedSelector {
+            distribution: "Chromium snapshot",
+            selector: "version 151.0.7922.76".into(),
+            reason: "snapshots are keyed by revision; use --revision".into(),
+        };
+        assert_eq!(
+            e.to_string(),
+            "Chromium snapshot cannot resolve version 151.0.7922.76: \
+             snapshots are keyed by revision; use --revision"
+        );
+    }
+
+    #[test]
+    fn display_rate_limited_names_the_limit_and_the_fix() {
+        let e = FetcherError::GitHubRateLimited {
+            reset_hint: ", resets at 1786023295".into(),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("60 requests/hour"), "{msg}");
+        assert!(msg.contains("GITHUB_TOKEN"), "{msg}");
+        assert!(msg.contains("resets at 1786023295"), "{msg}");
+    }
+
+    #[test]
+    fn display_asset_not_found_names_repo_tag_and_suffix() {
+        let e = FetcherError::AssetNotFound {
+            repo: "ungoogled-software/ungoogled-chromium-macos".into(),
+            tag: "151.0.7922.71-1.1".into(),
+            platform: "mac-arm64",
+            suffix: "_arm64-macos.dmg",
+        };
+        assert_eq!(
+            e.to_string(),
+            "ungoogled-software/ungoogled-chromium-macos release 151.0.7922.71-1.1 \
+             has no asset for mac-arm64 (expected one ending in _arm64-macos.dmg)"
+        );
     }
 }

--- a/crates/zendriver-fetcher/src/extract.rs
+++ b/crates/zendriver-fetcher/src/extract.rs
@@ -20,14 +20,18 @@
 //! write outside `dest_dir`. The extractor defends against those classes
 //! of attack:
 //!
-//! 1. `zip::read::ZipFile::enclosed_name()` rejects any entry whose
-//!    normalized path escapes the archive root (absolute, parent-traversal).
+//! 1. `zip::read::ZipFile::enclosed_name()` refuses an absolute entry path,
+//!    and any path whose running depth goes negative. Note what it does NOT
+//!    do: it returns what it accepts **unnormalized**, so `a/b/../../c`
+//!    survives with its `..` intact. Nothing here may assume otherwise.
 //! 2. After joining with `dest_dir`, the resolved path is verified to still
 //!    sit under `dest_dir` — defense in depth against any future change
-//!    to `enclosed_name`'s semantics.
+//!    to `enclosed_name`'s semantics. The probe that finds an existing
+//!    ancestor to canonicalize uses `symlink_metadata`, which does not follow
+//!    links, so a DANGLING link is seen rather than stepped over.
 //! 3. Symlink entries (detected via `unix_mode() & S_IFMT == S_IFLNK`) are
-//!    extracted only after their TARGET is validated to stay inside
-//!    `dest_dir`; anything else is refused.
+//!    extracted only after their TARGET is validated to stay inside the
+//!    archive's top-level directory; anything else is refused.
 //!
 //!    This used to refuse every symlink, justified as "Chrome for Testing
 //!    archives never ship symlinks". That is FALSE on macOS: every `.app`
@@ -43,13 +47,23 @@
 //!    The refusal existed for a real reason and the replacement keeps it
 //!    closed. Symlinks are the primary FOLLOW-ON vector for zip-slip: extract
 //!    `evil -> /etc`, then extract `evil/passwd` and the write lands outside
-//!    while every path in the archive looks innocent. So a target is accepted
-//!    only when it is relative AND `<entry's parent>/<target>`, normalized
-//!    LEXICALLY, still sits under the archive root.
+//!    while every path in the archive looks innocent.
 //!
-//!    Lexically, not via the filesystem, because the target frequently does
-//!    not exist yet — `Versions/Current` is written before `Versions/A`, so
-//!    `canonicalize` would fail on a link that is perfectly legitimate.
+//!    So a target is accepted only when it is relative AND resolves, from the
+//!    directory that really contains the link, to somewhere still inside the
+//!    top-level directory — checked at every step of the climb, not just at
+//!    the end.
+//!
+//!    **"Really contains" is load-bearing and was once the bug.** Taking the
+//!    link's parent from the archive text instead of from `canonicalize`
+//!    leaves the extractor reasoning about a different directory than the
+//!    kernel writes to, because an earlier entry can plant a link that a later
+//!    entry's own path runs through. See
+//!    `a_symlink_reached_through_an_earlier_symlink_cannot_escape` for the
+//!    three-entry archive that exploited exactly that gap. The target is still
+//!    resolved lexically from that canonical parent, with no stat, because the
+//!    target frequently does not exist yet — `Versions/Current` is written
+//!    before `Versions/A`, so stat-ing it would reject legitimate links.
 //!
 //!    Windows keeps skipping them: creating a symlink there needs privileges,
 //!    and no Windows Chrome archive contains one.
@@ -138,28 +152,31 @@ fn extract_blocking(
         if is_symlink(&entry) {
             let mut target = String::new();
             io::Read::read_to_string(&mut entry, &mut target)?;
-            let resolved = resolve_target(&rel_path, Path::new(&target)).ok_or_else(|| {
-                FetcherError::Extraction(format!(
-                    "zip entry {rel_path:?} is a symlink to {target:?}, which escapes the \
-                     destination directory; refusing"
-                ))
-            })?;
+
+            // The parent chain has to exist before the target can be resolved:
+            // resolution runs against where this link REALLY lands, which means
+            // canonicalizing its parent.
+            if let Some(parent) = out_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+
             // Files are already locked to the archive's single top-level
             // directory; hold links to it too. A link that leaves it stays
             // inside dest_dir, so it is not a zip-slip, but it can only point
             // at something this archive does not own — and dest_dir is shared
             // with other installs.
-            if let Some(top) = expected_top_prefix {
-                if !resolved.starts_with(top) {
-                    return Err(FetcherError::Extraction(format!(
-                        "zip entry {rel_path:?} is a symlink to {target:?}, which leaves the \
-                         archive's top-level directory {top:?}; refusing"
-                    )));
-                }
-            }
-            if let Some(parent) = out_path.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
+            let containment_root = match expected_top_prefix {
+                Some(top) => dest_canonical.join(top),
+                None => dest_canonical.clone(),
+            };
+            resolve_target(&out_path, Path::new(&target), &containment_root).ok_or_else(|| {
+                FetcherError::Extraction(format!(
+                    "zip entry {rel_path:?} is a symlink to {target:?}, which escapes {}; \
+                     refusing",
+                    containment_root.display()
+                ))
+            })?;
+
             // A re-extraction over a populated dir would otherwise fail with
             // EEXIST; the fetcher extracts into a fresh staging dir, but this
             // keeps the function idempotent rather than order-dependent.
@@ -187,7 +204,12 @@ fn extract_blocking(
         // `dest_canonical`. Catches future regressions in `enclosed_name`
         // semantics or surprise from filesystem-level path resolution.
         let mut probe_path = out_path.clone();
-        while !probe_path.exists() {
+        // `symlink_metadata`, not `exists()`: `exists` follows links, so a
+        // DANGLING one reads as absent and the walk steps straight over it to a
+        // parent that passes — then `File::create` follows it and writes
+        // wherever it pointed. Not following means a dangling link is seen,
+        // and `assert_under_dest` then fails to canonicalize it and refuses.
+        while std::fs::symlink_metadata(&probe_path).is_err() {
             // Walk up until we hit a directory that exists, so canonicalize
             // can succeed. The leaf file doesn't exist yet (we're about to
             // create it), so canonicalize its parent chain.
@@ -219,23 +241,35 @@ fn is_symlink(entry: &zip::read::ZipFile<'_>) -> bool {
         .is_some_and(|mode| mode & S_IFMT == S_IFLNK)
 }
 
-/// Where does a symlink at `link_rel` pointing at `target` actually land,
-/// expressed relative to the destination? `None` means it leaves.
+/// Where does a symlink at `link_path` pointing at `target` actually land?
+/// `None` means it leaves `containment_root`.
 ///
-/// Resolves `.` and `..` LEXICALLY — no filesystem access — because the target
-/// routinely does not exist yet at extraction time (`Versions/Current` precedes
-/// `Versions/A` in a macOS framework), so anything that stats the path would
-/// reject links that are perfectly legitimate.
+/// `link_path` is the link's absolute path on disk, and its parent must already
+/// exist. The target resolves against the DIRECTORY CONTAINING the link — not
+/// the link itself. Getting that wrong by one level makes every sibling link
+/// look like an escape, and makes a real escape look like a sibling.
 ///
-/// `link_rel` is the entry's own path relative to the destination, and the
-/// target resolves relative to the DIRECTORY CONTAINING the link — not to the
-/// link itself. Getting that wrong by one level makes every sibling link look
-/// like an escape, and makes a real escape look like a sibling.
+/// That containing directory is **canonicalized**, not taken from the entry's
+/// declared path, and the difference is the whole defence. An archive is
+/// extracted in order, so an earlier entry can plant a symlink that a later
+/// entry's own path then runs through. Reading the parent off the archive text
+/// makes `top/a/b/c/up/hop -> ../../../../X` look like it lands on `top/X`,
+/// while the kernel — for which `up` is already a link to `top` — creates it at
+/// `top/hop` and resolves four levels up from there, clear of the destination.
+/// Canonicalizing collapses that gap: the parent is wherever the kernel says it
+/// is, and there is no second opinion to disagree with.
+///
+/// The target itself is still resolved lexically from there, with no stat, and
+/// the containment check runs at every step of the climb rather than on the
+/// final result. Both matter: the target routinely does not exist yet at
+/// extraction time (`Versions/Current` precedes `Versions/A` in a macOS
+/// framework), so anything that stats it would reject legitimate links; and
+/// checking only the endpoint would admit `../../a/b`, which leaves and returns.
 ///
 /// Unix-only, because only the Unix arm creates symlinks — Windows skips those
 /// entries outright, and an ungated definition is dead code there.
 #[cfg(unix)]
-fn resolve_target(link_rel: &Path, target: &Path) -> Option<PathBuf> {
+fn resolve_target(link_path: &Path, target: &Path, containment_root: &Path) -> Option<PathBuf> {
     use std::path::Component;
 
     // An absolute target ignores the destination entirely: `evil -> /etc` then
@@ -244,21 +278,20 @@ fn resolve_target(link_rel: &Path, target: &Path) -> Option<PathBuf> {
         return None;
     }
 
-    let mut resolved = PathBuf::new();
-    for comp in link_rel
-        .parent()
-        .unwrap_or_else(|| Path::new(""))
-        .components()
-        .chain(target.components())
-    {
+    let mut resolved = std::fs::canonicalize(link_path.parent()?).ok()?;
+    if !resolved.starts_with(containment_root) {
+        return None;
+    }
+
+    for comp in target.components() {
         match comp {
             Component::Normal(name) => resolved.push(name),
             Component::CurDir => {}
-            // `pop` fails exactly when the climb has reached the top, which is
-            // the escape. Checked as we walk rather than on the final result,
-            // so `a/../../a/b` is refused even though it ends up inside.
+            // `pop` fails at the filesystem root; leaving the containment root
+            // is the escape. Checked as we climb rather than on the final
+            // result, so `../../a/b` is refused even though it ends up inside.
             Component::ParentDir => {
-                if !resolved.pop() {
+                if !resolved.pop() || !resolved.starts_with(containment_root) {
                     return None;
                 }
             }
@@ -408,13 +441,81 @@ mod tests {
         );
     }
 
+    /// A symlink whose own ENTRY PATH runs through a symlink an earlier entry
+    /// created. The archive is extracted in order, so the attacker controls
+    /// that ordering.
+    ///
+    /// Validating the target against the entry's *lexical* parent says
+    /// `top/a/b/c/up/hop -> ../../../../ESCAPED` lands on `top/ESCAPED`. The
+    /// kernel disagrees: `up` is already a link to `top`, so the link is really
+    /// created at `top/hop` and its target climbs four levels from there —
+    /// clear of the destination. A third entry writing to `top/hop` then
+    /// follows it and lands outside.
+    ///
+    /// `zip`'s `enclosed_name` is no help: it only refuses a path whose running
+    /// depth goes negative, and returns what it accepts unnormalized.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_symlink_reached_through_an_earlier_symlink_cannot_escape() {
+        let mut buf = std::io::Cursor::new(Vec::new());
+        {
+            let opts = zip::write::SimpleFileOptions::default();
+            let mut writer = zip::ZipWriter::new(&mut buf);
+            // 1. A link back up to the top-level dir. Contained, and legal.
+            writer
+                .add_symlink("top/a/b/c/up", "../../..", opts)
+                .unwrap();
+            // 2. Created THROUGH it, so it really lands at `top/hop`.
+            writer
+                .add_symlink("top/a/b/c/up/hop", "../../../../ESCAPED", opts)
+                .unwrap();
+            // 3. Written through the link planted by 2.
+            writer
+                .start_file("top/hop", opts.unix_permissions(0o755))
+                .unwrap();
+            writer.write_all(b"payload").unwrap();
+            writer.finish().unwrap();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let zip_path = dir.path().join("evil.zip");
+        // Nested deep enough that anything this archive manages to escape to
+        // still lands inside the tempdir, and so is both detectable here and
+        // cleaned up afterwards rather than left in the system temp root.
+        let dest = dir.path().join("l1/l2/l3/l4/out");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(&zip_path, buf.into_inner()).unwrap();
+
+        let result = extract(&zip_path, &dest, Some("top")).await;
+
+        // Nothing may land outside the destination, whatever the outcome.
+        let mut probe = dest.clone();
+        for _ in 0..4 {
+            probe.pop();
+            assert!(
+                !probe.join("ESCAPED").exists(),
+                "payload escaped to {}",
+                probe.join("ESCAPED").display()
+            );
+        }
+        result.expect_err("an archive that escapes through a chained symlink must be refused");
+    }
+
     /// The containment predicate on its own, including the shapes that are
-    /// easy to get wrong by one level.
+    /// easy to get wrong by one level. The directories are real, because
+    /// resolution runs against the link's canonicalized parent.
     #[cfg(unix)]
     #[test]
     fn target_containment_rules() {
-        let inside =
-            |link: &str, target: &str| resolve_target(Path::new(link), Path::new(target)).is_some();
+        let dir = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+        std::fs::create_dir_all(root.join("fw/Versions")).unwrap();
+        std::fs::create_dir_all(root.join("a/b")).unwrap();
+
+        let inside = |link: &str, target: &str| {
+            resolve_target(&root.join(link), Path::new(target), &root).is_some()
+        };
+
         // A target resolves relative to the link's PARENT, not the link.
         assert!(inside("fw/Versions/Current", "A"));
         assert!(inside("a/b/link", "../sibling"));
@@ -426,7 +527,7 @@ mod tests {
         assert!(!inside("a/b/link", "../../../etc"));
         assert!(!inside("link", ""));
         // Refused even though it ENDS inside — the climb itself is the escape,
-        // which is why depth is checked as we walk rather than at the end.
+        // which is why containment is checked as we walk rather than at the end.
         assert!(!inside("a/link", "../../a/b"));
     }
 

--- a/crates/zendriver-fetcher/src/extract.rs
+++ b/crates/zendriver-fetcher/src/extract.rs
@@ -1,16 +1,18 @@
 //! Zip archive extraction.
 //!
-//! Unzips a Chrome for Testing archive into a destination directory.
-//! Chrome for Testing ships a `.zip` on every platform (Linux, macOS, Windows),
-//! so a single sync `zip::ZipArchive` walk wrapped in
-//! [`tokio::task::spawn_blocking`] handles all three.
+//! Unzips a Chromium archive into a destination directory. Chrome for Testing
+//! and the Chromium snapshot bucket ship a `.zip` on every platform, as does
+//! ungoogled-chromium on Windows, so a single sync `zip::ZipArchive` walk
+//! wrapped in [`tokio::task::spawn_blocking`] handles all of them.
+//! ungoogled's other two packagings are [`crate::archive`]'s problem.
 //!
 //! On Unix, executable bits from the archive's `unix_mode()` are preserved
 //! so the extracted Chrome binary stays runnable without a chmod pass.
 //!
 //! # Trust boundary
 //!
-//! The archives we accept come from the Chrome for Testing CDN (Google).
+//! The archives reaching here come from Google's Chrome for Testing CDN, the
+//! Chromium snapshot bucket, and GitHub release assets.
 //! We trust the *content* of those archives — they may include arbitrary
 //! files and executable bits because that's what running Chrome requires.
 //! We do **not** trust the archive's *paths*: a malicious or corrupt zip

--- a/crates/zendriver-fetcher/src/extract.rs
+++ b/crates/zendriver-fetcher/src/extract.rs
@@ -136,6 +136,22 @@ fn extract_blocking(
             )));
         };
 
+        // `enclosed_name` accepts `a/b/../c`: it only refuses a path whose
+        // running depth goes negative, and returns what it accepts
+        // unnormalized. A surviving `..` makes the top-level check below mean
+        // less than it reads — that check inspects only the FIRST component,
+        // so `chrome-linux64/../elsewhere/x` passes it — and it lets the
+        // `create_dir_all` calls further down run on a path that validation
+        // later refuses. No archive from any of the three indexes ships one.
+        if rel_path
+            .components()
+            .any(|c| c == std::path::Component::ParentDir)
+        {
+            return Err(FetcherError::Extraction(format!(
+                "zip entry {rel_path:?} contains a parent-directory component; refusing"
+            )));
+        }
+
         // Enforce CfT top-level directory when the caller supplies one.
         if let Some(prefix) = expected_top_prefix {
             let top = rel_path.components().next().and_then(|c| match c {

--- a/crates/zendriver-fetcher/src/extract.rs
+++ b/crates/zendriver-fetcher/src/extract.rs
@@ -49,27 +49,30 @@
 //!    `evil -> /etc`, then extract `evil/passwd` and the write lands outside
 //!    while every path in the archive looks innocent.
 //!
-//!    So a target is accepted only when it is relative AND resolves, from the
-//!    directory that really contains the link, to somewhere still inside the
-//!    top-level directory — checked at every step of the climb, not just at
-//!    the end.
+//!    Containment is decided by [`assert_symlinks_contained`], which runs once
+//!    on the FINISHED tree rather than per entry. `resolve_target` still gives
+//!    each link a cheap lexical look on the way past, so an obviously bad one
+//!    is refused early with a precise message, but it is not the guarantee.
 //!
-//!    **Reasoning lexically about a path the kernel resolves differently was
-//!    the bug, twice.** An earlier entry can plant a symlink, and a later entry
-//!    can reach through it two ways — by its own entry path, or by its target
-//!    string. Both were exploitable and both are now closed by following the
-//!    filesystem rather than the archive's text:
+//!    **That split exists because per-entry validation failed three times.**
+//!    Deciding where a link will point, at the moment it is created, means
+//!    predicting — and the prediction is made against a filesystem the archive
+//!    is still building, in an order the archive chooses. The same gap was
+//!    reached three ways: through the link's parent, through a component of its
+//!    target, and through time, by aiming a target at a component that a later
+//!    entry turns into a symlink. Each fix made the prediction consult the
+//!    filesystem a little more and left the same residual: whatever had not
+//!    been created yet.
 //!
-//!    - the link's parent is `canonicalize`d, not taken from the entry path
-//!      (`a_symlink_reached_through_an_earlier_symlink_cannot_escape`);
-//!    - each target component that ALREADY EXISTS as a symlink is resolved as
-//!      the walk pushes it, so `u1/u2/u3/up/../../../X` cannot pop three levels
-//!      lexically from `up` while the kernel pops them from wherever `up`
-//!      pointed (`a_symlink_target_walking_through_an_earlier_symlink_cannot_escape`).
+//!    Real archives make that residual unavoidable. A Chrome for Testing macOS
+//!    bundle lists `Framework.framework/Resources -> Versions/Current/Resources`
+//!    around entry 132 and does not create `Versions/Current` until entry 646,
+//!    so refusing to reason lexically about not-yet-existing components would
+//!    reject Google's own build.
 //!
-//!    Components that do not exist yet stay lexical, and that is what keeps
-//!    legitimate links working: `Versions/Current` is written before
-//!    `Versions/A`, so stat-ing the whole target would reject it.
+//!    Checking the end state removes the question. Once the loop is done there
+//!    is no "not yet": `canonicalize` reports the path the kernel will use, and
+//!    the only thing left to ask is whether it is inside.
 //!
 //!    Windows keeps skipping them: creating a symlink there needs privileges,
 //!    and no Windows Chrome archive contains one.
@@ -247,8 +250,22 @@ fn extract_blocking(
         #[cfg(unix)]
         if let Some(mode) = entry.unix_mode() {
             use std::os::unix::fs::PermissionsExt as _;
-            std::fs::set_permissions(&out_path, std::fs::Permissions::from_mode(mode))?;
+            // Permission bits only. setuid/setgid/sticky are carried in the
+            // same field and no browser bundle needs them, so an archive is
+            // never the reason a file in the cache gains one.
+            std::fs::set_permissions(&out_path, std::fs::Permissions::from_mode(mode & 0o777))?;
         }
+    }
+
+    // Authoritative containment check, on the finished tree. See
+    // `assert_symlinks_contained` for why it cannot live inside the loop.
+    #[cfg(unix)]
+    {
+        let containment_root = match expected_top_prefix {
+            Some(top) => dest_canonical.join(top),
+            None => dest_canonical.clone(),
+        };
+        assert_symlinks_contained(&dest_canonical, &containment_root)?;
     }
 
     Ok(())
@@ -307,29 +324,7 @@ fn resolve_target(link_path: &Path, target: &Path, containment_root: &Path) -> O
 
     for comp in target.components() {
         match comp {
-            // Follow rather than assume. If this component already exists and is
-            // itself a symlink, the kernel follows it when resolving this
-            // target — so the walk has to follow it too, or every component
-            // after this one is reasoning about a directory the kernel is not
-            // standing in. That is the same lexical-vs-real gap canonicalizing
-            // the parent closes, reached through the target instead:
-            // `u1/u2/u3/up/../../../X` pops three lexically from `u1/u2/u3/up`
-            // and lands inside, while the kernel pops them from wherever `up`
-            // pointed and leaves.
-            //
-            // A component that does not exist yet stays lexical, which is what
-            // keeps `Versions/Current -> A` working: `A` is written after the
-            // link that names it.
-            Component::Normal(name) => {
-                resolved.push(name);
-                if std::fs::symlink_metadata(&resolved).is_ok_and(|md| md.file_type().is_symlink())
-                {
-                    resolved = std::fs::canonicalize(&resolved).ok()?;
-                    if !resolved.starts_with(containment_root) {
-                        return None;
-                    }
-                }
-            }
+            Component::Normal(name) => resolved.push(name),
             Component::CurDir => {}
             // `pop` fails at the filesystem root; leaving the containment root
             // is the escape. Checked as we climb rather than on the final
@@ -345,6 +340,62 @@ fn resolve_target(link_path: &Path, target: &Path, containment_root: &Path) -> O
         }
     }
     Some(resolved)
+}
+
+/// Verify every symlink in the finished tree resolves inside
+/// `containment_root`, refusing the whole extraction if any does not.
+///
+/// **This is the authoritative containment check, and it deliberately runs
+/// after the extraction loop rather than inside it.**
+///
+/// Validating a link as it is created means predicting where it will point.
+/// That prediction is made against a filesystem the archive is still building,
+/// in an order the archive chooses, and three separate escapes came out of that
+/// one gap — reached through the link's parent, then through a component of its
+/// target, then through *time*, by pointing a target at a component that a
+/// later entry turns into a symlink. Each was closed by making the prediction
+/// consult the filesystem a little more, and each left the same residual:
+/// whatever had not been created yet.
+///
+/// Predicting cannot converge, so this stops predicting. Once the loop is done
+/// there is no "not yet" left to reason about: `canonicalize` gives the path
+/// the kernel will actually use, and the only question is whether it is inside.
+///
+/// It also costs nothing in fidelity to real archives. A Chrome for Testing
+/// macOS bundle relies on exactly the ordering that made the prediction
+/// unsound — `Framework.framework/Resources -> Versions/Current/Resources`
+/// appears around entry 132, while `Versions/Current` is not created until
+/// entry 646 — and it passes here, because by the end everything resolves.
+///
+/// A symlink that does not resolve at all is refused too: a real bundle has
+/// none, and a dangling link is a path something else could later fill in.
+#[cfg(unix)]
+fn assert_symlinks_contained(dir: &Path, containment_root: &Path) -> Result<(), FetcherError> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        // `file_type` on a `DirEntry` does not follow links, so a symlinked
+        // directory is inspected rather than descended into — which is also
+        // what keeps a link cycle from recursing forever.
+        let file_type = entry.file_type()?;
+
+        if file_type.is_symlink() {
+            let resolved = std::fs::canonicalize(&path).map_err(|e| {
+                FetcherError::Extraction(format!(
+                    "zip entry {path:?} is a symlink that does not resolve ({e}); refusing"
+                ))
+            })?;
+            if !resolved.starts_with(containment_root) {
+                return Err(FetcherError::Extraction(format!(
+                    "zip entry {path:?} is a symlink resolving to {resolved:?}, outside \
+                     {containment_root:?}; refusing"
+                )));
+            }
+        } else if file_type.is_dir() {
+            assert_symlinks_contained(&path, containment_root)?;
+        }
+    }
+    Ok(())
 }
 
 /// Verify `path`, after `canonicalize`, still has `dest_canonical` as a
@@ -585,19 +636,109 @@ mod tests {
         // the three `..` are spent from there — out, l2, l1.
         std::fs::write(root.join("l1/VICTIM"), b"not the browser").unwrap();
 
-        let result = extract(&zip_path, &dest, Some("chrome-linux64")).await;
+        extract(&zip_path, &dest, Some("chrome-linux64"))
+            .await
+            .expect_err("a target walking through a planted symlink must be refused");
 
-        // Whatever the outcome, the path a caller would launch must not resolve
-        // out of the destination.
-        let launched = dest.join("chrome-linux64/chrome");
-        if let Ok(real) = std::fs::canonicalize(&launched) {
-            assert!(
-                real.starts_with(std::fs::canonicalize(&dest).unwrap()),
-                "returned browser path resolves to {}, outside the cache",
-                real.display()
-            );
+        assert_eq!(
+            std::fs::read(root.join("l1/VICTIM")).unwrap(),
+            b"not the browser",
+            "the out-of-tree file was touched"
+        );
+    }
+
+    /// The third shape, and the one that retired per-entry prediction: a target
+    /// validated against a filesystem state that a LATER entry invalidates.
+    ///
+    /// When `chrome` is checked, `u` and `d` do not exist, so the walk treats
+    /// them lexically and scores the target as landing on `chrome-linux64/evil`.
+    /// A later entry then makes `d` a symlink to `..` — contained, and accepted
+    /// honestly on its own terms — after which the *stored* target string
+    /// resolves through it to outside the destination. Nothing re-checked the
+    /// earlier link.
+    ///
+    /// The lexical treatment of not-yet-existing components could not simply be
+    /// removed: a real Chrome for Testing macOS bundle depends on it, listing
+    /// `Framework.framework/Resources -> Versions/Current/Resources` hundreds of
+    /// entries before it creates `Versions/Current`. Hence the end-state sweep.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_symlink_whose_target_a_later_entry_redirects_cannot_escape() {
+        let mut buf = std::io::Cursor::new(Vec::new());
+        {
+            let opts = zip::write::SimpleFileOptions::default();
+            let mut writer = zip::ZipWriter::new(&mut buf);
+            // Exactly `cft_binary_subpath(LinuxX64)` — the path ensure_chrome
+            // returns for the caller to execute.
+            writer
+                .add_symlink("chrome-linux64/chrome", "u/d/../../evil", opts)
+                .unwrap();
+            // Planted afterwards, which is what makes the earlier check stale.
+            writer
+                .add_symlink("chrome-linux64/u/d", "..", opts)
+                .unwrap();
+            writer.finish().unwrap();
         }
-        result.expect_err("a target walking through a planted symlink must be refused");
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+        let zip_path = root.join("evil.zip");
+        let dest = root.join("cache/build");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(&zip_path, buf.into_inner()).unwrap();
+        std::fs::write(root.join("cache/evil"), b"not the browser").unwrap();
+
+        // Refusing the whole extraction is the guarantee. The staging tree is
+        // discarded unpromoted, so a link left inside it is never reached; what
+        // must not happen is `ensure_chrome` succeeding and handing that path
+        // back.
+        extract(&zip_path, &dest, Some("chrome-linux64"))
+            .await
+            .expect_err("a target redirected by a later entry must be refused");
+
+        assert_eq!(
+            std::fs::read(root.join("cache/evil")).unwrap(),
+            b"not the browser",
+            "the out-of-tree file was touched"
+        );
+    }
+
+    /// setuid/setgid ride in the same field as the permission bits, and a
+    /// tampered archive is not a reason for a file in the cache to carry one.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn setuid_bits_from_an_archive_are_not_honoured() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let mut buf = std::io::Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut buf);
+            writer
+                .start_file(
+                    "chrome-linux64/chrome",
+                    zip::write::SimpleFileOptions::default().unix_permissions(0o4755),
+                )
+                .unwrap();
+            writer.write_all(b"payload").unwrap();
+            writer.finish().unwrap();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let zip_path = dir.path().join("suid.zip");
+        let dest = dir.path().join("out");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(&zip_path, buf.into_inner()).unwrap();
+
+        extract(&zip_path, &dest, Some("chrome-linux64"))
+            .await
+            .unwrap();
+
+        let mode = std::fs::metadata(dest.join("chrome-linux64/chrome"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o7000, 0, "setuid/setgid/sticky survived: {mode:o}");
+        assert!(mode & 0o111 != 0, "the executable bit must still be set");
     }
 
     /// The containment predicate on its own, including the shapes that are

--- a/crates/zendriver-fetcher/src/extract.rs
+++ b/crates/zendriver-fetcher/src/extract.rs
@@ -24,9 +24,33 @@
 //!    sit under `dest_dir` — defense in depth against any future change
 //!    to `enclosed_name`'s semantics.
 //! 3. Symlink entries (detected via `unix_mode() & S_IFMT == S_IFLNK`) are
-//!    skipped — Chrome for Testing archives never ship symlinks, and
-//!    accepting them would let an attacker plant a follow-on write that
-//!    escapes the directory via symlink resolution.
+//!    extracted only after their TARGET is validated to stay inside
+//!    `dest_dir`; anything else is refused.
+//!
+//!    This used to refuse every symlink, justified as "Chrome for Testing
+//!    archives never ship symlinks". That is FALSE on macOS: every `.app`
+//!    bundle carries framework `Versions/Current`-style links, so
+//!    `Fetcher::ensure_chrome()` had never once succeeded there —
+//!
+//!    ```text
+//!    zip entry "chrome-mac-arm64/Google Chrome for Testing.app/Contents/
+//!    Frameworks/Google Chrome for Testing Framework.framework/Resources"
+//!    is a symlink; refusing for safety
+//!    ```
+//!
+//!    The refusal existed for a real reason and the replacement keeps it
+//!    closed. Symlinks are the primary FOLLOW-ON vector for zip-slip: extract
+//!    `evil -> /etc`, then extract `evil/passwd` and the write lands outside
+//!    while every path in the archive looks innocent. So a target is accepted
+//!    only when it is relative AND `<entry's parent>/<target>`, normalized
+//!    LEXICALLY, still sits under the archive root.
+//!
+//!    Lexically, not via the filesystem, because the target frequently does
+//!    not exist yet — `Versions/Current` is written before `Versions/A`, so
+//!    `canonicalize` would fail on a link that is perfectly legitimate.
+//!
+//!    Windows keeps skipping them: creating a symlink there needs privileges,
+//!    and no Windows Chrome archive contains one.
 //! 4. Optional `expected_top_prefix` parameter requires every non-empty
 //!    entry to live under a single named top-level directory (e.g.
 //!    `chrome-linux64/`); enforced from the fetcher to lock the archive
@@ -104,21 +128,48 @@ fn extract_blocking(
             }
         }
 
-        // Refuse symlink entries — CfT archives don't use them and they
-        // are the primary follow-on vector for zip-slip on Unix.
-        #[cfg(unix)]
-        if let Some(mode) = entry.unix_mode() {
-            const S_IFMT: u32 = 0o170_000;
-            const S_IFLNK: u32 = 0o120_000;
-            if mode & S_IFMT == S_IFLNK {
-                return Err(FetcherError::Extraction(format!(
-                    "zip entry {:?} is a symlink; refusing for safety",
-                    rel_path
-                )));
-            }
-        }
-
         let out_path: PathBuf = dest_dir.join(&rel_path);
+
+        // Symlinks: validate the target, then create. See the trust-boundary
+        // note at the top of this module for why this is not a blanket refusal.
+        #[cfg(unix)]
+        if is_symlink(&entry) {
+            let mut target = String::new();
+            io::Read::read_to_string(&mut entry, &mut target)?;
+            let resolved = resolve_target(&rel_path, Path::new(&target)).ok_or_else(|| {
+                FetcherError::Extraction(format!(
+                    "zip entry {rel_path:?} is a symlink to {target:?}, which escapes the \
+                     destination directory; refusing"
+                ))
+            })?;
+            // Files are already locked to the archive's single top-level
+            // directory; hold links to it too. A link that leaves it stays
+            // inside dest_dir, so it is not a zip-slip, but it can only point
+            // at something this archive does not own — and dest_dir is shared
+            // with other installs.
+            if let Some(top) = expected_top_prefix {
+                if !resolved.starts_with(top) {
+                    return Err(FetcherError::Extraction(format!(
+                        "zip entry {rel_path:?} is a symlink to {target:?}, which leaves the \
+                         archive's top-level directory {top:?}; refusing"
+                    )));
+                }
+            }
+            if let Some(parent) = out_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            // A re-extraction over a populated dir would otherwise fail with
+            // EEXIST; the fetcher extracts into a fresh staging dir, but this
+            // keeps the function idempotent rather than order-dependent.
+            let _ = std::fs::remove_file(&out_path);
+            std::os::unix::fs::symlink(&target, &out_path)?;
+            continue;
+        }
+        // Windows: no privileges to create one, and no Windows archive has any.
+        #[cfg(not(unix))]
+        if is_symlink(&entry) {
+            continue;
+        }
 
         if entry.is_dir() {
             std::fs::create_dir_all(&out_path)?;
@@ -157,6 +208,62 @@ fn extract_blocking(
     Ok(())
 }
 
+/// True when a zip entry's mode marks it a symlink.
+fn is_symlink(entry: &zip::read::ZipFile<'_>) -> bool {
+    const S_IFMT: u32 = 0o170_000;
+    const S_IFLNK: u32 = 0o120_000;
+    entry
+        .unix_mode()
+        .is_some_and(|mode| mode & S_IFMT == S_IFLNK)
+}
+
+/// Where does a symlink at `link_rel` pointing at `target` actually land,
+/// expressed relative to the destination? `None` means it leaves.
+///
+/// Resolves `.` and `..` LEXICALLY — no filesystem access — because the target
+/// routinely does not exist yet at extraction time (`Versions/Current` precedes
+/// `Versions/A` in a macOS framework), so anything that stats the path would
+/// reject links that are perfectly legitimate.
+///
+/// `link_rel` is the entry's own path relative to the destination, and the
+/// target resolves relative to the DIRECTORY CONTAINING the link — not to the
+/// link itself. Getting that wrong by one level makes every sibling link look
+/// like an escape, and makes a real escape look like a sibling.
+fn resolve_target(link_rel: &Path, target: &Path) -> Option<PathBuf> {
+    use std::path::Component;
+
+    // An absolute target ignores the destination entirely: `evil -> /etc` then
+    // `evil/passwd` writes to /etc/passwd with no `..` anywhere in the archive.
+    if target.is_absolute() || target.as_os_str().is_empty() {
+        return None;
+    }
+
+    let mut resolved = PathBuf::new();
+    for comp in link_rel
+        .parent()
+        .unwrap_or_else(|| Path::new(""))
+        .components()
+        .chain(target.components())
+    {
+        match comp {
+            Component::Normal(name) => resolved.push(name),
+            Component::CurDir => {}
+            // `pop` fails exactly when the climb has reached the top, which is
+            // the escape. Checked as we walk rather than on the final result,
+            // so `a/../../a/b` is refused even though it ends up inside.
+            Component::ParentDir => {
+                if !resolved.pop() {
+                    return None;
+                }
+            }
+            // A root or drive prefix mid-path is not something a relative
+            // target can legitimately contain.
+            Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    Some(resolved)
+}
+
 /// Verify `path`, after `canonicalize`, still has `dest_canonical` as a
 /// prefix. Used to enforce the dest_dir containment invariant.
 fn assert_under_dest(path: &Path, dest_canonical: &Path) -> Result<(), FetcherError> {
@@ -176,6 +283,145 @@ fn assert_under_dest(path: &Path, dest_canonical: &Path) -> Result<(), FetcherEr
 mod tests {
     use super::*;
     use std::io::Write as _;
+
+    /// Build a zip containing one symlink entry pointing at `target`, plus any
+    /// extra plain files. The target is the entry's CONTENT, and the S_IFLNK
+    /// mode bit is what marks it — both are what a real macOS `.app` archive
+    /// carries.
+    #[cfg(unix)]
+    fn zip_with_symlink(link_name: &str, target: &str, extra: &[(&str, &str)]) -> Vec<u8> {
+        let mut buf = std::io::Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut buf);
+            for (name, body) in extra {
+                writer
+                    .start_file(*name, zip::write::SimpleFileOptions::default())
+                    .unwrap();
+                writer.write_all(body.as_bytes()).unwrap();
+            }
+            writer
+                .add_symlink(link_name, target, zip::write::SimpleFileOptions::default())
+                .unwrap();
+            writer.finish().unwrap();
+        }
+        buf.into_inner()
+    }
+
+    #[cfg(unix)]
+    async fn extract_bytes(
+        zip_bytes: Vec<u8>,
+    ) -> (tempfile::TempDir, PathBuf, Result<(), FetcherError>) {
+        let dir = tempfile::tempdir().unwrap();
+        let zip_path = dir.path().join("t.zip");
+        let dest = dir.path().join("out");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(&zip_path, zip_bytes).unwrap();
+        let r = extract(&zip_path, &dest, None).await;
+        (dir, dest, r)
+    }
+
+    /// The case that had never worked: a macOS framework's `Versions/Current`
+    /// style link, pointing at a sibling INSIDE the archive.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_relative_symlink_inside_the_archive_is_extracted() {
+        let z = zip_with_symlink("fw/Versions/Current", "A", &[("fw/Versions/A/lib", "real")]);
+        let (_d, dest, r) = extract_bytes(z).await;
+        r.expect("a contained symlink must extract");
+
+        let link = dest.join("fw/Versions/Current");
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "it must be a real symlink, not a regular file holding the target text"
+        );
+        assert_eq!(std::fs::read_link(&link).unwrap(), Path::new("A"));
+        // And it resolves to the sibling, which is the whole point.
+        assert_eq!(
+            std::fs::read_to_string(dest.join("fw/Versions/Current/lib")).unwrap(),
+            "real"
+        );
+    }
+
+    /// `evil -> /etc`, then `evil/passwd`. No `..` anywhere in the archive.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_absolute_target_is_refused() {
+        let (_d, _dest, r) = extract_bytes(zip_with_symlink("evil", "/etc", &[])).await;
+        let e = r.expect_err("an absolute symlink target must be refused");
+        assert!(format!("{e}").contains("escapes"), "{e}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_parent_traversing_target_is_refused() {
+        let (_d, _dest, r) =
+            extract_bytes(zip_with_symlink("a/b/evil", "../../../../etc", &[])).await;
+        let e = r.expect_err("a target climbing past the root must be refused");
+        assert!(format!("{e}").contains("escapes"), "{e}");
+    }
+
+    /// THE REGRESSION THAT MATTERS. A symlinked directory is extracted first,
+    /// then a later entry is written THROUGH it. The write must land inside
+    /// dest_dir — which is what makes the containment claim about the whole
+    /// archive rather than about each entry in isolation.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_write_through_an_extracted_symlink_stays_inside() {
+        let mut buf = std::io::Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut buf);
+            writer
+                .start_file("real/keep", zip::write::SimpleFileOptions::default())
+                .unwrap();
+            writer.write_all(b"x").unwrap();
+            writer
+                .add_symlink("link", "real", zip::write::SimpleFileOptions::default())
+                .unwrap();
+            writer
+                .start_file("link/through", zip::write::SimpleFileOptions::default())
+                .unwrap();
+            writer.write_all(b"written through the link").unwrap();
+            writer.finish().unwrap();
+        }
+        let (_d, dest, r) = extract_bytes(buf.into_inner()).await;
+        r.expect("writing through a contained symlink is legitimate");
+
+        // It followed the link, so the byte landed in `real/`, and `real/` is
+        // inside dest. Both halves matter: that it resolved, and that it stayed.
+        assert_eq!(
+            std::fs::read_to_string(dest.join("real/through")).unwrap(),
+            "written through the link"
+        );
+        let resolved = std::fs::canonicalize(dest.join("link/through")).unwrap();
+        assert!(
+            resolved.starts_with(std::fs::canonicalize(&dest).unwrap()),
+            "{resolved:?}"
+        );
+    }
+
+    /// The containment predicate on its own, including the shapes that are
+    /// easy to get wrong by one level.
+    #[test]
+    fn target_containment_rules() {
+        let inside =
+            |link: &str, target: &str| resolve_target(Path::new(link), Path::new(target)).is_some();
+        // A target resolves relative to the link's PARENT, not the link.
+        assert!(inside("fw/Versions/Current", "A"));
+        assert!(inside("a/b/link", "../sibling"));
+        assert!(inside("a/b/link", "./x"));
+        assert!(inside("link", "x/y/z"));
+        // Escapes.
+        assert!(!inside("link", "/etc"));
+        assert!(!inside("link", ".."));
+        assert!(!inside("a/b/link", "../../../etc"));
+        assert!(!inside("link", ""));
+        // Refused even though it ENDS inside — the climb itself is the escape,
+        // which is why depth is checked as we walk rather than at the end.
+        assert!(!inside("a/link", "../../a/b"));
+    }
 
     #[tokio::test]
     async fn extract_recovers_single_file_contents() {
@@ -235,12 +481,12 @@ mod tests {
         );
     }
 
-    /// A symlink entry (Unix mode bits include `S_IFLNK`) is rejected even
-    /// when its name is a safe relative path. CfT archives never use them.
+    /// A symlink that stays inside dest_dir but leaves the archive's declared
+    /// top-level directory is still refused — it can only point at something
+    /// this archive does not own.
     #[cfg(unix)]
     #[tokio::test]
-    async fn extract_rejects_symlink_entries() {
-        use zip::write::SimpleFileOptions;
+    async fn extract_rejects_symlink_leaving_the_top_level_dir() {
         let dir = tempfile::tempdir().unwrap();
         let zip_path = dir.path().join("symlink.zip");
         let dest_dir = dir.path().join("out");
@@ -249,11 +495,12 @@ mod tests {
         let mut buf = std::io::Cursor::new(Vec::new());
         {
             let mut writer = zip::ZipWriter::new(&mut buf);
-            // 0o120_000 | 0o777 marks the entry as a symlink in the
-            // archive's Unix mode bits.
-            let opts = SimpleFileOptions::default().unix_permissions(0o777);
             writer
-                .add_symlink("chrome-linux64/link", "../escape", opts)
+                .add_symlink(
+                    "chrome-linux64/link",
+                    "../escape",
+                    zip::write::SimpleFileOptions::default(),
+                )
                 .unwrap();
             writer.finish().unwrap();
         }

--- a/crates/zendriver-fetcher/src/extract.rs
+++ b/crates/zendriver-fetcher/src/extract.rs
@@ -229,6 +229,10 @@ fn is_symlink(entry: &zip::read::ZipFile<'_>) -> bool {
 /// target resolves relative to the DIRECTORY CONTAINING the link — not to the
 /// link itself. Getting that wrong by one level makes every sibling link look
 /// like an escape, and makes a real escape look like a sibling.
+///
+/// Unix-only, because only the Unix arm creates symlinks — Windows skips those
+/// entries outright, and an ungated definition is dead code there.
+#[cfg(unix)]
 fn resolve_target(link_rel: &Path, target: &Path) -> Option<PathBuf> {
     use std::path::Component;
 
@@ -404,6 +408,7 @@ mod tests {
 
     /// The containment predicate on its own, including the shapes that are
     /// easy to get wrong by one level.
+    #[cfg(unix)]
     #[test]
     fn target_containment_rules() {
         let inside =

--- a/crates/zendriver-fetcher/src/extract.rs
+++ b/crates/zendriver-fetcher/src/extract.rs
@@ -54,16 +54,22 @@
 //!    top-level directory — checked at every step of the climb, not just at
 //!    the end.
 //!
-//!    **"Really contains" is load-bearing and was once the bug.** Taking the
-//!    link's parent from the archive text instead of from `canonicalize`
-//!    leaves the extractor reasoning about a different directory than the
-//!    kernel writes to, because an earlier entry can plant a link that a later
-//!    entry's own path runs through. See
-//!    `a_symlink_reached_through_an_earlier_symlink_cannot_escape` for the
-//!    three-entry archive that exploited exactly that gap. The target is still
-//!    resolved lexically from that canonical parent, with no stat, because the
-//!    target frequently does not exist yet — `Versions/Current` is written
-//!    before `Versions/A`, so stat-ing it would reject legitimate links.
+//!    **Reasoning lexically about a path the kernel resolves differently was
+//!    the bug, twice.** An earlier entry can plant a symlink, and a later entry
+//!    can reach through it two ways — by its own entry path, or by its target
+//!    string. Both were exploitable and both are now closed by following the
+//!    filesystem rather than the archive's text:
+//!
+//!    - the link's parent is `canonicalize`d, not taken from the entry path
+//!      (`a_symlink_reached_through_an_earlier_symlink_cannot_escape`);
+//!    - each target component that ALREADY EXISTS as a symlink is resolved as
+//!      the walk pushes it, so `u1/u2/u3/up/../../../X` cannot pop three levels
+//!      lexically from `up` while the kernel pops them from wherever `up`
+//!      pointed (`a_symlink_target_walking_through_an_earlier_symlink_cannot_escape`).
+//!
+//!    Components that do not exist yet stay lexical, and that is what keeps
+//!    legitimate links working: `Versions/Current` is written before
+//!    `Versions/A`, so stat-ing the whole target would reject it.
 //!
 //!    Windows keeps skipping them: creating a symlink there needs privileges,
 //!    and no Windows Chrome archive contains one.
@@ -285,7 +291,29 @@ fn resolve_target(link_path: &Path, target: &Path, containment_root: &Path) -> O
 
     for comp in target.components() {
         match comp {
-            Component::Normal(name) => resolved.push(name),
+            // Follow rather than assume. If this component already exists and is
+            // itself a symlink, the kernel follows it when resolving this
+            // target — so the walk has to follow it too, or every component
+            // after this one is reasoning about a directory the kernel is not
+            // standing in. That is the same lexical-vs-real gap canonicalizing
+            // the parent closes, reached through the target instead:
+            // `u1/u2/u3/up/../../../X` pops three lexically from `u1/u2/u3/up`
+            // and lands inside, while the kernel pops them from wherever `up`
+            // pointed and leaves.
+            //
+            // A component that does not exist yet stays lexical, which is what
+            // keeps `Versions/Current -> A` working: `A` is written after the
+            // link that names it.
+            Component::Normal(name) => {
+                resolved.push(name);
+                if std::fs::symlink_metadata(&resolved).is_ok_and(|md| md.file_type().is_symlink())
+                {
+                    resolved = std::fs::canonicalize(&resolved).ok()?;
+                    if !resolved.starts_with(containment_root) {
+                        return None;
+                    }
+                }
+            }
             Component::CurDir => {}
             // `pop` fails at the filesystem root; leaving the containment root
             // is the escape. Checked as we climb rather than on the final
@@ -499,6 +527,61 @@ mod tests {
             );
         }
         result.expect_err("an archive that escapes through a chained symlink must be refused");
+    }
+
+    /// The same divergence as the test above, one axis over: this time the
+    /// planted link is walked through by the TARGET STRING rather than by the
+    /// entry path.
+    ///
+    /// `chrome` resolves lexically to `chrome-linux64/u1/VICTIM` — pushed four,
+    /// popped three, comfortably inside. The kernel instead follows `up` to
+    /// `chrome-linux64` and *then* spends the three `..`, landing two levels
+    /// above the destination. Canonicalizing the link's parent does not help
+    /// here; the symlink is in the middle of the target.
+    ///
+    /// Nothing is written outside either way — a file entry through an escaping
+    /// link is still refused — but the link itself is what `ensure_chrome`
+    /// returns for the caller to *execute*, and phase 4 `chmod +x`'s whatever it
+    /// points at.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_symlink_target_walking_through_an_earlier_symlink_cannot_escape() {
+        let mut buf = std::io::Cursor::new(Vec::new());
+        {
+            let opts = zip::write::SimpleFileOptions::default();
+            let mut writer = zip::ZipWriter::new(&mut buf);
+            writer
+                .add_symlink("chrome-linux64/u1/u2/u3/up", "../../..", opts)
+                .unwrap();
+            writer
+                .add_symlink("chrome-linux64/chrome", "u1/u2/u3/up/../../../VICTIM", opts)
+                .unwrap();
+            writer.finish().unwrap();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+        let zip_path = root.join("evil.zip");
+        let dest = root.join("l1/l2/out");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(&zip_path, buf.into_inner()).unwrap();
+        // Where the kernel actually lands: `up` reaches `chrome-linux64`, and
+        // the three `..` are spent from there — out, l2, l1.
+        std::fs::write(root.join("l1/VICTIM"), b"not the browser").unwrap();
+
+        let result = extract(&zip_path, &dest, Some("chrome-linux64")).await;
+
+        // Whatever the outcome, the path a caller would launch must not resolve
+        // out of the destination.
+        let launched = dest.join("chrome-linux64/chrome");
+        if let Ok(real) = std::fs::canonicalize(&launched) {
+            assert!(
+                real.starts_with(std::fs::canonicalize(&dest).unwrap()),
+                "returned browser path resolves to {}, outside the cache",
+                real.display()
+            );
+        }
+        result.expect_err("a target walking through a planted symlink must be refused");
     }
 
     /// The containment predicate on its own, including the shapes that are

--- a/crates/zendriver-fetcher/src/fetcher.rs
+++ b/crates/zendriver-fetcher/src/fetcher.rs
@@ -13,7 +13,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::cache::{build_dir, default_cache_dir};
+use crate::cache::{build_dir, default_cache_dir, with_suffix};
 use crate::distribution::Distribution;
 use crate::download::download;
 use crate::error::FetcherError;
@@ -257,12 +257,11 @@ impl Fetcher {
 
         // Phase 2: download to <build>.tmp.<ext>, beside the build directory
         // so the staging paths are namespaced exactly like the final one.
-        let tmp_archive = PathBuf::from(format!(
-            "{}.tmp.{}",
-            final_dir.display(),
-            resolved.archive.tmp_extension()
-        ));
-        let tmp_dir = PathBuf::from(format!("{}.tmp", final_dir.display()));
+        let tmp_archive = with_suffix(
+            &final_dir,
+            &format!(".tmp.{}", resolved.archive.tmp_extension()),
+        );
+        let tmp_dir = with_suffix(&final_dir, ".tmp");
 
         // Clean up any stale tmp from a prior crashed run.
         let _ = tokio::fs::remove_file(&tmp_archive).await;

--- a/crates/zendriver-fetcher/src/fetcher.rs
+++ b/crates/zendriver-fetcher/src/fetcher.rs
@@ -250,7 +250,7 @@ impl Fetcher {
             tokio::fs::create_dir_all(parent).await?;
         }
         let target_bin = final_dir.join(&resolved.binary_subpath);
-        if is_runnable(&target_bin).await {
+        if is_runnable(&target_bin).await && resolves_inside(&target_bin, &final_dir).await {
             emit(&progress_cb, FetcherPhase::Done, 0, None);
             return Ok(target_bin);
         }
@@ -323,7 +323,12 @@ impl Fetcher {
         {
             use std::os::unix::fs::PermissionsExt as _;
             let tmp_bin = tmp_dir.join(&resolved.binary_subpath);
-            if tmp_bin.exists() {
+            // `metadata` and `set_permissions` both FOLLOW symlinks, so this is
+            // a chmod aimed at wherever the path really lands. Extraction is
+            // supposed to have guaranteed that is inside the staging dir; check
+            // it here rather than inherit the guarantee, because the cost of
+            // being wrong is `+x` on someone else's file.
+            if tmp_bin.exists() && resolves_inside(&tmp_bin, &tmp_dir).await {
                 let mut perms = tokio::fs::metadata(&tmp_bin).await?.permissions();
                 perms.set_mode(perms.mode() | 0o111);
                 tokio::fs::set_permissions(&tmp_bin, perms).await?;
@@ -339,6 +344,16 @@ impl Fetcher {
                 let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
             }
             Err(e) => return Err(FetcherError::Io(e)),
+        }
+
+        // The returned path is executed by the caller, so the last thing this
+        // function does is confirm it still lands inside the build directory.
+        if !resolves_inside(&target_bin, &final_dir).await {
+            return Err(FetcherError::Extraction(format!(
+                "resolved browser path {} does not lie inside {}; refusing to return it",
+                target_bin.display(),
+                final_dir.display()
+            )));
         }
 
         emit(&progress_cb, FetcherPhase::Done, 0, None);
@@ -467,6 +482,27 @@ fn hex_encode(bytes: &[u8]) -> String {
         out.push(HEX[(b & 0x0f) as usize] as char);
     }
     out
+}
+
+/// True when `path` exists and, with every symlink followed, still lies inside
+/// `root`.
+///
+/// Both callers hand the path to something that follows links and then does
+/// something dangerous with what it finds — one `chmod +x`'s it, the other
+/// returns it to be executed as a browser. Extraction already refuses an
+/// archive whose symlinks leave the tree; this re-asks the question at the
+/// point of use, so the guarantee is checked where it matters rather than
+/// inherited from a check that ran earlier over different code.
+async fn resolves_inside(path: &std::path::Path, root: &std::path::Path) -> bool {
+    let (path, root) = (path.to_path_buf(), root.to_path_buf());
+    tokio::task::spawn_blocking(move || {
+        let (Ok(real), Ok(root)) = (path.canonicalize(), root.canonicalize()) else {
+            return false;
+        };
+        real.starts_with(root)
+    })
+    .await
+    .unwrap_or(false)
 }
 
 /// True iff `path` exists and (on Unix) has any executable bit set.

--- a/crates/zendriver-fetcher/src/fetcher.rs
+++ b/crates/zendriver-fetcher/src/fetcher.rs
@@ -462,6 +462,56 @@ async fn is_runnable(path: &std::path::Path) -> bool {
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
+    /// The macOS end-to-end case that could never have worked: a Chrome for
+    /// Testing `.app` bundle carries framework symlinks, so `ensure_chrome()`
+    /// aborted on the first one and no Mac user ever got a binary out of it.
+    ///
+    /// Ignored by default because it needs the network and downloads ~150 MB.
+    /// Downloading is not the assertion — the assertion is that what lands is a
+    /// binary that RUNS, which is the only thing that proves the bundle came
+    /// out intact rather than merely extracted without error.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    #[ignore = "network"]
+    async fn mac_chrome_for_testing_extracts_to_a_runnable_binary() {
+        let cache = tempfile::tempdir().unwrap();
+        let binary = Fetcher::new()
+            .cache_dir(cache.path())
+            // Explicit rather than relying on the default, so this keeps
+            // testing CfT if the default distribution ever changes.
+            .distribution(Distribution::ChromeForTesting)
+            .version(VersionSpec::Explicit("146.0.7680.153".to_string()))
+            .platform(Platform::MacArm64)
+            .ensure_chrome()
+            .await
+            .expect("a macOS CfT archive must extract");
+
+        let out = std::process::Command::new(&binary)
+            .arg("--version")
+            .output()
+            .expect("the extracted binary must be executable");
+        let version = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            version.contains("146.0.7680.153"),
+            "wrong or unrunnable binary at {binary:?}: {version:?}"
+        );
+
+        // The framework symlink from the original error, resolving to a real
+        // directory inside the bundle.
+        let resources = binary
+            .parent()
+            .unwrap()
+            .join("../Frameworks/Google Chrome for Testing Framework.framework/Resources");
+        assert!(
+            std::fs::symlink_metadata(&resources)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the framework link must survive as a symlink"
+        );
+        assert!(resources.is_dir(), "and must resolve to the versioned dir");
+    }
+
     use super::*;
     use std::io::Write as _;
     use wiremock::matchers::{method, path};

--- a/crates/zendriver-fetcher/src/fetcher.rs
+++ b/crates/zendriver-fetcher/src/fetcher.rs
@@ -461,6 +461,11 @@ async fn is_runnable(path: &std::path::Path) -> bool {
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
+    use super::*;
+    use std::io::Write as _;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
     /// The macOS end-to-end case that could never have worked: a Chrome for
     /// Testing `.app` bundle carries framework symlinks, so `ensure_chrome()`
     /// aborted on the first one and no Mac user ever got a binary out of it.
@@ -510,11 +515,6 @@ mod tests {
         );
         assert!(resources.is_dir(), "and must resolve to the versioned dir");
     }
-
-    use super::*;
-    use std::io::Write as _;
-    use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     /// Build a tiny zip in-memory containing a single entry at `entry` with
     /// the given sentinel content. Returns the raw zip bytes.

--- a/crates/zendriver-fetcher/src/fetcher.rs
+++ b/crates/zendriver-fetcher/src/fetcher.rs
@@ -1,20 +1,30 @@
 //! Public [`Fetcher`] entry point.
 //!
-//! Resolves a `(version, platform)` pair against the Chrome for Testing
-//! manifest, downloads the zip into a per-version atomic cache layout,
-//! extracts it, and hands back a path to the executable. If the binary is
-//! already cached and runnable, returns the path immediately.
+//! Resolves a `(distribution, version, platform)` triple against that
+//! distribution's index, downloads the archive into a per-build atomic cache
+//! layout, unpacks it, and hands back a path to the executable. If the binary
+//! is already cached and runnable, returns the path immediately.
+//!
+//! Only the first step varies by [`Distribution`]. Download, integrity check,
+//! unpack, promote and cache-hit detection are one code path for all three —
+//! see [`crate::resolver`] for the part that differs, and [`crate::archive`]
+//! for the three packagings it can produce.
 
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::cache::{binary_path, default_cache_dir};
+use crate::cache::{build_dir, default_cache_dir};
+use crate::distribution::Distribution;
 use crate::download::download;
 use crate::error::FetcherError;
-use crate::extract::extract;
-use crate::manifest::{fetch_channels_manifest_from, fetch_manifest_from};
+use crate::manifest::{
+    fetch_channels_manifest_from, fetch_github_releases, fetch_last_change, fetch_manifest_from,
+};
 use crate::platform::Platform;
-use crate::resolver::{resolve_channel_download_url, resolve_download_url};
+use crate::resolver::{
+    DEFAULT_GITHUB_API_BASE, DEFAULT_SNAPSHOT_BASE, Resolved, resolve_cft, resolve_cft_channel,
+    resolve_snapshot, resolve_ungoogled, snapshot_revision_for,
+};
 use crate::version::{Channel, VersionSpec};
 use crate::{FetcherPhase, FetcherProgress};
 
@@ -28,17 +38,22 @@ pub(crate) const DEFAULT_CFT_URL: &str =
 /// resolves through [`DEFAULT_CFT_URL`] like [`VersionSpec::Latest`]).
 pub(crate) const DEFAULT_CFT_CHANNELS_URL: &str = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json";
 
-/// Chrome for Testing binary downloader.
+/// Chromium binary downloader.
 ///
-/// Build with [`Fetcher::new`], optionally configure cache dir / version /
-/// platform / progress callback, then call [`Fetcher::ensure_chrome`] to
-/// resolve the path to a runnable Chrome binary (downloading + extracting
-/// on cache miss).
+/// Build with [`Fetcher::new`], optionally configure distribution / cache dir
+/// / version / platform / progress callback, then call
+/// [`Fetcher::ensure_chrome`] to resolve the path to a runnable browser
+/// binary (downloading + unpacking on cache miss).
+///
+/// Defaults to [`Distribution::ChromeForTesting`], which is what this crate
+/// has always fetched.
 pub struct Fetcher {
     cache_dir: Option<PathBuf>,
+    distribution: Distribution,
     version: VersionSpec,
     platform: Option<Platform>,
-    /// Override for the CFT manifest URL — `#[doc(hidden)]` test seam.
+    /// Override for the selected distribution's index endpoint —
+    /// `#[doc(hidden)]` test seam. See [`Fetcher::manifest_url`].
     manifest_url: Option<String>,
     progress_cb: Option<Arc<dyn Fn(FetcherProgress) + Send + Sync>>,
     /// Optional SHA256 the downloaded archive must match before extraction.
@@ -53,6 +68,7 @@ impl std::fmt::Debug for Fetcher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Fetcher")
             .field("cache_dir", &self.cache_dir)
+            .field("distribution", &self.distribution)
             .field("version", &self.version)
             .field("platform", &self.platform)
             .field("manifest_url", &self.manifest_url)
@@ -71,6 +87,7 @@ impl Default for Fetcher {
 impl Fetcher {
     /// Construct a new fetcher with default options:
     ///
+    /// - distribution = [`Distribution::ChromeForTesting`];
     /// - cache dir = OS cache dir (`$XDG_CACHE_HOME/zendriver/chrome` on
     ///   Linux, `~/Library/Caches/zendriver/chrome` on macOS, ...);
     /// - platform = auto-detected via [`Platform::auto_detect`];
@@ -83,12 +100,35 @@ impl Fetcher {
     pub fn new() -> Self {
         Self {
             cache_dir: None,
+            distribution: Distribution::ChromeForTesting,
             version: VersionSpec::Latest,
             platform: None,
             manifest_url: None,
             progress_cb: None,
             expected_sha256: None,
         }
+    }
+
+    /// Pick which Chromium build to fetch. Defaults to
+    /// [`Distribution::ChromeForTesting`].
+    ///
+    /// Each distribution namespaces its own cache sub-tree, so switching does
+    /// not invalidate anything already downloaded.
+    ///
+    /// ```no_run
+    /// # async fn ex() -> Result<(), zendriver_fetcher::FetcherError> {
+    /// use zendriver_fetcher::{Distribution, Fetcher, VersionSpec};
+    ///
+    /// let chromium = Fetcher::new()
+    ///     .distribution(Distribution::UngoogledChromium)
+    ///     .version(VersionSpec::Explicit("151.0.7922.71".into()))
+    ///     .ensure_chrome()
+    ///     .await?;
+    /// # let _ = chromium; Ok(()) }
+    /// ```
+    pub fn distribution(mut self, distribution: Distribution) -> Self {
+        self.distribution = distribution;
+        self
     }
 
     /// Override the cache directory root.
@@ -123,15 +163,21 @@ impl Fetcher {
         self
     }
 
-    /// Override the CFT manifest URL. Test seam — `#[doc(hidden)]` so users
-    /// don't accidentally point at a fork.
+    /// Override the index endpoint for the selected distribution. Test seam —
+    /// `#[doc(hidden)]` so users don't accidentally point at a fork.
     ///
-    /// Used for whichever manifest [`Fetcher::version`] resolves against:
-    /// the flat `known-good-versions-with-downloads.json` shape for
-    /// [`VersionSpec::Latest`]/[`VersionSpec::Stable`]/
-    /// [`VersionSpec::Explicit`]/[`VersionSpec::Channel(Channel::Stable)`](VersionSpec::Channel),
-    /// or the per-channel `last-known-good-versions-with-downloads.json`
-    /// shape for [`VersionSpec::Channel`]'s `Beta`/`Dev`/`Canary` variants.
+    /// What it overrides depends on which index resolution consults:
+    ///
+    /// - [`Distribution::ChromeForTesting`]: the full manifest URL — the flat
+    ///   `known-good-versions-with-downloads.json` shape for
+    ///   [`VersionSpec::Latest`]/[`VersionSpec::Stable`]/
+    ///   [`VersionSpec::Explicit`]/[`VersionSpec::Channel(Channel::Stable)`](VersionSpec::Channel),
+    ///   or the per-channel `last-known-good-versions-with-downloads.json`
+    ///   shape for `Beta`/`Dev`/`Canary`.
+    /// - [`Distribution::UngoogledChromium`]: the GitHub API base, to which
+    ///   `/repos/<owner>/<repo>/releases` is appended.
+    /// - [`Distribution::ChromiumSnapshot`]: the snapshot bucket base, to
+    ///   which `/<Platform>/…` is appended.
     #[doc(hidden)]
     pub fn manifest_url(mut self, url: impl Into<String>) -> Self {
         self.manifest_url = Some(url.into());
@@ -184,60 +230,59 @@ impl Fetcher {
     /// # Ok(()) }
     /// ```
     pub async fn ensure_chrome(self) -> Result<PathBuf, FetcherError> {
-        let cache_dir = self.cache_dir.unwrap_or_else(default_cache_dir);
+        let cache_dir = self.cache_dir.clone().unwrap_or_else(default_cache_dir);
         let platform = self
             .platform
             .or_else(Platform::auto_detect)
             .ok_or(FetcherError::UnsupportedPlatform)?;
-        let progress_cb = self.progress_cb;
+        let distribution = self.distribution;
+        let progress_cb = self.progress_cb.clone();
 
-        // Phase 1: resolve. `Beta`/`Dev`/`Canary` track their own latest
-        // known-good build, so they resolve through the per-channel
-        // manifest instead of the flat stable-only one; every other spec
-        // (including `Channel::Stable`) uses the flat manifest.
+        // Phase 1: resolve. The only step that knows about distributions.
         emit(&progress_cb, FetcherPhase::Resolving, 0, None);
-        let (version, url) = match self.version {
-            VersionSpec::Channel(channel @ (Channel::Beta | Channel::Dev | Channel::Canary)) => {
-                let manifest_url = self
-                    .manifest_url
-                    .unwrap_or_else(|| DEFAULT_CFT_CHANNELS_URL.into());
-                let manifest = fetch_channels_manifest_from(&manifest_url).await?;
-                resolve_channel_download_url(&manifest, channel, platform).await?
-            }
-            ref spec => {
-                let manifest_url = self.manifest_url.unwrap_or_else(|| DEFAULT_CFT_URL.into());
-                let manifest = fetch_manifest_from(&manifest_url).await?;
-                resolve_download_url(&manifest, spec, platform).await?
-            }
-        };
+        let resolved = self.resolve(platform).await?;
 
         // Compute final layout + cache hit check.
-        tokio::fs::create_dir_all(&cache_dir).await?;
-        let final_dir = cache_dir.join(&version);
-        let target_bin = binary_path(&cache_dir, &version, platform);
+        let final_dir = build_dir(&cache_dir, distribution, &resolved.build_id);
+        // `create_dir_all` on the parent, not the cache root: the
+        // non-default distributions live one level deeper.
+        if let Some(parent) = final_dir.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        let target_bin = final_dir.join(&resolved.binary_subpath);
         if is_runnable(&target_bin).await {
             emit(&progress_cb, FetcherPhase::Done, 0, None);
             return Ok(target_bin);
         }
 
-        // Phase 2: download to <version>.tmp.zip.
-        let tmp_zip = cache_dir.join(format!("{version}.tmp.zip"));
-        let tmp_dir = cache_dir.join(format!("{version}.tmp"));
+        // Phase 2: download to <build>.tmp.<ext>, beside the build directory
+        // so the staging paths are namespaced exactly like the final one.
+        let tmp_archive = PathBuf::from(format!(
+            "{}.tmp.{}",
+            final_dir.display(),
+            resolved.archive.tmp_extension()
+        ));
+        let tmp_dir = PathBuf::from(format!("{}.tmp", final_dir.display()));
 
         // Clean up any stale tmp from a prior crashed run.
-        let _ = tokio::fs::remove_file(&tmp_zip).await;
+        let _ = tokio::fs::remove_file(&tmp_archive).await;
         let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
 
         emit(&progress_cb, FetcherPhase::Downloading, 0, None);
-        download(&url, &tmp_zip, progress_cb.as_deref().map(|a| a as _)).await?;
+        download(
+            &resolved.url,
+            &tmp_archive,
+            progress_cb.as_deref().map(|a| a as _),
+        )
+        .await?;
 
         // Phase 2b: optional SHA256 integrity check before we trust the
-        // archive enough to extract it.
+        // archive enough to unpack it.
         if let Some(expected) = self.expected_sha256.as_deref() {
             emit(&progress_cb, FetcherPhase::Verifying, 0, None);
-            let actual = sha256_file(&tmp_zip).await?;
+            let actual = sha256_file(&tmp_archive).await?;
             if !sha256_eq(expected, &actual) {
-                let _ = tokio::fs::remove_file(&tmp_zip).await;
+                let _ = tokio::fs::remove_file(&tmp_archive).await;
                 return Err(FetcherError::IntegrityFailed {
                     expected: expected.to_string(),
                     actual,
@@ -245,29 +290,29 @@ impl Fetcher {
             }
         }
 
-        // Phase 3: extract to <version>.tmp/.
+        // Phase 3: unpack into <build>.tmp/. Zip extraction pins the expected
+        // top-level directory, rejecting mislabeled / tampered archives.
         emit(&progress_cb, FetcherPhase::Extracting, 0, None);
         tokio::fs::create_dir_all(&tmp_dir).await?;
-        // CfT archives place everything under a single `chrome-<platform>/`
-        // directory; pinning the expected prefix locks the extraction to
-        // that layout and rejects mislabeled / tampered archives.
-        let expected_top = platform.cft_top_dir();
-        let extract_result = extract(&tmp_zip, &tmp_dir, Some(expected_top)).await;
+        let unpack_result =
+            crate::archive::install(&resolved.archive, &tmp_archive, &tmp_dir).await;
 
-        // Always clean the zip, even if extract failed.
-        let _ = tokio::fs::remove_file(&tmp_zip).await;
-        extract_result?;
+        // Always clean the download, even if unpacking failed. (The
+        // `Executable` archive consumes it by renaming, so this is a no-op
+        // there.)
+        let _ = tokio::fs::remove_file(&tmp_archive).await;
+        unpack_result?;
 
         // Phase 4: ensure executable bit (Unix) BEFORE the atomic rename.
         // Setting perms after the rename would leave a window where a
-        // concurrent `Fetcher::ensure(...)` on the same cache_dir observes
-        // `final_dir` (cache-hit check at L159) but the binary inside is
+        // concurrent `ensure_chrome` on the same cache_dir observes
+        // `final_dir` (the cache-hit check above) but the binary inside is
         // still non-executable, forcing a wasteful re-download.
         emit(&progress_cb, FetcherPhase::Verifying, 0, None);
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt as _;
-            let tmp_bin = tmp_dir.join(crate::cache::binary_subpath(platform));
+            let tmp_bin = tmp_dir.join(&resolved.binary_subpath);
             if tmp_bin.exists() {
                 let mut perms = tokio::fs::metadata(&tmp_bin).await?.permissions();
                 perms.set_mode(perms.mode() | 0o111);
@@ -275,7 +320,7 @@ impl Fetcher {
             }
         }
 
-        // Phase 5: atomic promote <version>.tmp -> <version>.
+        // Phase 5: atomic promote <build>.tmp -> <build>.
         // If `final_dir` already exists (race: someone else just finished),
         // drop our work and use theirs.
         match tokio::fs::rename(&tmp_dir, &final_dir).await {
@@ -288,6 +333,60 @@ impl Fetcher {
 
         emit(&progress_cb, FetcherPhase::Done, 0, None);
         Ok(target_bin)
+    }
+
+    /// Turn this fetcher's `(distribution, version, platform)` triple into a
+    /// concrete download.
+    ///
+    /// Each arm fetches that distribution's index and hands it to the
+    /// matching pure resolver in [`crate::resolver`].
+    async fn resolve(&self, platform: Platform) -> Result<Resolved, FetcherError> {
+        match self.distribution {
+            Distribution::ChromeForTesting => match &self.version {
+                // `Beta`/`Dev`/`Canary` track their own latest known-good
+                // build, so they resolve through the per-channel manifest
+                // instead of the flat stable-only one; every other spec
+                // (including `Channel::Stable`) uses the flat manifest.
+                VersionSpec::Channel(
+                    channel @ (Channel::Beta | Channel::Dev | Channel::Canary),
+                ) => {
+                    let url = self.index_base(DEFAULT_CFT_CHANNELS_URL);
+                    let manifest = fetch_channels_manifest_from(&url).await?;
+                    resolve_cft_channel(&manifest, *channel, platform)
+                }
+                spec => {
+                    let url = self.index_base(DEFAULT_CFT_URL);
+                    let manifest = fetch_manifest_from(&url).await?;
+                    resolve_cft(&manifest, spec, platform)
+                }
+            },
+
+            Distribution::UngoogledChromium => {
+                // Three per-OS repos, so which repo to ask is itself a
+                // function of the target platform.
+                let repo = Distribution::ungoogled_repo(platform);
+                let api_base = self.index_base(DEFAULT_GITHUB_API_BASE);
+                let releases = fetch_github_releases(&api_base, repo).await?;
+                resolve_ungoogled(&releases, &self.version, platform, repo)
+            }
+
+            Distribution::ChromiumSnapshot => {
+                let base = self.index_base(DEFAULT_SNAPSHOT_BASE);
+                // Refusals happen here, before any network call.
+                let revision = match snapshot_revision_for(&self.version)? {
+                    Some(rev) => rev,
+                    None => fetch_last_change(&base, platform.as_snapshot_str()).await?,
+                };
+                Ok(resolve_snapshot(&base, revision, platform))
+            }
+        }
+    }
+
+    /// The configured index endpoint, or `default` when none was set.
+    fn index_base(&self, default: &str) -> String {
+        self.manifest_url
+            .clone()
+            .unwrap_or_else(|| default.to_string())
     }
 }
 
@@ -368,20 +467,25 @@ mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    /// Build a tiny zip in-memory containing `chrome-linux64/chrome` with
+    /// Build a tiny zip in-memory containing a single entry at `entry` with
     /// the given sentinel content. Returns the raw zip bytes.
-    fn build_stub_chrome_zip(sentinel: &[u8]) -> Vec<u8> {
+    fn build_stub_zip(entry: &str, sentinel: &[u8]) -> Vec<u8> {
         let mut buf = std::io::Cursor::new(Vec::new());
         {
             let mut writer = zip::ZipWriter::new(&mut buf);
             // Use unix mode 0o755 so the extracted file is already
-            // executable — matches the real CFT zip layout.
+            // executable — matches the real archive layouts.
             let opts = zip::write::SimpleFileOptions::default().unix_permissions(0o755);
-            writer.start_file("chrome-linux64/chrome", opts).unwrap();
+            writer.start_file(entry, opts).unwrap();
             writer.write_all(sentinel).unwrap();
             writer.finish().unwrap();
         }
         buf.into_inner()
+    }
+
+    /// The Chrome for Testing Linux layout, which most tests here use.
+    fn build_stub_chrome_zip(sentinel: &[u8]) -> Vec<u8> {
+        build_stub_zip("chrome-linux64/chrome", sentinel)
     }
 
     #[tokio::test]
@@ -597,5 +701,339 @@ mod tests {
         );
         let extracted = tokio::fs::read(&bin_path).await.unwrap();
         assert_eq!(extracted, sentinel);
+    }
+
+    /// The default must stay Chrome for Testing, or every existing caller
+    /// silently changes browser.
+    #[test]
+    fn a_fresh_fetcher_defaults_to_chrome_for_testing() {
+        assert_eq!(Fetcher::new().distribution, Distribution::ChromeForTesting);
+        assert!(format!("{:?}", Fetcher::new()).contains("ChromeForTesting"));
+    }
+
+    /// ungoogled end-to-end: the GitHub release list is the index, the tag
+    /// carries a packaging suffix, and the zip's top-level directory is the
+    /// asset name — three things no other distribution does.
+    #[tokio::test]
+    async fn ensure_chrome_end_to_end_for_ungoogled_windows() {
+        let server = MockServer::start().await;
+        let sentinel = b"MZ stub ungoogled chrome.exe";
+        let top = "ungoogled-chromium_151.0.7922.71-1.1_windows_x64";
+        let zip_bytes = build_stub_zip(&format!("{top}/chrome.exe"), sentinel);
+
+        let releases = format!(
+            r#"[{{
+                "tag_name": "151.0.7922.71-1.1",
+                "draft": false,
+                "prerelease": false,
+                "assets": [
+                    {{"name": "{top}.zip", "browser_download_url": "{server}/ug.zip"}}
+                ]
+            }}]"#,
+            server = server.uri()
+        );
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/repos/ungoogled-software/ungoogled-chromium-windows/releases",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(releases))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/ug.zip"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(zip_bytes))
+            .mount(&server)
+            .await;
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let bin_path = Fetcher::new()
+            .cache_dir(cache_root.path())
+            .distribution(Distribution::UngoogledChromium)
+            .platform(Platform::Win64)
+            // The tag is `151.0.7922.71-1.1`; the version is the prefix.
+            .version(VersionSpec::Explicit("151.0.7922.71".into()))
+            .manifest_url(server.uri())
+            .ensure_chrome()
+            .await
+            .unwrap();
+
+        // Namespaced under the distribution slug, keyed by the Chrome version
+        // rather than the full tag.
+        assert_eq!(
+            bin_path,
+            cache_root
+                .path()
+                .join("ungoogled/151.0.7922.71")
+                .join(top)
+                .join("chrome.exe")
+        );
+        assert_eq!(tokio::fs::read(&bin_path).await.unwrap(), sentinel);
+        assert!(!cache_root.path().join("151.0.7922.71").exists());
+    }
+
+    /// An AppImage is not an archive — install is a move plus a chmod, and
+    /// the AppImage itself is the executable.
+    #[tokio::test]
+    async fn ensure_chrome_installs_an_ungoogled_appimage_without_extracting() {
+        let server = MockServer::start().await;
+        let sentinel = b"\x7fELF stub appimage";
+
+        let releases = format!(
+            r#"[{{
+                "tag_name": "151.0.7922.71-1",
+                "draft": false,
+                "prerelease": false,
+                "assets": [
+                    {{"name": "ungoogled-chromium-151.0.7922.71-1-x86_64.AppImage.zsync",
+                      "browser_download_url": "{server}/sidecar"}},
+                    {{"name": "ungoogled-chromium-151.0.7922.71-1-x86_64.AppImage",
+                      "browser_download_url": "{server}/app"}}
+                ]
+            }}]"#,
+            server = server.uri()
+        );
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/repos/ungoogled-software/ungoogled-chromium-portablelinux/releases",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(releases))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/app"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(sentinel.to_vec()))
+            .mount(&server)
+            .await;
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let bin_path = Fetcher::new()
+            .cache_dir(cache_root.path())
+            .distribution(Distribution::UngoogledChromium)
+            .platform(Platform::LinuxX64)
+            .version(VersionSpec::Latest)
+            .manifest_url(server.uri())
+            .ensure_chrome()
+            .await
+            .unwrap();
+
+        // The `.zsync` sidecar is served from a route that is never mocked,
+        // so picking it would fail the test outright.
+        assert_eq!(
+            bin_path,
+            cache_root
+                .path()
+                .join("ungoogled/151.0.7922.71/chrome.AppImage")
+        );
+        assert_eq!(tokio::fs::read(&bin_path).await.unwrap(), sentinel);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let meta = tokio::fs::metadata(&bin_path).await.unwrap();
+            assert!(meta.permissions().mode() & 0o111 != 0);
+        }
+    }
+
+    /// Snapshot end-to-end: `LAST_CHANGE` names the revision, the URL uses
+    /// the bucket's own platform spelling, and the cache key is `r<rev>`.
+    #[tokio::test]
+    async fn ensure_chrome_end_to_end_for_a_chromium_snapshot() {
+        let server = MockServer::start().await;
+        let sentinel = b"#!/bin/sh\necho stub-snapshot\n";
+        let zip_bytes = build_stub_zip("chrome-linux/chrome", sentinel);
+
+        Mock::given(method("GET"))
+            .and(path("/Linux_x64/LAST_CHANGE"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("1674883"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/Linux_x64/1674883/chrome-linux.zip"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(zip_bytes))
+            .mount(&server)
+            .await;
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let bin_path = Fetcher::new()
+            .cache_dir(cache_root.path())
+            .distribution(Distribution::ChromiumSnapshot)
+            .platform(Platform::LinuxX64)
+            .version(VersionSpec::Latest)
+            .manifest_url(server.uri())
+            .ensure_chrome()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            bin_path,
+            cache_root
+                .path()
+                .join("snapshot/r1674883/chrome-linux/chrome")
+        );
+        assert_eq!(tokio::fs::read(&bin_path).await.unwrap(), sentinel);
+    }
+
+    /// A pinned revision must skip `LAST_CHANGE` entirely — the mock server
+    /// has no route for it, so consulting it would fail.
+    #[tokio::test]
+    async fn an_explicit_revision_bypasses_last_change() {
+        let server = MockServer::start().await;
+        let zip_bytes = build_stub_zip("chrome-win/chrome.exe", b"MZ stub");
+
+        Mock::given(method("GET"))
+            .and(path("/Win_x64/1600000/chrome-win.zip"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(zip_bytes))
+            .mount(&server)
+            .await;
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let bin_path = Fetcher::new()
+            .cache_dir(cache_root.path())
+            .distribution(Distribution::ChromiumSnapshot)
+            .platform(Platform::Win64)
+            .version(VersionSpec::Revision(1_600_000))
+            .manifest_url(server.uri())
+            .ensure_chrome()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            bin_path,
+            cache_root
+                .path()
+                .join("snapshot/r1600000/chrome-win/chrome.exe")
+        );
+    }
+
+    /// Asking the snapshot bucket for a version must fail before any request
+    /// goes out — there is nothing to look it up in, and returning the newest
+    /// snapshot would be a different browser.
+    #[tokio::test]
+    async fn snapshot_refuses_an_explicit_version_without_touching_the_network() {
+        let server = MockServer::start().await;
+        // Deliberately no mocks: any request at all fails the test.
+        let cache_root = tempfile::tempdir().unwrap();
+
+        let err = Fetcher::new()
+            .cache_dir(cache_root.path())
+            .distribution(Distribution::ChromiumSnapshot)
+            .platform(Platform::LinuxX64)
+            .version(VersionSpec::Explicit("151.0.7922.76".into()))
+            .manifest_url(server.uri())
+            .ensure_chrome()
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, FetcherError::UnsupportedSelector { .. }));
+        assert!(err.to_string().contains("--revision"), "{err}");
+        assert_eq!(server.received_requests().await.unwrap().len(), 0);
+    }
+
+    /// Two distributions publishing the same Chrome version must not share a
+    /// cache directory, or the second fetch serves the first one's binary.
+    #[tokio::test]
+    async fn the_same_version_from_two_distributions_does_not_collide() {
+        let server = MockServer::start().await;
+        let cft_sentinel = b"chrome-for-testing".to_vec();
+        let ug_sentinel = b"ungoogled".to_vec();
+
+        let manifest = format!(
+            r#"{{"versions":[{{"version":"151.0.7922.71","revision":"1","downloads":{{"chrome":[
+                {{"platform":"linux64","url":"{server}/cft.zip"}}]}}}}]}}"#,
+            server = server.uri()
+        );
+        let releases = format!(
+            r#"[{{"tag_name":"151.0.7922.71-1","draft":false,"prerelease":false,"assets":[
+                {{"name":"ungoogled-chromium-151.0.7922.71-1-x86_64.AppImage",
+                  "browser_download_url":"{server}/ug.AppImage"}}]}}]"#,
+            server = server.uri()
+        );
+
+        Mock::given(method("GET"))
+            .and(path("/manifest.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(manifest))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/cft.zip"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_bytes(build_stub_chrome_zip(&cft_sentinel)),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/repos/ungoogled-software/ungoogled-chromium-portablelinux/releases",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(releases))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/ug.AppImage"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(ug_sentinel.clone()))
+            .mount(&server)
+            .await;
+
+        let cache_root = tempfile::tempdir().unwrap();
+
+        let cft = Fetcher::new()
+            .cache_dir(cache_root.path())
+            .platform(Platform::LinuxX64)
+            .version(VersionSpec::Explicit("151.0.7922.71".into()))
+            .manifest_url(format!("{}/manifest.json", server.uri()))
+            .ensure_chrome()
+            .await
+            .unwrap();
+        let ug = Fetcher::new()
+            .cache_dir(cache_root.path())
+            .distribution(Distribution::UngoogledChromium)
+            .platform(Platform::LinuxX64)
+            .version(VersionSpec::Explicit("151.0.7922.71".into()))
+            .manifest_url(server.uri())
+            .ensure_chrome()
+            .await
+            .unwrap();
+
+        assert_ne!(cft, ug);
+        assert_eq!(tokio::fs::read(&cft).await.unwrap(), cft_sentinel);
+        assert_eq!(tokio::fs::read(&ug).await.unwrap(), ug_sentinel);
+    }
+
+    /// GitHub answers 403 with `x-ratelimit-remaining: 0` when the
+    /// unauthenticated 60/hour budget is gone. That has to reach the operator
+    /// as an explanation, not as a bare HTTP status.
+    #[tokio::test]
+    async fn github_rate_limiting_surfaces_as_an_actionable_message() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/repos/ungoogled-software/ungoogled-chromium-macos/releases",
+            ))
+            .respond_with(
+                ResponseTemplate::new(403)
+                    .insert_header("x-ratelimit-remaining", "0")
+                    .insert_header("x-ratelimit-reset", "1786023295")
+                    .set_body_string(r#"{"message":"API rate limit exceeded"}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let err = Fetcher::new()
+            .cache_dir(cache_root.path())
+            .distribution(Distribution::UngoogledChromium)
+            .platform(Platform::MacArm64)
+            .version(VersionSpec::Latest)
+            .manifest_url(server.uri())
+            .ensure_chrome()
+            .await
+            .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(matches!(err, FetcherError::GitHubRateLimited { .. }));
+        assert!(msg.contains("60 requests/hour"), "{msg}");
+        assert!(msg.contains("GITHUB_TOKEN"), "{msg}");
+        assert!(msg.contains("1786023295"), "{msg}");
     }
 }

--- a/crates/zendriver-fetcher/src/fetcher.rs
+++ b/crates/zendriver-fetcher/src/fetcher.rs
@@ -255,17 +255,28 @@ impl Fetcher {
             return Ok(target_bin);
         }
 
-        // Phase 2: download to <build>.tmp.<ext>, beside the build directory
-        // so the staging paths are namespaced exactly like the final one.
+        // Phase 2: download to <build>.tmp.<stamp>.<ext>, beside the build
+        // directory so the staging paths are namespaced exactly like the final
+        // one.
+        //
+        // The stamp makes staging per-FETCH, not per-build. Two `ensure_chrome`
+        // calls for the same build previously derived the same `<build>.tmp`,
+        // and each one's "clean up a stale tmp" step deleted the other's
+        // half-written tree — after which one of them renamed whatever was left
+        // into the cache under the canonical name, where the cache-hit check
+        // accepts a truncated browser from then on.
+        //
+        // ponytail: a hard crash now leaks `<build>.tmp.<stamp>` instead of it
+        // being cleared by the next run of the same build. That is the right
+        // side of the trade — a leaked directory in a cache is recoverable,
+        // a silently truncated browser promoted under the canonical name is
+        // not. Reap by mtime age if the leakage ever actually matters.
+        let stamp = staging_stamp();
         let tmp_archive = with_suffix(
             &final_dir,
-            &format!(".tmp.{}", resolved.archive.tmp_extension()),
+            &format!(".tmp.{stamp}.{}", resolved.archive.tmp_extension()),
         );
-        let tmp_dir = with_suffix(&final_dir, ".tmp");
-
-        // Clean up any stale tmp from a prior crashed run.
-        let _ = tokio::fs::remove_file(&tmp_archive).await;
-        let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
+        let tmp_dir = with_suffix(&final_dir, &format!(".tmp.{stamp}"));
 
         emit(&progress_cb, FetcherPhase::Downloading, 0, None);
         download(
@@ -402,6 +413,25 @@ fn emit(
             phase,
         });
     }
+}
+
+/// Token that makes a staging path unique to one fetch.
+///
+/// Process id covers concurrent processes sharing a cache directory (the CI
+/// case the `cache_dir` option exists for), and the clock plus an in-process
+/// counter covers concurrent tasks inside one process.
+fn staging_stamp() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    format!(
+        "{}-{nanos}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    )
 }
 
 /// Compute the lowercase-hex SHA256 of `path`'s contents. The hash is
@@ -588,9 +618,14 @@ mod tests {
         let extracted = tokio::fs::read(&bin_path).await.unwrap();
         assert_eq!(extracted, sentinel);
 
-        // No leftover tmp artifacts.
-        assert!(!cache_root.path().join("120.0.6099.234.tmp.zip").exists());
-        assert!(!cache_root.path().join("120.0.6099.234.tmp").exists());
+        // No leftover staging artifacts of any shape.
+        let leftovers: Vec<_> = std::fs::read_dir(cache_root.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "staging left behind: {leftovers:?}");
 
         // Executable bit set on Unix.
         #[cfg(unix)]
@@ -750,6 +785,70 @@ mod tests {
         );
         let extracted = tokio::fs::read(&bin_path).await.unwrap();
         assert_eq!(extracted, sentinel);
+    }
+
+    /// Two fetches of the SAME build sharing a cache directory — the CI shape
+    /// the `cache_dir` option exists for.
+    ///
+    /// They used to derive the same `<build>.tmp`, so each one's stale-tmp
+    /// cleanup deleted the other's half-written tree, and whichever won the
+    /// rename published whatever was left under the canonical name. A
+    /// truncated browser passes `is_runnable` and is then served from cache
+    /// forever, so the damage outlives the run that caused it.
+    ///
+    /// Both must come back with the whole binary.
+    #[tokio::test]
+    async fn concurrent_fetches_of_one_build_do_not_corrupt_the_cache() {
+        let server = MockServer::start().await;
+        let sentinel: Vec<u8> = std::iter::repeat_n(b"chrome-payload-", 4096)
+            .flatten()
+            .copied()
+            .collect();
+        let zip_bytes = build_stub_chrome_zip(&sentinel);
+
+        let manifest_json = format!(
+            r#"{{"versions":[{{"version":"120.0.6099.234","revision":"1234","downloads":{{"chrome":[{{"platform":"linux64","url":"{server}/chrome.zip"}}]}}}}]}}"#,
+            server = server.uri()
+        );
+        Mock::given(method("GET"))
+            .and(path("/manifest.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(manifest_json))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/chrome.zip"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(zip_bytes))
+            .mount(&server)
+            .await;
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let manifest_url = format!("{}/manifest.json", server.uri());
+
+        let fetch = || {
+            let (dir, url) = (cache_root.path().to_path_buf(), manifest_url.clone());
+            async move {
+                Fetcher::new()
+                    .cache_dir(dir)
+                    .platform(Platform::LinuxX64)
+                    .version(VersionSpec::Latest)
+                    .manifest_url(url)
+                    .ensure_chrome()
+                    .await
+            }
+        };
+
+        let (a, b) = tokio::join!(fetch(), fetch());
+        let (a, b) = (a.unwrap(), b.unwrap());
+
+        assert_eq!(a, b, "both fetches must name the same cached binary");
+        for path in [&a, &b] {
+            assert_eq!(
+                tokio::fs::read(path).await.unwrap(),
+                sentinel,
+                "cache holds a truncated binary at {}",
+                path.display()
+            );
+        }
     }
 
     /// The default must stay Chrome for Testing, or every existing caller

--- a/crates/zendriver-fetcher/src/lib.rs
+++ b/crates/zendriver-fetcher/src/lib.rs
@@ -1,13 +1,12 @@
-//! Chrome for Testing binary downloader.
+//! Chromium binary downloader.
 //!
 //! See the [Fetcher chapter](https://turtiesocks.github.io/zendriver-rs/fetcher.html)
 //! of the [zendriver-rs user guide](https://turtiesocks.github.io/zendriver-rs/)
 //! for cache-layout details, offline-mode workflows, and CI integration tips.
 //!
-//! Resolves a [`VersionSpec`] + [`Platform`] pair against the
-//! [Chrome for Testing manifest][cft-manifest], downloads the matching zip,
-//! extracts it into an atomic cache layout, and hands back a path to the
-//! executable.
+//! Resolves a [`Distribution`] + [`VersionSpec`] + [`Platform`] triple against
+//! that distribution's index, downloads the matching archive, unpacks it into
+//! an atomic cache layout, and hands back a path to the executable.
 //!
 //! Public entry point is [`Fetcher`]; progress is reported through
 //! [`FetcherProgress`] callbacks tagged with a [`FetcherPhase`].
@@ -24,22 +23,58 @@
 //! # Ok(()) }
 //! ```
 //!
+//! # Distributions
+//!
+//! [`Distribution::default()`] is [`Distribution::ChromeForTesting`], so the
+//! example above fetches exactly what this crate always has. Two further
+//! indexes are available, and *only* resolution differs between them —
+//! download, integrity check, unpack and cache are one shared path:
+//!
+//! | [`Distribution`] | Index | Keyed by |
+//! |---|---|---|
+//! | [`ChromeForTesting`](Distribution::ChromeForTesting) | one [JSON manifest][cft-manifest] | version |
+//! | [`UngoogledChromium`](Distribution::UngoogledChromium) | three GitHub repos, one per OS | version (tag prefix) |
+//! | [`ChromiumSnapshot`](Distribution::ChromiumSnapshot) | a GCS bucket per platform | **revision** |
+//!
+//! ```no_run
+//! # async fn ex() -> Result<(), zendriver_fetcher::FetcherError> {
+//! use zendriver_fetcher::{Distribution, Fetcher, VersionSpec};
+//!
+//! let chromium = Fetcher::new()
+//!     .distribution(Distribution::UngoogledChromium)
+//!     .version(VersionSpec::Explicit("151.0.7922.71".into()))
+//!     .ensure_chrome()
+//!     .await?;
+//! # let _ = chromium; Ok(()) }
+//! ```
+//!
+//! Availability is a per-platform question — the three ungoogled repos
+//! release independently, and the snapshot bucket has no version index at all
+//! — so [`list_builds`] answers it for the platform you actually want instead
+//! of assuming parity.
+//!
 //! [cft-manifest]: https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json
 
+pub mod archive;
 pub mod cache;
+pub mod distribution;
 pub mod download;
 pub mod error;
 pub mod extract;
 pub mod fetcher;
+pub mod list;
 pub mod manifest;
 pub mod platform;
 pub mod resolver;
 pub mod tls;
 pub mod version;
 
+pub use distribution::Distribution;
 pub use error::FetcherError;
 pub use fetcher::Fetcher;
+pub use list::list_builds;
 pub use platform::Platform;
+pub use resolver::Build;
 pub use version::{Channel, VersionSpec};
 
 /// Lifecycle phase of an in-flight fetch.

--- a/crates/zendriver-fetcher/src/list.rs
+++ b/crates/zendriver-fetcher/src/list.rs
@@ -1,0 +1,194 @@
+//! Enumerate the builds a distribution actually publishes for a platform.
+//!
+//! Exists because "what can I download?" has a genuinely different answer per
+//! platform, and guessing is how you end up asking macOS for a version only
+//! Windows has. The CLI's interactive picker is built on this; so is any
+//! caller that wants to show a menu rather than hardcode a version.
+//!
+//! [`Distribution::ChromiumSnapshot`] is the thin one: the bucket has no
+//! index, so the only enumerable build is the tip named by `LAST_CHANGE`.
+//! Older snapshots are reachable, but only if you already know the revision.
+
+use crate::distribution::Distribution;
+use crate::error::FetcherError;
+use crate::manifest::{fetch_github_releases, fetch_last_change, fetch_manifest_from};
+use crate::platform::Platform;
+use crate::resolver::{
+    Build, DEFAULT_GITHUB_API_BASE, DEFAULT_SNAPSHOT_BASE, list_cft, list_ungoogled,
+};
+use crate::version::VersionSpec;
+
+/// Builds `distribution` publishes for `platform`, newest first.
+///
+/// # Errors
+///
+/// Whatever the distribution's index fetch returns — including
+/// [`FetcherError::GitHubRateLimited`] for ungoogled-chromium on an
+/// unauthenticated host that has used its 60 requests.
+///
+/// ```no_run
+/// # async fn ex() -> Result<(), zendriver_fetcher::FetcherError> {
+/// use zendriver_fetcher::{Distribution, Platform, list_builds};
+///
+/// for build in list_builds(Distribution::UngoogledChromium, Platform::MacArm64).await? {
+///     println!("{}", build.label);
+/// }
+/// # Ok(()) }
+/// ```
+pub async fn list_builds(
+    distribution: Distribution,
+    platform: Platform,
+) -> Result<Vec<Build>, FetcherError> {
+    list_builds_from(distribution, platform, None).await
+}
+
+/// [`list_builds`] with an overridable index endpoint — the same
+/// `#[doc(hidden)]` test seam as [`Fetcher::manifest_url`](crate::Fetcher::manifest_url).
+#[doc(hidden)]
+pub async fn list_builds_from(
+    distribution: Distribution,
+    platform: Platform,
+    index_base: Option<&str>,
+) -> Result<Vec<Build>, FetcherError> {
+    match distribution {
+        Distribution::ChromeForTesting => {
+            let url = index_base.unwrap_or(crate::fetcher::DEFAULT_CFT_URL);
+            let manifest = fetch_manifest_from(url).await?;
+            Ok(list_cft(&manifest, platform))
+        }
+        Distribution::UngoogledChromium => {
+            let api_base = index_base.unwrap_or(DEFAULT_GITHUB_API_BASE);
+            let repo = Distribution::ungoogled_repo(platform);
+            let releases = fetch_github_releases(api_base, repo).await?;
+            Ok(list_ungoogled(&releases, platform))
+        }
+        Distribution::ChromiumSnapshot => {
+            let base = index_base.unwrap_or(DEFAULT_SNAPSHOT_BASE);
+            let revision = fetch_last_change(base, platform.as_snapshot_str()).await?;
+            Ok(vec![Build {
+                spec: VersionSpec::Revision(revision),
+                label: format!(
+                    "r{revision}  (newest snapshot for {}; older builds need an explicit revision)",
+                    platform.as_snapshot_str()
+                ),
+            }])
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn lists_chrome_for_testing_versions_newest_first() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/manifest.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"{"versions":[
+                    {"version":"119.0.6045.105","revision":"1230","downloads":{"chrome":[
+                        {"platform":"linux64","url":"https://example.com/119.zip"}]}},
+                    {"version":"120.0.6099.234","revision":"1234","downloads":{"chrome":[
+                        {"platform":"linux64","url":"https://example.com/120.zip"}]}}
+                ]}"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let url = format!("{}/manifest.json", server.uri());
+        let builds = list_builds_from(
+            Distribution::ChromeForTesting,
+            Platform::LinuxX64,
+            Some(&url),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(builds.len(), 2);
+        assert_eq!(builds[0].label, "120.0.6099.234");
+    }
+
+    /// The listing must go to the repo for the *requested* platform, which is
+    /// what makes per-platform availability visible instead of assumed.
+    #[tokio::test]
+    async fn lists_ungoogled_releases_from_the_platforms_own_repo() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/repos/ungoogled-software/ungoogled-chromium-macos/releases",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"[{"tag_name":"150.0.7871.46-1.1","draft":false,"prerelease":false,"assets":[
+                    {"name":"ungoogled-chromium_150.0.7871.46-1.1_arm64-macos.dmg",
+                     "browser_download_url":"https://example.com/150.dmg"}]}]"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let builds = list_builds_from(
+            Distribution::UngoogledChromium,
+            Platform::MacArm64,
+            Some(&server.uri()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(builds.len(), 1);
+        assert_eq!(
+            builds[0].spec,
+            VersionSpec::Explicit("150.0.7871.46".into())
+        );
+    }
+
+    /// Snapshots can only offer the tip, and the label has to say so rather
+    /// than imply the list is complete.
+    #[tokio::test]
+    async fn snapshot_listing_offers_only_the_tip_and_says_so() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/Mac_Arm/LAST_CHANGE"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("1674890"))
+            .mount(&server)
+            .await;
+
+        let builds = list_builds_from(
+            Distribution::ChromiumSnapshot,
+            Platform::MacArm64,
+            Some(&server.uri()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(builds.len(), 1);
+        assert_eq!(builds[0].spec, VersionSpec::Revision(1674890));
+        assert!(builds[0].label.contains("r1674890"), "{}", builds[0].label);
+        assert!(
+            builds[0].label.contains("explicit revision"),
+            "{}",
+            builds[0].label
+        );
+    }
+
+    #[tokio::test]
+    async fn last_change_that_is_not_a_number_is_an_error_not_a_panic() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/Linux_x64/LAST_CHANGE"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html>nope</html>"))
+            .mount(&server)
+            .await;
+
+        let err = list_builds_from(
+            Distribution::ChromiumSnapshot,
+            Platform::LinuxX64,
+            Some(&server.uri()),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, FetcherError::VersionNotFound(_)), "{err:?}");
+    }
+}

--- a/crates/zendriver-fetcher/src/manifest.rs
+++ b/crates/zendriver-fetcher/src/manifest.rs
@@ -11,50 +11,41 @@ use serde::Deserialize;
 
 use crate::error::FetcherError;
 
-#[allow(dead_code, reason = "consumed by resolver in Task 18")]
 #[derive(Debug, Deserialize)]
 pub(crate) struct KnownGoodVersionsResponse {
     pub versions: Vec<VersionEntry>,
 }
 
-#[allow(dead_code, reason = "consumed by resolver in Task 18")]
+/// One version in the flat manifest.
+///
+/// Only the fields resolution reads are modelled — the manifest also carries a
+/// Chromium `revision` per entry, which nothing here keys on, and serde drops
+/// what is not declared.
 #[derive(Debug, Deserialize)]
 pub(crate) struct VersionEntry {
     pub version: String,
-    pub revision: String,
     pub downloads: Downloads,
 }
 
-#[allow(dead_code, reason = "consumed by resolver in Task 18")]
 #[derive(Debug, Deserialize)]
 pub(crate) struct Downloads {
     pub chrome: Vec<Download>,
 }
 
-#[allow(dead_code, reason = "consumed by resolver in Task 18")]
 #[derive(Debug, Deserialize)]
 pub(crate) struct Download {
     pub platform: String,
     pub url: String,
 }
 
-#[expect(dead_code, reason = "consumed by resolver in Task 18")]
-pub(crate) async fn fetch_manifest() -> Result<KnownGoodVersionsResponse, FetcherError> {
-    fetch_manifest_from(
-        "https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json",
-    )
-    .await
-}
-
-/// Test helper — same as [`fetch_manifest`] but allows overriding the URL for
-/// wiremock-based testing.
+/// Fetch and parse Chrome for Testing's flat version manifest from `url`.
+///
+/// The URL is a parameter rather than a constant so tests can point it at a
+/// wiremock server; callers pass [`DEFAULT_CFT_URL`](crate::fetcher::DEFAULT_CFT_URL).
 pub(crate) async fn fetch_manifest_from(
     url: &str,
 ) -> Result<KnownGoodVersionsResponse, FetcherError> {
-    let resp = crate::tls::get(url).await?;
-    let text = resp.text().await?;
-    let parsed: KnownGoodVersionsResponse = serde_json::from_str(&text)?;
-    Ok(parsed)
+    Ok(serde_json::from_str(&fetch_text(url).await?)?)
 }
 
 /// Chrome for Testing's per-channel manifest —
@@ -69,26 +60,31 @@ pub(crate) struct ChannelsResponse {
 /// One channel's entry in [`ChannelsResponse`] — same shape as
 /// [`VersionEntry`] (the manifest omits only the redundant `channel` name
 /// field, already carried as this entry's map key).
-#[allow(
-    dead_code,
-    reason = "revision not consumed by the resolver yet, same as VersionEntry"
-)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct ChannelEntry {
     pub version: String,
-    pub revision: String,
     pub downloads: Downloads,
 }
 
-/// Same rationale as [`fetch_manifest_from`] — allows overriding the URL
-/// for wiremock-based testing.
+/// Same rationale as [`fetch_manifest_from`] — the URL is a parameter so tests
+/// can point it at a wiremock server.
 pub(crate) async fn fetch_channels_manifest_from(
     url: &str,
 ) -> Result<ChannelsResponse, FetcherError> {
-    let resp = crate::tls::get(url).await?;
-    let text = resp.text().await?;
-    let parsed: ChannelsResponse = serde_json::from_str(&text)?;
-    Ok(parsed)
+    Ok(serde_json::from_str(&fetch_text(url).await?)?)
+}
+
+/// GET `url` and return the body, failing on a non-success status.
+///
+/// The `error_for_status` is the point: without it a 404 or a CDN 503 is an
+/// HTML error page handed to `serde_json`, and the operator gets
+/// "expected value at line 1 column 1" instead of the status code.
+async fn fetch_text(url: &str) -> Result<String, FetcherError> {
+    Ok(crate::tls::get(url)
+        .await?
+        .error_for_status()?
+        .text()
+        .await?)
 }
 
 /// One entry from GitHub's `GET /repos/{owner}/{repo}/releases` response.
@@ -145,11 +141,7 @@ pub(crate) async fn fetch_last_change(
         "{}/{platform_dir}/LAST_CHANGE",
         snapshot_base.trim_end_matches('/')
     );
-    let text = crate::tls::get(&url)
-        .await?
-        .error_for_status()?
-        .text()
-        .await?;
+    let text = fetch_text(&url).await?;
     text.trim().parse::<u64>().map_err(|_| {
         FetcherError::VersionNotFound(format!(
             "{url} returned {:?}, which is not a revision number",
@@ -183,7 +175,8 @@ mod tests {
         assert_eq!(manifest.versions.len(), 1);
         let v = &manifest.versions[0];
         assert_eq!(v.version, "120.0.6099.234");
-        assert_eq!(v.revision, "1234");
+        // The fixture carries `revision` too; undeclared fields are dropped
+        // rather than failing the parse.
         assert_eq!(v.downloads.chrome.len(), 2);
         assert_eq!(v.downloads.chrome[0].platform, "linux64");
         assert_eq!(
@@ -195,5 +188,27 @@ mod tests {
             v.downloads.chrome[1].url,
             "https://example.com/chrome-mac-x64.zip"
         );
+    }
+
+    /// A CDN that answers 503 with an HTML error page must surface as the
+    /// status code. Feeding that page to `serde_json` instead reports
+    /// "expected value at line 1 column 1", which sends the operator looking
+    /// for a manifest-format change that never happened.
+    #[tokio::test]
+    async fn an_http_error_is_reported_as_http_not_as_a_parse_failure() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/manifest.json"))
+            .respond_with(
+                ResponseTemplate::new(503).set_body_string("<html>Service Unavailable</html>"),
+            )
+            .mount(&server)
+            .await;
+
+        let err = fetch_manifest_from(&format!("{}/manifest.json", server.uri()))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FetcherError::Http(_)), "{err:?}");
+        assert!(err.to_string().contains("503"), "{err}");
     }
 }

--- a/crates/zendriver-fetcher/src/manifest.rs
+++ b/crates/zendriver-fetcher/src/manifest.rs
@@ -91,6 +91,73 @@ pub(crate) async fn fetch_channels_manifest_from(
     Ok(parsed)
 }
 
+/// One entry from GitHub's `GET /repos/{owner}/{repo}/releases` response.
+///
+/// ungoogled-chromium publishes no manifest — the release list *is* the
+/// index, one per OS. Only the fields resolution needs are modelled; GitHub's
+/// payload is large and the rest is ignored.
+#[derive(Debug, Deserialize)]
+pub(crate) struct GitHubRelease {
+    pub tag_name: String,
+    #[serde(default)]
+    pub draft: bool,
+    #[serde(default)]
+    pub prerelease: bool,
+    #[serde(default)]
+    pub assets: Vec<GitHubAsset>,
+}
+
+/// A file attached to a [`GitHubRelease`].
+#[derive(Debug, Deserialize)]
+pub(crate) struct GitHubAsset {
+    pub name: String,
+    pub browser_download_url: String,
+}
+
+/// Fetch a repo's release list, newest first (GitHub's own ordering).
+///
+/// One request with `per_page=100` rather than pagination: each page costs
+/// one of the 60 unauthenticated requests per hour, and a single page covers
+/// well over a year of ungoogled releases.
+pub(crate) async fn fetch_github_releases(
+    api_base: &str,
+    repo: &str,
+) -> Result<Vec<GitHubRelease>, FetcherError> {
+    let url = format!(
+        "{}/repos/{repo}/releases?per_page=100",
+        api_base.trim_end_matches('/')
+    );
+    let text = crate::tls::get_github(&url).await?;
+    Ok(serde_json::from_str(&text)?)
+}
+
+/// Fetch the newest revision published for `platform_dir` in Chromium's
+/// snapshot bucket.
+///
+/// `LAST_CHANGE` is a plain-text integer, not JSON. The snapshot bucket has
+/// no manifest of any kind — which is precisely why snapshots cannot be
+/// resolved by version.
+pub(crate) async fn fetch_last_change(
+    snapshot_base: &str,
+    platform_dir: &str,
+) -> Result<u64, FetcherError> {
+    let url = format!(
+        "{}/{platform_dir}/LAST_CHANGE",
+        snapshot_base.trim_end_matches('/')
+    );
+    let text = crate::tls::get(&url)
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    text.trim().parse::<u64>().map_err(|_| {
+        FetcherError::VersionNotFound(format!(
+            "{url} returned {:?}, which is not a revision number",
+            text.chars().take(64).collect::<String>()
+        ))
+    })
+}
+
 #[cfg(test)]
 #[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {

--- a/crates/zendriver-fetcher/src/platform.rs
+++ b/crates/zendriver-fetcher/src/platform.rs
@@ -1,4 +1,11 @@
-//! Target platforms understood by the Chrome for Testing manifest.
+//! Target platforms, and how each distribution spells them.
+//!
+//! One [`Platform`] value, three naming schemes. Chrome for Testing uses
+//! lowercase hyphenated keys (`mac-arm64`); Chromium's snapshot bucket uses
+//! capitalised directory names (`Mac_Arm`); ungoogled-chromium encodes the
+//! platform in an asset *filename suffix* (`_arm64-macos.dmg`) inside a
+//! per-OS repo. Keeping all three spellings beside the enum makes that
+//! divergence visible instead of scattering it through the resolvers.
 
 /// Supported host platforms.
 ///
@@ -19,6 +26,33 @@ pub enum Platform {
 }
 
 impl Platform {
+    /// Every supported platform. Used by the CLI's `--platform` help text and
+    /// by tests that assert exhaustive coverage.
+    pub const ALL: &'static [Platform] = &[
+        Platform::LinuxX64,
+        Platform::MacX64,
+        Platform::MacArm64,
+        Platform::Win32,
+        Platform::Win64,
+    ];
+
+    /// Parse a Chrome for Testing platform key (`"mac-arm64"`, `"linux64"`, …).
+    ///
+    /// The CfT spelling is the user-facing one — it is the shortest and the
+    /// one that appears in Google's own docs. The snapshot bucket's
+    /// `Mac_Arm`-style names are an implementation detail of that index and
+    /// are translated internally by [`Platform::as_snapshot_str`].
+    ///
+    /// ```
+    /// use zendriver_fetcher::Platform;
+    /// assert_eq!(Platform::parse("mac-arm64"), Some(Platform::MacArm64));
+    /// assert_eq!(Platform::parse("solaris"), None);
+    /// ```
+    pub fn parse(s: &str) -> Option<Self> {
+        let s = s.trim().to_ascii_lowercase();
+        Platform::ALL.iter().copied().find(|p| p.as_cft_str() == s)
+    }
+
     /// Detect the current host platform, if supported.
     ///
     /// Returns `None` for platforms not covered by Chrome for Testing
@@ -75,6 +109,61 @@ impl Platform {
             Platform::Win64 => "chrome-win64",
         }
     }
+
+    /// Directory name for this platform in Chromium's snapshot bucket
+    /// (e.g. `"Mac_Arm"`, `"Win_x64"`, `"Linux_x64"`).
+    ///
+    /// Deliberately *not* the Chrome for Testing spelling — the two indexes
+    /// disagree on every single platform, so mixing them up produces 404s
+    /// rather than type errors.
+    ///
+    /// ```
+    /// use zendriver_fetcher::Platform;
+    /// assert_eq!(Platform::MacArm64.as_cft_str(), "mac-arm64");
+    /// assert_eq!(Platform::MacArm64.as_snapshot_str(), "Mac_Arm");
+    /// ```
+    pub fn as_snapshot_str(&self) -> &'static str {
+        match self {
+            Platform::LinuxX64 => "Linux_x64",
+            Platform::MacX64 => "Mac",
+            Platform::MacArm64 => "Mac_Arm",
+            Platform::Win32 => "Win",
+            Platform::Win64 => "Win_x64",
+        }
+    }
+
+    /// Archive stem inside a snapshot revision directory: the zip is
+    /// `<stem>.zip` and every entry inside it lives under `<stem>/`.
+    ///
+    /// Snapshots name the archive after the *OS*, not the arch — both
+    /// `Mac` and `Mac_Arm` publish `chrome-mac.zip`.
+    pub(crate) fn snapshot_archive_stem(&self) -> &'static str {
+        match self {
+            Platform::LinuxX64 => "chrome-linux",
+            Platform::MacX64 | Platform::MacArm64 => "chrome-mac",
+            Platform::Win32 | Platform::Win64 => "chrome-win",
+        }
+    }
+
+    /// Filename suffix identifying this platform's ungoogled-chromium release
+    /// asset, e.g. `"_arm64-macos.dmg"`.
+    ///
+    /// Each per-OS repo attaches several assets per release (installers,
+    /// `.zsync` sidecars, multiple arches); matching on the full suffix is
+    /// what picks exactly one. Note in particular that `.AppImage.zsync`
+    /// does not end in `.AppImage`, so suffix matching excludes it for free.
+    pub(crate) fn ungoogled_asset_suffix(&self) -> &'static str {
+        match self {
+            // Portable-Linux publishes both an AppImage and a `.tar.xz`. The
+            // AppImage is a single self-contained executable, so it needs no
+            // decompressor dependency at all — see `Archive::Executable`.
+            Platform::LinuxX64 => "-x86_64.AppImage",
+            Platform::MacX64 => "_x86_64-macos.dmg",
+            Platform::MacArm64 => "_arm64-macos.dmg",
+            Platform::Win32 => "_windows_x86.zip",
+            Platform::Win64 => "_windows_x64.zip",
+        }
+    }
 }
 
 #[cfg(test)]
@@ -95,5 +184,75 @@ mod tests {
         assert_eq!(Platform::MacArm64.as_cft_str(), "mac-arm64");
         assert_eq!(Platform::Win32.as_cft_str(), "win32");
         assert_eq!(Platform::Win64.as_cft_str(), "win64");
+    }
+
+    const ALL: &[Platform] = Platform::ALL;
+
+    #[test]
+    fn parse_round_trips_every_platform() {
+        for &p in ALL {
+            assert_eq!(Platform::parse(p.as_cft_str()), Some(p));
+        }
+        assert_eq!(Platform::parse("  MAC-ARM64 "), Some(Platform::MacArm64));
+        assert_eq!(Platform::parse("Mac_Arm"), None);
+        assert_eq!(Platform::parse(""), None);
+    }
+
+    #[test]
+    fn snapshot_str_matches_the_bucket_directory_names() {
+        assert_eq!(Platform::LinuxX64.as_snapshot_str(), "Linux_x64");
+        assert_eq!(Platform::MacX64.as_snapshot_str(), "Mac");
+        assert_eq!(Platform::MacArm64.as_snapshot_str(), "Mac_Arm");
+        assert_eq!(Platform::Win32.as_snapshot_str(), "Win");
+        assert_eq!(Platform::Win64.as_snapshot_str(), "Win_x64");
+    }
+
+    /// The two indexes spell every platform differently. Pinning that here
+    /// means a future edit that "unifies" the two names fails loudly instead
+    /// of producing 404s at download time.
+    #[test]
+    fn cft_and_snapshot_names_differ_for_every_platform() {
+        for &p in ALL {
+            assert_ne!(
+                p.as_cft_str(),
+                p.as_snapshot_str(),
+                "{p:?}: CfT and snapshot names must not be conflated"
+            );
+        }
+    }
+
+    #[test]
+    fn snapshot_archive_stem_is_per_os_not_per_arch() {
+        // Both macOS arches publish the same `chrome-mac.zip` name, under
+        // different bucket directories.
+        assert_eq!(
+            Platform::MacArm64.snapshot_archive_stem(),
+            Platform::MacX64.snapshot_archive_stem()
+        );
+        assert_eq!(Platform::MacArm64.snapshot_archive_stem(), "chrome-mac");
+        assert_eq!(Platform::Win64.snapshot_archive_stem(), "chrome-win");
+        assert_eq!(Platform::LinuxX64.snapshot_archive_stem(), "chrome-linux");
+    }
+
+    #[test]
+    fn ungoogled_asset_suffixes_are_unique_per_platform() {
+        for (i, &a) in ALL.iter().enumerate() {
+            for &b in &ALL[i + 1..] {
+                assert_ne!(
+                    a.ungoogled_asset_suffix(),
+                    b.ungoogled_asset_suffix(),
+                    "{a:?} and {b:?} share an asset suffix"
+                );
+            }
+        }
+    }
+
+    /// The `.zsync` sidecars sit next to the AppImage in every portablelinux
+    /// release; suffix matching must not pick one up.
+    #[test]
+    fn linux_asset_suffix_excludes_the_zsync_sidecar() {
+        let suffix = Platform::LinuxX64.ungoogled_asset_suffix();
+        assert!("ungoogled-chromium-151.0.7922.71-1-x86_64.AppImage".ends_with(suffix));
+        assert!(!"ungoogled-chromium-151.0.7922.71-1-x86_64.AppImage.zsync".ends_with(suffix));
     }
 }

--- a/crates/zendriver-fetcher/src/resolver.rs
+++ b/crates/zendriver-fetcher/src/resolver.rs
@@ -330,6 +330,10 @@ fn is_plain_filename(name: &str) -> bool {
         // wherever the cache is later read, and archives are routinely
         // fetched for a platform other than the running one.
         && !name.contains('\\')
+        // A drive-relative name like `C:evil` has no separator at all, yet
+        // `Path::join` on Windows *replaces* the base with it rather than
+        // appending — same escape as `..`, reached without a `..`.
+        && !name.contains(':')
         && !name.contains('\0')
 }
 
@@ -923,6 +927,35 @@ mod tests {
         // fetched for a platform other than the running one.
         assert!(!is_plain_filename(r"..\evil.zip"));
         assert!(!is_plain_filename("evil\0.zip"));
+        // Drive-relative: no separator anywhere, but `Path::join` on Windows
+        // discards the base for it, so it escapes exactly like `..` would.
+        assert!(!is_plain_filename("C:evil_windows_x64.zip"));
+        assert!(!is_plain_filename(r"C:\evil_windows_x64.zip"));
+    }
+
+    /// The Windows half of the escape the plain-filename check exists to
+    /// close. `..` was covered; a drive letter reaches the same place without
+    /// one, because `Path::join` on Windows *replaces* the base when the
+    /// joined path carries a prefix.
+    #[test]
+    fn a_drive_relative_asset_name_is_never_selected() {
+        let releases: Vec<GitHubRelease> = serde_json::from_str(
+            r#"[{
+                "tag_name": "151.0.7922.71-1.1",
+                "draft": false,
+                "prerelease": false,
+                "assets": [
+                    {"name": "C:evil_windows_x64.zip",
+                     "browser_download_url": "https://example.com/evil.zip"}
+                ]
+            }]"#,
+        )
+        .unwrap();
+
+        let err = resolve_ungoogled(&releases, &VersionSpec::Latest, Platform::Win64, "repo")
+            .unwrap_err();
+        assert!(matches!(err, FetcherError::VersionNotFound(_)), "{err:?}");
+        assert!(list_ungoogled(&releases, Platform::Win64).is_empty());
     }
 
     #[test]

--- a/crates/zendriver-fetcher/src/resolver.rs
+++ b/crates/zendriver-fetcher/src/resolver.rs
@@ -57,6 +57,13 @@ pub(crate) struct Resolved {
     /// How the download is packaged.
     pub archive: Archive,
     /// Executable path relative to the build directory.
+    ///
+    /// **Invariant: this must stay inside the build directory.** It is joined
+    /// onto the cache path and the result is both `chmod +x`'d and handed to
+    /// the caller to *execute*, so a `..` reaching it is a code-execution
+    /// primitive rather than a wrong-path bug. Every component is either a
+    /// crate constant or an index-supplied name validated by
+    /// [`is_plain_filename`].
     pub binary_subpath: PathBuf,
 }
 
@@ -294,7 +301,36 @@ fn asset_for<'a>(
     release: &'a GitHubRelease,
     suffix: &str,
 ) -> Option<&'a crate::manifest::GitHubAsset> {
-    release.assets.iter().find(|a| a.name.ends_with(suffix))
+    release
+        .assets
+        .iter()
+        .find(|a| is_plain_filename(&a.name) && a.name.ends_with(suffix))
+}
+
+/// Is `name` a single, ordinary filename?
+///
+/// Asset names are index-controlled data that end up in **filesystem paths**:
+/// the Windows zip's top-level directory is its asset name minus `.zip`, and
+/// that becomes a component of the cached binary's path. A name carrying `..`
+/// or a separator would push [`Resolved::binary_subpath`] outside the build
+/// directory, and `ensure_chrome`'s cache-hit check runs
+/// `build_dir.join(binary_subpath)` *before* downloading anything — so a
+/// compromised repo could hand the caller an arbitrary existing executable to
+/// launch, without ever serving a byte.
+///
+/// Matching only plain filenames closes that without trusting the index. It
+/// fails closed: an unusable asset simply does not match, and the caller gets
+/// the ordinary [`FetcherError::AssetNotFound`].
+fn is_plain_filename(name: &str) -> bool {
+    !name.is_empty()
+        && name != "."
+        && name != ".."
+        && !name.contains('/')
+        // Rejected on every host, not just Windows: the name has to be safe
+        // wherever the cache is later read, and archives are routinely
+        // fetched for a platform other than the running one.
+        && !name.contains('\\')
+        && !name.contains('\0')
 }
 
 /// Does `tag` name Chrome version `want`?
@@ -834,6 +870,59 @@ mod tests {
         let msg = err.to_string();
         assert!(matches!(err, FetcherError::AssetNotFound { .. }));
         assert!(msg.contains("_windows_x86.zip"), "{msg}");
+    }
+
+    /// An asset name reaches the filesystem: the Windows zip's top-level
+    /// directory is that name minus `.zip`, and it lands in
+    /// `binary_subpath`. `ensure_chrome` joins that onto the cache path and
+    /// returns it for the caller to *execute*, checking it before any
+    /// download — so a `..` here would let a compromised repo nominate an
+    /// arbitrary existing binary without serving a byte. Such assets must
+    /// not match at all.
+    #[test]
+    fn an_asset_name_that_escapes_the_build_directory_is_never_selected() {
+        let releases: Vec<GitHubRelease> = serde_json::from_str(
+            r#"[{
+                "tag_name": "151.0.7922.71-1.1",
+                "draft": false,
+                "prerelease": false,
+                "assets": [
+                    {"name": "../../../../../../usr/bin_windows_x64.zip",
+                     "browser_download_url": "https://example.com/evil.zip"},
+                    {"name": "nested/path_windows_x64.zip",
+                     "browser_download_url": "https://example.com/evil2.zip"}
+                ]
+            }]"#,
+        )
+        .unwrap();
+
+        let err = resolve_ungoogled(&releases, &VersionSpec::Latest, Platform::Win64, "repo")
+            .unwrap_err();
+        // Fails closed: the hostile asset simply is not a candidate.
+        assert!(matches!(err, FetcherError::VersionNotFound(_)), "{err:?}");
+        assert!(list_ungoogled(&releases, Platform::Win64).is_empty());
+    }
+
+    #[test]
+    fn plain_filename_check_accepts_real_assets_and_rejects_path_shapes() {
+        assert!(is_plain_filename(
+            "ungoogled-chromium_151.0.7922.71-1.1_windows_x64.zip"
+        ));
+        assert!(is_plain_filename(
+            "ungoogled-chromium-151.0.7922.71-1-x86_64.AppImage"
+        ));
+        // A leading dot is only suspicious, not an escape.
+        assert!(is_plain_filename("..leading-dots_windows_x64.zip"));
+
+        assert!(!is_plain_filename(""));
+        assert!(!is_plain_filename("."));
+        assert!(!is_plain_filename(".."));
+        assert!(!is_plain_filename("../evil.zip"));
+        assert!(!is_plain_filename("a/b.zip"));
+        // Backslashes are rejected on every host, since a build is routinely
+        // fetched for a platform other than the running one.
+        assert!(!is_plain_filename(r"..\evil.zip"));
+        assert!(!is_plain_filename("evil\0.zip"));
     }
 
     #[test]

--- a/crates/zendriver-fetcher/src/resolver.rs
+++ b/crates/zendriver-fetcher/src/resolver.rs
@@ -51,6 +51,13 @@ pub(crate) const DEFAULT_GITHUB_API_BASE: &str = "https://api.github.com";
 pub(crate) struct Resolved {
     /// Cache directory name and the build identity reported to the caller:
     /// a Chrome version for CfT/ungoogled, `r<revision>` for snapshots.
+    ///
+    /// **Invariant: a single plain directory name.** It is joined onto the
+    /// cache root to form the build directory, so a `..` or an absolute value
+    /// relocates the whole install — and, because the cache-hit check runs
+    /// before any download, can nominate an existing binary to execute.
+    /// Enforced by [`checked_build_id`] at every construction site that takes
+    /// it from an index.
     pub build_id: String,
     /// Where to download it from.
     pub url: String,
@@ -144,7 +151,7 @@ pub(crate) fn resolve_cft(
         .find(|d| d.platform == key)
         .ok_or(FetcherError::UnsupportedPlatform)?;
 
-    Ok(cft_resolved(&entry.version, &download.url, platform))
+    cft_resolved(&entry.version, &download.url, platform)
 }
 
 /// Resolve a non-stable [`Channel`] from Chrome for Testing's
@@ -174,18 +181,18 @@ pub(crate) fn resolve_cft_channel(
         .find(|d| d.platform == platform_key)
         .ok_or(FetcherError::UnsupportedPlatform)?;
 
-    Ok(cft_resolved(&entry.version, &download.url, platform))
+    cft_resolved(&entry.version, &download.url, platform)
 }
 
-fn cft_resolved(version: &str, url: &str, platform: Platform) -> Resolved {
-    Resolved {
-        build_id: version.to_string(),
+fn cft_resolved(version: &str, url: &str, platform: Platform) -> Result<Resolved, FetcherError> {
+    Ok(Resolved {
+        build_id: checked_build_id(version, Distribution::ChromeForTesting)?,
         url: url.to_string(),
         archive: Archive::Zip {
             top_dir: platform.cft_top_dir().to_string(),
         },
         binary_subpath: cft_binary_subpath(platform),
-    }
+    })
 }
 
 /// Versions the manifest actually publishes for `platform`, newest first.
@@ -195,6 +202,9 @@ pub(crate) fn list_cft(manifest: &KnownGoodVersionsResponse, platform: Platform)
         .versions
         .iter()
         .rev() // the manifest is oldest-first
+        // Never offer a build that resolution would refuse — same rule, and
+        // the same fail-closed direction, as `asset_for`.
+        .filter(|v| is_plain_filename(&v.version))
         .filter(|v| v.downloads.chrome.iter().any(|d| d.platform == key))
         .map(|v| Build {
             spec: VersionSpec::Explicit(v.version.clone()),
@@ -282,7 +292,10 @@ pub(crate) fn resolve_ungoogled(
     let archive_top = asset.name.strip_suffix(".zip").unwrap_or(&asset.name);
 
     Ok(Resolved {
-        build_id: chrome_version_of_tag(&release.tag_name).to_string(),
+        build_id: checked_build_id(
+            chrome_version_of_tag(&release.tag_name),
+            Distribution::UngoogledChromium,
+        )?,
         url: asset.browser_download_url.clone(),
         archive: ungoogled_archive(platform, archive_top),
         binary_subpath: ungoogled_binary_subpath(platform, archive_top),
@@ -295,6 +308,7 @@ pub(crate) fn list_ungoogled(releases: &[GitHubRelease], platform: Platform) -> 
     releases
         .iter()
         .filter(|r| is_published(r))
+        .filter(|r| is_plain_filename(chrome_version_of_tag(&r.tag_name)))
         .filter(|r| asset_for(r, suffix).is_some())
         .map(|r| {
             let version = chrome_version_of_tag(&r.tag_name);
@@ -447,6 +461,33 @@ pub(crate) fn resolve_snapshot(base: &str, revision: u64, platform: Platform) ->
 // ---------------------------------------------------------------------------
 // shared
 // ---------------------------------------------------------------------------
+
+/// Accept a build id only if it is a single plain directory name.
+///
+/// `build_id` is index-controlled — a Chrome for Testing manifest `version`, or
+/// the version half of an ungoogled release tag — and [`crate::cache::build_dir`]
+/// joins it straight onto the cache root. `VersionSpec::Latest`, the default,
+/// constrains it not at all: whatever the index says is newest is what lands in
+/// a path.
+///
+/// So the same reasoning as [`is_plain_filename`] applies with the same force.
+/// `ensure_chrome` joins `binary_subpath` onto the build directory and checks it
+/// for runnability *before* downloading anything, then returns it for the caller
+/// to execute — so a `..` or an absolute value here lets a compromised index
+/// nominate an arbitrary existing binary without ever serving a byte, and an
+/// ordinary one relocates the whole install outside the cache.
+///
+/// Fails closed, like every other check on index data here.
+fn checked_build_id(build_id: &str, distribution: Distribution) -> Result<String, FetcherError> {
+    if is_plain_filename(build_id) {
+        Ok(build_id.to_string())
+    } else {
+        Err(FetcherError::VersionNotFound(format!(
+            "the {} index offered build id {build_id:?}, which is not a plain directory name",
+            distribution.title()
+        )))
+    }
+}
 
 fn revision_unsupported(distribution: &'static str, revision: u64) -> FetcherError {
     FetcherError::UnsupportedSelector {
@@ -920,6 +961,69 @@ mod tests {
         // Fails closed: the hostile asset simply is not a candidate.
         assert!(matches!(err, FetcherError::VersionNotFound(_)), "{err:?}");
         assert!(list_ungoogled(&releases, Platform::Win64).is_empty());
+    }
+
+    /// The tag is the *other* index-controlled string that reaches a path, and
+    /// it reaches a bigger one: `build_id` is the cache directory itself.
+    /// `VersionSpec::Latest` — the default — puts no constraint on the tag at
+    /// all, so whatever the index calls newest is what gets joined onto the
+    /// cache root.
+    #[test]
+    fn a_tag_that_escapes_the_cache_root_is_refused() {
+        let releases = |tag: &str| -> Vec<GitHubRelease> {
+            serde_json::from_str(&format!(
+                r#"[{{
+                    "tag_name": "{tag}",
+                    "draft": false,
+                    "prerelease": false,
+                    "assets": [
+                        {{"name": "ungoogled-chromium_151_windows_x64.zip",
+                         "browser_download_url": "https://example.com/x.zip"}}
+                    ]
+                }}]"#
+            ))
+            .unwrap()
+        };
+
+        // `chrome_version_of_tag` splits on `-`, so a tag without one passes
+        // through whole.
+        for tag in ["../../../../PLANTED", "/tmp/evil", "..", "."] {
+            let rs = releases(tag);
+            let err =
+                resolve_ungoogled(&rs, &VersionSpec::Latest, Platform::Win64, "repo").unwrap_err();
+            assert!(
+                matches!(err, FetcherError::VersionNotFound(_)),
+                "tag {tag:?} produced {err:?}"
+            );
+            assert!(
+                list_ungoogled(&rs, Platform::Win64).is_empty(),
+                "tag {tag:?} was still offered in the listing"
+            );
+        }
+
+        // A normal tag still resolves, packaging suffix and all.
+        let ok = resolve_ungoogled(
+            &releases("151.0.7922.71-1.1"),
+            &VersionSpec::Latest,
+            Platform::Win64,
+            "repo",
+        )
+        .unwrap();
+        assert_eq!(ok.build_id, "151.0.7922.71");
+    }
+
+    /// Same hole, reached through the Chrome for Testing manifest's `version`.
+    #[test]
+    fn a_manifest_version_that_escapes_the_cache_root_is_refused() {
+        let manifest: KnownGoodVersionsResponse = serde_json::from_str(
+            r#"{"versions":[{"version":"../../../../PLANTED","revision":"1","downloads":{
+                "chrome":[{"platform":"linux64","url":"https://example.com/x.zip"}]}}]}"#,
+        )
+        .unwrap();
+
+        let err = resolve_cft(&manifest, &VersionSpec::Latest, Platform::LinuxX64).unwrap_err();
+        assert!(matches!(err, FetcherError::VersionNotFound(_)), "{err:?}");
+        assert!(list_cft(&manifest, Platform::LinuxX64).is_empty());
     }
 
     #[test]

--- a/crates/zendriver-fetcher/src/resolver.rs
+++ b/crates/zendriver-fetcher/src/resolver.rs
@@ -268,13 +268,28 @@ pub(crate) fn resolve_ungoogled(
                 *rev,
             ));
         }
-        VersionSpec::Explicit(want) => releases
-            .iter()
-            .filter(|r| is_published(r))
-            .find(|r| tag_matches_version(&r.tag_name, want))
-            .ok_or_else(|| {
-                FetcherError::VersionNotFound(format!("{want} (searched {repo} releases)"))
-            })?,
+        VersionSpec::Explicit(want) => {
+            // One Chrome version can be tagged more than once — the packaging
+            // revision differs (`-1`, `-1.1`) and the repos re-cut a release to
+            // add an arch. So prefer a matching release that actually carries
+            // this platform's asset, rather than whichever tag matched first;
+            // otherwise a version the listing offers can fail to resolve.
+            let matching = || {
+                releases
+                    .iter()
+                    .filter(|r| is_published(r))
+                    .filter(|r| tag_matches_version(&r.tag_name, want))
+            };
+            matching()
+                .find(|r| asset_for(r, suffix).is_some())
+                // Fall back to any tag match so a version built for no arch at
+                // all still reports `AssetNotFound`, naming the suffix it
+                // looked for, rather than the blunter `VersionNotFound`.
+                .or_else(|| matching().next())
+                .ok_or_else(|| {
+                    FetcherError::VersionNotFound(format!("{want} (searched {repo} releases)"))
+                })?
+        }
     };
 
     let asset = asset_for(release, suffix).ok_or_else(|| FetcherError::AssetNotFound {
@@ -901,6 +916,43 @@ mod tests {
         assert!(matches!(err, FetcherError::VersionNotFound(_)));
         assert!(msg.contains("151.0.7922.71"), "{msg}");
         assert!(msg.contains("ungoogled-chromium-macos"), "{msg}");
+    }
+
+    /// One Chrome version, two tags — the repos re-cut a release to add an
+    /// arch, so the tag that matches first is not always the one carrying this
+    /// platform's build. Picking by tag order alone makes a version the listing
+    /// offers fail to resolve.
+    #[test]
+    fn an_explicit_version_prefers_the_tag_that_has_this_platforms_asset() {
+        let releases: Vec<GitHubRelease> = serde_json::from_str(
+            r#"[
+                {"tag_name": "151.0.7922.71-1.2", "draft": false, "prerelease": false,
+                 "assets": [{"name": "ungoogled-chromium_151.0.7922.71-1.2_windows_x64.zip",
+                             "browser_download_url": "https://example.com/x64.zip"}]},
+                {"tag_name": "151.0.7922.71-1.1", "draft": false, "prerelease": false,
+                 "assets": [{"name": "ungoogled-chromium_151.0.7922.71-1.1_windows_x86.zip",
+                             "browser_download_url": "https://example.com/x86.zip"}]}
+            ]"#,
+        )
+        .unwrap();
+
+        // win32's asset is on the SECOND tag; the first one matches the version
+        // just as well and has no x86 build.
+        let r = resolve_ungoogled(
+            &releases,
+            &VersionSpec::Explicit("151.0.7922.71".into()),
+            Platform::Win32,
+            "repo",
+        )
+        .unwrap();
+        assert_eq!(r.url, "https://example.com/x86.zip");
+
+        // And the listing offered it, so the two now agree.
+        assert!(
+            list_ungoogled(&releases, Platform::Win32)
+                .iter()
+                .any(|b| b.spec == VersionSpec::Explicit("151.0.7922.71".into()))
+        );
     }
 
     /// A release that exists but carries no asset for this arch is a distinct

--- a/crates/zendriver-fetcher/src/resolver.rs
+++ b/crates/zendriver-fetcher/src/resolver.rs
@@ -274,16 +274,17 @@ pub(crate) fn resolve_ungoogled(
         suffix,
     })?;
 
-    let archive = ungoogled_archive(platform, &asset.name);
-    // The Windows zip's top-level directory is the asset name without its
-    // extension, so the binary path has to be threaded through from the asset
-    // rather than derived from the platform alone.
-    let archive_top = asset.name.trim_end_matches(".zip");
+    // The Windows zip's top-level directory is the asset name minus `.zip`, so
+    // unlike every other case it comes from the asset rather than from the
+    // platform. Derived once and shared: the archive's expected top-level
+    // directory and the binary's path through it have to be the same string,
+    // or extraction succeeds and the lookup afterwards misses.
+    let archive_top = asset.name.strip_suffix(".zip").unwrap_or(&asset.name);
 
     Ok(Resolved {
         build_id: chrome_version_of_tag(&release.tag_name).to_string(),
         url: asset.browser_download_url.clone(),
-        archive,
+        archive: ungoogled_archive(platform, archive_top),
         binary_subpath: ungoogled_binary_subpath(platform, archive_top),
     })
 }
@@ -369,7 +370,9 @@ fn chrome_version_of_tag(tag: &str) -> &str {
     tag.split('-').next().unwrap_or(tag)
 }
 
-fn ungoogled_archive(platform: Platform, asset_name: &str) -> Archive {
+/// How this platform's ungoogled asset is packaged. `archive_top` is the zip's
+/// top-level directory, used only on Windows — see [`resolve_ungoogled`].
+fn ungoogled_archive(platform: Platform, archive_top: &str) -> Archive {
     match platform {
         Platform::LinuxX64 => Archive::Executable {
             file_name: UNGOOGLED_APPIMAGE_NAME.to_string(),
@@ -378,7 +381,7 @@ fn ungoogled_archive(platform: Platform, asset_name: &str) -> Archive {
             app_dir: UNGOOGLED_APP_BUNDLE.to_string(),
         },
         Platform::Win32 | Platform::Win64 => Archive::Zip {
-            top_dir: asset_name.trim_end_matches(".zip").to_string(),
+            top_dir: archive_top.to_string(),
         },
     }
 }

--- a/crates/zendriver-fetcher/src/resolver.rs
+++ b/crates/zendriver-fetcher/src/resolver.rs
@@ -1,26 +1,86 @@
-//! Version + platform → download URL resolution.
+//! Version + platform → download URL resolution, per distribution.
 //!
-//! Given a parsed Chrome-for-Testing manifest plus a
-//! [`VersionSpec`]/[`Platform`] pair, picks the matching `(version, url)`
-//! tuple — or returns a specific [`FetcherError`] when no match is possible.
+//! This is the *whole* distribution axis. Everything after resolution —
+//! streaming, SHA256, unpacking, the atomic cache — is shared, so each
+//! distribution's contribution is a single function that turns a
+//! [`VersionSpec`] + [`Platform`] into a [`Resolved`].
 //!
-//! Split out from manifest fetching so unit tests can drive the resolver
-//! with hand-built manifests, without touching the network.
+//! The three indexes are shaped very differently:
+//!
+//! - **Chrome for Testing** publishes one JSON manifest covering every
+//!   version and platform. A lookup is a filter over a list.
+//! - **ungoogled-chromium** publishes no manifest. Three per-OS GitHub repos
+//!   each cut their own releases, tagged `<chrome version>-<packaging>`, so
+//!   an explicit version matches on the tag *prefix* and availability is
+//!   answered per platform rather than assumed uniform.
+//! - **Chromium snapshots** are keyed by revision, with no version index at
+//!   all. That makes [`VersionSpec::Explicit`] unanswerable, and it is
+//!   refused rather than silently served the newest build.
+//!
+//! Every function here is pure — it takes an already-fetched manifest or
+//! release list — so the tests drive them from inline JSON literals with no
+//! network involved.
 
+use std::path::PathBuf;
+
+use crate::archive::Archive;
+use crate::cache::{
+    UNGOOGLED_APP_BUNDLE, UNGOOGLED_APPIMAGE_NAME, cft_binary_subpath, snapshot_binary_subpath,
+    ungoogled_binary_subpath,
+};
+use crate::distribution::Distribution;
 use crate::error::FetcherError;
-use crate::manifest::{ChannelsResponse, KnownGoodVersionsResponse};
+use crate::manifest::{ChannelsResponse, GitHubRelease, KnownGoodVersionsResponse};
 use crate::platform::Platform;
 use crate::version::{Channel, VersionSpec};
 
-/// Resolve a `(version_string, download_url)` pair from a parsed
-/// [`KnownGoodVersionsResponse`] manifest.
+/// Canonical base for Chromium's continuous-build snapshot bucket.
+pub(crate) const DEFAULT_SNAPSHOT_BASE: &str =
+    "https://commondatastorage.googleapis.com/chromium-browser-snapshots";
+
+/// Canonical base for GitHub's REST API.
+pub(crate) const DEFAULT_GITHUB_API_BASE: &str = "https://api.github.com";
+
+/// A download, fully pinned down.
 ///
-/// Only reached for [`VersionSpec::Latest`]/[`VersionSpec::Stable`]/
+/// Carries the archive shape and binary location alongside the URL because
+/// those differ per distribution *and* per platform: a CfT zip, an ungoogled
+/// AppImage and an ungoogled disk image need three different unpack steps and
+/// land the executable in three different places.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Resolved {
+    /// Cache directory name and the build identity reported to the caller:
+    /// a Chrome version for CfT/ungoogled, `r<revision>` for snapshots.
+    pub build_id: String,
+    /// Where to download it from.
+    pub url: String,
+    /// How the download is packaged.
+    pub archive: Archive,
+    /// Executable path relative to the build directory.
+    pub binary_subpath: PathBuf,
+}
+
+/// One selectable build, for menus and listings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Build {
+    /// Selector that resolves exactly this build.
+    pub spec: VersionSpec,
+    /// One-line description, e.g. `151.0.7922.71 (tag 151.0.7922.71-1.1)`.
+    pub label: String,
+}
+
+// ---------------------------------------------------------------------------
+// Chrome for Testing
+// ---------------------------------------------------------------------------
+
+/// Resolve against Chrome for Testing's flat
+/// `known-good-versions-with-downloads.json` manifest.
+///
+/// Reached for [`VersionSpec::Latest`]/[`VersionSpec::Stable`]/
 /// [`VersionSpec::Channel(Channel::Stable)`](VersionSpec::Channel)/
 /// [`VersionSpec::Explicit`] — the non-stable channels resolve through
-/// [`resolve_channel_download_url`] against a different (per-channel)
-/// manifest instead, since `known-good-versions-with-downloads.json` only
-/// ever tracks the stable channel's history.
+/// [`resolve_cft_channel`] against the per-channel manifest instead, since
+/// the flat manifest only ever tracks stable's history.
 ///
 /// # Errors
 ///
@@ -28,12 +88,13 @@ use crate::version::{Channel, VersionSpec};
 ///   match any entry in the manifest.
 /// - [`FetcherError::UnsupportedPlatform`] if the manifest has no download
 ///   for `platform`.
-pub(crate) async fn resolve_download_url(
+/// - [`FetcherError::UnsupportedSelector`] for [`VersionSpec::Revision`],
+///   which Chrome for Testing does not index.
+pub(crate) fn resolve_cft(
     manifest: &KnownGoodVersionsResponse,
     spec: &VersionSpec,
     platform: Platform,
-) -> Result<(String, String), FetcherError> {
-    // Pick the manifest entry matching the version spec.
+) -> Result<Resolved, FetcherError> {
     let entry = match spec {
         VersionSpec::Latest | VersionSpec::Stable | VersionSpec::Channel(Channel::Stable) => {
             manifest
@@ -42,12 +103,13 @@ pub(crate) async fn resolve_download_url(
                 .ok_or_else(|| FetcherError::VersionNotFound("manifest is empty".to_string()))?
         }
         VersionSpec::Channel(Channel::Beta | Channel::Dev | Channel::Canary) => {
-            // Callers should route these through `resolve_channel_download_url`
-            // + `ChannelsResponse` instead (see `Fetcher::ensure_chrome`).
-            // Defensive fallback if this function is ever called directly
-            // with a non-stable channel against the flat manifest.
+            // Callers route these through `resolve_cft_channel` +
+            // `ChannelsResponse` (see `Fetcher::ensure_chrome`). Defensive
+            // fallback if this is ever called directly with a non-stable
+            // channel against the flat manifest.
             return Err(FetcherError::UnsupportedPlatform);
         }
+        VersionSpec::Revision(rev) => return Err(revision_unsupported(spec_dist_cft(), *rev)),
         VersionSpec::Explicit(want) => manifest
             .versions
             .iter()
@@ -55,7 +117,6 @@ pub(crate) async fn resolve_download_url(
             .ok_or_else(|| FetcherError::VersionNotFound(want.clone()))?,
     };
 
-    // Walk that entry's downloads.chrome for a matching platform.
     let key = platform.as_cft_str();
     let download = entry
         .downloads
@@ -64,26 +125,23 @@ pub(crate) async fn resolve_download_url(
         .find(|d| d.platform == key)
         .ok_or(FetcherError::UnsupportedPlatform)?;
 
-    Ok((entry.version.clone(), download.url.clone()))
+    Ok(cft_resolved(&entry.version, &download.url, platform))
 }
 
-/// Resolve a `(version_string, download_url)` pair for a non-stable
-/// [`Channel`] from a parsed [`ChannelsResponse`] manifest (Chrome for
-/// Testing's `last-known-good-versions-with-downloads.json`).
+/// Resolve a non-stable [`Channel`] from Chrome for Testing's
+/// `last-known-good-versions-with-downloads.json`.
 ///
 /// # Errors
 ///
 /// - [`FetcherError::VersionNotFound`] if the manifest's `channels` map has
-///   no entry for `channel` (unexpected — CfT always publishes all four —
-///   but the map is caller-supplied JSON, so this stays a recoverable error
-///   rather than a panic).
+///   no entry for `channel`.
 /// - [`FetcherError::UnsupportedPlatform`] if the channel entry has no
 ///   download for `platform`.
-pub(crate) async fn resolve_channel_download_url(
+pub(crate) fn resolve_cft_channel(
     manifest: &ChannelsResponse,
     channel: Channel,
     platform: Platform,
-) -> Result<(String, String), FetcherError> {
+) -> Result<Resolved, FetcherError> {
     let channel_key = channel.as_cft_str();
     let entry = manifest.channels.get(channel_key).ok_or_else(|| {
         FetcherError::VersionNotFound(format!("channel {channel_key} not present in manifest"))
@@ -97,7 +155,256 @@ pub(crate) async fn resolve_channel_download_url(
         .find(|d| d.platform == platform_key)
         .ok_or(FetcherError::UnsupportedPlatform)?;
 
-    Ok((entry.version.clone(), download.url.clone()))
+    Ok(cft_resolved(&entry.version, &download.url, platform))
+}
+
+fn cft_resolved(version: &str, url: &str, platform: Platform) -> Resolved {
+    Resolved {
+        build_id: version.to_string(),
+        url: url.to_string(),
+        archive: Archive::Zip {
+            top_dir: platform.cft_top_dir().to_string(),
+        },
+        binary_subpath: cft_binary_subpath(platform),
+    }
+}
+
+/// Versions the manifest actually publishes for `platform`, newest first.
+pub(crate) fn list_cft(manifest: &KnownGoodVersionsResponse, platform: Platform) -> Vec<Build> {
+    let key = platform.as_cft_str();
+    manifest
+        .versions
+        .iter()
+        .rev() // the manifest is oldest-first
+        .filter(|v| v.downloads.chrome.iter().any(|d| d.platform == key))
+        .map(|v| Build {
+            spec: VersionSpec::Explicit(v.version.clone()),
+            label: v.version.clone(),
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// ungoogled-chromium
+// ---------------------------------------------------------------------------
+
+/// Resolve against one per-OS ungoogled-chromium repo's release list.
+///
+/// `releases` is GitHub's own newest-first ordering. Drafts and prereleases
+/// are skipped, and a release only counts if it actually carries an asset for
+/// `platform` — the three repos release independently, so "this version
+/// exists" and "this version exists *for your platform*" are different
+/// questions and only the second one matters.
+///
+/// # Errors
+///
+/// - [`FetcherError::VersionNotFound`] if no release matches the spec.
+/// - [`FetcherError::AssetNotFound`] if the matched release publishes nothing
+///   for `platform`.
+/// - [`FetcherError::UnsupportedSelector`] for channels and revisions, which
+///   ungoogled-chromium does not publish.
+pub(crate) fn resolve_ungoogled(
+    releases: &[GitHubRelease],
+    spec: &VersionSpec,
+    platform: Platform,
+    repo: &str,
+) -> Result<Resolved, FetcherError> {
+    let suffix = platform.ungoogled_asset_suffix();
+
+    let release = match spec {
+        VersionSpec::Latest | VersionSpec::Stable | VersionSpec::Channel(Channel::Stable) => {
+            // Newest release that has a build for *this* platform.
+            releases
+                .iter()
+                .filter(|r| is_published(r))
+                .find(|r| asset_for(r, suffix).is_some())
+                .ok_or_else(|| {
+                    FetcherError::VersionNotFound(format!(
+                        "{repo} publishes no release with a {suffix} asset"
+                    ))
+                })?
+        }
+        VersionSpec::Channel(channel) => {
+            return Err(FetcherError::UnsupportedSelector {
+                distribution: Distribution::UngoogledChromium.title(),
+                selector: format!("the {} channel", channel.as_cft_str()),
+                reason: "ungoogled-chromium cuts a single release stream per platform and has no \
+                         channels; use the latest release or pin an explicit version"
+                    .to_string(),
+            });
+        }
+        VersionSpec::Revision(rev) => {
+            return Err(revision_unsupported(
+                Distribution::UngoogledChromium.title(),
+                *rev,
+            ));
+        }
+        VersionSpec::Explicit(want) => releases
+            .iter()
+            .filter(|r| is_published(r))
+            .find(|r| tag_matches_version(&r.tag_name, want))
+            .ok_or_else(|| {
+                FetcherError::VersionNotFound(format!("{want} (searched {repo} releases)"))
+            })?,
+    };
+
+    let asset = asset_for(release, suffix).ok_or_else(|| FetcherError::AssetNotFound {
+        repo: repo.to_string(),
+        tag: release.tag_name.clone(),
+        platform: platform.as_cft_str(),
+        suffix,
+    })?;
+
+    let archive = ungoogled_archive(platform, &asset.name);
+    // The Windows zip's top-level directory is the asset name without its
+    // extension, so the binary path has to be threaded through from the asset
+    // rather than derived from the platform alone.
+    let archive_top = asset.name.trim_end_matches(".zip");
+
+    Ok(Resolved {
+        build_id: chrome_version_of_tag(&release.tag_name).to_string(),
+        url: asset.browser_download_url.clone(),
+        archive,
+        binary_subpath: ungoogled_binary_subpath(platform, archive_top),
+    })
+}
+
+/// Releases with a build for `platform`, newest first.
+pub(crate) fn list_ungoogled(releases: &[GitHubRelease], platform: Platform) -> Vec<Build> {
+    let suffix = platform.ungoogled_asset_suffix();
+    releases
+        .iter()
+        .filter(|r| is_published(r))
+        .filter(|r| asset_for(r, suffix).is_some())
+        .map(|r| {
+            let version = chrome_version_of_tag(&r.tag_name);
+            Build {
+                spec: VersionSpec::Explicit(version.to_string()),
+                label: format!("{version}  (tag {})", r.tag_name),
+            }
+        })
+        .collect()
+}
+
+fn is_published(release: &GitHubRelease) -> bool {
+    !release.draft && !release.prerelease
+}
+
+fn asset_for<'a>(
+    release: &'a GitHubRelease,
+    suffix: &str,
+) -> Option<&'a crate::manifest::GitHubAsset> {
+    release.assets.iter().find(|a| a.name.ends_with(suffix))
+}
+
+/// Does `tag` name Chrome version `want`?
+///
+/// ungoogled tags are `<chrome version>-<packaging revision>` —
+/// `151.0.7922.71-1.1` on Windows/macOS, `151.0.7922.71-1` on portablelinux —
+/// so matching is by prefix, not equality. The `-` boundary check is what
+/// stops `151.0.7922.7` matching `151.0.7922.71-1.1`; a bare `starts_with`
+/// would hand back a different build than the one requested.
+fn tag_matches_version(tag: &str, want: &str) -> bool {
+    tag == want
+        || tag
+            .strip_prefix(want)
+            .is_some_and(|rest| rest.starts_with('-'))
+}
+
+/// Chrome version carried by an ungoogled tag: everything before the
+/// packaging suffix.
+fn chrome_version_of_tag(tag: &str) -> &str {
+    tag.split('-').next().unwrap_or(tag)
+}
+
+fn ungoogled_archive(platform: Platform, asset_name: &str) -> Archive {
+    match platform {
+        Platform::LinuxX64 => Archive::Executable {
+            file_name: UNGOOGLED_APPIMAGE_NAME.to_string(),
+        },
+        Platform::MacX64 | Platform::MacArm64 => Archive::AppBundleDmg {
+            app_dir: UNGOOGLED_APP_BUNDLE.to_string(),
+        },
+        Platform::Win32 | Platform::Win64 => Archive::Zip {
+            top_dir: asset_name.trim_end_matches(".zip").to_string(),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Chromium snapshots
+// ---------------------------------------------------------------------------
+
+/// Which revision a spec selects, or `None` for "whatever `LAST_CHANGE` says".
+///
+/// Pure, so the refusals are testable without a network stub — and they are
+/// the interesting part. The snapshot bucket is laid out
+/// `<platform>/<revision>/…` and publishes no version index whatsoever, so
+/// there is nothing to look `151.0.7922.76` up in. Answering such a request
+/// with the newest snapshot would return a *different browser* than the one
+/// asked for, which is worse than an error, so it is refused with the
+/// alternative named.
+pub(crate) fn snapshot_revision_for(spec: &VersionSpec) -> Result<Option<u64>, FetcherError> {
+    match spec {
+        VersionSpec::Latest | VersionSpec::Stable | VersionSpec::Channel(Channel::Stable) => {
+            Ok(None)
+        }
+        VersionSpec::Revision(rev) => Ok(Some(*rev)),
+        VersionSpec::Channel(channel) => Err(FetcherError::UnsupportedSelector {
+            distribution: Distribution::ChromiumSnapshot.title(),
+            selector: format!("the {} channel", channel.as_cft_str()),
+            reason: "the snapshot bucket is a continuous per-commit build with no channels; \
+                     use the latest snapshot or pin a revision"
+                .to_string(),
+        }),
+        VersionSpec::Explicit(version) => Err(FetcherError::UnsupportedSelector {
+            distribution: Distribution::ChromiumSnapshot.title(),
+            selector: format!("version {version}"),
+            reason: format!(
+                "snapshots are keyed by revision, not version, and the bucket publishes no \
+                 version index — there is nothing to look {version} up in. Pin a revision \
+                 instead (VersionSpec::Revision / --revision), or take the newest snapshot \
+                 with --version latest"
+            ),
+        }),
+    }
+}
+
+/// Build the download for a known snapshot revision.
+///
+/// The bucket layout is `<base>/<Platform>/<revision>/<stem>.zip`, and the
+/// zip's single top-level directory is that same `<stem>`.
+pub(crate) fn resolve_snapshot(base: &str, revision: u64, platform: Platform) -> Resolved {
+    let dir = platform.as_snapshot_str();
+    let stem = platform.snapshot_archive_stem();
+    Resolved {
+        // `r` prefix so a revision can never be mistaken for — or collide
+        // with — a version directory in the cache.
+        build_id: format!("r{revision}"),
+        url: format!("{}/{dir}/{revision}/{stem}.zip", base.trim_end_matches('/')),
+        archive: Archive::Zip {
+            top_dir: stem.to_string(),
+        },
+        binary_subpath: snapshot_binary_subpath(platform),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// shared
+// ---------------------------------------------------------------------------
+
+fn spec_dist_cft() -> &'static str {
+    Distribution::ChromeForTesting.title()
+}
+
+fn revision_unsupported(distribution: &'static str, revision: u64) -> FetcherError {
+    FetcherError::UnsupportedSelector {
+        distribution,
+        selector: format!("revision {revision}"),
+        reason: "this distribution is indexed by version, not by Chromium revision; \
+                 use --distribution snapshot to fetch by revision"
+            .to_string(),
+    }
 }
 
 #[cfg(test)]
@@ -106,10 +413,19 @@ mod tests {
     use super::*;
 
     fn fixture_manifest() -> KnownGoodVersionsResponse {
-        // Hand-built equivalent of the wiremock fixture in manifest.rs:
-        // one version with linux64 + mac-x64 downloads.
+        // Oldest-first, like the real manifest: one older version and one
+        // newer, with different platform coverage.
         let json = r#"{
             "versions": [
+                {
+                    "version": "119.0.6045.105",
+                    "revision": "1230",
+                    "downloads": {
+                        "chrome": [
+                            {"platform": "linux64", "url": "https://example.com/119-linux64.zip"}
+                        ]
+                    }
+                },
                 {
                     "version": "120.0.6099.234",
                     "revision": "1234",
@@ -125,26 +441,31 @@ mod tests {
         serde_json::from_str(json).unwrap()
     }
 
-    #[tokio::test]
-    async fn latest_returns_last_entry_url_for_matching_platform() {
-        let manifest = fixture_manifest();
-        let (version, url) =
-            resolve_download_url(&manifest, &VersionSpec::Latest, Platform::LinuxX64)
-                .await
-                .unwrap();
-        assert_eq!(version, "120.0.6099.234");
-        assert_eq!(url, "https://example.com/chrome-linux64.zip");
+    #[test]
+    fn latest_returns_last_entry_url_for_matching_platform() {
+        let r = resolve_cft(
+            &fixture_manifest(),
+            &VersionSpec::Latest,
+            Platform::LinuxX64,
+        )
+        .unwrap();
+        assert_eq!(r.build_id, "120.0.6099.234");
+        assert_eq!(r.url, "https://example.com/chrome-linux64.zip");
+        assert_eq!(
+            r.archive,
+            Archive::Zip {
+                top_dir: "chrome-linux64".into()
+            }
+        );
     }
 
-    #[tokio::test]
-    async fn explicit_unknown_version_returns_version_not_found() {
-        let manifest = fixture_manifest();
-        let err = resolve_download_url(
-            &manifest,
+    #[test]
+    fn explicit_unknown_version_returns_version_not_found() {
+        let err = resolve_cft(
+            &fixture_manifest(),
             &VersionSpec::Explicit("999.0".to_string()),
             Platform::LinuxX64,
         )
-        .await
         .unwrap_err();
         match err {
             FetcherError::VersionNotFound(v) => assert_eq!(v, "999.0"),
@@ -152,29 +473,53 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn beta_channel_returns_unsupported_platform_against_flat_manifest() {
-        // `resolve_download_url` + the flat `KnownGoodVersionsResponse`
-        // manifest never resolve a non-stable channel — that now routes
-        // through `resolve_channel_download_url` + `ChannelsResponse`
-        // instead (see the tests below). This just pins the defensive
-        // fallback in case `resolve_download_url` is ever called directly
-        // with a non-stable channel.
-        let manifest = fixture_manifest();
-        let err = resolve_download_url(
-            &manifest,
+    #[test]
+    fn beta_channel_returns_unsupported_platform_against_flat_manifest() {
+        // The flat manifest never resolves a non-stable channel — that routes
+        // through `resolve_cft_channel` + `ChannelsResponse` instead. This
+        // pins the defensive fallback.
+        let err = resolve_cft(
+            &fixture_manifest(),
             &VersionSpec::Channel(Channel::Beta),
             Platform::LinuxX64,
         )
-        .await
         .unwrap_err();
         assert!(matches!(err, FetcherError::UnsupportedPlatform));
     }
 
+    #[test]
+    fn cft_refuses_a_revision_and_points_at_snapshots() {
+        let err = resolve_cft(
+            &fixture_manifest(),
+            &VersionSpec::Revision(1674890),
+            Platform::LinuxX64,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(matches!(err, FetcherError::UnsupportedSelector { .. }));
+        assert!(msg.contains("revision 1674890"), "{msg}");
+        assert!(msg.contains("--distribution snapshot"), "{msg}");
+    }
+
+    #[test]
+    fn list_cft_is_newest_first_and_platform_filtered() {
+        let manifest = fixture_manifest();
+
+        let linux = list_cft(&manifest, Platform::LinuxX64);
+        assert_eq!(linux.len(), 2);
+        assert_eq!(linux[0].label, "120.0.6099.234");
+        assert_eq!(linux[1].label, "119.0.6045.105");
+
+        // Only the newer entry has a mac-x64 download.
+        let mac = list_cft(&manifest, Platform::MacX64);
+        assert_eq!(mac.len(), 1);
+        assert_eq!(mac[0].spec, VersionSpec::Explicit("120.0.6099.234".into()));
+
+        // ...and none has a win64 one.
+        assert!(list_cft(&manifest, Platform::Win64).is_empty());
+    }
+
     fn fixture_channels_manifest() -> ChannelsResponse {
-        // Hand-built equivalent of Chrome for Testing's
-        // `last-known-good-versions-with-downloads.json`: keyed by channel
-        // name rather than a flat version list.
         let json = r#"{
             "timestamp": "2026-07-16T00:00:00.000Z",
             "channels": {
@@ -223,56 +568,425 @@ mod tests {
         serde_json::from_str(json).unwrap()
     }
 
-    #[tokio::test]
-    async fn beta_channel_resolves_from_channels_manifest() {
-        let manifest = fixture_channels_manifest();
-        let (version, url) =
-            resolve_channel_download_url(&manifest, Channel::Beta, Platform::LinuxX64)
-                .await
-                .unwrap();
-        assert_eq!(version, "121.0.6100.10");
-        assert_eq!(url, "https://example.com/beta-linux64.zip");
+    #[test]
+    fn beta_channel_resolves_from_channels_manifest() {
+        let r = resolve_cft_channel(
+            &fixture_channels_manifest(),
+            Channel::Beta,
+            Platform::LinuxX64,
+        )
+        .unwrap();
+        assert_eq!(r.build_id, "121.0.6100.10");
+        assert_eq!(r.url, "https://example.com/beta-linux64.zip");
     }
 
-    #[tokio::test]
-    async fn dev_and_canary_channels_resolve_from_channels_manifest() {
+    #[test]
+    fn dev_and_canary_channels_resolve_from_channels_manifest() {
         let manifest = fixture_channels_manifest();
 
-        let (version, url) =
-            resolve_channel_download_url(&manifest, Channel::Dev, Platform::MacX64)
-                .await
-                .unwrap();
-        assert_eq!(version, "122.0.6101.5");
-        assert_eq!(url, "https://example.com/dev-mac-x64.zip");
+        let r = resolve_cft_channel(&manifest, Channel::Dev, Platform::MacX64).unwrap();
+        assert_eq!(r.build_id, "122.0.6101.5");
+        assert_eq!(r.url, "https://example.com/dev-mac-x64.zip");
 
-        let (version, url) =
-            resolve_channel_download_url(&manifest, Channel::Canary, Platform::LinuxX64)
-                .await
-                .unwrap();
-        assert_eq!(version, "123.0.6102.1");
-        assert_eq!(url, "https://example.com/canary-linux64.zip");
+        let r = resolve_cft_channel(&manifest, Channel::Canary, Platform::LinuxX64).unwrap();
+        assert_eq!(r.build_id, "123.0.6102.1");
+        assert_eq!(r.url, "https://example.com/canary-linux64.zip");
     }
 
-    #[tokio::test]
-    async fn channel_missing_platform_returns_unsupported_platform() {
-        let manifest = fixture_channels_manifest();
+    #[test]
+    fn channel_missing_platform_returns_unsupported_platform() {
         // "Dev" only has a mac-x64 download in the fixture.
-        let err = resolve_channel_download_url(&manifest, Channel::Dev, Platform::LinuxX64)
-            .await
-            .unwrap_err();
+        let err = resolve_cft_channel(
+            &fixture_channels_manifest(),
+            Channel::Dev,
+            Platform::LinuxX64,
+        )
+        .unwrap_err();
         assert!(matches!(err, FetcherError::UnsupportedPlatform));
     }
 
-    #[tokio::test]
-    async fn channel_missing_from_manifest_returns_version_not_found() {
+    #[test]
+    fn channel_missing_from_manifest_returns_version_not_found() {
         let json = r#"{ "timestamp": "2026-07-16T00:00:00.000Z", "channels": {} }"#;
         let manifest: ChannelsResponse = serde_json::from_str(json).unwrap();
-        let err = resolve_channel_download_url(&manifest, Channel::Beta, Platform::LinuxX64)
-            .await
-            .unwrap_err();
+        let err = resolve_cft_channel(&manifest, Channel::Beta, Platform::LinuxX64).unwrap_err();
         match err {
             FetcherError::VersionNotFound(msg) => assert!(msg.contains("Beta")),
             other => panic!("expected VersionNotFound, got {other:?}"),
         }
+    }
+
+    // -- ungoogled ---------------------------------------------------------
+
+    /// Trimmed to the fields the resolver reads, in GitHub's newest-first
+    /// order, and modelling the availability skew that actually existed on
+    /// 2026-08-06: Windows had 151, macOS was still on 150.
+    fn fixture_windows_releases() -> Vec<GitHubRelease> {
+        let json = r#"[
+            {
+                "tag_name": "151.0.7922.71-1.1",
+                "draft": false,
+                "prerelease": false,
+                "assets": [
+                    {"name": "ungoogled-chromium_151.0.7922.71-1.1_installer_x64.exe",
+                     "browser_download_url": "https://example.com/151-installer-x64.exe"},
+                    {"name": "ungoogled-chromium_151.0.7922.71-1.1_windows_x64.zip",
+                     "browser_download_url": "https://example.com/151-windows-x64.zip"},
+                    {"name": "ungoogled-chromium_151.0.7922.71-1.1_windows_x86.zip",
+                     "browser_download_url": "https://example.com/151-windows-x86.zip"}
+                ]
+            },
+            {
+                "tag_name": "150.0.7871.186-1.1",
+                "draft": false,
+                "prerelease": false,
+                "assets": [
+                    {"name": "ungoogled-chromium_150.0.7871.186-1.1_windows_x64.zip",
+                     "browser_download_url": "https://example.com/150-windows-x64.zip"}
+                ]
+            }
+        ]"#;
+        serde_json::from_str(json).unwrap()
+    }
+
+    fn fixture_macos_releases() -> Vec<GitHubRelease> {
+        let json = r#"[
+            {
+                "tag_name": "150.0.7871.46-1.1",
+                "draft": false,
+                "prerelease": false,
+                "assets": [
+                    {"name": "ungoogled-chromium_150.0.7871.46-1.1_arm64-macos.dmg",
+                     "browser_download_url": "https://example.com/150-arm64.dmg"},
+                    {"name": "ungoogled-chromium_150.0.7871.46-1.1_x86_64-macos.dmg",
+                     "browser_download_url": "https://example.com/150-x86_64.dmg"}
+                ]
+            }
+        ]"#;
+        serde_json::from_str(json).unwrap()
+    }
+
+    fn fixture_linux_releases() -> Vec<GitHubRelease> {
+        // portablelinux uses a *shorter* packaging suffix (`-1`, not `-1.1`)
+        // and attaches `.zsync` sidecars next to each AppImage.
+        let json = r#"[
+            {
+                "tag_name": "151.0.7922.71-1",
+                "draft": false,
+                "prerelease": false,
+                "assets": [
+                    {"name": "ungoogled-chromium-151.0.7922.71-1-x86_64.AppImage",
+                     "browser_download_url": "https://example.com/151-x86_64.AppImage"},
+                    {"name": "ungoogled-chromium-151.0.7922.71-1-x86_64.AppImage.zsync",
+                     "browser_download_url": "https://example.com/151-x86_64.AppImage.zsync"},
+                    {"name": "ungoogled-chromium-151.0.7922.71-1-x86_64_linux.tar.xz",
+                     "browser_download_url": "https://example.com/151-x86_64.tar.xz"}
+                ]
+            }
+        ]"#;
+        serde_json::from_str(json).unwrap()
+    }
+
+    /// The headline ungoogled behaviour: a tag carries a packaging suffix, so
+    /// an explicit version matches the tag's *prefix*.
+    #[test]
+    fn explicit_version_matches_an_ungoogled_tag_by_prefix() {
+        let r = resolve_ungoogled(
+            &fixture_windows_releases(),
+            &VersionSpec::Explicit("151.0.7922.71".into()),
+            Platform::Win64,
+            "ungoogled-software/ungoogled-chromium-windows",
+        )
+        .unwrap();
+        assert_eq!(r.build_id, "151.0.7922.71");
+        assert_eq!(r.url, "https://example.com/151-windows-x64.zip");
+    }
+
+    /// Both suffix shapes in the wild resolve: `-1.1` on Windows/macOS and
+    /// `-1` on portablelinux.
+    #[test]
+    fn prefix_matching_handles_both_packaging_suffix_shapes() {
+        assert!(tag_matches_version("151.0.7922.71-1.1", "151.0.7922.71"));
+        assert!(tag_matches_version("151.0.7922.71-1", "151.0.7922.71"));
+        // The full tag also works, for anyone copying it off the releases page.
+        assert!(tag_matches_version(
+            "151.0.7922.71-1.1",
+            "151.0.7922.71-1.1"
+        ));
+    }
+
+    /// A bare `starts_with` would match here and hand back build `…71` for a
+    /// request for `…7`. The `-` boundary is what prevents it.
+    #[test]
+    fn prefix_matching_stops_at_the_packaging_separator() {
+        assert!(!tag_matches_version("151.0.7922.71-1.1", "151.0.7922.7"));
+        assert!(!tag_matches_version("151.0.7922.71-1.1", "151.0"));
+        assert!(!tag_matches_version("151.0.7922.71-1.1", "150.0.7871.46"));
+    }
+
+    #[test]
+    fn ungoogled_picks_the_right_asset_and_archive_per_platform() {
+        // Windows: a zip whose top-level dir is the asset name minus `.zip`.
+        let win = resolve_ungoogled(
+            &fixture_windows_releases(),
+            &VersionSpec::Latest,
+            Platform::Win64,
+            "repo",
+        )
+        .unwrap();
+        assert_eq!(
+            win.archive,
+            Archive::Zip {
+                top_dir: "ungoogled-chromium_151.0.7922.71-1.1_windows_x64".into()
+            }
+        );
+        assert_eq!(
+            win.binary_subpath,
+            std::path::Path::new("ungoogled-chromium_151.0.7922.71-1.1_windows_x64/chrome.exe")
+        );
+
+        // Linux: the AppImage, never the `.zsync` sidecar or the tarball.
+        let linux = resolve_ungoogled(
+            &fixture_linux_releases(),
+            &VersionSpec::Latest,
+            Platform::LinuxX64,
+            "repo",
+        )
+        .unwrap();
+        assert_eq!(linux.url, "https://example.com/151-x86_64.AppImage");
+        assert_eq!(
+            linux.archive,
+            Archive::Executable {
+                file_name: "chrome.AppImage".into()
+            }
+        );
+
+        // macOS: the arch-matching disk image.
+        let mac = resolve_ungoogled(
+            &fixture_macos_releases(),
+            &VersionSpec::Latest,
+            Platform::MacArm64,
+            "repo",
+        )
+        .unwrap();
+        assert_eq!(mac.url, "https://example.com/150-arm64.dmg");
+        assert_eq!(
+            mac.archive,
+            Archive::AppBundleDmg {
+                app_dir: "Chromium.app".into()
+            }
+        );
+        assert_eq!(
+            resolve_ungoogled(
+                &fixture_macos_releases(),
+                &VersionSpec::Latest,
+                Platform::MacX64,
+                "repo",
+            )
+            .unwrap()
+            .url,
+            "https://example.com/150-x86_64.dmg"
+        );
+    }
+
+    /// Availability genuinely differs per platform. Asking macOS for the
+    /// version Windows has must report *that*, not fall back to something
+    /// else.
+    #[test]
+    fn a_version_present_on_windows_but_not_macos_reports_not_found() {
+        let err = resolve_ungoogled(
+            &fixture_macos_releases(),
+            &VersionSpec::Explicit("151.0.7922.71".into()),
+            Platform::MacArm64,
+            "ungoogled-software/ungoogled-chromium-macos",
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(matches!(err, FetcherError::VersionNotFound(_)));
+        assert!(msg.contains("151.0.7922.71"), "{msg}");
+        assert!(msg.contains("ungoogled-chromium-macos"), "{msg}");
+    }
+
+    /// A release that exists but carries no asset for this arch is a distinct
+    /// failure from "no such version", and says which suffix it looked for.
+    #[test]
+    fn release_without_an_asset_for_the_platform_reports_asset_not_found() {
+        let releases: Vec<GitHubRelease> = serde_json::from_str(
+            r#"[{
+                "tag_name": "151.0.7922.71-1.1",
+                "draft": false,
+                "prerelease": false,
+                "assets": [
+                    {"name": "ungoogled-chromium_151.0.7922.71-1.1_windows_x64.zip",
+                     "browser_download_url": "https://example.com/x64.zip"}
+                ]
+            }]"#,
+        )
+        .unwrap();
+
+        let err = resolve_ungoogled(
+            &releases,
+            &VersionSpec::Explicit("151.0.7922.71".into()),
+            Platform::Win32,
+            "ungoogled-software/ungoogled-chromium-windows",
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(matches!(err, FetcherError::AssetNotFound { .. }));
+        assert!(msg.contains("_windows_x86.zip"), "{msg}");
+    }
+
+    #[test]
+    fn ungoogled_skips_drafts_and_prereleases() {
+        let releases: Vec<GitHubRelease> = serde_json::from_str(
+            r#"[
+                {"tag_name": "152.0.0.1-1.1", "draft": true, "prerelease": false,
+                 "assets": [{"name": "ungoogled-chromium_152.0.0.1-1.1_windows_x64.zip",
+                             "browser_download_url": "https://example.com/draft.zip"}]},
+                {"tag_name": "152.0.0.0-1.1", "draft": false, "prerelease": true,
+                 "assets": [{"name": "ungoogled-chromium_152.0.0.0-1.1_windows_x64.zip",
+                             "browser_download_url": "https://example.com/pre.zip"}]},
+                {"tag_name": "151.0.7922.71-1.1", "draft": false, "prerelease": false,
+                 "assets": [{"name": "ungoogled-chromium_151.0.7922.71-1.1_windows_x64.zip",
+                             "browser_download_url": "https://example.com/real.zip"}]}
+            ]"#,
+        )
+        .unwrap();
+
+        let r =
+            resolve_ungoogled(&releases, &VersionSpec::Latest, Platform::Win64, "repo").unwrap();
+        assert_eq!(r.url, "https://example.com/real.zip");
+        assert_eq!(list_ungoogled(&releases, Platform::Win64).len(), 1);
+    }
+
+    /// `Latest` must skip past a newer release that has no build for this
+    /// platform rather than failing or returning the wrong asset.
+    #[test]
+    fn latest_skips_releases_lacking_this_platforms_asset() {
+        let releases: Vec<GitHubRelease> = serde_json::from_str(
+            r#"[
+                {"tag_name": "152.0.0.0-1.1", "draft": false, "prerelease": false,
+                 "assets": [{"name": "ungoogled-chromium_152.0.0.0-1.1_windows_x64.zip",
+                             "browser_download_url": "https://example.com/152-x64.zip"}]},
+                {"tag_name": "151.0.7922.71-1.1", "draft": false, "prerelease": false,
+                 "assets": [{"name": "ungoogled-chromium_151.0.7922.71-1.1_windows_x86.zip",
+                             "browser_download_url": "https://example.com/151-x86.zip"}]}
+            ]"#,
+        )
+        .unwrap();
+
+        let r =
+            resolve_ungoogled(&releases, &VersionSpec::Latest, Platform::Win32, "repo").unwrap();
+        assert_eq!(r.build_id, "151.0.7922.71");
+        assert_eq!(r.url, "https://example.com/151-x86.zip");
+    }
+
+    #[test]
+    fn ungoogled_refuses_channels_and_revisions() {
+        let releases = fixture_windows_releases();
+
+        let err = resolve_ungoogled(
+            &releases,
+            &VersionSpec::Channel(Channel::Beta),
+            Platform::Win64,
+            "repo",
+        )
+        .unwrap_err();
+        assert!(matches!(err, FetcherError::UnsupportedSelector { .. }));
+        assert!(err.to_string().contains("no channels"), "{err}");
+
+        let err = resolve_ungoogled(
+            &releases,
+            &VersionSpec::Revision(1674890),
+            Platform::Win64,
+            "repo",
+        )
+        .unwrap_err();
+        assert!(matches!(err, FetcherError::UnsupportedSelector { .. }));
+    }
+
+    #[test]
+    fn list_ungoogled_labels_carry_both_version_and_tag() {
+        let builds = list_ungoogled(&fixture_linux_releases(), Platform::LinuxX64);
+        assert_eq!(builds.len(), 1);
+        assert_eq!(
+            builds[0].spec,
+            VersionSpec::Explicit("151.0.7922.71".into())
+        );
+        assert!(builds[0].label.contains("151.0.7922.71"));
+        assert!(builds[0].label.contains("tag 151.0.7922.71-1"));
+    }
+
+    // -- snapshots ---------------------------------------------------------
+
+    /// The load-bearing snapshot behaviour: an explicit version is refused,
+    /// with the reason and the alternative in the message. Silently returning
+    /// the newest snapshot would hand back a different browser.
+    #[test]
+    fn snapshot_refuses_an_explicit_version_and_says_why() {
+        let err =
+            snapshot_revision_for(&VersionSpec::Explicit("151.0.7922.76".into())).unwrap_err();
+        let msg = err.to_string();
+        assert!(matches!(err, FetcherError::UnsupportedSelector { .. }));
+        assert!(msg.contains("151.0.7922.76"), "{msg}");
+        assert!(msg.contains("keyed by revision"), "{msg}");
+        assert!(msg.contains("--revision"), "{msg}");
+    }
+
+    #[test]
+    fn snapshot_refuses_channels() {
+        let err = snapshot_revision_for(&VersionSpec::Channel(Channel::Canary)).unwrap_err();
+        assert!(matches!(err, FetcherError::UnsupportedSelector { .. }));
+        assert!(err.to_string().contains("no channels"), "{err}");
+    }
+
+    #[test]
+    fn snapshot_latest_defers_to_last_change_and_revision_pins() {
+        assert_eq!(snapshot_revision_for(&VersionSpec::Latest).unwrap(), None);
+        assert_eq!(snapshot_revision_for(&VersionSpec::Stable).unwrap(), None);
+        assert_eq!(
+            snapshot_revision_for(&VersionSpec::Channel(Channel::Stable)).unwrap(),
+            None
+        );
+        assert_eq!(
+            snapshot_revision_for(&VersionSpec::Revision(1674890)).unwrap(),
+            Some(1674890)
+        );
+    }
+
+    /// Snapshot URLs use the bucket's own platform spelling, which differs
+    /// from CfT's on every platform.
+    #[test]
+    fn snapshot_urls_use_the_bucket_platform_names() {
+        let r = resolve_snapshot(DEFAULT_SNAPSHOT_BASE, 1674890, Platform::MacArm64);
+        assert_eq!(r.build_id, "r1674890");
+        assert_eq!(
+            r.url,
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac_Arm/1674890/chrome-mac.zip"
+        );
+        assert_eq!(
+            r.archive,
+            Archive::Zip {
+                top_dir: "chrome-mac".into()
+            }
+        );
+
+        assert_eq!(
+            resolve_snapshot(DEFAULT_SNAPSHOT_BASE, 1674856, Platform::Win64).url,
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win_x64/1674856/chrome-win.zip"
+        );
+        assert_eq!(
+            resolve_snapshot(DEFAULT_SNAPSHOT_BASE, 1674883, Platform::LinuxX64).url,
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/1674883/chrome-linux.zip"
+        );
+    }
+
+    /// A snapshot build id can never collide with a CfT/ungoogled version
+    /// directory, which is what lets them share a cache root.
+    #[test]
+    fn snapshot_build_ids_are_revision_prefixed() {
+        let r = resolve_snapshot(DEFAULT_SNAPSHOT_BASE, 1674890, Platform::LinuxX64);
+        assert!(r.build_id.starts_with('r'));
+        assert!(!r.build_id.contains('.'));
     }
 }

--- a/crates/zendriver-fetcher/src/resolver.rs
+++ b/crates/zendriver-fetcher/src/resolver.rs
@@ -109,14 +109,26 @@ pub(crate) fn resolve_cft(
                 .last()
                 .ok_or_else(|| FetcherError::VersionNotFound("manifest is empty".to_string()))?
         }
-        VersionSpec::Channel(Channel::Beta | Channel::Dev | Channel::Canary) => {
+        VersionSpec::Channel(channel @ (Channel::Beta | Channel::Dev | Channel::Canary)) => {
             // Callers route these through `resolve_cft_channel` +
             // `ChannelsResponse` (see `Fetcher::ensure_chrome`). Defensive
             // fallback if this is ever called directly with a non-stable
-            // channel against the flat manifest.
-            return Err(FetcherError::UnsupportedPlatform);
+            // channel against the flat manifest — which tracks stable only,
+            // so there is genuinely nothing here to answer with.
+            return Err(FetcherError::UnsupportedSelector {
+                distribution: Distribution::ChromeForTesting.title(),
+                selector: format!("the {} channel", channel.as_cft_str()),
+                reason: "the flat known-good-versions manifest tracks stable only; the \
+                         non-stable channels resolve through the per-channel manifest"
+                    .to_string(),
+            });
         }
-        VersionSpec::Revision(rev) => return Err(revision_unsupported(spec_dist_cft(), *rev)),
+        VersionSpec::Revision(rev) => {
+            return Err(revision_unsupported(
+                Distribution::ChromeForTesting.title(),
+                *rev,
+            ));
+        }
         VersionSpec::Explicit(want) => manifest
             .versions
             .iter()
@@ -433,10 +445,6 @@ pub(crate) fn resolve_snapshot(base: &str, revision: u64, platform: Platform) ->
 // shared
 // ---------------------------------------------------------------------------
 
-fn spec_dist_cft() -> &'static str {
-    Distribution::ChromeForTesting.title()
-}
-
 fn revision_unsupported(distribution: &'static str, revision: u64) -> FetcherError {
     FetcherError::UnsupportedSelector {
         distribution,
@@ -513,18 +521,22 @@ mod tests {
         }
     }
 
+    /// The flat manifest never resolves a non-stable channel — that routes
+    /// through `resolve_cft_channel` + `ChannelsResponse` instead. The
+    /// defensive fallback has to name the channel, not report an unsupported
+    /// *platform*, which would send the reader debugging platform detection.
     #[test]
-    fn beta_channel_returns_unsupported_platform_against_flat_manifest() {
-        // The flat manifest never resolves a non-stable channel — that routes
-        // through `resolve_cft_channel` + `ChannelsResponse` instead. This
-        // pins the defensive fallback.
+    fn beta_channel_is_refused_by_name_against_the_flat_manifest() {
         let err = resolve_cft(
             &fixture_manifest(),
             &VersionSpec::Channel(Channel::Beta),
             Platform::LinuxX64,
         )
         .unwrap_err();
-        assert!(matches!(err, FetcherError::UnsupportedPlatform));
+        let msg = err.to_string();
+        assert!(matches!(err, FetcherError::UnsupportedSelector { .. }));
+        assert!(msg.contains("Beta channel"), "{msg}");
+        assert!(msg.contains("per-channel manifest"), "{msg}");
     }
 
     #[test]

--- a/crates/zendriver-fetcher/src/tls.rs
+++ b/crates/zendriver-fetcher/src/tls.rs
@@ -31,6 +31,77 @@ pub(crate) async fn get(url: &str) -> Result<reqwest::Response, reqwest::Error> 
     reqwest::get(url).await
 }
 
+/// User-Agent sent to `api.github.com`.
+///
+/// Not cosmetic: GitHub's API answers **403** to any request without a
+/// User-Agent, which reads exactly like a rate-limit rejection and sends you
+/// hunting for a token you do not need.
+const GITHUB_USER_AGENT: &str = concat!("zendriver-fetcher/", env!("CARGO_PKG_VERSION"));
+
+/// GET a JSON document from GitHub's REST API.
+///
+/// Sends the required User-Agent, pins the `2022-11-28` API version, and
+/// attaches `GITHUB_TOKEN` as a bearer token when the environment has one.
+/// A rejection that looks like rate limiting becomes
+/// [`FetcherError::GitHubRateLimited`](crate::FetcherError::GitHubRateLimited),
+/// whose message names the 60/hour unauthenticated ceiling and the variable
+/// that lifts it — a bare `403` would leave the caller guessing.
+pub(crate) async fn get_github(url: &str) -> Result<String, crate::error::FetcherError> {
+    install_default_crypto_provider();
+
+    let mut req = reqwest::Client::builder()
+        .user_agent(GITHUB_USER_AGENT)
+        .build()?
+        .get(url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28");
+
+    if let Ok(token) = std::env::var("GITHUB_TOKEN")
+        && !token.trim().is_empty()
+    {
+        req = req.bearer_auth(token.trim());
+    }
+
+    let resp = req.send().await?;
+
+    if is_rate_limited(resp.status(), resp.headers()) {
+        return Err(crate::error::FetcherError::GitHubRateLimited {
+            reset_hint: reset_hint(resp.headers()),
+        });
+    }
+
+    Ok(resp.error_for_status()?.text().await?)
+}
+
+/// True when a GitHub response is a rate-limit rejection.
+///
+/// GitHub signals the primary limit with `403` + `x-ratelimit-remaining: 0`,
+/// and secondary/abuse limits with `429`. A `403` with budget left over is
+/// something else (a bad token, say) and is left to `error_for_status`.
+fn is_rate_limited(status: reqwest::StatusCode, headers: &reqwest::header::HeaderMap) -> bool {
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return true;
+    }
+    if status != reqwest::StatusCode::FORBIDDEN {
+        return false;
+    }
+    headers
+        .get("x-ratelimit-remaining")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .is_some_and(|remaining| remaining == 0)
+}
+
+/// `", resets at <unix timestamp>"` when GitHub told us when the window rolls
+/// over, otherwise an empty string.
+fn reset_hint(headers: &reqwest::header::HeaderMap) -> String {
+    headers
+        .get("x-ratelimit-reset")
+        .and_then(|v| v.to_str().ok())
+        .map(|ts| format!(", resets at {}", ts.trim()))
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -52,6 +123,64 @@ mod tests {
         let _ = rustls::ClientConfig::builder()
             .with_root_certificates(rustls::RootCertStore::empty())
             .with_no_client_auth();
+    }
+
+    fn headers(pairs: &[(&str, &str)]) -> reqwest::header::HeaderMap {
+        let mut h = reqwest::header::HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                reqwest::header::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                v.parse().unwrap(),
+            );
+        }
+        h
+    }
+
+    #[test]
+    fn forbidden_with_no_budget_left_is_rate_limiting() {
+        assert!(is_rate_limited(
+            reqwest::StatusCode::FORBIDDEN,
+            &headers(&[("x-ratelimit-remaining", "0")]),
+        ));
+    }
+
+    /// A 403 that still has budget is a different problem (bad token, blocked
+    /// resource) and must not be reported as rate limiting.
+    #[test]
+    fn forbidden_with_budget_left_is_not_rate_limiting() {
+        assert!(!is_rate_limited(
+            reqwest::StatusCode::FORBIDDEN,
+            &headers(&[("x-ratelimit-remaining", "41")]),
+        ));
+        assert!(!is_rate_limited(
+            reqwest::StatusCode::FORBIDDEN,
+            &headers(&[]),
+        ));
+    }
+
+    #[test]
+    fn too_many_requests_is_rate_limiting_regardless_of_headers() {
+        assert!(is_rate_limited(
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            &headers(&[]),
+        ));
+    }
+
+    #[test]
+    fn success_is_never_rate_limiting() {
+        assert!(!is_rate_limited(
+            reqwest::StatusCode::OK,
+            &headers(&[("x-ratelimit-remaining", "0")]),
+        ));
+    }
+
+    #[test]
+    fn reset_hint_is_empty_without_the_header() {
+        assert_eq!(reset_hint(&headers(&[])), "");
+        assert_eq!(
+            reset_hint(&headers(&[("x-ratelimit-reset", "1786023295")])),
+            ", resets at 1786023295"
+        );
     }
 
     /// End-to-end proof over real HTTPS, through the same door the crate's own requests use.

--- a/crates/zendriver-fetcher/src/tls.rs
+++ b/crates/zendriver-fetcher/src/tls.rs
@@ -56,7 +56,8 @@ pub(crate) async fn get_github(url: &str) -> Result<String, crate::error::Fetche
         .header("Accept", "application/vnd.github+json")
         .header("X-GitHub-Api-Version", "2022-11-28");
 
-    if let Ok(token) = std::env::var("GITHUB_TOKEN")
+    if is_github_api(url)
+        && let Ok(token) = std::env::var("GITHUB_TOKEN")
         && !token.trim().is_empty()
     {
         req = req.bearer_auth(token.trim());
@@ -71,6 +72,20 @@ pub(crate) async fn get_github(url: &str) -> Result<String, crate::error::Fetche
     }
 
     Ok(resp.error_for_status()?.text().await?)
+}
+
+/// Is `url` GitHub's own API host, over TLS?
+///
+/// The release-lookup base is overridable — that is how the tests point it at
+/// a wiremock server — and `GITHUB_TOKEN` is a credential. It goes to
+/// `https://api.github.com` or it does not go at all; an unauthenticated
+/// request to somewhere else is a smaller failure than a leaked token.
+///
+/// The scheme is half the check: `http://api.github.com` is the right host and
+/// would still put a bearer token on the wire in cleartext.
+fn is_github_api(url: &str) -> bool {
+    reqwest::Url::parse(url)
+        .is_ok_and(|u| u.scheme() == "https" && u.host_str() == Some("api.github.com"))
 }
 
 /// True when a GitHub response is a rate-limit rejection.
@@ -172,6 +187,25 @@ mod tests {
             reqwest::StatusCode::OK,
             &headers(&[("x-ratelimit-remaining", "0")]),
         ));
+    }
+
+    /// The token is scoped to GitHub's host, not to "whatever base was
+    /// configured" — the base is overridable, and a bearer token sent to an
+    /// arbitrary host is a leaked credential.
+    #[test]
+    fn only_githubs_own_api_host_is_credentialed() {
+        assert!(is_github_api(
+            "https://api.github.com/repos/ungoogled-software/ungoogled-chromium-macos/releases"
+        ));
+
+        assert!(!is_github_api("http://127.0.0.1:8080/repos/x/y/releases"));
+        // Right host, no TLS: the token would go out in cleartext.
+        assert!(!is_github_api("http://api.github.com/repos/x/y/releases"));
+        // Suffix and userinfo tricks both resolve to a host that is not ours.
+        assert!(!is_github_api("https://api.github.com.evil.test/repos"));
+        assert!(!is_github_api("https://api.github.com@evil.test/repos"));
+        assert!(!is_github_api("https://github.com/repos/x/y/releases"));
+        assert!(!is_github_api("not a url"));
     }
 
     #[test]

--- a/crates/zendriver-fetcher/src/version.rs
+++ b/crates/zendriver-fetcher/src/version.rs
@@ -32,17 +32,39 @@ impl Channel {
     }
 }
 
-/// How to resolve a Chrome for Testing version.
+/// Which build to resolve.
+///
+/// Not every selector is meaningful for every
+/// [`Distribution`](crate::Distribution): a snapshot bucket has no channels
+/// and no version index, and a version-keyed distribution has no revisions.
+/// The combinations that cannot be honoured return
+/// [`FetcherError::UnsupportedSelector`](crate::FetcherError::UnsupportedSelector)
+/// naming the alternative, rather than quietly resolving something else.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum VersionSpec {
-    /// Last entry in the manifest (effectively the newest known good version).
+    /// Newest build the distribution publishes for the target platform.
     Latest,
     /// Alias for the stable channel; for now identical to [`VersionSpec::Latest`].
     Stable,
-    /// Pick a specific release channel.
+    /// Pick a specific release channel. Chrome for Testing only — neither
+    /// ungoogled-chromium nor the snapshot bucket publishes channels.
     Channel(Channel),
     /// Exact version string, e.g. `"126.0.6478.182"`.
+    ///
+    /// Matched exactly against Chrome for Testing's manifest, and as a **tag
+    /// prefix** for ungoogled-chromium, whose tags append a packaging suffix
+    /// (`151.0.7922.71-1.1`). Refused for
+    /// [`Distribution::ChromiumSnapshot`](crate::Distribution::ChromiumSnapshot),
+    /// which has no version index — use [`VersionSpec::Revision`] there.
     Explicit(String),
+    /// Exact Chromium revision (commit position), e.g. `1674890`.
+    ///
+    /// The only way to pin a specific
+    /// [`Distribution::ChromiumSnapshot`](crate::Distribution::ChromiumSnapshot)
+    /// build, since that bucket is keyed by revision. Refused for the
+    /// version-keyed distributions.
+    Revision(u64),
 }
 
 #[cfg(test)]

--- a/crates/zendriver-mcp/mcp-coverage-ledger.toml
+++ b/crates/zendriver-mcp/mcp-coverage-ledger.toml
@@ -1011,3 +1011,19 @@ excluded = "process-wide TLS setup, not browser automation; the MCP server insta
 [[entry]]
 api = "zendriver::tls::install_default_crypto_provider"
 excluded = "process-wide TLS setup, not browser automation; exposed for embedders that want to install eagerly, and meaningless over the MCP wire"
+
+# ── fetcher distributions: ungoogled-chromium + Chromium snapshots ─────────
+# The fetcher grew a distribution axis. `browser_fetch_chrome` still resolves
+# Chrome for Testing (the default), so these are library-level selectors the
+# MCP wire surface does not yet expose.
+[[entry]]
+api = "zendriver::Distribution"
+excluded = "selects which Chromium build the fetcher downloads; browser_fetch_chrome exposes only the Chrome for Testing default so far"
+
+[[entry]]
+api = "zendriver::FetcherBuild"
+excluded = "one row of a build listing (selector + label); a menu type for CLI/library callers, not a browser-automation action"
+
+[[entry]]
+api = "zendriver::list_builds"
+excluded = "enumerates downloadable builds for a platform; a discovery helper for pickers, and browser_fetch_chrome takes a version directly"

--- a/crates/zendriver/src/lib.rs
+++ b/crates/zendriver/src/lib.rs
@@ -245,18 +245,23 @@ pub use expect::file_chooser::{FileChooserExpectation, FileChooserMode, MatchedF
 /// `zendriver-fetcher` sub-crate; these aliases let downstream code reach the
 /// types without depending on the sub-crate directly. Drive via
 /// [`BrowserBuilder::ensure_chrome`] for the common "just download Chrome"
-/// case, or instantiate [`Fetcher`] directly for version/channel/cache
-/// customization.
+/// case, or instantiate [`Fetcher`] directly for
+/// distribution/version/channel/cache customization.
+///
+/// [`Distribution`] picks which build to fetch: Chrome for Testing (the
+/// default), ungoogled-chromium, or a Chromium snapshot.
 ///
 /// The fetcher's release-channel enum is re-exported as `FetcherChannel` to
 /// avoid colliding with the browser-discovery [`Channel`] enum (Chrome /
 /// Chromium / Brave / Edge / Auto): the two name different concepts — a
 /// Chrome-for-Testing *release* channel (Stable/Beta/Dev/Canary) versus which
-/// installed *browser* to launch.
+/// installed *browser* to launch. `Build` is likewise re-exported as
+/// `FetcherBuild`, since a "build" here is one downloadable browser rather
+/// than anything to do with building the crate.
 #[cfg(feature = "fetcher")]
 pub use zendriver_fetcher::{
-    Channel as FetcherChannel, Fetcher, FetcherError, FetcherPhase, FetcherProgress, Platform,
-    VersionSpec,
+    Build as FetcherBuild, Channel as FetcherChannel, Distribution, Fetcher, FetcherError,
+    FetcherPhase, FetcherProgress, Platform, VersionSpec, list_builds,
 };
 
 /// Proxied exit-IP -> country resolver, derived from the browser's proxy.

--- a/docs/book/src/fetcher.md
+++ b/docs/book/src/fetcher.md
@@ -1,10 +1,13 @@
 # Fetcher
 
-The `fetcher` Cargo feature downloads a Chrome binary from Google's
-[Chrome for Testing][cft] (CFT) distribution and hands back a path you
-can pass to `BrowserBuilder::executable`. Useful in CI runners that
-don't ship Chrome, in containers, or whenever you want a version pinned
-independently of the host's Chrome install.
+The `fetcher` Cargo feature downloads a Chromium build and hands back a
+path you can pass to `BrowserBuilder::executable`. Useful in CI runners
+that don't ship Chrome, in containers, or whenever you want a version
+pinned independently of the host's Chrome install.
+
+It fetches Google's [Chrome for Testing][cft] (CFT) by default; two other
+distributions are available, described under
+[Distributions](#distributions).
 
 [cft]: https://googlechromelabs.github.io/chrome-for-testing/
 
@@ -72,9 +75,90 @@ Customization points:
   shared CI volume so multiple jobs share one download.
 - **`.on_progress(cb)`** — receive a [`FetcherProgress`] snapshot on
   every phase transition + per-chunk during download.
+- **`.distribution(Distribution)`** — choose which Chromium build to
+  fetch. Defaults to `ChromeForTesting`; see below.
 
 [`Platform::auto_detect`]: https://docs.rs/zendriver/latest/zendriver/enum.Platform.html#method.auto_detect
 [`FetcherProgress`]: https://docs.rs/zendriver/latest/zendriver/struct.FetcherProgress.html
+
+## Distributions
+
+`Distribution::default()` is `ChromeForTesting`, so everything above
+describes what you get without touching this knob. Only *resolution*
+varies between distributions — download, integrity check, unpacking and
+the atomic cache are one shared path.
+
+| Distribution | Index | Keyed by | Packaging |
+|---|---|---|---|
+| `ChromeForTesting` | one JSON manifest | version | zip (all platforms) |
+| `UngoogledChromium` | three GitHub repos, one per OS | version (tag prefix) | zip / AppImage / dmg |
+| `ChromiumSnapshot` | a GCS bucket per platform | **revision** | zip (all platforms) |
+
+```rust,no_run
+# async fn ex() -> Result<(), zendriver::FetcherError> {
+use zendriver::{Distribution, Fetcher, VersionSpec};
+
+let chromium = Fetcher::new()
+    .distribution(Distribution::UngoogledChromium)
+    .version(VersionSpec::Explicit("151.0.7922.71".into()))
+    .ensure_chrome()
+    .await?;
+# let _ = chromium; Ok(()) }
+```
+
+### ungoogled-chromium
+
+Chromium with Google integration stripped out. There is no single
+manifest: binaries come from three independent per-OS repos under the
+`ungoogled-software` org, each releasing on its own cadence.
+
+- Tags carry a packaging suffix (`151.0.7922.71-1.1`), so
+  `VersionSpec::Explicit("151.0.7922.71")` matches on the version
+  **prefix** rather than by equality.
+- **Availability differs per platform, and that is not a bug.** On
+  2026-08-06 Windows and Linux were on `151.0.7922.71` while macOS was
+  still on `150.0.7871.46`. `list_builds` answers the question for the
+  platform you actually asked about.
+- Packaging differs too: Windows a zip, Linux an AppImage (taken over
+  the `.tar.xz` so no xz decompressor enters the dependency graph), and
+  macOS a `.dmg`. Disk images are unpacked with `hdiutil`, so
+  ungoogled-on-macOS can only be fetched **from** a macOS host; every
+  other combination is cross-platform.
+- Release lookups hit `api.github.com`, which allows **60 requests per
+  hour** unauthenticated. Set `GITHUB_TOKEN` to raise that to 5000; the
+  rate-limit error names both.
+
+### Chromium snapshots
+
+Per-commit continuous builds from Google's GCS bucket, laid out
+`<platform>/<revision>/chrome-<os>.zip`.
+
+**Snapshots are keyed by revision, not by version**, and the bucket
+publishes no version index — so there is nothing to look
+`151.0.7922.76` up in. `VersionSpec::Explicit` is therefore *refused*
+here rather than quietly resolved to the newest snapshot, since handing
+back a different browser than the one requested is worse than an error.
+Pin one with `VersionSpec::Revision(1674890)`, or take the tip with
+`VersionSpec::Latest`.
+
+Snapshots also use their own platform spelling (`Mac_Arm`, `Win_x64`,
+`Linux_x64`) rather than CFT's (`mac-arm64`, `win64`, `linux64`); the
+translation is internal, and you keep using the CFT names.
+
+### Listing what is available
+
+```rust,no_run
+# async fn ex() -> Result<(), zendriver::FetcherError> {
+use zendriver::{Distribution, Platform, list_builds};
+
+for build in list_builds(Distribution::UngoogledChromium, Platform::MacArm64).await? {
+    println!("{}", build.label);
+}
+# Ok(()) }
+```
+
+Snapshots return a single entry — the tip named by `LAST_CHANGE`. Older
+snapshots remain reachable, but only by revision.
 
 ## Cache layout
 
@@ -98,11 +182,66 @@ layout verbatim:
       Google Chrome for Testing.app/Contents/MacOS/...  (macOS Apple Silicon)
 ```
 
-Writes are atomic. The fetcher downloads + extracts into a
-`<version>.tmp/` sibling, then a single `rename` promotes it to
-`<version>/`. Crashing mid-download leaves a `.tmp/` that the next run
+The other distributions namespace themselves one level deeper:
+
+```text
+<cache_dir>/
+  ungoogled/151.0.7922.71/...
+  snapshot/r1674890/...
+```
+
+CFT stays un-prefixed so caches populated by earlier versions of the
+crate keep hitting. The others are prefixed because a Chrome version
+number is not unique across distributions — CFT `151.0.7922.71` and
+ungoogled `151.0.7922.71` are different binaries, and a shared directory
+would serve whichever landed first.
+
+Writes are atomic. The fetcher downloads + unpacks into a
+`<build>.tmp/` sibling, then a single `rename` promotes it to
+`<build>/`. Crashing mid-download leaves a `.tmp/` that the next run
 detects, deletes, and retries — no half-extracted binaries ever appear
 under the canonical name.
+
+## The `zendriver-fetch` CLI
+
+The same resolver, as a standalone binary:
+
+```bash
+cargo install zendriver-fetcher --features cli
+```
+
+The `cli` feature is off by default — this is a library first, and
+`clap` has no business in the dependency graph of a crate that only
+downloads a browser.
+
+Fully specified, it never prompts and exits non-zero on failure, which
+is what CI needs:
+
+```bash
+zendriver-fetch --distribution cft --version 146.0.7680.153 \
+                --platform mac-arm64 --out ./chrome
+```
+
+It prints the resolved binary path on stdout and progress on stderr, so
+`CHROME=$(zendriver-fetch ... )` works. `--quiet` drops the progress.
+
+Run it with a distribution or version missing and it turns interactive:
+it asks which distribution, lists the builds that distribution really
+publishes for the resolved platform (newest first, paged), and confirms
+before downloading.
+
+**If stdin is not a terminal, it refuses to prompt** and prints the
+flags it needed instead. A CLI that blocks on stdin inside CI does not
+fail — it hangs until the job times out.
+
+| Flag | Meaning |
+|---|---|
+| `-d, --distribution` | `cft`, `ungoogled`, or `snapshot` |
+| `--version` | Browser version, or `latest` |
+| `--revision` | Chromium revision (snapshots only; conflicts with `--version`) |
+| `-p, --platform` | `linux64`, `mac-x64`, `mac-arm64`, `win32`, `win64`; defaults to this host |
+| `-o, --out` | Cache directory; defaults to the OS cache dir |
+| `-q, --quiet` | Suppress progress output |
 
 ## Progress callbacks
 
@@ -178,4 +317,9 @@ runners; cached runs take &lt;1 s in `ensure_chrome`.
 - **You need Chrome stable on Linux ARM64** — CFT doesn't ship a
   `linux-arm64` build today;
   [`Platform::auto_detect`] returns `None` on that host and
-  `ensure_chrome` errors out.
+  `ensure_chrome` errors out. (ungoogled-chromium's portablelinux repo
+  *does* publish arm64 AppImages, but `Platform` has no `LinuxArm64`
+  variant yet, so they aren't selectable.)
+- **You want ungoogled-chromium for macOS from a Linux or Windows
+  box** — it ships as a `.dmg`, and unpacking one needs macOS's
+  `hdiutil`.


### PR DESCRIPTION
`zendriver-fetcher` downloaded Chrome for Testing and nothing else. This adds a `Distribution` axis with two more indexes, plus a `cargo install`-able CLI.

`Distribution::default()` is `ChromeForTesting`, so every existing caller keeps exactly the behaviour it had, down to the cache directory it already populated.

## Only resolution differs

Download, SHA256 verification, unpacking, the atomic per-build cache and the progress callbacks stay one shared path. Each distribution contributes a single pure function from `(VersionSpec, Platform)` to a `Resolved`, which is what makes all three testable from inline JSON with no network.

### Chrome for Testing, unchanged

One JSON manifest covering every version on every platform. A lookup is a filter over a list, and the stable/beta/dev/canary split across two manifest shapes is exactly as it was.

### ungoogled-chromium: three indexes, not one

There is no manifest. Binaries come from three independent per-OS repos under the `ungoogled-software` org, so *which repo to ask is a function of the target platform*:

| Platform | Repo |
|---|---|
| macOS | `ungoogled-chromium-macos` |
| Windows | `ungoogled-chromium-windows` |
| Linux | `ungoogled-chromium-portablelinux` |

Three consequences, each of which needed code.

#### Tags carry a packaging suffix

`151.0.7922.71-1.1` on Windows and macOS, `151.0.7922.71-1` on portablelinux. So `Explicit("151.0.7922.71")` matches on the tag *prefix*, with a `-` boundary check, because a bare `starts_with` would resolve a request for `151.0.7922.7` to build `…71`. That is a different browser, silently.

#### Availability differs per platform, and it is not a bug

As I write this, Windows and Linux are on `151.0.7922.71` while macOS is still on `150.0.7871.46`. Resolution answers for the platform you asked about rather than assuming parity, and the "not found" error names the repo it searched:

```
$ zendriver-fetch --distribution ungoogled --version 151.0.7922.71 --platform mac-arm64
error: version not found: 151.0.7922.71 (searched ungoogled-software/ungoogled-chromium-macos releases)

$ zendriver-fetch --distribution ungoogled --version 151.0.7922.71 --platform win64
/tmp/.../ungoogled/151.0.7922.71/ungoogled-chromium_151.0.7922.71-1.1_windows_x64/chrome.exe
```

The org's main `ungoogled-software/ungoogled-chromium` repo also tags releases, but they carry zero assets. It is the patch set, not a build, so it is deliberately not reachable as a binary source and a test pins that.

#### Packaging differs three ways

Which is why `archive.rs` exists. Windows is a zip like everything else. Linux takes the AppImage over the `.tar.xz` published beside it: an AppImage *is* the executable, so unpacking is a move plus a chmod and no xz decompressor enters the dependency graph. macOS is a `.dmg`, mounted with `hdiutil` and copied out with `ditto`, which means ungoogled-for-macOS can only be fetched *from* a Mac. Every other combination is cross-platform.

Release lookups also hit `api.github.com`, which is 60 requests/hour unauthenticated. Two things fall out of that. The request sends a User-Agent, because GitHub answers 403 without one and that reads exactly like rate limiting, sending you hunting for a token you do not need. And a real rate-limit rejection becomes a message naming the limit, the reset time, and `GITHUB_TOKEN`.

### Chromium snapshots: the awkward one

Snapshots are keyed by *revision*, not version. The bucket is `<platform>/<revision>/chrome-<os>.zip`, `LAST_CHANGE` names the tip, and there is no version index of any kind.

So `VersionSpec::Explicit("151.0.7922.76")` is unanswerable here. There is nothing to look it up in. The options were to map version to revision through chromiumdash or to refuse, and this refuses:

```
$ zendriver-fetch --distribution snapshot --version 151.0.7922.76 --platform linux64
error: Chromium snapshot cannot resolve version 151.0.7922.76: snapshots are keyed by
revision, not version, and the bucket publishes no version index — there is nothing to
look 151.0.7922.76 up in. Pin a revision instead (VersionSpec::Revision / --revision),
or take the newest snapshot with --version latest
```

The alternative worth naming is the one I did *not* build: quietly returning the newest snapshot. That hands back a browser other than the one requested, under a version number that looks honoured, and nothing downstream can tell. An error is better, and the refusal happens before any network call, so it costs nothing.

`VersionSpec::Revision(u64)` is the way to pin one, and `--revision` exposes it. Snapshots also spell every platform differently from CfT (`Mac_Arm` vs `mac-arm64`, `Win_x64` vs `win64`); a test pins that the two namings never converge, because conflating them produces 404s rather than type errors.

## Cache layout

Chrome for Testing stays un-prefixed so caches populated by earlier versions keep hitting. The others namespace by slug:

```
<cache_dir>/
  146.0.7680.153/...        Chrome for Testing, as before
  ungoogled/151.0.7922.71/...
  snapshot/r1674890/...
```

The asymmetry is deliberate in both directions. A Chrome version number is not unique across distributions, so CfT `151.0.7922.71` and ungoogled `151.0.7922.71` sharing a directory would serve whichever landed first. A test covers exactly that.

## The CLI

```bash
cargo install zendriver-fetcher --features cli
```

The feature is off by default. This is a library first, and `clap` has no business in the dependency graph of a crate that only downloads a browser.

Fully specified, it never prompts and exits non-zero on failure:

```bash
zendriver-fetch --distribution cft --version 146.0.7680.153 \
                --platform mac-arm64 --out ./chrome
```

Path on stdout, progress on stderr, so `CHROME=$(zendriver-fetch ...)` works.

Leave a flag out at a terminal and it turns interactive: pick a distribution, then page through the builds that distribution actually publishes for the resolved platform. That is a hand-rolled numbered menu rather than a prompt crate, about 40 lines, and it keeps a dependency out of the graph entirely.

The guard rail between the two modes matters more than either mode. **If stdin is not a terminal, it refuses to prompt** and prints the flags it needed:

```
$ zendriver-fetch --platform linux64 < /dev/null
error: stdin is not a terminal, so there is nobody to prompt — pass
--distribution <cft|ungoogled|snapshot> and --version <VERSION|latest>
(or --revision <N> for snapshots) on the command line
```

A CLI that blocks on stdin inside CI does not fail. It hangs until the job times out.

One naming casualty: there is no `--version` flag for the tool itself, because that name selects the browser version, which is the whole point.

## macOS: symlinks validated instead of refused

`extract.rs` refused every symlink entry, on the stated premise that "Chrome for
Testing archives never ship symlinks". That premise is false. Every macOS `.app`
bundle carries framework `Versions/Current` links, so `ensure_chrome()` had never
once succeeded on a Mac, and `ChromiumSnapshot` on `Mac`/`Mac_Arm` inherited it:

```
$ zendriver-fetch --distribution cft --version 146.0.7680.153 --platform mac-arm64
error: extraction: zip entry "chrome-mac-arm64/Google Chrome for Testing.app/Contents/
Frameworks/Google Chrome for Testing Framework.framework/Resources" is a symlink;
refusing for safety
```

The refusal existed for a real reason and this keeps it closed. Symlinks are the
primary follow-on vector for zip-slip: extract `evil -> /etc`, then extract
`evil/passwd`, and the write lands outside while every path in the archive looks
innocent. A target is now accepted only when it is relative and resolves, from
the directory that really holds the link, to somewhere still inside the archive's
own top-level directory.

What the containment rests on:

Containment is decided once, after the extraction loop, by walking the finished
tree and canonicalizing every symlink in it. Per-entry checks still run — they
give early, precise errors — but they are not the guarantee.

That split is the third design, and it exists because the first two were broken
by review. Deciding where a link will point *as it is created* means predicting,
and the prediction is made against a filesystem the archive is still building, in
an order the archive chooses. Checking the end state removes the question: once
the loop is done there is no "not yet" left, `canonicalize` reports the path the
kernel will use, and the only thing to ask is whether it is inside.

It cannot be replaced by simply refusing to reason about not-yet-existing
components, either — a real Chrome for Testing macOS bundle lists
`Framework.framework/Resources -> Versions/Current/Resources` around entry 132
and does not create `Versions/Current` until entry 646. Google's own archive
depends on the ordering that made prediction unsound.

Entry paths may not contain `..` at all. `enclosed_name` permits them, and one
surviving `..` makes the top-level check — which reads only the first component —
mean less than it says. No archive from any of the three indexes ships one.

The target resolves against the directory *containing* the link, not the link
itself. Off by one level and every sibling link reads as an escape, while a real
escape reads as a sibling.

`..` is checked as the walk proceeds rather than on the final result, so
`a/../../a/b` is refused even though it ends up inside.

Writes *through* a link were already covered: `assert_under_dest` canonicalizes,
and canonicalize follows symlinks. That defence now sits behind a validated link
rather than a blanket ban. The probe that picks the path to canonicalize uses
`symlink_metadata`, so a dangling link is seen rather than stepped over.

One tightening beyond the reported bug. Files were already locked to the
archive's single top-level directory, and links now are too. A link like
`chrome-linux64/link -> ../escape` lands at `dest/escape`, inside `dest_dir` and
so not a zip-slip, but it can only point at something this archive does not own,
and `dest_dir` is shared with other installs. The pre-existing test that asserted
the blanket refusal now asserts this rule instead.

Windows keeps skipping symlink entries. Creating one there needs privileges, and
no Windows Chrome archive contains any.

## Verification

Every new test is offline except the macOS extraction one, which downloads a real CfT bundle and runs it. That one is `#[ignore = "network"]`, so CI stays offline. Downloading is not its assertion; the assertion is that what lands is a binary that RUNS, which is the only thing proving the bundle came out intact rather than merely extracted without error. The rest are pure resolvers driven from inline JSON literals, and end-to-end paths on wiremock.

```
cargo build   --workspace --all-features                          EXIT=0
cargo test    --workspace --lib  --all-features --no-fail-fast    EXIT=0
cargo test    --workspace --doc  --all-features --no-fail-fast    EXIT=0
cargo test    -p zendriver-fetcher --bins --features cli          EXIT=0
cargo clippy  --workspace --all-targets --all-features -- -D warnings   EXIT=0
cargo fmt     --all --check                                       EXIT=0
```

1624 passed, 0 failed.

Real downloads, run by hand, one per distribution plus the macOS case this fixes:

```
$ zendriver-fetch --distribution cft --version 146.0.7680.153 --platform linux64
/tmp/zdfetch-e2e/cft/146.0.7680.153/chrome-linux64/chrome
  ELF 64-bit LSB pie executable, x86-64

$ zendriver-fetch --distribution cft --version 146.0.7680.153 --platform mac-arm64
/tmp/zdfetch-e2e/cft-mac/146.0.7680.153/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing
  Mach-O 64-bit executable arm64
  $ "$P" --version  ->  Google Chrome for Testing 146.0.7680.153
  5 symlinks in the bundle, every one resolving inside the cache dir, including
  Versions/Current -> 146.0.7680.153, which the other four resolve through

$ zendriver-fetch --distribution ungoogled --version latest --platform mac-arm64
/tmp/zdfetch-e2e/ug/ungoogled/150.0.7871.46/Chromium.app/Contents/MacOS/Chromium
  Mach-O 64-bit executable arm64
  $ "$P" --version  ->  Chromium 150.0.7871.46

$ zendriver-fetch --distribution snapshot --version latest --platform linux64
/tmp/zdfetch-e2e/snap/snapshot/r1674883/chrome-linux/chrome
  ELF 64-bit LSB pie executable, x86-64
```

The ungoogled run exercises the macOS `.dmg` path from mount through `ditto` to unmount, and its `150.0.7871.46` is the platform skew above showing up live.

CI gains explicit clippy and test steps for the `cli` feature, because neither `--workspace --all-targets` nor `--workspace --lib` compiles a non-default-feature binary, and it would otherwise rot unnoticed.

All three zip-slip escapes were reproduced against the real `extract()` before being fixed, and the archives that produced them are now tests. Nine real archives were extracted end to end to confirm the tightening rejects nothing legitimate — Chrome for Testing on `mac-arm64`, `mac-x64`, `linux64` and `win64`, Chromium snapshots on four platforms, and an ungoogled Windows zip — plus a survey of 246 archives (61,878 entries) finding zero `..` components and zero absolute paths. The macOS bundle keeps all five framework symlinks and the extracted binary runs. `checked_build_id` was checked against live data — all 2448 Chrome for Testing versions and the ungoogled repos' current tags pass it, so it rejects nothing real.

Still unexercised by any real run, and worth knowing before merging: the fetcher's own tests never execute on Windows (that job is filtered to `binary_id(zendriver::prerelease_verification)`), so the Windows-specific paths are reasoned and unit-tested rather than run; the ungoogled AppImage path is tested with stub bytes rather than a real AppImage, which wants FUSE at run time; and a hard crash during a macOS `.dmg` install can leave a volume mounted, which now leaks rather than wedging the next run, since staging paths are per-fetch.

## What review caught

Everything after the merge commit is a review fix. Three are the same shape — index-controlled data reaching a filesystem path that `ensure_chrome` later hands back to be executed — and one is a target that never compiled at all.

**An asset name.** The Windows zip's top-level directory is that name minus `.zip`, and it becomes a component of `Resolved::binary_subpath`. `ensure_chrome` joins that subpath onto the cache path and checks it with `is_runnable` *before* downloading anything, then returns the result for the caller to execute. So an asset named `../../../usr/bin/x_windows_x64.zip` from a compromised repo would nominate an arbitrary existing executable as "the browser" without ever serving a byte, and the extractor's own containment checks never get a turn because nothing is extracted on that path. Resolution now matches only plain filenames, in `asset_for` so listing agrees with it, failing closed. The first pass at that missed Windows drive-relative names, which carry no separator to catch: `Path::join` discards the base for `C:evil`, so it escapes exactly where `..` would.

**The build id.** The same primitive through a different field, and a wider one, because `build_id` *is* the cache directory. It comes from a CfT manifest `version` or the version half of an ungoogled tag, and `VersionSpec::Latest` — the default — constrains it not at all. A release tagged `../../../../PLANTED` relocates the whole install, and an absolute tag does it without counting depth. The same predicate guards it now, and the listings filter on it so nothing is offered that resolution would refuse.

**A symlink reached through an earlier symlink.** Validating a target against the entry's *lexical* parent was wrong, and the induction argument this PR used to justify it was wrong with it. Archives extract in order, so an attacker picks what gets planted before what traverses it:

```text
top/a/b/c/up        symlink -> ../../..
top/a/b/c/up/hop    symlink -> ../../../../ESCAPED
top/hop             file, mode 0755
```

Entry 2 reads as landing on `top/ESCAPED` — contained, and inside the pinned top-level directory, so both checks passed. The kernel disagrees: `up` is already a link to `top`, so entry 2 is really created at `top/hop` and climbs four levels from *there*. Entry 3 then writes through it, and `extract` returned `Ok(())` while the payload landed outside. `zip`'s `enclosed_name` turns out to return what it accepts unnormalized, `..` intact, so entry paths cannot be assumed flat either. Canonicalizing the link's parent removes the second opinion, and that three-entry archive is now a test.

**Windows never compiled.** `resolve_target` is reachable only from the `#[cfg(unix)]` arm, so on a Windows target it is an unreferenced function and `-D dead-code` failed the build outright. Only the Windows integration job builds this crate for a non-unix target, which is why every other job stayed green.

**The symlink fix was itself half a fix.** A later adversarial pass broke it, end to end, twice. Canonicalizing the link's parent closes the divergence on the link's *path* and leaves it wide open on the link's *target*, which was still walked as a string:

```text
chrome-linux64/u1/u2/u3/up  symlink -> ../../..
chrome-linux64/chrome       symlink -> u1/u2/u3/up/../../../VICTIM
```

The lexical walk pushes four and pops three, scoring `chrome-linux64/u1/VICTIM` — inside. The kernel follows `up` first, because the earlier entry already created it, and spends the three `..` from `chrome-linux64`: two levels above the destination, and a longer ladder reaches an arbitrary absolute path. Nothing is written out there, since a file entry through an escaping link is still refused — but the escaping link is exactly what `ensure_chrome` returns to be executed, and phase 4 `chmod +x`'s whatever it points at. Target components that already exist as symlinks are now resolved as the walk pushes them; ones that do not exist yet stay lexical, so `Versions/Current -> A` still works.

The same pass found that `..` surviving in an entry path let `create_dir_all` run outside the destination before validation refused the entry, and that two `ensure_chrome` calls for one build shared staging paths — each deleting the other's half-written tree, after which one promoted whatever remained under the canonical name, where a truncated browser passes `is_runnable` and is served from cache forever.

**And then a third time, which is why the design changed.** A narrower pass aimed only at the extractor found the same class again, reached through *time* rather than position: a target validated against a filesystem state that a later entry invalidates.

```text
chrome-linux64/chrome  ->  u/d/../../evil     u and d do not exist yet, so the
                                              walk is lexical: lands on
                                              chrome-linux64/evil, accepted
chrome-linux64/u/d     ->  ..                 contained, accepted honestly,
                                              and planted afterwards
```

Nothing revalidates the first link, whose stored target now resolves through the second to outside the destination — and that path is `cft_binary_subpath(LinuxX64)` exactly, so it is what `ensure_chrome` hands back to be executed.

Three failures, one cause: predicting where a path will land while the kernel decides later. Each fix made the prediction consult the filesystem a little more and left the same residual — whatever had not been created yet — and that residual cannot be removed, because Google's own bundle depends on it. Containment is now checked on the finished tree instead, which is both stronger and less code than the version it replaced.

The rest were smaller: manifest fetches handed a CDN's HTML error page to `serde_json` rather than reporting the status it came with, `GITHUB_TOKEN` followed the overridable API base wherever it pointed, the staging path was spelled through `display()`, which is lossy on a cache directory that is not valid UTF-8, and archive mode bits were applied verbatim, so a tampered archive could set setuid on a file in the cache.

## Still not fixed here

Two smaller limitations, both documented in the book chapter:

- ungoogled-chromium for macOS can only be fetched from a Mac, since `.dmg` needs `hdiutil`.
- ungoogled's portablelinux repo publishes arm64 AppImages, but `Platform` has no `LinuxArm64` variant, so they are not selectable. CfT has no Linux arm64 build at all, which is why the variant never existed.

## Note on the full suite

`cargo test --workspace --all-features` also has one failure, `spoofed_passes_areyouheadless`, which launches a real Chrome and scrapes `arh.antoinevastel.com`. It fails identically on unmodified `origin/main`, and it is unrelated to this branch.

The cause is not the DOM moving, as first assumed here: that endpoint currently returns **HTTP 502** (nginx is up, the app behind it is not — the host's root answers 200, and the other stealth test's `intoli.com` page answers 200). So `document.querySelector('#res')` is null, `.textContent` throws, and the test panics on the scrape before it ever reaches its assertion. It is not reporting that stealth was detected; it is reporting nothing.

Worth knowing separately from this PR: `nightly-stealth-tests` has been red every night for at least 2026-08-04 through 2026-08-06 while the parent run reports success, because that lane is `continue-on-error: true` and cron-only. Filed as its own concern rather than fixed here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)





