### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "async-trait",
  "base64",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-cloudflare"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-datadome"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "futures",
  "psl",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-imperva"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "futures",
  "serde",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-interception"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "async-trait",
  "base64",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.16.15"
+version = "0.16.16"
 dependencies = [
  "async-trait",
  "axum",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-transport"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.5.6", default-features = false }
-zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.5" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.12.3" }
-zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.13" }
-zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.17" }
+zendriver               = { path = "crates/zendriver", version = "0.5.7", default-features = false }
+zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.6" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.12.4" }
+zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.14" }
+zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.18" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.2.1" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.15" }
-zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.3" }
-zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.20" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.18" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.16" }
+zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.4" }
+zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.21" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.19" }
 
 # MCP server
 # Pinned exactly, matching proxybroker-rs: rmcp's macro and transport surface moves across

--- a/crates/zendriver-cloudflare/CHANGELOG.md
+++ b/crates/zendriver-cloudflare/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.14] - 2026-08-08
+
+### Fixed
+
+- Reach terminals that were structurally unreachable ([#152](https://github.com/TurtIeSocks/zendriver-rs/pull/152))
+
+
 ## [0.2.13] - 2026-08-08
 
 

--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-cloudflare"
 description = "Cloudflare Turnstile bypass for zendriver"
-version = "0.2.13"
+version = "0.2.14"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-datadome/CHANGELOG.md
+++ b/crates/zendriver-datadome/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.1.21] - 2026-08-08
+
+### Fixed
+
+- Reach terminals that were structurally unreachable ([#152](https://github.com/TurtIeSocks/zendriver-rs/pull/152))
+
+
 ## [0.1.20] - 2026-08-08
 
 

--- a/crates/zendriver-datadome/Cargo.toml
+++ b/crates/zendriver-datadome/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-datadome"
 description = "DataDome anti-bot bypass for zendriver"
-version = "0.1.20"
+version = "0.1.21"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.19] - 2026-08-08
+
+
 ## [0.3.18] - 2026-08-08
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.3.18"
+version = "0.3.19"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-imperva/CHANGELOG.md
+++ b/crates/zendriver-imperva/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.4] - 2026-08-08
+
+### Fixed
+
+- Reach terminals that were structurally unreachable ([#152](https://github.com/TurtIeSocks/zendriver-rs/pull/152))
+
+
 ## [0.3.3] - 2026-08-08
 
 

--- a/crates/zendriver-imperva/Cargo.toml
+++ b/crates/zendriver-imperva/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-imperva"
 description = "Imperva WAF / Incapsula bypass for zendriver"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-interception/CHANGELOG.md
+++ b/crates/zendriver-interception/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.18] - 2026-08-08
+
+
 ## [0.3.17] - 2026-08-08
 
 

--- a/crates/zendriver-interception/Cargo.toml
+++ b/crates/zendriver-interception/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-interception"
 description = "Network interception (Fetch.* CDP domain) for zendriver"
-version = "0.3.17"
+version = "0.3.18"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.16.16] - 2026-08-08
+
+### Fixed
+
+- Reach terminals that were structurally unreachable ([#152](https://github.com/TurtIeSocks/zendriver-rs/pull/152))
+
+
 ## [0.16.15] - 2026-08-08
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.16.15"
+version = "0.16.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.12.4] - 2026-08-08
+
+
 ## [0.12.3] - 2026-08-08
 
 

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.12.3"
+version = "0.12.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-transport/CHANGELOG.md
+++ b/crates/zendriver-transport/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-08-08
+
+### Fixed
+
+- Reach terminals that were structurally unreachable ([#152](https://github.com/TurtIeSocks/zendriver-rs/pull/152))
+
+
 ## [0.2.5] - 2026-08-08
 
 ### Fixed

--- a/crates/zendriver-transport/Cargo.toml
+++ b/crates/zendriver-transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-transport"
 description = "Internal: WebSocket + CDP routing actor for zendriver"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.5.7] - 2026-08-08
+
+### Fixed
+
+- Reach terminals that were structurally unreachable ([#152](https://github.com/TurtIeSocks/zendriver-rs/pull/152))
+
+
 ## [0.5.6] - 2026-08-08
 
 ### Fixed

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.5.6"
+version = "0.5.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-transport`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `zendriver-cloudflare`: 0.2.13 -> 0.2.14 (✓ API compatible changes)
* `zendriver-datadome`: 0.1.20 -> 0.1.21 (✓ API compatible changes)
* `zendriver-imperva`: 0.3.3 -> 0.3.4 (✓ API compatible changes)
* `zendriver`: 0.5.6 -> 0.5.7 (✓ API compatible changes)
* `zendriver-mcp`: 0.16.15 -> 0.16.16 (✓ API compatible changes)
* `zendriver-interception`: 0.3.17 -> 0.3.18
* `zendriver-stealth`: 0.12.3 -> 0.12.4
* `zendriver-fingerprints`: 0.3.18 -> 0.3.19

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-transport`

<blockquote>

## [0.2.6] - 2026-08-08

### Fixed

- Reach terminals that were structurally unreachable ([#152](https://github.com/TurtIeSocks/zendriver-rs/pull/152))
</blockquote>

## `zendriver-cloudflare`

<blockquote>

## [0.2.14] - 2026-08-08

### Fixed

- Reach terminals that were structurally unreachable ([#152](https://github.com/TurtIeSocks/zendriver-rs/pull/152))
</blockquote>

## `zendriver-datadome`

<blockquote>

## [0.1.21] - 2026-08-08

### Fixed

- Reach terminals that were structurally unreachable ([#152](https://github.com/TurtIeSocks/zendriver-rs/pull/152))
</blockquote>

## `zendriver-imperva`

<blockquote>

## [0.3.4] - 2026-08-08

### Fixed

- Reach terminals that were structurally unreachable ([#152](https://github.com/TurtIeSocks/zendriver-rs/pull/152))
</blockquote>

## `zendriver`

<blockquote>

## [0.5.7] - 2026-08-08

### Fixed

- Reach terminals that were structurally unreachable ([#152](https://github.com/TurtIeSocks/zendriver-rs/pull/152))
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.16.16] - 2026-08-08

### Fixed

- Reach terminals that were structurally unreachable ([#152](https://github.com/TurtIeSocks/zendriver-rs/pull/152))
</blockquote>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).