### PR TITLE
chore: release

### DIFF
--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -12,6 +12,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 - Rebuild the visibility predicate, and prove it against real Chrome ([#158](https://github.com/TurtIeSocks/zendriver-rs/pull/158))
 
 
+## [0.5.11] - 2026-08-08
+
+### Fixed
+
+- Rebuild the visibility predicate, and prove it against real Chrome ([#158](https://github.com/TurtIeSocks/zendriver-rs/pull/158))
+
+
 ### Fixed
 
 - Clipped screenshots no longer come back blank when the rect reaches past the


### PR DESCRIPTION



## 🤖 New release

* `zendriver`: 0.5.10 -> 0.5.11
* `zendriver-mcp`: 0.16.19 -> 0.16.20

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver`

<blockquote>


## [0.5.11] - 2026-08-08

### Fixed

- Rebuild the visibility predicate, and prove it against real Chrome ([#158](https://github.com/TurtIeSocks/zendriver-rs/pull/158))
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).