### PR TITLE
fix(stealth): fold the persona into the fingerprint so it reaches CDP

### DIFF
--- a/crates/zendriver-stealth/src/fingerprint.rs
+++ b/crates/zendriver-stealth/src/fingerprint.rs
@@ -163,11 +163,25 @@ pub struct Fingerprint {
     pub memory_gb: u32,
     pub ua_string: String,
     pub ua_metadata: UserAgentMetadata,
+    /// IANA timezone driving `Emulation.setTimezoneOverride`, from
+    /// [`StealthProfile::timezone`](crate::StealthProfile::timezone) or from a
+    /// [`Persona`](crate::Persona), which wins and is folded in when the
+    /// observer is built. `None` sends no override.
     pub timezone: Option<String>,
+    /// Locale driving `Emulation.setLocaleOverride` when
+    /// [`languages`](Self::languages) is unset. Same two sources as
+    /// [`timezone`](Self::timezone).
     pub locale: Option<String>,
+    /// Ordered language list driving `Accept-Language`, `navigator.languages`
+    /// and — from its first entry — `Emulation.setLocaleOverride`, which is
+    /// what keeps the JS-visible locale inside the list the header advertises.
+    /// Falls back to [`locale`](Self::locale) when unset, and the header falls
+    /// back further to `["en-US", "en"]` when that is unset too (the locale
+    /// override is then simply not sent).
     pub languages: Option<Vec<String>>,
     /// Screen / device-metrics override resolved from
-    /// [`StealthProfile::screen`](crate::StealthProfile::screen). `None` by
+    /// [`StealthProfile::screen`](crate::StealthProfile::screen), or from a
+    /// [`Persona`](crate::Persona)'s own `screen`, which wins. `None` by
     /// default (`auto_detect` never probes a screen size) — the observer's
     /// fixed 1920x1080 default is untouched until this is explicitly set.
     pub screen: Option<crate::persona::specs::ScreenSpec>,
@@ -202,6 +216,44 @@ impl Fingerprint {
             languages: None,
             screen: None,
         })
+    }
+
+    /// Fold a [`Persona`](crate::Persona)'s explicitly-set fields into this
+    /// fingerprint.
+    ///
+    /// Four axes exist on both types — `timezone`, `locale`, `languages`,
+    /// `screen` — and three separate consumers read them: the CDP
+    /// `Emulation.set*Override` calls, the `Accept-Language` header, and the
+    /// JS patches. Merging once, at the single point where a persona and a
+    /// fingerprint meet
+    /// ([`StealthObserver::with_persona`](crate::StealthObserver::with_persona)),
+    /// is what keeps those consumers from disagreeing: each reads the merged
+    /// value rather than re-deriving the precedence for itself.
+    ///
+    /// Precedence: an explicitly-set persona field wins; `None` inherits
+    /// whatever the fingerprint already resolved — from
+    /// [`StealthProfile`](crate::StealthProfile)'s per-field setters, or from
+    /// the host probe. A [`Persona::default`](crate::Persona::default) is a
+    /// no-op, and the merge is idempotent.
+    ///
+    /// An empty `languages` list counts as unset, matching how every consumer
+    /// in [`lang`](crate::lang) already reads one: `Some(vec![])` describes a
+    /// persona that pins no languages, not one that advertises none, and
+    /// letting it overwrite would make an empty persona field destroy a
+    /// configured [`StealthProfile::languages`](crate::StealthProfile::languages).
+    pub(crate) fn overlay_persona(&mut self, persona: &crate::Persona) {
+        if let Some(timezone) = &persona.timezone {
+            self.timezone = Some(timezone.clone());
+        }
+        if let Some(locale) = &persona.locale {
+            self.locale = Some(locale.clone());
+        }
+        if let Some(languages) = persona.languages.as_ref().filter(|v| !v.is_empty()) {
+            self.languages = Some(languages.clone());
+        }
+        if let Some(screen) = persona.screen {
+            self.screen = Some(screen);
+        }
     }
 
     /// Recompose UA string + UAM after platform/version overrides.

--- a/crates/zendriver-stealth/src/lang.rs
+++ b/crates/zendriver-stealth/src/lang.rs
@@ -26,13 +26,85 @@ pub fn accept_language(langs: &[String]) -> String {
         .join(",")
 }
 
-/// Resolve the effective language list at apply time.
+/// What both language surfaces fall back to when nothing at all is configured.
+fn default_languages() -> Vec<String> {
+    vec!["en-US".to_string(), "en".to_string()]
+}
+
+/// Derive a language list from a single locale.
+///
+/// A region locale yields `[locale, base_lang]` where `base_lang` is the
+/// subtag before `-` (e.g. `"fr-FR"` -> `["fr-FR", "fr"]`); a bare locale (no
+/// `-`) yields a single entry.
+fn derive_from_locale(locale: &str) -> Vec<String> {
+    let base = locale.split('-').next().unwrap_or(locale);
+    if base == locale {
+        vec![locale.to_string()]
+    } else {
+        vec![locale.to_string(), base.to_string()]
+    }
+}
+
+/// The single resolution both locale-bearing CDP surfaces read: the language
+/// list a [`Fingerprint`] actually configures, or `None` when it configures
+/// neither `languages` nor `locale`.
+///
+/// Precedence is `languages` -> derived from `locale`, and the two callers
+/// differ only in what they do with `None`: the `Accept-Language` header
+/// substitutes `["en-US", "en"]` ([`fingerprint_languages`]), while
+/// `Emulation.setLocaleOverride` sends nothing at all
+/// ([`effective_locale`]) so Chrome keeps its own.
+///
+/// # Why `languages` outranks `locale`
+///
+/// In a real Chrome `navigator.language` is always `navigator.languages[0]`.
+/// A caller who sets both and lets them disagree is asking for a browser that
+/// cannot exist, so honoring both is not an option and the list has to win:
+/// `navigator.languages` is observable in full, and a `language` that is not
+/// its head is a mismatch no genuine browser produces. Resolving the header
+/// and the locale override independently is what produced exactly that — the
+/// header advertising one list while `Intl` reported a locale from outside it.
+/// An explicit `locale` with no `languages` still drives both surfaces.
+///
+/// This is the post-merge view. Once
+/// [`Fingerprint::overlay_persona`](crate::Fingerprint::overlay_persona) has
+/// folded a persona in, the fingerprint already carries whatever the persona
+/// pinned, so the observer reads that one value instead of re-deriving the
+/// persona-vs-fingerprint precedence at each CDP call site.
+fn configured_languages(fp: &Fingerprint) -> Option<Vec<String>> {
+    if let Some(langs) = fp.languages.as_ref().filter(|v| !v.is_empty()) {
+        return Some(langs.clone());
+    }
+    fp.locale.as_deref().map(derive_from_locale)
+}
+
+/// The language list to advertise, falling back to `["en-US", "en"]` when the
+/// fingerprint configures none. See [`configured_languages`].
+pub(crate) fn fingerprint_languages(fp: &Fingerprint) -> Vec<String> {
+    configured_languages(fp).unwrap_or_else(default_languages)
+}
+
+/// The locale to pin via `Emulation.setLocaleOverride`, or `None` to send no
+/// override at all.
+///
+/// By construction this is the head of [`fingerprint_languages`] whenever
+/// anything is configured, which is the coherence the two surfaces need — see
+/// [`configured_languages`] for why the list, not `locale`, decides.
+pub(crate) fn effective_locale(fp: &Fingerprint) -> Option<String> {
+    configured_languages(fp)?.into_iter().next()
+}
+
+/// Resolve the effective language list at apply time, persona first.
 ///
 /// Precedence: `persona.languages` -> `fingerprint.languages` ->
-/// derive from the primary locale -> `["en-US", "en"]`. Deriving from a
-/// region locale yields `[locale, base_lang]` where `base_lang` is the
-/// subtag before `-` (e.g. `"fr-FR"` -> `["fr-FR", "fr"]`); a bare locale
-/// (no `-`) yields a single entry.
+/// derive from the primary locale (`persona.locale` before `fp.locale`) ->
+/// `["en-US", "en"]`.
+///
+/// For a fingerprint the persona has already been folded into, this agrees
+/// with [`fingerprint_languages`] by construction — the persona's values are
+/// on `fp` by then. It stays persona-first for the public
+/// [`bootstrap_script`](crate::patches::bootstrap_script) path, whose caller
+/// may hand it an unmerged pair.
 pub(crate) fn resolve_languages(persona: &Persona, fp: &Fingerprint) -> Vec<String> {
     if let Some(langs) = persona.languages.as_ref().filter(|v| !v.is_empty()) {
         return langs.clone();
@@ -40,17 +112,9 @@ pub(crate) fn resolve_languages(persona: &Persona, fp: &Fingerprint) -> Vec<Stri
     if let Some(langs) = fp.languages.as_ref().filter(|v| !v.is_empty()) {
         return langs.clone();
     }
-    let locale = persona.locale.clone().or_else(|| fp.locale.clone());
-    match locale {
-        Some(loc) => {
-            let base = loc.split('-').next().unwrap_or(&loc).to_string();
-            if base != loc {
-                vec![loc, base]
-            } else {
-                vec![loc]
-            }
-        }
-        None => vec!["en-US".to_string(), "en".to_string()],
+    match persona.locale.as_deref().or(fp.locale.as_deref()) {
+        Some(locale) => derive_from_locale(locale),
+        None => default_languages(),
     }
 }
 

--- a/crates/zendriver-stealth/src/observer.rs
+++ b/crates/zendriver-stealth/src/observer.rs
@@ -13,7 +13,7 @@ use zendriver_transport::{CallError, ObserverError, PausedSession, TargetObserve
 
 use crate::patches::{bootstrap_script, bootstrap_script_native_webgl, geometry_bootstrap_with};
 use crate::persona::GeoPos;
-use crate::persona::specs::{ScreenSpec, UaMetadata};
+use crate::persona::specs::UaMetadata;
 use crate::{Fingerprint, Persona, ProfileKind, StealthProfile};
 
 /// Observer that applies a [`StealthProfile`] + [`Fingerprint`] to every page
@@ -28,20 +28,19 @@ pub struct StealthObserver {
     /// need to pay the patches-bundle cost for them.
     bootstrap: String,
     /// Mock geolocation coordinates from the resolved [`Persona`], sent via
-    /// `Emulation.setGeolocationOverride`. Unlike `timezone`/`locale` (carried
-    /// on [`Fingerprint`]), geolocation has no `Fingerprint` counterpart, so
-    /// it's captured here straight off the persona at construction time.
+    /// `Emulation.setGeolocationOverride`. Unlike
+    /// `timezone`/`locale`/`languages`/`screen` (folded into `fingerprint` by
+    /// [`Fingerprint::overlay_persona`]), geolocation has no `Fingerprint`
+    /// counterpart, so it's captured here straight off the persona at
+    /// construction time.
     geolocation: Option<GeoPos>,
     /// Custom UA-CH from the resolved [`Persona`]'s `ua.ua_metadata`. When
     /// set, [`UaMetadata::resolve`] fills any unset sub-field from
     /// `fingerprint.ua_metadata` and the result drives
     /// `Emulation.setUserAgentOverride.userAgentMetadata` in place of the
-    /// fingerprint-derived value outright.
+    /// fingerprint-derived value outright. Field-wise rather than
+    /// whole-value, which is why it is not folded into `fingerprint`.
     ua_metadata: Option<UaMetadata>,
-    /// Custom screen / device-metrics from the resolved [`Persona`]. When
-    /// set, drives `Emulation.setDeviceMetricsOverride` in place of the
-    /// fixed 1920x1080 default.
-    screen: Option<ScreenSpec>,
 }
 
 impl StealthObserver {
@@ -59,13 +58,24 @@ impl StealthObserver {
     }
 
     /// Build a new observer with an explicit [`Persona`] driving the surface
-    /// patches. `identity` still supplies the coherent UA / Chrome version.
+    /// patches. `fingerprint` still supplies the coherent UA / Chrome version.
+    ///
+    /// This is where the persona and the fingerprint are combined, so it is
+    /// where they are merged: the persona's `timezone` / `locale` /
+    /// `languages` / `screen` are folded into `fingerprint` up front, and
+    /// every consumer below — the
+    /// `Emulation.set*Override` calls, the `Accept-Language` header, the
+    /// bootstrap script's geometry and `navigator.languages` patches — then
+    /// reads that one merged value. An explicitly-set persona field wins over
+    /// the fingerprint's; `None` inherits the fingerprint's.
     #[must_use]
     pub fn with_persona(
         profile: StealthProfile,
-        fingerprint: Fingerprint,
+        mut fingerprint: Fingerprint,
         persona: Persona,
     ) -> Self {
+        fingerprint.overlay_persona(&persona);
+
         let bootstrap = match profile.kind() {
             ProfileKind::Spoofed => {
                 if profile.native_webgl_enabled() {
@@ -81,24 +91,25 @@ impl StealthObserver {
             // its own window) and `availHeight === height` (no taskbar inset). Those are
             // artifacts this library introduces, not properties of the host, so repairing
             // them keeps `Native` native rather than spoofing anything.
-            // The persona's screen still reaches this arm even in `Native`: it
+            // The configured screen still reaches this arm even in `Native`: it
             // carries no identity, only the geometry CDP cannot set. A profile
             // captured on real hardware brings its own insets, and presenting
             // the derived defaults instead would describe a machine that does
-            // not exist. `None` is byte-identical to the old call.
-            ProfileKind::Native => geometry_bootstrap_with(persona.screen.as_ref()),
+            // not exist. `None` is byte-identical to the old call. It reads the
+            // merged `fingerprint.screen` so the JS geometry and the CDP metrics
+            // override below describe the same display — a screen that reached
+            // one but not the other is worse than one that reached neither.
+            ProfileKind::Native => geometry_bootstrap_with(fingerprint.screen.as_ref()),
             ProfileKind::Off => String::new(),
         };
         let geolocation = persona.geolocation;
         let ua_metadata = persona.ua.as_ref().and_then(|u| u.ua_metadata.clone());
-        let screen = persona.screen;
         Self {
             profile,
             fingerprint,
             bootstrap,
             geolocation,
             ua_metadata,
-            screen,
         }
     }
 }
@@ -125,7 +136,11 @@ impl TargetObserver for StealthObserver {
         // metadata too, so we don't have to send Network.setUserAgentOverride
         // separately.
         let accept_language = {
-            let langs = crate::lang::resolve_languages(&Persona::default(), &self.fingerprint);
+            // The fingerprint is already merged with the persona (see
+            // `with_persona`), so its language list is the effective one — a
+            // caller's `Persona::languages` / `Persona::locale` reaches the
+            // header from here.
+            let langs = crate::lang::fingerprint_languages(&self.fingerprint);
             // `Emulation.setUserAgentOverride.acceptLanguage` wants a PLAIN
             // comma-separated locale list (e.g. `en-US,en`) — Chrome appends the
             // `;q=` weights itself. Passing an already-weighted string (the
@@ -169,9 +184,11 @@ impl TargetObserver for StealthObserver {
 
         // Screen-size override + focus emulation: keeps headless from leaking
         // an oddly-shaped viewport and from reporting `document.hasFocus()`
-        // false for the (always-backgrounded) headless tab. Persona screen
-        // wins when supplied; absent → today's fixed 1920x1080 default.
-        let (screen_width, screen_height, device_scale_factor) = match self.screen {
+        // false for the (always-backgrounded) headless tab. The merged
+        // fingerprint's screen (persona's when it set one, else the
+        // `StealthProfile::screen` pin) wins; neither set → the fixed
+        // 1920x1080 default.
+        let (screen_width, screen_height, device_scale_factor) = match self.fingerprint.screen {
             Some(s) => (s.width, s.height, s.device_pixel_ratio),
             None => (1920, 1080, 1.0),
         };
@@ -202,19 +219,13 @@ impl TargetObserver for StealthObserver {
                 .await?;
         }
         // Keep the JS-visible locale (navigator.language, Intl) coherent with
-        // the always-sent Accept-Language. Prefer an explicit fingerprint
-        // locale; otherwise, if the fingerprint pins a `languages` list, derive
-        // the locale from its primary entry — a `languages`-without-`locale`
-        // fingerprint must not leave the JS locale at Chrome's default while the
-        // Accept-Language header says otherwise. A pure-default fingerprint (no
-        // locale, no languages) keeps Chrome's native locale; we don't force one.
-        let effective_locale = self.fingerprint.locale.clone().or_else(|| {
-            self.fingerprint
-                .languages
-                .as_ref()
-                .and_then(|langs| langs.first())
-                .cloned()
-        });
+        // the Accept-Language sent above by resolving both from the same
+        // helper: this is the head of that same list, so the two surfaces
+        // cannot disagree. Resolving them separately is what let them —
+        // `Intl` reported a locale the header never advertised. A fingerprint
+        // configuring neither locale nor languages yields `None` and keeps
+        // Chrome's native locale; we don't force one.
+        let effective_locale = crate::lang::effective_locale(&self.fingerprint);
         if let Some(ref locale) = effective_locale {
             // `Emulation.setLocaleOverride` is browser-global: only one override
             // can be in effect at a time. A page with a cross-origin OOPIF (its
@@ -1087,5 +1098,508 @@ mod tests {
         .unwrap();
         mock.reply(id, json!({})).await;
         conn.shutdown();
+    }
+}
+
+/// The persona has to reach the wire, not just the bootstrap script.
+///
+/// Every assertion here is over the CDP frames the observer actually sent, via
+/// [`drive_attach`] rather than `expect_cmd`: `expect_cmd` silently discards
+/// non-matching frames, so it can only prove "X arrived eventually", and it has
+/// no timeout, so a command that stops being sent hangs the test instead of
+/// failing it. The bugs in this area are precisely "the override was never
+/// sent" and "the override carried the wrong value", so the test has to see the
+/// whole ordered frame list.
+#[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used)]
+mod persona_reaches_cdp_tests {
+    use super::*;
+    use crate::Platform;
+    use crate::persona::specs::ScreenSpec;
+    use serde_json::{Value, json};
+    use zendriver_transport::testing::MockConnection;
+
+    /// A fingerprint with every persona-overlappable field left unset, so each
+    /// test pins only the axis it is about.
+    fn bare_fingerprint() -> Fingerprint {
+        Fingerprint {
+            platform: Platform::MacIntel,
+            chrome_major: 120,
+            chrome_full: "120.0.6099.234".into(),
+            cpu_count: 10,
+            memory_gb: 8,
+            ua_string: crate::ua::compose_ua_string(Platform::MacIntel, "120.0.6099.234"),
+            ua_metadata: crate::UserAgentMetadata::realistic(
+                Platform::MacIntel,
+                120,
+                "120.0.6099.234",
+            ),
+            timezone: None,
+            locale: None,
+            languages: None,
+            screen: None,
+        }
+    }
+
+    /// Drive one page-target attach through `observer` and return every CDP
+    /// frame it sent, in order, replying `{}` to each.
+    ///
+    /// Stops at the actor's terminal call — `Runtime.runIfWaitingForDebugger`
+    /// on success, `Target.detachFromTarget` when an observer errored — so a
+    /// missing override shows up as an absent entry in the returned list, and
+    /// a wedged observer fails on the per-frame budget instead of hanging.
+    async fn drive_attach(observer: StealthObserver) -> Vec<Value> {
+        const FRAME_BUDGET: std::time::Duration = std::time::Duration::from_secs(2);
+
+        let (mut mock, conn) =
+            MockConnection::pair_with_observers(vec![std::sync::Arc::new(observer)
+                as std::sync::Arc<dyn zendriver_transport::TargetObserver>]);
+        mock.emit_event(
+            "Target.attachedToTarget",
+            json!({
+                "sessionId": "S1",
+                "targetInfo": {
+                    "targetId": "T1",
+                    "type": "page",
+                    "url": "about:blank",
+                    "attached": true,
+                },
+                "waitingForDebugger": true,
+            }),
+        )
+        .await;
+
+        let mut frames = Vec::new();
+        while let Some((method, id)) = mock.recv_cmd_timeout(FRAME_BUDGET).await {
+            frames.push(mock.last_sent().clone());
+            mock.reply(id, json!({})).await;
+            if method == "Runtime.runIfWaitingForDebugger" || method == "Target.detachFromTarget" {
+                break;
+            }
+        }
+        conn.shutdown();
+
+        let methods = method_names(&frames);
+        assert!(
+            methods
+                .iter()
+                .any(|m| m == "Runtime.runIfWaitingForDebugger"),
+            "the observer never completed — no debugger release in {methods:?}"
+        );
+        frames
+    }
+
+    /// The single trimmed line of `source` starting with `prefix`. Keeps a
+    /// failure over the bootstrap readable — the script is thousands of lines,
+    /// and only the substituted token is in question.
+    fn line_with<'a>(source: &'a str, prefix: &str) -> &'a str {
+        source
+            .lines()
+            .map(str::trim)
+            .find(|l| l.starts_with(prefix))
+            .unwrap_or("<no such line>")
+    }
+
+    fn method_names(frames: &[Value]) -> Vec<String> {
+        frames
+            .iter()
+            .map(|f| f["method"].as_str().unwrap_or_default().to_string())
+            .collect()
+    }
+
+    /// The `params` of the single frame for `method`, panicking with the whole
+    /// observed sequence when it was never sent.
+    fn params<'a>(frames: &'a [Value], method: &str) -> &'a Value {
+        frames
+            .iter()
+            .find(|f| f["method"] == method)
+            .map(|f| &f["params"])
+            .unwrap_or_else(|| {
+                panic!(
+                    "{method} was never sent; the observer sent {:?}",
+                    method_names(frames)
+                )
+            })
+    }
+
+    /// `Persona::timezone` is the caller's explicit pin and must win over the
+    /// fingerprint's. The two fixtures are deliberately different real zones:
+    /// a persona value equal to the fingerprint's would be satisfied by the
+    /// bug, which sent the fingerprint's unconditionally.
+    #[tokio::test]
+    async fn persona_timezone_wins_over_the_fingerprints_in_the_cdp_override() {
+        let fp = Fingerprint {
+            timezone: Some("America/New_York".into()),
+            ..bare_fingerprint()
+        };
+        let persona = Persona {
+            timezone: Some("Asia/Tokyo".into()),
+            ..Persona::default()
+        };
+
+        let frames = drive_attach(StealthObserver::with_persona(
+            StealthProfile::spoofed(),
+            fp,
+            persona,
+        ))
+        .await;
+
+        assert_eq!(
+            params(&frames, "Emulation.setTimezoneOverride")["timezoneId"].as_str(),
+            Some("Asia/Tokyo"),
+            "an explicitly set Persona::timezone must reach Emulation.setTimezoneOverride"
+        );
+    }
+
+    /// The persona is also the only source when the fingerprint pins nothing —
+    /// the override was not sent at all in that case, so `Intl` reported the
+    /// host's real zone while the rest of the identity claimed otherwise.
+    #[tokio::test]
+    async fn persona_timezone_is_sent_when_the_fingerprint_pins_none() {
+        let persona = Persona {
+            timezone: Some("Europe/Berlin".into()),
+            ..Persona::default()
+        };
+
+        let frames = drive_attach(StealthObserver::with_persona(
+            StealthProfile::spoofed(),
+            bare_fingerprint(),
+            persona,
+        ))
+        .await;
+
+        assert_eq!(
+            params(&frames, "Emulation.setTimezoneOverride")["timezoneId"].as_str(),
+            Some("Europe/Berlin"),
+        );
+    }
+
+    /// One persona locale has to move both surfaces at once: the JS-visible
+    /// locale (`Emulation.setLocaleOverride`) and the header
+    /// (`setUserAgentOverride.acceptLanguage`). Splitting them is the
+    /// cross-surface tell the coherence work exists to close.
+    #[tokio::test]
+    async fn persona_locale_drives_both_the_locale_override_and_accept_language() {
+        let fp = Fingerprint {
+            locale: Some("en-GB".into()),
+            ..bare_fingerprint()
+        };
+        let persona = Persona {
+            locale: Some("fr-FR".into()),
+            ..Persona::default()
+        };
+
+        let frames = drive_attach(StealthObserver::with_persona(
+            StealthProfile::spoofed(),
+            fp,
+            persona,
+        ))
+        .await;
+
+        assert_eq!(
+            params(&frames, "Emulation.setLocaleOverride")["locale"].as_str(),
+            Some("fr-FR"),
+        );
+        assert_eq!(
+            params(&frames, "Emulation.setUserAgentOverride")["acceptLanguage"].as_str(),
+            Some("fr-FR,fr"),
+            "Accept-Language must be derived from the persona's locale, not the fingerprint's"
+        );
+    }
+
+    /// `Persona::languages` is the more specific pin and outranks a
+    /// fingerprint `languages` list on both surfaces.
+    ///
+    /// The fingerprint pins a *conflicting* `locale` on purpose. Leaving it
+    /// `None` is the one case where the two surfaces happened to agree no
+    /// matter which order they resolved in, so it could not tell a coherent
+    /// implementation from an incoherent one — the locale override resolved
+    /// locale-first and the header resolved languages-first, and only an
+    /// unset locale hid that.
+    #[tokio::test]
+    async fn persona_languages_drive_accept_language_and_the_locale_override() {
+        let fp = Fingerprint {
+            locale: Some("en-GB".into()),
+            languages: Some(vec!["en-GB".into(), "en".into()]),
+            ..bare_fingerprint()
+        };
+        let persona = Persona {
+            languages: Some(vec!["ja-JP".into(), "ja".into()]),
+            ..Persona::default()
+        };
+
+        let frames = drive_attach(StealthObserver::with_persona(
+            StealthProfile::spoofed(),
+            fp,
+            persona,
+        ))
+        .await;
+
+        assert_eq!(
+            params(&frames, "Emulation.setUserAgentOverride")["acceptLanguage"].as_str(),
+            Some("ja-JP,ja"),
+        );
+        assert_eq!(
+            params(&frames, "Emulation.setLocaleOverride")["locale"].as_str(),
+            Some("ja-JP"),
+            "the locale override must stay coherent with the persona's language list"
+        );
+    }
+
+    /// The other direction of the same seam: `StealthProfile::screen` lands on
+    /// `Fingerprint::screen`, which nothing read — the observer took its screen
+    /// from the persona alone, so the profile setter was inert and its rustdoc
+    /// ("replaces the observer's fixed 1920x1080 default") was false.
+    #[tokio::test]
+    async fn fingerprint_screen_reaches_device_metrics_when_the_persona_has_none() {
+        let fp = Fingerprint {
+            screen: Some(ScreenSpec::new(1366, 768, 1.0)),
+            ..bare_fingerprint()
+        };
+
+        let frames = drive_attach(StealthObserver::with_persona(
+            StealthProfile::spoofed(),
+            fp,
+            Persona::default(),
+        ))
+        .await;
+
+        let metrics = params(&frames, "Emulation.setDeviceMetricsOverride");
+        assert_eq!(metrics["width"].as_u64(), Some(1366));
+        assert_eq!(metrics["height"].as_u64(), Some(768));
+        assert_eq!(metrics["screenWidth"].as_u64(), Some(1366));
+        assert_eq!(metrics["screenHeight"].as_u64(), Some(768));
+    }
+
+    /// A screen that reaches the CDP metrics but not the geometry patch is
+    /// worse than one that reaches neither: `screen.availHeight` would then be
+    /// derived from a size the patch never saw. Both have to move together.
+    #[tokio::test]
+    async fn fingerprint_screen_also_reaches_the_geometry_patch() {
+        let fp = Fingerprint {
+            screen: Some(
+                ScreenSpec::new(1366, 768, 1.0)
+                    .with_avail(1366, 728)
+                    .with_inner_height(640),
+            ),
+            ..bare_fingerprint()
+        };
+
+        let frames = drive_attach(StealthObserver::with_persona(
+            StealthProfile::spoofed(),
+            fp,
+            Persona::default(),
+        ))
+        .await;
+
+        let source = params(&frames, "Page.addScriptToEvaluateOnNewDocument")["source"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        assert_eq!(
+            line_with(&source, "const AVAIL_H"),
+            "const AVAIL_H = 728;",
+            "the measured availHeight must reach the geometry patch"
+        );
+        assert_eq!(
+            line_with(&source, "const INNER_H"),
+            "const INNER_H = 640;",
+            "the measured innerHeight must reach the geometry patch"
+        );
+    }
+
+    /// Precedence guard rather than a regression: the persona already won for
+    /// `screen`, and folding the two sources together must not flip that.
+    #[tokio::test]
+    async fn persona_screen_still_wins_over_the_fingerprints() {
+        let fp = Fingerprint {
+            screen: Some(ScreenSpec::new(1366, 768, 1.0)),
+            ..bare_fingerprint()
+        };
+        let persona = Persona {
+            screen: Some(ScreenSpec::new(1536, 864, 1.25)),
+            ..Persona::default()
+        };
+
+        let frames = drive_attach(StealthObserver::with_persona(
+            StealthProfile::spoofed(),
+            fp,
+            persona,
+        ))
+        .await;
+
+        let metrics = params(&frames, "Emulation.setDeviceMetricsOverride");
+        assert_eq!(metrics["width"].as_u64(), Some(1536));
+        assert_eq!(metrics["height"].as_u64(), Some(864));
+        assert_eq!(metrics["deviceScaleFactor"].as_f64(), Some(1.25));
+    }
+
+    /// An empty persona list is the absence of a value, not a value. Every
+    /// other language consumer in the crate already reads it that way
+    /// (`lang::resolve_languages` and `lang::fingerprint_languages` both
+    /// filter it), so a merge that treated `Some(vec![])` as a pin let a
+    /// persona with no languages destroy a configured one and drop both
+    /// surfaces back to the `en-US` default.
+    #[tokio::test]
+    async fn an_empty_persona_language_list_leaves_the_fingerprints_pin_alone() {
+        let fp = Fingerprint {
+            languages: Some(vec!["de-DE".into(), "de".into()]),
+            ..bare_fingerprint()
+        };
+        let persona = Persona {
+            languages: Some(Vec::new()),
+            ..Persona::default()
+        };
+
+        let frames = drive_attach(StealthObserver::with_persona(
+            StealthProfile::spoofed(),
+            fp,
+            persona,
+        ))
+        .await;
+
+        assert_eq!(
+            params(&frames, "Emulation.setUserAgentOverride")["acceptLanguage"].as_str(),
+            Some("de-DE,de"),
+            "an empty persona list must not wipe StealthProfile::languages"
+        );
+        assert_eq!(
+            params(&frames, "Emulation.setLocaleOverride")["locale"].as_str(),
+            Some("de-DE"),
+        );
+    }
+
+    /// Browser truth, and the reason the two locale surfaces resolve
+    /// languages-first: in a real Chrome `navigator.language` is always
+    /// `navigator.languages[0]`. A caller who pins a `locale` and a
+    /// disagreeing `languages` list is asking for something Chrome cannot
+    /// produce, so the list wins on both surfaces rather than each surface
+    /// picking its own answer.
+    #[tokio::test]
+    async fn the_locale_override_is_the_head_of_the_advertised_language_list() {
+        let fp = Fingerprint {
+            locale: Some("en-GB".into()),
+            languages: Some(vec!["de-DE".into(), "de".into()]),
+            ..bare_fingerprint()
+        };
+
+        let frames = drive_attach(StealthObserver::with_persona(
+            StealthProfile::spoofed(),
+            fp,
+            Persona::default(),
+        ))
+        .await;
+
+        let accept_language = params(&frames, "Emulation.setUserAgentOverride")["acceptLanguage"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        let locale = params(&frames, "Emulation.setLocaleOverride")["locale"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+
+        assert_eq!(accept_language, "de-DE,de");
+        assert_eq!(
+            locale,
+            accept_language.split(',').next().unwrap_or_default(),
+            "the locale override must be the head of the list the header advertises; \
+             got locale={locale:?} against acceptLanguage={accept_language:?}"
+        );
+    }
+
+    /// The `Native` arm builds its own bootstrap (geometry repair only, no
+    /// identity spoofing) and so reads the merged screen on a different code
+    /// path from every `spoofed()` test above. Left uncovered, reverting that
+    /// one line leaves the whole suite green.
+    #[tokio::test]
+    async fn fingerprint_screen_reaches_the_native_geometry_bootstrap() {
+        let fp = Fingerprint {
+            screen: Some(
+                ScreenSpec::new(1440, 900, 2.0)
+                    .with_avail(1440, 860)
+                    .with_inner_height(780),
+            ),
+            ..bare_fingerprint()
+        };
+
+        let frames = drive_attach(StealthObserver::with_persona(
+            StealthProfile::native(),
+            fp,
+            Persona::default(),
+        ))
+        .await;
+
+        let source = params(&frames, "Page.addScriptToEvaluateOnNewDocument")["source"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        assert_eq!(
+            line_with(&source, "const AVAIL_H"),
+            "const AVAIL_H = 860;",
+            "the measured availHeight must reach Native's geometry bootstrap"
+        );
+        assert_eq!(
+            line_with(&source, "const INNER_H"),
+            "const INNER_H = 780;",
+            "the measured innerHeight must reach Native's geometry bootstrap"
+        );
+
+        // The CDP override and the JS geometry have to describe one display,
+        // which is the whole reason the arm reads the merged value.
+        let metrics = params(&frames, "Emulation.setDeviceMetricsOverride");
+        assert_eq!(metrics["width"].as_u64(), Some(1440));
+        assert_eq!(metrics["height"].as_u64(), Some(900));
+    }
+
+    /// The documented fallback for both `Persona::timezone` and
+    /// `Fingerprint::timezone`: nothing configured means no override, so
+    /// Chrome keeps the host's zone rather than being pinned to a fabricated
+    /// default. Only [`drive_attach`] can assert this — it returns the whole
+    /// ordered frame list, where absence is observable.
+    #[tokio::test]
+    async fn no_timezone_or_locale_configured_sends_neither_override() {
+        let frames = drive_attach(StealthObserver::with_persona(
+            StealthProfile::spoofed(),
+            bare_fingerprint(),
+            Persona::default(),
+        ))
+        .await;
+
+        let methods = method_names(&frames);
+        assert!(
+            !methods.iter().any(|m| m == "Emulation.setTimezoneOverride"),
+            "no timezone is configured, so no override may be sent; got {methods:?}"
+        );
+        assert!(
+            !methods.iter().any(|m| m == "Emulation.setLocaleOverride"),
+            "no locale and no languages are configured, so no override may be sent; \
+             got {methods:?}"
+        );
+    }
+
+    /// The symmetric case to
+    /// [`persona_timezone_is_sent_when_the_fingerprint_pins_none`]: a
+    /// `StealthProfile::timezone` pin with no persona at all still has to
+    /// reach the wire. The merge is what both directions run through, so
+    /// covering only the persona direction would leave half of it unheld.
+    #[tokio::test]
+    async fn fingerprint_timezone_reaches_cdp_when_the_persona_pins_none() {
+        let fp = Fingerprint {
+            timezone: Some("Australia/Sydney".into()),
+            ..bare_fingerprint()
+        };
+
+        let frames = drive_attach(StealthObserver::with_persona(
+            StealthProfile::spoofed(),
+            fp,
+            Persona::default(),
+        ))
+        .await;
+
+        assert_eq!(
+            params(&frames, "Emulation.setTimezoneOverride")["timezoneId"].as_str(),
+            Some("Australia/Sydney"),
+        );
     }
 }

--- a/crates/zendriver-stealth/src/patches.rs
+++ b/crates/zendriver-stealth/src/patches.rs
@@ -59,6 +59,13 @@ const MOUSE: &str = include_str!("patches/mouse.js");
 /// the UA coherent: when the persona changes platform we rebuild the UA-CH
 /// metadata against the real Chrome version instead of a stale fallback.
 ///
+/// The window/screen geometry is the one surface `identity` can drive on its
+/// own: `persona.screen` is used when set, and a persona that leaves it unset
+/// falls back to `identity.screen`. That keeps the emitted `avail*`/`outer*`
+/// insets describing whatever display
+/// `Emulation.setDeviceMetricsOverride` was given, which resolves the same
+/// two sources the same way.
+///
 /// Order: identity IIFE first (webdriver-most-probed-first, navigator_props
 /// last), then the PRNG definition, then each persona surface.
 #[must_use]
@@ -164,10 +171,17 @@ fn bootstrap_script_impl(persona: &Persona, identity: &Fingerprint, spoof_webgl:
     body.push('\n');
     body.push_str(PRNG);
 
-    // Geometry coherence runs unconditionally (no persona spec) — it repairs the
-    // outer*/avail* props that the CDP metrics override cannot reach.
+    // Geometry coherence runs unconditionally — it repairs the outer*/avail*
+    // props that the CDP metrics override cannot reach. Same precedence as
+    // every other shared axis (persona pin first, else the fingerprint's), so
+    // the insets describe the display `Emulation.setDeviceMetricsOverride`
+    // sizes. `StealthObserver::with_persona` has already merged the two, which
+    // makes this a no-op there; it still matters for a caller driving the
+    // public `bootstrap_script` with an unmerged pair.
     body.push('\n');
-    body.push_str(&screen_patch(persona.screen.as_ref()));
+    body.push_str(&screen_patch(
+        persona.screen.as_ref().or(identity.screen.as_ref()),
+    ));
     // Synthetic pointer entropy, also unconditional.
     body.push('\n');
     body.push_str(MOUSE);

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -40,19 +40,41 @@ pub struct Persona {
     pub ua: Option<UaSpec>,
     pub hardware_concurrency: Option<u32>,
     pub device_memory_gb: Option<u32>,
+    /// IANA timezone name (e.g. `"Europe/Berlin"`). Drives
+    /// `Emulation.setTimezoneOverride`, which is what `Intl` and `Date` read.
+    /// When unset, the [`Fingerprint`](crate::Fingerprint)'s own timezone
+    /// applies — from
+    /// [`StealthProfile::timezone`](crate::StealthProfile::timezone) — and
+    /// when neither is set no override is sent and Chrome keeps the host's.
     pub timezone: Option<String>,
+    /// Locale tag (e.g. `"fr-FR"`). When [`languages`](Self::languages) is
+    /// unset, drives both `Emulation.setLocaleOverride` and the
+    /// `Accept-Language` header derived from it (`"fr-FR"` → `fr-FR,fr`);
+    /// when the list is set, the list drives both instead. Same fallback as
+    /// [`timezone`](Self::timezone): the fingerprint's locale, then Chrome's
+    /// own.
     pub locale: Option<String>,
     /// Ordered language list (e.g. `["de-DE", "de"]`). Drives
-    /// `navigator.languages` and the q-weighted `Accept-Language`. When unset,
-    /// derived from [`locale`](Self::locale).
+    /// `navigator.languages`, the q-weighted `Accept-Language`, and
+    /// `Emulation.setLocaleOverride` from its first entry. When unset, all
+    /// three derive from [`locale`](Self::locale).
+    ///
+    /// The list outranks [`locale`](Self::locale) because a real Chrome
+    /// always reports `navigator.language` as `navigator.languages[0]` — a
+    /// locale outside the advertised list is a browser that cannot exist. An
+    /// empty list counts as unset and inherits the fingerprint's, rather than
+    /// erasing it.
     pub languages: Option<Vec<String>>,
     /// Mock coordinates for the Geolocation API (`Emulation.setGeolocationOverride`).
     /// Coherence axis alongside [`timezone`](Self::timezone) /
     /// [`locale`](Self::locale) — keeps `navigator.geolocation` in step with
     /// the exit IP's real location instead of leaking the host's.
     pub geolocation: Option<GeoPos>,
-    /// Screen / device-metrics override (`Emulation.setDeviceMetricsOverride`).
-    /// `None` → the observer's fixed 1920x1080 default (today's behavior).
+    /// Screen / device-metrics override (`Emulation.setDeviceMetricsOverride`
+    /// plus the bootstrap's `outer*`/`avail*` geometry repair, which CDP
+    /// cannot reach). Wins over
+    /// [`StealthProfile::screen`](crate::StealthProfile::screen); `None` falls
+    /// back to it, and to the fixed 1920x1080 default when neither is set.
     pub screen: Option<ScreenSpec>,
     pub webgl: Option<WebglSpec>,
     /// WebGPU adapter override — decorate a real adapter's `.info` (deriving

--- a/crates/zendriver-stealth/src/profile.rs
+++ b/crates/zendriver-stealth/src/profile.rs
@@ -235,16 +235,29 @@ impl StealthProfile {
     }
     /// Override the reported locale (e.g. `"en-US"`, `"fr-FR"`).
     ///
-    /// Sends `Emulation.setLocaleOverride` and adds `--lang=...` to the
-    /// launch flags.
+    /// Adds `--lang=...` to the launch flags, and — unless
+    /// [`languages`](Self::languages) is also set — sends
+    /// `Emulation.setLocaleOverride` and supplies the `Accept-Language` list
+    /// derived from it (`"fr-FR"` → `fr-FR,fr`).
+    ///
+    /// When both are set, the list wins the two CDP surfaces and only the
+    /// `--lang` flag still follows this value; see
+    /// [`languages`](Self::languages) for why.
     #[must_use]
     pub fn locale(mut self, l: impl Into<String>) -> Self {
         self.per_field.locale = Some(l.into());
         self
     }
-    /// Override the reported language list (drives `navigator.languages` +
-    /// q-weighted `Accept-Language`). When unset, derived from
-    /// [`locale`](Self::locale).
+    /// Override the reported language list (drives `navigator.languages`, the
+    /// q-weighted `Accept-Language`, and `Emulation.setLocaleOverride` from
+    /// its first entry). When unset, all three are derived from
+    /// [`locale`](Self::locale) instead.
+    ///
+    /// The list outranks [`locale`](Self::locale) on all three because a real
+    /// Chrome always reports `navigator.language` as `navigator.languages[0]`:
+    /// setting both to disagreeing values describes a browser that cannot
+    /// exist, and a `language` outside the advertised list is the more
+    /// visible half of that contradiction. An empty list counts as unset.
     #[must_use]
     pub fn languages(mut self, langs: impl IntoIterator<Item = String>) -> Self {
         self.per_field.languages = Some(langs.into_iter().collect());
@@ -286,7 +299,9 @@ impl StealthProfile {
     /// Override the reported screen / device-metrics
     /// (`Emulation.setDeviceMetricsOverride`) wholesale.
     ///
-    /// Replaces the observer's fixed 1920x1080 default. Like
+    /// Replaces the observer's fixed 1920x1080 default, and supplies the
+    /// bootstrap's `avail*` / `outer*` insets so the JS geometry describes the
+    /// same display CDP sizes. Like
     /// [`user_agent_metadata`](Self::user_agent_metadata), this is a
     /// profile-level pin; a [`Persona`](crate::Persona)'s `screen` field
     /// (threaded via

--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -1357,8 +1357,10 @@ impl BrowserBuilder {
         self
     }
 
-    /// Set the base fingerprint [`Persona`] driving the spoofed-mode surface
-    /// patches (canvas/WebGL/audio/fonts/clientRects/WebRTC/hardware).
+    /// Set the base fingerprint [`Persona`]: it drives the spoofed-mode
+    /// surface patches (canvas/WebGL/audio/fonts/clientRects/WebRTC/hardware)
+    /// and, for every stealth profile except `off`, the emulation overrides —
+    /// `timezone`, `locale` / `languages`, `screen` and `geolocation`.
     ///
     /// When unset, [`Persona::system`] (host-probed) is used. Combine with
     /// [`BrowserBuilder::persona_overlay`] for field-wise tweaks and

--- a/docs/api-audit/pr-plan.md
+++ b/docs/api-audit/pr-plan.md
@@ -42,7 +42,7 @@ diff self-evidently scoped.
 | **3e** | Query builders — `RoleMatch`, `NameMatch`, `AriaRole::Other`, `FindAllBuilder`, `ClearOptions`, `ScrollOptions::anchor`; element reads through the isolated world | |
 | **4a** | `impl Default for InputProfile`, then the nine new axes across all three presets | Default must land first or every later field is breaking |
 | **4b** | Route `type_keys` / `press` / `press_with` and both `mouse_drag`s through the profile; `input_seed` | |
-| **4c** | `StealthProfile::{focus_emulation, patch_workers, default_languages}`; `Surface::{Plugins, Codecs, BrokenImage}` | |
+| **4c** | `StealthProfile::{focus_emulation, patch_workers, default_languages}`; `Surface::{Plugins, Codecs, BrokenImage}`; reconcile the two `--lang` emitters — `BrowserBuilder::lang` (`browser.rs:1718`) and `StealthProfile::locale` (`profile.rs:545`) both push one, so setting both puts two in argv | the `--lang` half of the locale axis; 2a folds the CDP half |
 | **4d** | `ScreenSpec`, `BatterySpec`, `MediaDeviceSpec`, `VoiceSpec`; probe `Browser.getVersion` instead of the pinned Chrome 148 | |
 | **5a-1** | `ignore_default_args` / `ignore_all_default_args` / `default_args()` | |
 | **5a-2** | `remote_debugging_port` / `_address` + the `parse_devtools_active_port` hardcode, `proxy_bypass`, `profile_directory`, `stray_targets` | |

--- a/docs/book/src/stealth.md
+++ b/docs/book/src/stealth.md
@@ -133,7 +133,7 @@ let profile = StealthProfile::spoofed()
     .cpu_count(8)               // navigator.hardwareConcurrency
     .chrome_version(126)        // Chrome major in UA + Sec-CH-UA
     .platform(Platform::Win32)  // navigator.platform + OS in UA
-    .locale("en-US")            // navigator.language + --lang flag
+    .locale("en-US")            // navigator.language + Accept-Language + --lang
     .timezone("America/New_York");
 
 let browser = Browser::builder()
@@ -142,6 +142,21 @@ let browser = Browser::builder()
     .await?;
 # Ok(()) }
 ```
+
+`locale` alone is usually enough. It sets the `--lang` launch flag, the
+JS-visible locale that `navigator.language` and `Intl` read, and an
+`Accept-Language` derived from it (`en-US` gives `en-US,en;q=0.9`). Reach
+for `.languages([...])` when you need the header to advertise a longer or
+differently-weighted list. Its first entry then becomes
+`navigator.language` as well, because Chrome always reports that as
+`navigator.languages[0]`, and a locale sitting outside the advertised
+list is a mismatch no real browser produces.
+
+A [`Persona`](https://docs.rs/zendriver-stealth/latest/zendriver_stealth/struct.Persona.html)
+carries the same `timezone` / `locale` / `languages` / `screen` fields,
+and whichever ones it sets take precedence over the profile's. Anything
+it leaves unset falls through to the values above, so a persona can pin
+one axis without restating the rest.
 
 You can also override the User-Agent string verbatim — useful when
 you need an exact UA that doesn't match the auto-composed one:


### PR DESCRIPTION
`BrowserBuilder::persona` accepted a timezone, locale, language list and screen, then dropped all four. `with_persona` kept only `geolocation`, `ua_metadata` and `screen`; everything else was gone before any consumer saw it.

**The reason it survived this long is the interesting part.** `Emulation.setTimezoneOverride` and `setLocaleOverride` were both being sent — they just carried the *fingerprint's* values. A caller who set `Persona::timezone` got a correct-looking CDP frame containing someone else's timezone. Nothing in the suite asserted otherwise, so there was no red anywhere to notice.

## The fix

Fold once, in `Fingerprint::overlay_persona`, at the single point a `Persona` and a `Fingerprint` actually meet — reached by both `launch()` and `connect()`. Every downstream consumer (the two CDP overrides, Accept-Language, the JS patches) then reads one merged value instead of re-deriving precedence four times. An explicitly set persona field wins; an unset one inherits.

Two more bugs fell out of doing it:

- **`Fingerprint::screen` was read by nothing at all**, which made `StealthProfile::screen()` entirely inert. The same accepted-then-discarded shape this PR exists to fix, one layer down.
- **The two locale surfaces resolved the same fields in opposite orders.** A persona language list over a fingerprint locale produced a header and a `navigator.languages` saying one thing while `Intl` said another. Both now resolve through one helper, **languages-first** — in a real Chrome `navigator.language === navigator.languages[0]` always, so when the two disagree, honouring both is impossible and the list has to win.

An empty `languages` list is treated as unset, matching every other language consumer in the crate. Left alone it destroyed a configured `StealthProfile` pin and silently stopped the locale override being sent at all — reachable from MCP `browser_open.persona`, which deserializes raw persona JSON.

## Verification

12 tests, each asserting the **params** of the CDP frame rather than that a method was called. Every one was seen failing before the fix that makes it pass.

Then 13 mutations, reverting each fix in turn: **every test dies on the mutation that reintroduces its bug, and nothing else fails.** Three of them are the sole guard for their line — the empty-list filter, the `ProfileKind::Native` arm, and the assertion that *no* override is sent when nothing is configured. That last one is why the tests use a helper that returns the whole ordered frame list rather than `expect_cmd`, which silently discards non-matching frames and so cannot prove absence at all.

`fmt` clean · clippy clean on default **and** `--features geo` (which CI never lints) · **312 stealth tests**, 445 in `zendriver` · `mdbook build` clean · schema snapshots unchanged, no `.snap.new`.

No public API change: both new functions are `pub(crate)`, and `with_persona`'s signature is untouched. No baseline or ledger work.

## One thing deliberately not done

With nothing configured anywhere, the bootstrap patches `navigator.languages` to `["en-US","en"]` and the header matches, but `navigator.language` stays whatever the host Chrome reports, because no override is sent. Pre-existing and outside this row — and fixing it would mean forcing a locale nobody asked for, which the project's no-auto-behavior rule rules out. Flagged rather than backlogged.

---
PR 2a of [pr-plan.md](docs/api-audit/pr-plan.md). 🤖 Generated with [Claude Code](https://claude.com/claude-code)