### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-cloudflare"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "futures",
  "psl",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "futures",
  "serde",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "async-trait",
  "base64",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.16.14"
+version = "0.16.15"
 dependencies = [
  "async-trait",
  "axum",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-transport"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.5.5", default-features = false }
-zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.4" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.12.2" }
-zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.12" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.16" }
+zendriver               = { path = "crates/zendriver", version = "0.5.6", default-features = false }
+zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.5" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.12.3" }
+zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.13" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.17" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.2.1" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.14" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.2" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.19" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.17" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.15" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.3" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.20" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.18" }
 
 # MCP server
 # Pinned exactly, matching proxybroker-rs: rmcp's macro and transport surface moves across

--- a/crates/zendriver-cloudflare/CHANGELOG.md
+++ b/crates/zendriver-cloudflare/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.13] - 2026-08-08
+
+
 ## [0.2.12] - 2026-07-29
 
 ### Internal

--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-cloudflare"
 description = "Cloudflare Turnstile bypass for zendriver"
-version = "0.2.12"
+version = "0.2.13"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.20] - 2026-08-08
+
+
 ## [0.1.19] - 2026-08-06
 
 

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.19"
+version = "0.1.20"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.18] - 2026-08-08
+
+
 ## [0.3.17] - 2026-08-06
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.3.17"
+version = "0.3.18"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.3] - 2026-08-08
+
+
 ## [0.3.2] - 2026-08-06
 
 

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.17] - 2026-08-08
+
+
 ## [0.3.16] - 2026-08-06
 
 ### Fixed

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.3.16"
+version = "0.3.17"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.16.15] - 2026-08-08
+
+
 ## [0.16.14] - 2026-08-07
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.16.14"
+version = "0.16.15"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.12.3] - 2026-08-08
+
+
 ## [0.12.2] - 2026-08-06
 
 ### Fixed

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.12.2"
+version = "0.12.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-transport/CHANGELOG.md
+++ b/crates/zendriver-transport/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-08-08
+
+### Fixed
+
+- Report disconnects honestly and bound reconnect ([#150](https://github.com/TurtIeSocks/zendriver-rs/pull/150))
+
+
 ## [0.2.4] - 2026-07-29
 
 ### Internal

--- a/crates/zendriver-transport/Cargo.toml
+++ b/crates/zendriver-transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-transport"
 description = "Internal: WebSocket + CDP routing actor for zendriver"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.5.6] - 2026-08-08
+
+### Fixed
+
+- Report disconnects honestly and bound reconnect ([#150](https://github.com/TurtIeSocks/zendriver-rs/pull/150))
+
+
 ## [0.5.5] - 2026-08-07
 
 

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.5.5"
+version = "0.5.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-transport`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `zendriver`: 0.5.5 -> 0.5.6 (✓ API compatible changes)
* `zendriver-cloudflare`: 0.2.12 -> 0.2.13
* `zendriver-interception`: 0.3.16 -> 0.3.17
* `zendriver-datadome`: 0.1.19 -> 0.1.20
* `zendriver-imperva`: 0.3.2 -> 0.3.3
* `zendriver-stealth`: 0.12.2 -> 0.12.3
* `zendriver-fingerprints`: 0.3.17 -> 0.3.18
* `zendriver-mcp`: 0.16.14 -> 0.16.15

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-transport`

<blockquote>

## [0.2.5] - 2026-08-08

### Fixed

- Report disconnects honestly and bound reconnect ([#150](https://github.com/TurtIeSocks/zendriver-rs/pull/150))
</blockquote>

## `zendriver`

<blockquote>

## [0.5.6] - 2026-08-08

### Fixed

- Report disconnects honestly and bound reconnect ([#150](https://github.com/TurtIeSocks/zendriver-rs/pull/150))
</blockquote>









</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).