### PR TITLE
fix(release): bump past the yanked versions so publishing can resume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver"
-version = "0.5.24"
+version = "0.5.25"
 dependencies = [
  "async-trait",
  "base64",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "zendriver-mcp"
-version = "0.16.33"
+version = "0.16.34"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ authors = ["zendriver-rs contributors"]
 
 [workspace.dependencies]
 # Internal
-zendriver               = { path = "crates/zendriver", version = "0.5.24", default-features = false }
+zendriver               = { path = "crates/zendriver", version = "0.5.25", default-features = false }
 zendriver-transport     = { path = "crates/zendriver-transport", version = "0.2.6" }
 zendriver-stealth       = { path = "crates/zendriver-stealth", version = "0.12.5" }
 zendriver-cloudflare    = { path = "crates/zendriver-cloudflare", version = "0.2.15" }
 zendriver-interception  = { path = "crates/zendriver-interception", version = "0.3.18" }
 zendriver-fetcher       = { path = "crates/zendriver-fetcher", version = "0.2.1" }
-zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.33" }
+zendriver-mcp           = { path = "crates/zendriver-mcp", version = "0.16.34" }
 zendriver-imperva       = { path = "crates/zendriver-imperva", version = "0.3.4" }
 zendriver-datadome      = { path = "crates/zendriver-datadome", version = "0.1.21" }
 zendriver-fingerprints  = { path = "crates/zendriver-fingerprints", version = "0.3.20" }

--- a/crates/zendriver-mcp/Cargo.toml
+++ b/crates/zendriver-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zendriver-mcp"
-version = "0.16.33"
+version = "0.16.34"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/zendriver/Cargo.toml
+++ b/crates/zendriver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zendriver"
 description = "Async-first browser automation via the Chrome DevTools Protocol, with anti-detection controls on by default"
-version = "0.5.24"
+version = "0.5.25"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Every Release run since 2026-08-08 has failed on:

```
failed to select a version for the requirement `zendriver = "^0.5.24"`
  version 0.5.24 is yanked
```

This one is mine. Repairing the runaway-release state, I set the crate versions to the registry maximum — 0.5.24 and 0.16.33 — reasoning that local should match crates.io. Both were then yanked in the same cleanup, because the runaway range was 0.5.12 **through 0.5.24 inclusive**. Matching a registry maximum is worthless when that maximum is about to be yanked, and I did both in the same sitting without connecting them.

The result is stuck, not just stale: `zendriver` skips its own publish as "already published", and `zendriver-mcp` — the only crate depending on it — cannot be packaged at all, because cargo refuses to resolve a yanked dependency. No bump clears that, since the version it would bump from is the yanked one.

0.5.25 and 0.16.34 were never published, so they are free. They are also precisely the versions the repair overwrote. Restoring them lets `zendriver` publish first, after which `zendriver-mcp`'s caret requirement resolves against a live version.

Verified locally rather than by pushing and watching: `cargo package -p zendriver --no-verify` now succeeds at 0.5.25 (it failed the equivalent step in CI), and the workspace builds at both new versions. `fmt` clean.

Every other crate kept publishing normally — `zendriver-stealth` 0.12.5, `zendriver-cloudflare` 0.2.15, `zendriver-fingerprints` 0.3.20 are all live and tagged. Only these two were blocked.

Worth noting separately: the Release job was red for two days and nothing surfaced it. That is the same shape as the stealth canary that sat red behind `continue-on-error` — a failing publish is invisible unless someone opens the Actions tab. Happy to add an alert on Release failure as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)