### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fetcher"
-version = "0.1.15"
+version = "0.2.0"
 dependencies = [
  "clap",
  "dirs",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.16.12"
+version = "0.16.13"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.5.3", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.5.4", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.4" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.12.2" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.12" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.16" }
-zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.1.15" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.12" }
+zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.2.0" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.13" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.2" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.19" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.17" }

--- a/crates/zendriver-fetcher/CHANGELOG.md
+++ b/crates/zendriver-fetcher/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.2.0] - 2026-08-07
+
+### Added
+
+- Resolve ungoogled-chromium and Chromium snapshots
+- Add the zendriver-fetch CLI behind a non-default cli feature
+
+### Changed
+
+- Build staging paths without a lossy display() round-trip
+- Derive the CfT binary path from cft_top_dir
+- Compute the ungoogled zip top-level directory once
+
+### Fixed
+
+- Ignore ungoogled assets whose name is not a plain filename
+- Extract validated symlinks, or macOS never gets a binary
+- Gate resolve_target to unix so Windows builds compile
+- Reject drive-relative ungoogled asset names
+- Send GITHUB_TOKEN only to https://api.github.com
+- Fail manifest fetches on HTTP status
+- Name the channel the flat manifest cannot resolve
+- Resolve symlink targets against the link's real parent
+- Validate the build id an index hands back
+- Resolve symlink target components against the filesystem
+- Refuse zip entries carrying a parent-directory component
+- Give each fetch its own staging directory
+- Prefer the ungoogled tag that has this platform's asset
+- Verify symlink containment on the finished tree
+
+
 ## [0.1.15] - 2026-07-29
 
 

--- a/crates/zendriver-fetcher/Cargo.toml
+++ b/crates/zendriver-fetcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fetcher"
 description = "Chromium binary downloader for zendriver — Chrome for Testing, ungoogled-chromium and Chromium snapshots"
-version = "0.1.15"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.16.13] - 2026-08-07
+
+### Added
+
+- Resolve ungoogled-chromium and Chromium snapshots
+
+
 ## [0.16.12] - 2026-08-06
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.16.12"
+version = "0.16.13"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-08-07
+
+### Added
+
+- Resolve ungoogled-chromium and Chromium snapshots
+
+
 ## [0.5.3] - 2026-08-06
 
 

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-fetcher`: 0.1.15 -> 0.2.0 (⚠ API breaking changes)
* `zendriver`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `zendriver-mcp`: 0.16.12 -> 0.16.13 (✓ API compatible changes)

### ⚠ `zendriver-fetcher` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum VersionSpec in /tmp/.tmptnB02g/zendriver-rs/crates/zendriver-fetcher/src/version.rs:45
  enum VersionSpec in /tmp/.tmptnB02g/zendriver-rs/crates/zendriver-fetcher/src/version.rs:45
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-fetcher`

<blockquote>

## [0.2.0] - 2026-08-07

### Added

- Resolve ungoogled-chromium and Chromium snapshots
- Add the zendriver-fetch CLI behind a non-default cli feature

### Changed

- Build staging paths without a lossy display() round-trip
- Derive the CfT binary path from cft_top_dir
- Compute the ungoogled zip top-level directory once

### Fixed

- Ignore ungoogled assets whose name is not a plain filename
- Extract validated symlinks, or macOS never gets a binary
- Gate resolve_target to unix so Windows builds compile
- Reject drive-relative ungoogled asset names
- Send GITHUB_TOKEN only to https://api.github.com
- Fail manifest fetches on HTTP status
- Name the channel the flat manifest cannot resolve
- Resolve symlink targets against the link's real parent
- Validate the build id an index hands back
- Resolve symlink target components against the filesystem
- Refuse zip entries carrying a parent-directory component
- Give each fetch its own staging directory
- Prefer the ungoogled tag that has this platform's asset
- Verify symlink containment on the finished tree
</blockquote>

## `zendriver`

<blockquote>

## [0.5.4] - 2026-08-07

### Added

- Resolve ungoogled-chromium and Chromium snapshots
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.16.13] - 2026-08-07

### Added

- Resolve ungoogled-chromium and Chromium snapshots
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).