### PR TITLE
fix(ci): block the no-op merge without closing the PR

### DIFF
--- a/.github/workflows/release-plz-pr.yml
+++ b/.github/workflows/release-plz-pr.yml
@@ -53,6 +53,34 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+      # Second line of defence, independent of why a release PR appeared.
+      # A release that changes no crate version is by definition a no-op, and
+      # it was this loop's own tell: 15 consecutive changelog-only "releases"
+      # ran while nothing was watching for exactly that shape.
+      #
+      # Block the MERGE, do not close the PR. The same changelog-only shape is
+      # also produced legitimately, by a hand-edited version -- release-plz
+      # then has nothing left to bump and opens a PR carrying only the
+      # changelog entry. Closing that one on 2026-08-18 cost the 0.5.25
+      # heading, and a changelog drifting from what actually published is the
+      # condition that started the loop in the first place. Leaving it open and
+      # red puts a human in front of the decision instead of guessing which
+      # case this is.
+      - name: Refuse to auto-merge a release PR that bumps no version
+        id: noop-guard
+        if: ${{ steps.release-plz.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          PR_NUMBER: ${{ fromJSON(steps.release-plz.outputs.pr).number }}
+        run: |
+          if ! gh pr diff "$PR_NUMBER" --name-only | grep -q 'Cargo\.toml$'; then
+            echo "::error::release PR #$PR_NUMBER bumps no crate version, so it will not be auto-merged."
+            echo "::error::That is the no-op shape that looped on 2026-08-08 -- and also what a"
+            echo "::error::hand-edited version leaves behind. Left open for a human: merge it if the"
+            echo "::error::changelog entry is wanted, close it if this is a loop."
+            exit 1
+          fi
+
       # Auto-merge the release PR so publishing stays hands-off: the
       # merge pushes "chore: release ..." to main, which triggers
       # release-plz-release.yml to publish to crates.io.
@@ -72,26 +100,7 @@ jobs:
       # each one waited its full ~7 minutes for green CI and got it,
       # because an empty release genuinely passes every check. Required
       # checks answer "is this branch broken", never "should this exist";
-      # that question is the job of the two guards above and below.
-      # Second line of defence, independent of why a release PR appeared.
-      # A release that changes no crate version is by definition a no-op, and
-      # it was this loop's own tell: 15 consecutive changelog-only "releases"
-      # ran while nothing was watching for exactly that shape. Refuse to merge
-      # one, and leave the run red so a human sees it.
-      - name: Refuse a release PR that bumps no version
-        if: ${{ steps.release-plz.outputs.prs_created == 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          PR_NUMBER: ${{ fromJSON(steps.release-plz.outputs.pr).number }}
-        run: |
-          if ! gh pr diff "$PR_NUMBER" --name-only | grep -q 'Cargo\.toml$'; then
-            echo "::error::release PR #$PR_NUMBER changes no Cargo.toml version."
-            echo "::error::That is the no-op release shape that looped on 2026-08-08."
-            gh pr close "$PR_NUMBER" \
-              --comment "Closed automatically: this release PR bumps no crate version." || true
-            exit 1
-          fi
-
+      # that question is the job of the job-level `if:` and the no-op step above.
       - name: Auto-merge the release PR
         if: ${{ steps.release-plz.outputs.prs_created == 'true' }}
         env:

--- a/crates/zendriver-mcp/CHANGELOG.md
+++ b/crates/zendriver-mcp/CHANGELOG.md
@@ -5,6 +5,14 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.16.34] - 2026-08-18
+
+### Fixed
+
+- Publishing works again. This crate depends on `zendriver`, and 0.5.24 was
+  yanked while still being the declared version, so `cargo package` refused to
+  resolve it. No source change beyond the version string.
+
 ## [0.16.33] - 2026-08-08
 
 Nothing changed in 0.16.21 through 0.16.33. A release-automation loop cut them

--- a/crates/zendriver/CHANGELOG.md
+++ b/crates/zendriver/CHANGELOG.md
@@ -5,6 +5,15 @@ Changelog](https://keepachangelog.com/en/1.1.0/). Adheres to [SemVer](https://se
 
 ## [Unreleased]
 
+## [0.5.25] - 2026-08-18
+
+### Fixed
+
+- Publishing works again. 0.5.24 was yanked while it was also the version this
+  crate declared, so `zendriver-mcp` could not be packaged against it and no
+  bump could clear that -- the version it would have bumped from was the yanked
+  one. 0.5.25 carries no source change from 0.5.24 beyond the version string.
+
 ## [0.5.24] - 2026-08-08
 
 Nothing changed in 0.5.12 through 0.5.24. A release-automation loop cut them and


### PR DESCRIPTION
The no-op guard fired on release PR #228 and closed it. Correct by its own rule, wrong in effect.

A changelog-only release PR has two causes. In the runaway loop it meant release-plz had lost its place and was cutting empty versions — the shape the guard exists to catch. But it also appears **legitimately** after a hand-edited version: release-plz finds nothing left to bump and opens a PR carrying only the changelog entry. That is what #227 produced, and closing it discarded the `0.5.25` heading. A changelog that no longer matches what published is precisely the condition that started the loop.

The guard's job is to stop the merge, not destroy the work. It now fails the run and leaves the PR open, putting a human in front of a decision the workflow cannot make: merge it if the entry is wanted, close it if this is a loop. Publishing is unaffected either way — that runs on push, which is why 0.5.25 reached crates.io despite #228 being closed.

Also restores the two lost changelog entries by hand, and corrects a comment claiming the guards sit "above and below" the auto-merge step — after reordering so the auto-merge rationale sits with the step it actually describes, both are above it.

The changelog well-formedness check passes on the restored files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)