### PR TITLE
chore: release

### DIFF
--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -5,6 +5,18 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.16.34] - 2026-08-18
+
+### Added
+
+- Make the Turnstile markers and click policy caller data ([#224](https://github.com/TurtIeSocks/zendriver-rs/pull/224))
+
+### Fixed
+
+- Undo the runaway release state, and stop it recurring ([#218](https://github.com/TurtIeSocks/zendriver-rs/pull/218))
+- Bump past the yanked versions so publishing can resume ([#227](https://github.com/TurtIeSocks/zendriver-rs/pull/227))
+
+
 ## [0.16.33] - 2026-08-08
 
 Nothing changed in 0.16.21 through 0.16.33. A release-automation loop cut them

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,19 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.5.25] - 2026-08-18
+
+### Added
+
+- Make the Turnstile markers and click policy caller data ([#224](https://github.com/TurtIeSocks/zendriver-rs/pull/224))
+
+### Fixed
+
+- Undo the runaway release state, and stop it recurring ([#218](https://github.com/TurtIeSocks/zendriver-rs/pull/218))
+- Fold the persona into the fingerprint so it reaches CDP ([#222](https://github.com/TurtIeSocks/zendriver-rs/pull/222))
+- Bump past the yanked versions so publishing can resume ([#227](https://github.com/TurtIeSocks/zendriver-rs/pull/227))
+
+
 ## [0.5.24] - 2026-08-08
 
 Nothing changed in 0.5.12 through 0.5.24. A release-automation loop cut them and


### PR DESCRIPTION



## 🤖 New release

* `zendriver`: 0.5.11 -> 0.5.25
* `zendriver-mcp`: 0.16.20 -> 0.16.34

<details><summary><i><b>Changelog</b></i></summary><p>

## `zendriver`

<blockquote>

## [0.5.25] - 2026-08-18

### Added

- Make the Turnstile markers and click policy caller data ([#224](https://github.com/TurtIeSocks/zendriver-rs/pull/224))

### Fixed

- Undo the runaway release state, and stop it recurring ([#218](https://github.com/TurtIeSocks/zendriver-rs/pull/218))
- Fold the persona into the fingerprint so it reaches CDP ([#222](https://github.com/TurtIeSocks/zendriver-rs/pull/222))
- Bump past the yanked versions so publishing can resume ([#227](https://github.com/TurtIeSocks/zendriver-rs/pull/227))
</blockquote>

## `zendriver-mcp`

<blockquote>

## [0.16.34] - 2026-08-18

### Added

- Make the Turnstile markers and click policy caller data ([#224](https://github.com/TurtIeSocks/zendriver-rs/pull/224))

### Fixed

- Undo the runaway release state, and stop it recurring ([#218](https://github.com/TurtIeSocks/zendriver-rs/pull/218))
- Bump past the yanked versions so publishing can resume ([#227](https://github.com/TurtIeSocks/zendriver-rs/pull/227))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).