### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-fingerprints"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "dirs",
  "fastrand",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-stealth"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "chromiumoxide_cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,14 @@ authors = ["zendriver-rs contributors"]
 # Internal
 zendriver               = { path = "crates/zendriver", version = "0.5.24", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.6" }
-zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.12.4" }
+zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.12.5" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.14" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.18" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.2.1" }
 zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.33" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.4" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.21" }
-zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.19" }
+zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.20" }
 
 # MCP server
 # Pinned exactly, matching proxybroker-rs: rmcp's macro and transport surface moves across

--- a/crates/zendriver-fingerprints/CHANGELOG.md
+++ b/crates/zendriver-fingerprints/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.3.20] - 2026-08-08
+
+
 ## [0.3.19] - 2026-08-08
 
 

--- a/crates/zendriver-fingerprints/Cargo.toml
+++ b/crates/zendriver-fingerprints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-fingerprints"
 description = "Real-device persona sources (pool + generative) for zendriver-rs"
-version = "0.3.19"
+version = "0.3.20"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver-stealth/CHANGELOG.md
+++ b/crates/zendriver-stealth/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate documented here. Format: [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://semver.org/).
 
+## [0.12.5] - 2026-08-08
+
+### Fixed
+
+- Fold the persona into the fingerprint so it reaches CDP ([#222](https://github.com/TurtIeSocks/zendriver-rs/pull/222))
+
+
 ## [0.12.4] - 2026-08-08
 
 

--- a/crates/zendriver-stealth/Cargo.toml
+++ b/crates/zendriver-stealth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-stealth"
 description = "Anti-detection patches and profiles for zendriver"
-version = "0.12.4"
+version = "0.12.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-stealth`: 0.12.4 -> 0.12.5 (✓ API compatible changes)
* `zendriver`: 0.5.11 -> 0.5.24
* `zendriver-mcp`: 0.16.20 -> 0.16.33
* `zendriver-fingerprints`: 0.3.19 -> 0.3.20

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-stealth`

<blockquote>

## [0.12.5] - 2026-08-08

### Fixed

- Fold the persona into the fingerprint so it reaches CDP ([#222](https://github.com/TurtIeSocks/zendriver-rs/pull/222))
</blockquote>

## `zendriver`

<blockquote>

## [0.5.24] - 2026-08-08

Nothing changed in 0.5.12 through 0.5.24. A release-automation loop cut them and
they are yanked; every one is byte-identical to 0.5.11 apart from the version
string. Listed once here rather than as thirteen empty headings.
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.16.33] - 2026-08-08

Nothing changed in 0.16.21 through 0.16.33. A release-automation loop cut them
and they are yanked; this crate only moved because its `zendriver` dependency
was being bumped. Listed once here rather than as thirteen empty headings.
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).