### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "async-trait",
  "base64",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.16.19"
+version = "0.16.20"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.5.10", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.5.11", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.6" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.12.4" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.14" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.18" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.2.1" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.19" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.20" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.4" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.21" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.19" }

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.16.20] - 2026-08-08
+
+
 ## [0.16.19] - 2026-08-08
 
 

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.16.19"
+version = "0.16.20"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.5.11] - 2026-08-08
+
+### Fixed
+
+- Rebuild the visibility predicate, and prove it against real Chrome ([#158](https://github.com/TurtIeSocks/zendriver-rs/pull/158))
+
+
 ### Fixed
 
 - Clipped screenshots no longer come back blank when the rect reaches past the

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.5.10"
+version = "0.5.11"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver`: 0.5.10 -> 0.5.11 (✓ API compatible changes)
* `zendriver-mcp`: 0.16.19 -> 0.16.20

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver`

<blockquote>


## [0.5.11] - 2026-08-08

### Fixed

- Rebuild the visibility predicate, and prove it against real Chrome ([#158](https://github.com/TurtIeSocks/zendriver-rs/pull/158))
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).