### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-cloudflare"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ authors = ["zendriver-rs contributors"]
 zendriver               = { path = "crates/zendriver", version = "0.5.24", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.6" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.12.5" }
-zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.14" }
+zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.15" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.18" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.2.1" }
 zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.33" }

--- a/crates/zendriver-cloudflare/CHANGELOG.md
+++ b/crates/zendriver-cloudflare/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.2.15] - 2026-08-09
+
+### Added
+
+- Make the Turnstile markers and click policy caller data ([#224](https://github.com/TurtIeSocks/zendriver-rs/pull/224))
+
+
 ## [0.2.14] - 2026-08-08
 
 ### Fixed

--- a/crates/zendriver-cloudflare/Cargo.toml
+++ b/crates/zendriver-cloudflare/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver-cloudflare"
 description = "Cloudflare Turnstile bypass for zendriver"
-version = "0.2.14"
+version = "0.2.15"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `zendriver-cloudflare`: 0.2.14 -> 0.2.15 (✓ API compatible changes)
* `zendriver`: 0.5.11 -> 0.5.24
* `zendriver-mcp`: 0.16.20 -> 0.16.33

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver-cloudflare`

<blockquote>

## [0.2.15] - 2026-08-09

### Added

- Make the Turnstile markers and click policy caller data ([#224](https://github.com/TurtIeSocks/zendriver-rs/pull/224))
</blockquote>

## `zendriver`

<blockquote>

## [0.5.24] - 2026-08-08

Nothing changed in 0.5.12 through 0.5.24. A release-automation loop cut them and
they are yanked; every one is byte-identical to 0.5.11 apart from the version
string. Listed once here rather than as thirteen empty headings.
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.16.33] - 2026-08-08

Nothing changed in 0.16.21 through 0.16.33. A release-automation loop cut them
and they are yanked; this crate only moved because its `zendriver` dependency
was being bumped. Listed once here rather than as thirteen empty headings.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).