### PR TITLE
feat(launch): validate launch inputs instead of quietly correcting them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,16 @@ cargo clippy --workspace --all-targets --locked -- -D warnings
   remaining warning is a hard failure).
 - Re-stage / amend after the fixes so the pushed commit is already clean.
 
-CI clippy runs on **default features**; if you touched feature-gated code
-(`interception` / `expect` / `monitor` / `cloudflare` / `imperva` / `datadome` /
-`fetcher` / `geo` / `tracker-blocking` / `fingerprints`), also run
-`cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings`.
+CI clippy runs on **default features**; if you touched any of the
+feature-gated crates listed under Workspace layout, also run the all-features
+pass in its own target dir:
+
+`CARGO_TARGET_DIR=target/all-features cargo clippy -p zendriver-mcp --all-features --all-targets -- -D warnings`
+
+A dedicated `CARGO_TARGET_DIR` keeps the default-feature and all-feature
+clippy caches from invalidating each other — without it they share `target/`
+and `--all-features` changing the feature set forces a full rebuild on every
+feature-gated push. Costs extra disk, saves that rebuild.
 
 ## Schema snapshots (zendriver-mcp)
 
@@ -102,21 +108,22 @@ The published MCP tool count = tools compiled with the default features
 README / rustdoc / book as an incomplete PR — same bar as the MCP coverage
 check above.
 
+## PR scope
+
+Default to one PR for related fixes rather than splitting on review-hygiene
+grounds alone. Caught 2026-08-06 on #161: the macOS symlink fix went onto its
+own branch off `main` because the PR body argued the work "deserves its own
+review rather than a footnote in a feature PR." That reasoning ignored the
+deciding fact: the CLI that reproduces the bug exists only on the PR branch,
+so a fix on `main` was unreachable. Rin's reasons for keeping it one PR: the
+diff is small next to the PR, the two are genuinely related, and this repo
+carries heavy CI ceremony while she was already carrying PRs from another
+session.
+
 ## Workspace layout
 
-9-crate workspace (`edition = 2024`, MSRV 1.85). Roles:
-
-| Crate | Role |
-|-------|------|
-| `zendriver` | Core: async browser automation over the Chrome DevTools Protocol. The public API everything extends. |
-| `zendriver-transport` | Internal WebSocket + CDP routing actor (plumbing). |
-| `zendriver-stealth` | Anti-detection patches + personas. |
-| `zendriver-fingerprints` | Real-device persona sources (pool + generative). |
-| `zendriver-interception` | Network interception via the `Fetch.*` CDP domain. |
-| `zendriver-cloudflare` | Cloudflare Turnstile bypass. |
-| `zendriver-imperva` | Imperva WAF / Incapsula bypass. |
-| `zendriver-fetcher` | Chromium binary downloader (Chrome for Testing / ungoogled-chromium / snapshots), plus the `zendriver-fetch` CLI behind the non-default `cli` feature. |
-| `zendriver-mcp` | MCP server exposing the `zendriver` surface as agent tools (see MCP coverage above). |
+9-crate workspace (`edition = 2024`, MSRV 1.85) — each crate's Cargo.toml
+`description` states its role.
 
 Capability crates are wired into `zendriver` behind features (`interception` /
 `cloudflare` / `imperva` / `datadome` / `fetcher` / `expect` / `monitor` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,10 +72,14 @@ Treat a public API with no MCP tool and no ledger entry as a coverage gap to
 close. The `mcp-coverage` CI job (`.github/workflows/mcp-coverage.yml`) enforces
 this: `tests/public_api.rs` diffs the current `zendriver` public API against
 `public-api-baseline.txt` and fails if any new item is missing from the ledger.
-Run it locally (needs nightly + `cargo-public-api` v0.52.0):
+Run it locally (needs `cargo-public-api` v0.52.0). **Pass
+`PUBLIC_API_TOOLCHAIN`** — the test defaults to bare `nightly`, and any nightly
+newer than the pin renders some types differently (`std::io::error::Error`
+became `core::io::error::Error`), which surfaces as half a dozen phantom
+"missing ledger entries" that do not reproduce in CI:
 
 ```bash
-cargo +nightly test -p zendriver-mcp --features public-api-check --test public_api --locked
+PUBLIC_API_TOOLCHAIN=nightly-2026-06-10 cargo test -p zendriver-mcp --features public-api-check --test public_api --locked
 ```
 
 If you intentionally changed the public API, regenerate the baseline:

--- a/crates/zendriver-mcp/mcp-coverage-ledger.toml
+++ b/crates/zendriver-mcp/mcp-coverage-ledger.toml
@@ -1059,3 +1059,18 @@ excluded = "geometry carried by ClickTarget into the on_click callback; callback
 [[entry]]
 api = "zendriver::CloudflareBypass::on_click"
 excluded = "callback API; no request/response tool shape"
+
+# ── PR 2b launch-path validation: ci_defaults ──────────────────────────────
+# The container launch defaults (`--no-sandbox`, `--disable-dev-shm-usage`)
+# stop being decided solely by sniffing the `CI` environment variable. That
+# matters over the wire too: an MCP server in a root container needs them
+# without `CI` being set, and one on a CI runner may want them off.
+[[entry]]
+api = "zendriver::browser::BrowserBuilder::ci_defaults"
+covered = "browser_open.ci_defaults"
+
+# `StealthProfile::chrome_full_version` is not listed here as its own entry:
+# `cargo-public-api -p zendriver` reports re-exported *types* from
+# `zendriver-stealth` but not their inherent methods, so it never reaches the
+# baseline diff. It is nonetheless reachable, via
+# `browser_stealth_set.overrides.chrome_full_version`.

--- a/crates/zendriver-mcp/public-api-baseline.txt
+++ b/crates/zendriver-mcp/public-api-baseline.txt
@@ -285,6 +285,7 @@ pub fn zendriver::browser::BrowserBuilder::arg(self, impl core::convert::Into<al
 pub fn zendriver::browser::BrowserBuilder::args(self, impl core::iter::traits::collect::IntoIterator<Item = alloc::string::String>) -> Self
 pub fn zendriver::browser::BrowserBuilder::block_trackers(self, bool) -> Self
 pub fn zendriver::browser::BrowserBuilder::channel(self, zendriver::browser::Channel) -> Self
+pub fn zendriver::browser::BrowserBuilder::ci_defaults(self, bool) -> Self
 pub fn zendriver::browser::BrowserBuilder::downloads_dir(self, impl core::convert::Into<std::path::PathBuf>) -> Self
 pub fn zendriver::browser::BrowserBuilder::executable(self, impl core::convert::Into<std::path::PathBuf>) -> Self
 pub fn zendriver::browser::BrowserBuilder::expert(self, bool) -> Self
@@ -6326,6 +6327,7 @@ pub fn zendriver::browser::BrowserBuilder::arg(self, impl core::convert::Into<al
 pub fn zendriver::browser::BrowserBuilder::args(self, impl core::iter::traits::collect::IntoIterator<Item = alloc::string::String>) -> Self
 pub fn zendriver::browser::BrowserBuilder::block_trackers(self, bool) -> Self
 pub fn zendriver::browser::BrowserBuilder::channel(self, zendriver::browser::Channel) -> Self
+pub fn zendriver::browser::BrowserBuilder::ci_defaults(self, bool) -> Self
 pub fn zendriver::browser::BrowserBuilder::downloads_dir(self, impl core::convert::Into<std::path::PathBuf>) -> Self
 pub fn zendriver::browser::BrowserBuilder::executable(self, impl core::convert::Into<std::path::PathBuf>) -> Self
 pub fn zendriver::browser::BrowserBuilder::expert(self, bool) -> Self

--- a/crates/zendriver-mcp/src/state.rs
+++ b/crates/zendriver-mcp/src/state.rs
@@ -94,9 +94,18 @@ pub struct StealthOverrides {
     /// Spoofed `navigator.hardwareConcurrency`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cpu_count: Option<u32>,
-    /// Spoofed Chrome major version.
+    /// Spoofed Chrome major version. The other three digits of the version
+    /// string are fabricated from it (the server logs a warning saying so);
+    /// set `chrome_full_version` instead to state all four.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chrome_version: Option<u32>,
+    /// Spoofed Chrome version in full, `major.minor.build.patch` (e.g.
+    /// `"125.0.6422.113"`). Drives the UA-CH `fullVersionList`, and its
+    /// leading component becomes the reported major, so it outranks
+    /// `chrome_version` when both are set. Use a real Chrome release's
+    /// version; an invented build number is itself a fingerprinting tell.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chrome_full_version: Option<String>,
     /// Full User-Agent string override.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_agent: Option<String>,

--- a/crates/zendriver-mcp/src/tools/lifecycle.rs
+++ b/crates/zendriver-mcp/src/tools/lifecycle.rs
@@ -30,6 +30,22 @@ pub struct OpenInput {
     /// Run Chrome with `--headless=new` (default: `true`).
     #[serde(default = "default_true")]
     pub headless: bool,
+    /// Add the container launch defaults `--no-sandbox` and
+    /// `--disable-dev-shm-usage`.
+    ///
+    /// Both exist for one environment: a container running as root, where
+    /// Chrome's sandbox refuses to start and the small `/dev/shm` starves the
+    /// renderer. Left unset this follows the `CI` environment variable, which
+    /// is what the server has always done. Pass `true` to get them in a
+    /// container that sets no `CI`, or `false` to keep them out of an
+    /// environment that does. `--no-sandbox` drops Chrome's process
+    /// isolation, so only use it on a throwaway browser.
+    ///
+    /// `false` reliably controls the `--no-sandbox` half only: the `native`
+    /// and `spoofed` stealth profiles emit `--disable-dev-shm-usage`
+    /// themselves, and that one weakens nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ci_defaults: Option<bool>,
     /// GPU backend Chrome renders WebGL / WebGPU with (default: `disabled`).
     ///
     /// `disabled` keeps zendriver's historical flags. `swift_shader` forces a
@@ -216,6 +232,9 @@ pub async fn open(
         .headless(input.headless)
         .gpu_backend(input.gpu_backend)
         .stealth(stealth);
+    if let Some(on) = input.ci_defaults {
+        builder = builder.ci_defaults(on);
+    }
     if let Some(choice) = input.input_profile {
         builder = builder.input_profile(input_profile_for(choice));
     }
@@ -449,6 +468,9 @@ fn apply_overrides(mut profile: StealthProfile, overrides: &StealthOverrides) ->
     }
     if let Some(chrome_version) = overrides.chrome_version {
         profile = profile.chrome_version(chrome_version);
+    }
+    if let Some(ref chrome_full_version) = overrides.chrome_full_version {
+        profile = profile.chrome_full_version(chrome_full_version);
     }
     if let Some(ref user_agent) = overrides.user_agent {
         profile = profile.user_agent(user_agent);

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__lifecycle_open_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__lifecycle_open_in.snap
@@ -12,6 +12,11 @@ properties:
     type:
       - boolean
       - "null"
+  ci_defaults:
+    description: "Add the container launch defaults `--no-sandbox` and\n`--disable-dev-shm-usage`.\n\nBoth exist for one environment: a container running as root, where\nChrome's sandbox refuses to start and the small `/dev/shm` starves the\nrenderer. Left unset this follows the `CI` environment variable, which\nis what the server has always done. Pass `true` to get them in a\ncontainer that sets no `CI`, or `false` to keep them out of an\nenvironment that does. `--no-sandbox` drops Chrome's process\nisolation, so only use it on a throwaway browser.\n\n`false` reliably controls the `--no-sandbox` half only: the `native`\nand `spoofed` stealth profiles emit `--disable-dev-shm-usage`\nthemselves, and that one weakens nothing."
+    type:
+      - boolean
+      - "null"
   geo_auto:
     description: "Auto-derive `locale`/`languages`/`timezone` from the exit IP via a\nproxied probe to an IP-geolocation service (default `ip-api.com`).\nOpt-in; makes at most ONE outbound HTTP request, at launch, and only\nwhen this is `true`. Mirrors `proxy` above when both are set, so the\nprobe reports the same exit IP Chrome will actually use. The resolved\ntimezone is the EXACT IANA zone the probe reports for the exit IP\n(not a country-representative one), so multi-timezone countries (US,\nRU, CA, AU, BR, ...) get the visitor's real local zone. Overridden by\nan explicit `persona`/locale, which also skips the probe. Always\npresent in the schema so the wire shape is feature-stable; only takes\neffect when the server is built with the `geo` feature (otherwise\nignored — a warning is logged)."
     type: boolean

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__stealth_set_in.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__stealth_set_in.snap
@@ -27,8 +27,13 @@ $defs:
         type:
           - boolean
           - "null"
+      chrome_full_version:
+        description: "Spoofed Chrome version in full, `major.minor.build.patch` (e.g.\n`\"125.0.6422.113\"`). Drives the UA-CH `fullVersionList`, and its\nleading component becomes the reported major, so it outranks\n`chrome_version` when both are set. Use a real Chrome release's\nversion; an invented build number is itself a fingerprinting tell."
+        type:
+          - string
+          - "null"
       chrome_version:
-        description: Spoofed Chrome major version.
+        description: "Spoofed Chrome major version. The other three digits of the version\nstring are fabricated from it (the server logs a warning saying so);\nset `chrome_full_version` instead to state all four."
         type:
           - integer
           - "null"

--- a/crates/zendriver-mcp/tests/snapshots/schema_snapshots__stealth_set_out.snap
+++ b/crates/zendriver-mcp/tests/snapshots/schema_snapshots__stealth_set_out.snap
@@ -30,8 +30,13 @@ $defs:
         type:
           - boolean
           - "null"
+      chrome_full_version:
+        description: "Spoofed Chrome version in full, `major.minor.build.patch` (e.g.\n`\"125.0.6422.113\"`). Drives the UA-CH `fullVersionList`, and its\nleading component becomes the reported major, so it outranks\n`chrome_version` when both are set. Use a real Chrome release's\nversion; an invented build number is itself a fingerprinting tell."
+        type:
+          - string
+          - "null"
       chrome_version:
-        description: Spoofed Chrome major version.
+        description: "Spoofed Chrome major version. The other three digits of the version\nstring are fabricated from it (the server logs a warning saying so);\nset `chrome_full_version` instead to state all four."
         type:
           - integer
           - "null"

--- a/crates/zendriver-stealth/src/fingerprint.rs
+++ b/crates/zendriver-stealth/src/fingerprint.rs
@@ -486,12 +486,26 @@ fn parse_pe_file_version(bytes: &[u8]) -> Option<(u32, String)> {
     None
 }
 
+/// Bound the *probed* host CPU count to what browsers commonly report.
+///
+/// This is the probe path, where the input is a measurement of whatever host
+/// happens to be running — a 128-thread build machine is a real number and a
+/// terrible thing to advertise. An explicit
+/// [`StealthProfile::cpu_count`](crate::StealthProfile::cpu_count) is a
+/// different kind of input: it is a statement of intent, is not clamped, and
+/// only warns. Keep the two apart.
 pub(crate) fn clamp_cpu_count(n: u32) -> u32 {
     n.clamp(2, 32)
 }
 
 /// Detect total RAM in GB, clamped to the spec-compliant values
-/// for `navigator.deviceMemory` (capped at 8 per W3C; floor at 4 for plausibility).
+/// for `navigator.deviceMemory` (capped at 8 per W3C; floor at 4 for
+/// plausibility).
+///
+/// Probe path, same division as [`clamp_cpu_count`]: rounding a measurement
+/// is not the same act as overriding
+/// [`StealthProfile::memory_gb`](crate::StealthProfile::memory_gb), which is
+/// reported exactly as the caller stated it.
 #[allow(clippy::result_large_err)]
 pub(crate) fn detect_memory_gb() -> Result<u32, StealthError> {
     let mut sys = sysinfo::System::new();

--- a/crates/zendriver-stealth/src/lib.rs
+++ b/crates/zendriver-stealth/src/lib.rs
@@ -47,6 +47,8 @@ pub mod observer;
 pub mod patches;
 pub mod persona;
 pub mod profile;
+#[cfg(test)]
+mod test_logs;
 pub mod ua;
 
 // Re-exports added as types land in Tasks 1–13:

--- a/crates/zendriver-stealth/src/patches.rs
+++ b/crates/zendriver-stealth/src/patches.rs
@@ -689,6 +689,7 @@ fn push_webrtc(out: &mut String, spec: Option<&WebrtcSpec>) {
 mod tests {
     use super::*;
     use crate::persona::surface::Strategy;
+    use crate::test_logs::captured_warnings;
     use crate::{Platform, UserAgentMetadata};
 
     fn mock_identity() -> Fingerprint {
@@ -827,8 +828,11 @@ mod tests {
         };
         let s = bootstrap_script(&persona, &mock_identity());
         assert!(s.contains("\"cpuCount\":4"), "cpu override missing");
-        // deviceMemory is rendered into the fp json untouched here (the JS
-        // clamps); persona value should appear.
+        // `memoryGb` reaches the page exactly as written: it is rendered into
+        // the fp JSON untouched, and `navigator_props.js` serves it through a
+        // bare getter. Nothing downstream corrects it — which is the point,
+        // and why the resolver warns about implausible values rather than
+        // rewriting them.
         assert!(s.contains("\"memoryGb\":16"), "memory override missing");
         assert!(s.contains("fr-FR"), "locale override missing");
     }
@@ -937,41 +941,6 @@ mod tests {
         // Drop the `);` that closes the call; the profile itself ends in `}`.
         let json = arg.trim().trim_end_matches([';', ')']);
         serde_json::from_str(json).expect("the substituted argument is JSON")
-    }
-
-    /// Run `f` with a tracing subscriber capturing WARN and above, and return
-    /// what it logged. A coherence warning nobody can observe is
-    /// indistinguishable from no warning at all.
-    fn captured_warnings(f: impl FnOnce()) -> String {
-        use std::io::Write;
-        use std::sync::{Arc, Mutex};
-
-        #[derive(Clone, Default)]
-        struct Sink(Arc<Mutex<Vec<u8>>>);
-        impl Write for Sink {
-            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-                self.0.lock().unwrap().extend_from_slice(buf);
-                Ok(buf.len())
-            }
-            fn flush(&mut self) -> std::io::Result<()> {
-                Ok(())
-            }
-        }
-        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Sink {
-            type Writer = Self;
-            fn make_writer(&'a self) -> Self {
-                self.clone()
-            }
-        }
-
-        let sink = Sink::default();
-        let subscriber = tracing_subscriber::fmt()
-            .with_writer(sink.clone())
-            .with_max_level(tracing::Level::WARN)
-            .finish();
-        tracing::subscriber::with_default(subscriber, f);
-        let bytes = sink.0.lock().unwrap().clone();
-        String::from_utf8(bytes).expect("log output is utf-8")
     }
 
     #[test]

--- a/crates/zendriver-stealth/src/persona/mod.rs
+++ b/crates/zendriver-stealth/src/persona/mod.rs
@@ -437,6 +437,7 @@ fn persona_from_probe(v: &serde_json::Value) -> Persona {
 #[cfg(test)]
 mod persona_tests {
     use super::*;
+    use crate::test_logs::captured_warnings;
 
     #[test]
     fn default_persona_is_all_none() {
@@ -473,43 +474,6 @@ mod persona_tests {
         let b = Persona::system();
         // Cached → same values.
         assert_eq!(a.device_memory_gb, b.device_memory_gb);
-    }
-
-    /// Run `f` with a tracing subscriber capturing WARN and above, and return
-    /// what it logged. A failure warning nobody can observe is
-    /// indistinguishable from the silent fabrication it replaced. (Twin of the
-    /// helper in `patches.rs`'s test module — kept local rather than shared to
-    /// avoid a test-support module for two callers.)
-    fn captured_warnings(f: impl FnOnce()) -> String {
-        use std::io::Write;
-        use std::sync::{Arc, Mutex};
-
-        #[derive(Clone, Default)]
-        struct Sink(Arc<Mutex<Vec<u8>>>);
-        impl Write for Sink {
-            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-                self.0.lock().unwrap().extend_from_slice(buf);
-                Ok(buf.len())
-            }
-            fn flush(&mut self) -> std::io::Result<()> {
-                Ok(())
-            }
-        }
-        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Sink {
-            type Writer = Self;
-            fn make_writer(&'a self) -> Self {
-                self.clone()
-            }
-        }
-
-        let sink = Sink::default();
-        let subscriber = tracing_subscriber::fmt()
-            .with_writer(sink.clone())
-            .with_max_level(tracing::Level::WARN)
-            .finish();
-        tracing::subscriber::with_default(subscriber, f);
-        let bytes = sink.0.lock().unwrap().clone();
-        String::from_utf8(bytes).expect("log output is utf-8")
     }
 
     // `StealthError` is large because `PatchFailed` wraps `CallError` (~152B);

--- a/crates/zendriver-stealth/src/profile.rs
+++ b/crates/zendriver-stealth/src/profile.rs
@@ -60,12 +60,34 @@ impl Platform {
     }
 }
 
+/// Appended to a major-only [`StealthProfile::chrome_version`] pin to make a
+/// four-part version string. Fabricated, not probed — see the warning the
+/// resolver emits beside it.
+const SYNTHETIC_VERSION_TAIL: &str = ".0.6099.234";
+
+/// The range `navigator.hardwareConcurrency` commonly falls in on real
+/// browsers. Advisory only: values outside it are warned about and still
+/// reported as the caller stated them.
+const PLAUSIBLE_CPU_COUNTS: std::ops::RangeInclusive<u32> = 2..=32;
+
+/// The values `navigator.deviceMemory` exposes to JS, per the [Device Memory
+/// spec](https://www.w3.org/TR/device-memory/). Advisory, same as above.
+const SPEC_DEVICE_MEMORY_VALUES: [u32; 4] = [1, 2, 4, 8];
+
+/// The leading `major` of a `major.minor.build.patch` version string.
+fn major_from_full_version(full: &str) -> Option<u32> {
+    full.split('.').next()?.parse().ok()
+}
+
 #[derive(Debug, Clone, Default)]
 #[allow(dead_code)]
 pub(crate) struct PerFieldOverride {
     pub memory_gb: Option<u32>,
     pub cpu_count: Option<u32>,
     pub chrome_major: Option<u32>,
+    /// Full `major.minor.build.patch` version. Outranks `chrome_major`, which
+    /// can only be completed by inventing the other three digits.
+    pub chrome_full: Option<String>,
     pub platform: Option<Platform>,
     pub timezone: Option<String>,
     pub locale: Option<String>,
@@ -188,22 +210,15 @@ impl StealthProfile {
     }
     /// Override the reported `navigator.deviceMemory` (in GB).
     ///
-    /// Per the [HTML Device Memory spec][spec] the value Chrome reports
-    /// is one of `{1, 2, 4, 8}` (Chrome does not expose fractional values
-    /// to JS). The resolver snaps `gb` to the nearest valid integer at
-    /// or below it:
+    /// Reported exactly as given. Per the [HTML Device Memory spec][spec] the
+    /// value a real Chrome reports is one of `{1, 2, 4, 8}` — it does not
+    /// expose fractional values or anything above `8` to JS — so anything
+    /// else is a fingerprinting tell, and the resolver logs a warning naming
+    /// the value rather than correcting it. Which one you want is your call;
+    /// this is not the layer that gets to overrule it.
     ///
-    /// | Input `gb` | Reported |
-    /// |-----------:|---------:|
-    /// | `0` or `1` | `1`      |
-    /// | `2` or `3` | `2`      |
-    /// | `4`–`7`    | `4`      |
-    /// | `8`+       | `8`      |
-    ///
-    /// Snap-down (not nearest-round) matches Chrome's own behavior and
-    /// avoids inflating the reported value above what the host plausibly
-    /// has. Anything outside `{1, 2, 4, 8}` is itself a stealth tell
-    /// because real browsers never report it.
+    /// The host probe behind the *default* still rounds, because there the
+    /// input is a measurement rather than a statement of intent.
     ///
     /// [spec]: https://www.w3.org/TR/device-memory/
     #[must_use]
@@ -213,17 +228,57 @@ impl StealthProfile {
     }
     /// Override the reported `navigator.hardwareConcurrency` (CPU count).
     ///
-    /// Clamped to `2..=32` at resolve time — values outside that range are
-    /// implausibly low/high and trip simple heuristics.
+    /// Reported exactly as given. Values outside `2..=32` are warned about at
+    /// resolve time — a one-CPU container and a 64-thread workstation are both
+    /// real, but both are rare enough in browser traffic to be worth flagging.
+    /// Same division as [`memory_gb`](Self::memory_gb): the host probe behind
+    /// the default clamps, an explicit value does not.
     #[must_use]
     pub fn cpu_count(mut self, n: u32) -> Self {
         self.per_field.cpu_count = Some(n);
         self
     }
     /// Override the reported Chrome major version (e.g. `125`).
+    ///
+    /// The UA string and UA-CH `full_version` need all four digits, so a
+    /// major on its own leaves the other three to be invented — a build number
+    /// that no Chrome release ever carried, presented as this browser's own.
+    /// The resolver does it (there is no alternative once only the major is
+    /// known) and warns that it did. Pass
+    /// [`chrome_full_version`](Self::chrome_full_version) instead when the
+    /// exact build matters.
     #[must_use]
     pub fn chrome_version(mut self, major: u32) -> Self {
         self.per_field.chrome_major = Some(major);
+        self
+    }
+
+    /// Override the reported Chrome version in full, `major.minor.build.patch`
+    /// (e.g. `"125.0.6422.113"`).
+    ///
+    /// Used verbatim for the UA string and the UA-CH `full_version`, and its
+    /// leading component becomes the reported major — so this outranks
+    /// [`chrome_version`](Self::chrome_version) when both are set, rather than
+    /// composing a version out of two halves that disagree.
+    ///
+    /// A value whose leading component is not a number (`"beta"`) is still
+    /// used verbatim, but has no major to give: the reported major then falls
+    /// back to an explicit [`chrome_version`](Self::chrome_version) if there
+    /// is one, else the probed value, and the resolver warns naming which.
+    ///
+    /// Take the value from a real Chrome release (a version string this
+    /// project can verify, e.g. from Chrome for Testing's release feed); an
+    /// invented build number is itself a fingerprinting tell.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zendriver_stealth::StealthProfile;
+    /// let profile = StealthProfile::spoofed().chrome_full_version("125.0.6422.113");
+    /// ```
+    #[must_use]
+    pub fn chrome_full_version(mut self, full: impl Into<String>) -> Self {
+        self.per_field.chrome_full = Some(full.into());
         self
     }
     /// Override the reported [`Platform`] (`navigator.platform` + UA OS
@@ -466,30 +521,69 @@ impl StealthProfile {
         if let Some(p) = self.per_field.platform {
             fp.platform = p;
         }
-        if let Some(c) = self.per_field.chrome_major {
+        // A stated full version is the more specific of the two, so it carries
+        // the major as well — nothing here composes a version out of two
+        // halves that disagree.
+        if let Some(full) = self.per_field.chrome_full.as_deref() {
+            match major_from_full_version(full) {
+                Some(major) => fp.chrome_major = major,
+                None => {
+                    // Nothing to read out of the string, so fall back to an
+                    // explicit `chrome_version` before the probed value.
+                    // Discarding a major the caller stated, because the *other*
+                    // version setter was unusable, is a silent override of a
+                    // stated intent — the thing this whole path stopped doing.
+                    let reported = self.per_field.chrome_major.unwrap_or(fp.chrome_major);
+                    fp.chrome_major = reported;
+                    tracing::warn!(
+                        chrome_full_version = full,
+                        chrome_major = reported,
+                        from_explicit_chrome_version = self.per_field.chrome_major.is_some(),
+                        "stealth chrome_full_version does not start with a numeric major; \
+                         using it verbatim and reporting the chrome_major shown here",
+                    );
+                }
+            }
+            fp.chrome_full = full.to_string();
+        } else if let Some(c) = self.per_field.chrome_major {
             fp.chrome_major = c;
-            fp.chrome_full = format!("{c}.0.6099.234"); // synthesize a full version if user only set major
+            // The UA string and UA-CH `full_version` need four digits, and a
+            // major is one of them. The remaining three are invented here —
+            // which is defensible only as long as it is said out loud, since
+            // the result is indistinguishable from a probed build number.
+            fp.chrome_full = format!("{c}{SYNTHETIC_VERSION_TAIL}");
+            tracing::warn!(
+                chrome_major = c,
+                chrome_full = %fp.chrome_full,
+                "stealth chrome_version pins only the major; the remaining build digits are \
+                 fabricated and match no real Chrome release — pass chrome_full_version(..) \
+                 with a real one to control them",
+            );
         }
         if let Some(n) = self.per_field.cpu_count {
-            fp.cpu_count = n.clamp(2, 32);
-        }
-        if let Some(g) = self.per_field.memory_gb {
-            // Snap-down to the nearest spec-valid value Chrome exposes
-            // to JS — see `memory_gb` doc table.
-            let snapped = match g {
-                0..=1 => 1,
-                2..=3 => 2,
-                4..=7 => 4,
-                _ => 8,
-            };
-            if snapped != g {
-                tracing::debug!(
-                    requested = g,
-                    chosen = snapped,
-                    "stealth memory_gb snapped to nearest navigator.deviceMemory spec value",
+            // Reported exactly as stated. A one-CPU container and a 64-thread
+            // workstation are both real machines, and quietly rewriting either
+            // hands back a host the caller never described — while leaving
+            // them believing they configured it.
+            if !PLAUSIBLE_CPU_COUNTS.contains(&n) {
+                tracing::warn!(
+                    cpu_count = n,
+                    "stealth cpu_count is outside the 2..=32 range browsers commonly report; \
+                     reporting it verbatim, but navigator.hardwareConcurrency is a tell there",
                 );
             }
-            fp.memory_gb = snapped;
+            fp.cpu_count = n;
+        }
+        if let Some(g) = self.per_field.memory_gb {
+            if !SPEC_DEVICE_MEMORY_VALUES.contains(&g) {
+                tracing::warn!(
+                    memory_gb = g,
+                    "stealth memory_gb is not one of the 1/2/4/8 values \
+                     navigator.deviceMemory exposes; reporting it verbatim, but no real \
+                     Chrome reports it",
+                );
+            }
+            fp.memory_gb = g;
         }
         // Always recompose so `ua_metadata.{platform_version, architecture,
         // bitness}` track any `platform` / `chrome_major` overrides applied
@@ -898,5 +992,158 @@ mod profile_tests {
             .unwrap();
         // No override → today's behavior: no screen field influence at all.
         assert_eq!(resolved.screen, None);
+    }
+
+    // ----- 2b: explicit overrides are reported, not corrected -------------
+
+    fn resolved_with(profile: StealthProfile) -> Fingerprint {
+        profile
+            .fingerprint(bare_fp())
+            .resolve_fingerprint(std::path::Path::new("/nonexistent"))
+            .unwrap()
+    }
+
+    /// Both fixtures sit OUTSIDE the old `2..=32` clamp, in both directions,
+    /// and both describe real machines: a one-CPU container, and any
+    /// Threadripper. Rewriting either produces a host the caller never asked
+    /// for — and, worse, one they still believe they configured.
+    #[test]
+    fn explicit_cpu_count_is_reported_verbatim() {
+        for n in [1, 64] {
+            let fp = resolved_with(StealthProfile::native().cpu_count(n));
+            assert_eq!(fp.cpu_count, n, "cpu_count({n}) must survive verbatim");
+        }
+    }
+
+    /// `3` is not a `navigator.deviceMemory` value any real Chrome reports and
+    /// `64` is above the spec's cap — the old code quietly snapped them to `2`
+    /// and `8`. Both are now the caller's call, so both come back unchanged.
+    #[test]
+    fn explicit_memory_gb_is_reported_verbatim() {
+        for gb in [3, 64] {
+            let fp = resolved_with(StealthProfile::native().memory_gb(gb));
+            assert_eq!(fp.memory_gb, gb, "memory_gb({gb}) must survive verbatim");
+        }
+    }
+
+    /// Dropping the correction without saying anything would just move the
+    /// surprise later, to whichever detector notices `deviceMemory === 3`. The
+    /// value stands; the operator gets told why it is a tell.
+    #[test]
+    fn an_implausible_explicit_value_is_announced_not_corrected() {
+        let logs = crate::test_logs::captured_warnings(|| {
+            let fp = resolved_with(StealthProfile::native().memory_gb(3).cpu_count(64));
+            assert_eq!(fp.memory_gb, 3);
+            assert_eq!(fp.cpu_count, 64);
+        });
+        assert!(logs.contains("memory_gb"), "got: {logs}");
+        assert!(logs.contains("cpu_count"), "got: {logs}");
+    }
+
+    /// A plausible value must stay quiet — a warning that fires on every
+    /// launch is one nobody reads.
+    #[test]
+    fn plausible_explicit_values_warn_about_nothing() {
+        let logs = crate::test_logs::captured_warnings(|| {
+            let fp = resolved_with(StealthProfile::native().memory_gb(8).cpu_count(16));
+            assert_eq!(fp.memory_gb, 8);
+            assert_eq!(fp.cpu_count, 16);
+        });
+        assert!(logs.is_empty(), "expected no warnings, got: {logs}");
+    }
+
+    /// Pinning only the major left the other three digits invented — a full
+    /// version string that names a Chrome build which never shipped, presented
+    /// as the browser's own. Callers can now state it.
+    #[test]
+    fn explicit_chrome_full_version_is_used_verbatim_and_carries_its_major() {
+        let fp = resolved_with(StealthProfile::native().chrome_full_version("125.0.6422.113"));
+        assert_eq!(fp.chrome_full, "125.0.6422.113");
+        assert_eq!(fp.chrome_major, 125);
+        // The UA string itself only ever carries Chrome's reduced version, so
+        // the stated build shows up where Chrome actually reports it: the
+        // UA-CH `fullVersionList`.
+        assert!(
+            fp.ua_metadata
+                .full_version_list
+                .iter()
+                .any(|b| b.version == "125.0.6422.113"),
+            "UA-CH must carry the stated build: {:?}",
+            fp.ua_metadata.full_version_list
+        );
+        assert!(
+            fp.ua_string.contains("Chrome/125.0.0.0"),
+            "the UA string keeps Chrome's reduced form: {}",
+            fp.ua_string
+        );
+    }
+
+    /// Major-only still has to synthesize the rest — the UA needs four digits
+    /// — but silently is exactly how a fabricated build number gets mistaken
+    /// for a probed one.
+    #[test]
+    fn a_major_only_pin_says_that_it_invented_the_build_digits() {
+        let logs = crate::test_logs::captured_warnings(|| {
+            let fp = resolved_with(StealthProfile::native().chrome_version(125));
+            assert_eq!(fp.chrome_major, 125);
+            assert!(fp.chrome_full.starts_with("125."), "got {}", fp.chrome_full);
+        });
+        assert!(logs.contains("chrome_full_version"), "got: {logs}");
+    }
+
+    /// A full version with no numeric leading component cannot supply the
+    /// major, so an explicit [`StealthProfile::chrome_version`] has to — it is
+    /// the only major anyone actually stated. Reporting the *probed* one there
+    /// discards a caller's setting without saying so, which is the exact
+    /// silent override the rest of this PR removes.
+    ///
+    /// `131` is deliberately not the fixture's probed `120`: a test pinned to
+    /// the probed value would pass against the code that drops the setting.
+    #[test]
+    fn a_non_numeric_full_version_still_honors_an_explicit_major() {
+        let logs = crate::test_logs::captured_warnings(|| {
+            let fp = resolved_with(
+                StealthProfile::native()
+                    .chrome_version(131)
+                    .chrome_full_version("beta"),
+            );
+            assert_eq!(
+                fp.chrome_major, 131,
+                "an explicit chrome_version must not be discarded"
+            );
+            assert_eq!(fp.chrome_full, "beta");
+        });
+        assert!(
+            logs.contains("131"),
+            "the warning must name the major it reported: {logs}"
+        );
+    }
+
+    /// With nothing stated, the probed major is genuinely the best available
+    /// answer — but the warning still has to name what it settled on, so
+    /// "which major did this launch claim" never needs guessing.
+    #[test]
+    fn a_non_numeric_full_version_falls_back_to_the_probed_major() {
+        let logs = crate::test_logs::captured_warnings(|| {
+            let fp = resolved_with(StealthProfile::native().chrome_full_version("beta"));
+            assert_eq!(fp.chrome_major, 120, "the probed major from the fixture");
+        });
+        assert!(
+            logs.contains("120"),
+            "the warning must name the major it reported: {logs}"
+        );
+    }
+
+    /// The full version is the more specific statement, so it wins the major
+    /// too — nothing here composes a version out of two disagreeing halves.
+    #[test]
+    fn chrome_full_version_outranks_a_conflicting_major() {
+        let fp = resolved_with(
+            StealthProfile::native()
+                .chrome_version(120)
+                .chrome_full_version("125.0.6422.113"),
+        );
+        assert_eq!(fp.chrome_full, "125.0.6422.113");
+        assert_eq!(fp.chrome_major, 125);
     }
 }

--- a/crates/zendriver-stealth/src/test_logs.rs
+++ b/crates/zendriver-stealth/src/test_logs.rs
@@ -1,0 +1,61 @@
+//! Capture `tracing` events emitted by the code under test — test-only.
+//!
+//! Some behaviour here is observable *only* as a log line. Where the fix for
+//! a silent correction is "report the value the caller asked for, and say
+//! why it looks wrong", a test that asserts the value alone stays green
+//! against code that says nothing at all — so the saying has to be asserted
+//! too.
+//!
+//! The crate's single copy: `patches`, `persona` and `profile` all capture
+//! warnings, and the interest-cache rebuild below is the kind of correctness
+//! detail that has to live in one place to stay right in all three.
+
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+
+/// A `MakeWriter` that appends every formatted event to a shared buffer.
+#[derive(Clone, Default)]
+struct Sink(Arc<Mutex<Vec<u8>>>);
+
+impl Write for Sink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .expect("log buffer poisoned")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Sink {
+    type Writer = Self;
+    fn make_writer(&'a self) -> Self {
+        self.clone()
+    }
+}
+
+/// Run `f` with a `WARN`-level capturing subscriber installed as the
+/// thread-local default, returning everything it logged as one string.
+pub(crate) fn captured_warnings(f: impl FnOnce()) -> String {
+    let sink = Sink::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(sink.clone())
+        .with_max_level(tracing::Level::WARN)
+        .without_time()
+        .finish();
+    tracing::subscriber::with_default(subscriber, || {
+        // `tracing` caches each callsite's interest globally the first time it
+        // is evaluated. A site first reached with no subscriber installed —
+        // which is every other test in this binary — caches "never" and would
+        // stay invisible here, making this capture pass alone and fail in a
+        // full run. Rebuilding re-evaluates every callsite against the
+        // subscriber that is current now.
+        tracing::callsite::rebuild_interest_cache();
+        f();
+    });
+    let bytes = sink.0.lock().expect("log buffer poisoned").clone();
+    String::from_utf8_lossy(&bytes).into_owned()
+}

--- a/crates/zendriver/src/browser.rs
+++ b/crates/zendriver/src/browser.rs
@@ -67,6 +67,9 @@ pub enum Channel {
     Edge,
     /// First Chromium-family browser found — the historical default (Chrome,
     /// then Chromium). Use a specific channel to force Brave / Edge.
+    ///
+    /// The only variant under which the `CHROME_BIN` environment variable is
+    /// honored; see [`BrowserBuilder::channel`].
     #[default]
     Auto,
 }
@@ -114,6 +117,17 @@ pub fn find_chrome_executable_for_channel(channel: Channel) -> Result<PathBuf, B
     Err(BrowserError::ExecutableNotFound {
         searched: candidates,
     })
+}
+
+/// The `CHROME_BIN` environment override, if set to a non-empty value.
+///
+/// The one place the variable is read; [`BrowserBuilder::resolve_executable`]
+/// takes the result as an argument so its precedence rules are testable
+/// without mutating process-wide state.
+fn chrome_bin_from_env() -> Option<PathBuf> {
+    std::env::var_os("CHROME_BIN")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
 }
 
 /// Build the ordered candidate-path list for `channel`.
@@ -635,6 +649,10 @@ pub struct BrowserBuilder {
     /// Sandbox toggle. `None`/`Some(true)` = sandbox on (no flag);
     /// `Some(false)` = emit `--no-sandbox`. See [`BrowserBuilder::sandbox`].
     pub(crate) sandbox: Option<bool>,
+    /// Container-friendly launch defaults. `Some` decides outright; `None`
+    /// falls back to the presence of the `CI` environment variable. See
+    /// [`BrowserBuilder::ci_defaults`].
+    pub(crate) ci_defaults: Option<bool>,
     /// Which browser [`Channel`] to discover when no explicit `executable` is
     /// set. Defaults to [`Channel::Auto`].
     pub(crate) channel: Channel,
@@ -675,10 +693,13 @@ pub struct BrowserBuilder {
     /// profile's `Default/Preferences` at launch. User entries override the
     /// default suppression set. See [`BrowserBuilder::preference`].
     pub(crate) preferences: Vec<(String, serde_json::Value)>,
-    /// Structured browser-wide proxy (userinfo-stripped server + optional
-    /// credentials), set via [`BrowserBuilder::proxy`]. Emitted as
-    /// `--proxy-server=` at launch and mirrored by `geo_auto`'s probe.
-    pub(crate) proxy: Option<crate::proxy::ParsedProxy>,
+    /// Browser-wide proxy URL exactly as the caller passed it to
+    /// [`BrowserBuilder::proxy`], stored raw and parsed at launch by
+    /// [`BrowserBuilder::resolved_proxy`] — the deferred-work shape the
+    /// tracker-blocklist sources use, and the only one available to a setter
+    /// that cannot return an error. The resolved form is emitted as
+    /// `--proxy-server=` and mirrored by `geo_auto`'s probe.
+    pub(crate) proxy: Option<String>,
     /// Optional `(username, password)` for proxy / HTTP basic-auth handling.
     /// Only honored when the `interception` feature is enabled; when present
     /// at launch, an interception actor is spawned on the main tab session
@@ -739,17 +760,13 @@ impl std::fmt::Debug for BrowserBuilder {
             .field("preferences", &self.preferences)
             .field(
                 "proxy",
-                &self.proxy.as_ref().map(|p| {
-                    format!(
-                        "ParsedProxy {{ server: {:?}, credentials: {} }}",
-                        p.server,
-                        if p.credentials.is_some() {
-                            "Some(<redacted>)"
-                        } else {
-                            "None"
-                        }
-                    )
-                }),
+                // Raw, so any userinfo it carries has to be redacted here —
+                // a `Debug` print of a builder must never expose a password.
+                &self
+                    .proxy
+                    .as_deref()
+                    .map(crate::proxy::redact_userinfo)
+                    .unwrap_or_else(|| "None".into()),
             );
         #[cfg(feature = "interception")]
         s.field(
@@ -863,7 +880,10 @@ impl BrowserBuilder {
 
     /// Override the Chrome executable path.
     ///
-    /// When unset, [`find_chrome_executable`] discovers one at launch time.
+    /// Outranks everything else: the `CHROME_BIN` environment variable and
+    /// [`channel`](Self::channel) discovery are both skipped when this is set.
+    /// Unset, the binary comes from `CHROME_BIN` or from discovery — see
+    /// [`channel`](Self::channel) for which wins when.
     ///
     /// # Examples
     ///
@@ -930,35 +950,68 @@ impl BrowserBuilder {
 
     /// Route the browser through `proxy` (`scheme://[user:pass@]host:port`).
     /// Emits `--proxy-server=<host:port>` (Chrome ignores userinfo there) and,
-    /// when the URL carries credentials and `proxy_auth` is unset, auto-wires
-    /// them. The structured form lets `geo_auto()` probe the exit IP through
-    /// the same proxy.
+    /// when the URL carries credentials and [`proxy_auth`](Self::proxy_auth)
+    /// is unset, auto-wires them. The structured form also lets
+    /// [`geo_auto`](Self::geo_auto) probe the exit IP through the same proxy.
     ///
-    /// # Errors
-    /// Silently ignores an unparseable URL (logs a warning) to keep the
-    /// builder chainable; the bad value simply isn't applied.
+    /// The URL is not parsed here — it is parsed by [`launch`](Self::launch) /
+    /// [`connect`](Self::connect), which **fail** on one they cannot parse.
+    /// A caller who asked to be behind a proxy and silently got a direct
+    /// connection has a privacy failure, not a convenience one, so the bad
+    /// value stops the launch instead of being dropped.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn ex() -> zendriver::Result<()> {
+    /// let browser = zendriver::Browser::builder()
+    ///     .proxy("http://user:pass@my-proxy.example:3128")
+    ///     .launch().await?;   // errors here if the URL is unparseable
+    /// # browser.close().await?;
+    /// # Ok(()) }
+    /// ```
     #[must_use]
     pub fn proxy(mut self, proxy: impl Into<String>) -> Self {
-        let raw = proxy.into();
-        match crate::proxy::split_proxy_url(&raw) {
-            Ok(parsed) => {
-                // Auto-wiring `proxy_auth` from the URL's userinfo only makes
-                // sense when that field exists at all, which requires the
-                // `interception` feature (it drives the `Fetch.authRequired`
-                // auto-reply actor at launch).
-                #[cfg(feature = "interception")]
-                {
-                    if self.proxy_auth.is_none() {
-                        if let Some((u, p)) = parsed.credentials.clone() {
-                            self.proxy_auth = Some((u, p));
-                        }
-                    }
-                }
-                self.proxy = Some(parsed);
-            }
-            Err(e) => tracing::warn!(error = %e, "proxy: ignoring invalid proxy URL"),
-        }
+        self.proxy = Some(proxy.into());
         self
+    }
+
+    /// Parse the configured [`proxy`](Self::proxy) URL.
+    ///
+    /// Called at the very top of [`launch`](Self::launch) / [`connect`](Self::connect),
+    /// before a process is spawned or an endpoint dialled, so that an
+    /// unparseable URL can never leave a live Chrome issuing requests
+    /// directly. Errors carry the URL with any userinfo redacted.
+    pub(crate) fn resolved_proxy(
+        &self,
+    ) -> Result<Option<crate::proxy::ParsedProxy>, ZendriverError> {
+        self.proxy
+            .as_deref()
+            .map(crate::proxy::split_proxy_url)
+            .transpose()
+    }
+
+    /// The credentials the `Fetch.authRequired` auto-reply actor should
+    /// answer with: an explicit [`proxy_auth`](Self::proxy_auth) if there is
+    /// one, else the userinfo embedded in the proxy URL.
+    ///
+    /// Read by the actor's own `if let` in [`launch`](Self::launch) rather
+    /// than written into the builder beforehand: a separate statement that
+    /// fills the field is a statement that can go missing, and a launch that
+    /// silently stopped answering `Fetch.authRequired` 407s every request
+    /// through a credentialed proxy forever. The fallback belongs where it is
+    /// consumed.
+    ///
+    /// Only ever fills a hole, so an explicit `.proxy_auth(..)` wins
+    /// regardless of the order the two were called in.
+    #[cfg(feature = "interception")]
+    fn resolved_proxy_auth(
+        &self,
+        proxy: Option<&crate::proxy::ParsedProxy>,
+    ) -> Option<(String, String)> {
+        self.proxy_auth
+            .clone()
+            .or_else(|| proxy.and_then(|p| p.credentials.clone()))
     }
 
     /// Enable the bundled curated tracker/fingerprinter blocklist for this
@@ -1106,11 +1159,10 @@ impl BrowserBuilder {
     /// Passing `false` appends `--no-sandbox`. Leaving it unset (or `true`)
     /// keeps the sandbox enabled and emits no flag.
     ///
-    /// Independent of the CI auto-disable: when the `CI` env var is set,
-    /// `launch` still auto-adds `--no-sandbox` + `--disable-dev-shm-usage`
-    /// (the GitHub-Actions / Docker containers run as root, where the
-    /// user-namespace sandbox refuses to start). Calling `sandbox(false)`
-    /// just opts in explicitly outside CI.
+    /// `sandbox(true)` also outranks the container defaults described in
+    /// [`ci_defaults`](Self::ci_defaults): those may still add
+    /// `--disable-dev-shm-usage`, but they will not take away a sandbox you
+    /// asked for.
     ///
     /// Disabling the sandbox weakens Chrome's process isolation — only do so
     /// in trusted, throwaway environments (containers, ephemeral VMs).
@@ -1126,6 +1178,49 @@ impl BrowserBuilder {
         self
     }
 
+    /// Add the container-friendly launch defaults `--no-sandbox` and
+    /// `--disable-dev-shm-usage` (default: **unset**, see below).
+    ///
+    /// Both exist for one environment: a container running as root, where
+    /// Chrome's user-namespace sandbox refuses to start and the small
+    /// `/dev/shm` starves the renderer on real workloads. They are wrong
+    /// everywhere else — `--no-sandbox` drops Chrome's process isolation.
+    ///
+    /// Left unset, this follows the presence of the `CI` environment
+    /// variable, which is what zendriver has always done; the launch now says
+    /// so in the log when that fallback fires. Pass `true` to get the same
+    /// defaults off a CI runner (a Dockerfile, a systemd unit), or `false` to
+    /// keep them out of a launch whose environment happens to set `CI`.
+    /// Either way, an explicit [`sandbox(true)`](Self::sandbox) still wins the
+    /// `--no-sandbox` half.
+    ///
+    /// `false` reliably controls only that half. The
+    /// [`native`](zendriver_stealth::StealthProfile::native) and
+    /// [`spoofed`](zendriver_stealth::StealthProfile::spoofed) profiles emit
+    /// `--disable-dev-shm-usage` of their own accord, so with either attached
+    /// — `native` is the default — the flag stays in the argv regardless.
+    /// Only [`off`](zendriver_stealth::StealthProfile::off), which contributes
+    /// no flags at all, leaves `ci_defaults(false)` in sole control of both.
+    /// The `/dev/shm` flag trades shared memory for disk and weakens no
+    /// isolation, which is why it gets no second knob.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn ex() -> zendriver::Result<()> {
+    /// // Running as root inside a container that sets no `CI` variable:
+    /// let browser = zendriver::Browser::builder()
+    ///     .ci_defaults(true)
+    ///     .launch().await?;
+    /// # browser.close().await?;
+    /// # Ok(()) }
+    /// ```
+    #[must_use]
+    pub fn ci_defaults(mut self, on: bool) -> Self {
+        self.ci_defaults = Some(on);
+        self
+    }
+
     /// Pick which browser [`Channel`] to discover at launch (default:
     /// [`Channel::Auto`]).
     ///
@@ -1135,10 +1230,22 @@ impl BrowserBuilder {
     /// channel discovery entirely; when an explicit executable is set the
     /// channel is ignored.
     ///
+    /// # `CHROME_BIN`
+    ///
+    /// The `CHROME_BIN` environment variable is consulted **only** under
+    /// [`Channel::Auto`], where it answers "which Chrome, when nobody said".
+    /// Naming a channel *is* saying, so a variable inherited from a shell
+    /// cannot swap the browser you asked for — it is ignored, with an `info!`
+    /// line naming the path it skipped. Under `Auto` it wins over discovery,
+    /// also with an `info!` naming it, so which binary launched is never a
+    /// guess. Full precedence: [`executable`](Self::executable) > `CHROME_BIN`
+    /// (Auto only) > per-channel discovery.
+    ///
     /// # Examples
     ///
     /// ```no_run
     /// use zendriver::Channel;
+    /// // Brave, whatever `CHROME_BIN` happens to say in this shell.
     /// let builder = zendriver::Browser::builder().channel(Channel::Brave);
     /// ```
     #[must_use]
@@ -1434,11 +1541,24 @@ impl BrowserBuilder {
     /// timezone is the EXACT IANA zone ip-api reports for the exit IP, not
     /// the country-representative zone — multi-timezone countries (US, RU,
     /// CA, AU, BR, ...) get the visitor's real local zone.
+    ///
+    /// **Call this after [`proxy`](Self::proxy).** The proxy to mirror is read
+    /// here, when this method runs, so `.geo_auto().proxy(..)` builds a probe
+    /// that has nothing to mirror and goes out over the real connection —
+    /// disclosing the host's own IP to `ip-api.com` and deriving a locale for
+    /// the wrong country. `.proxy(..).geo_auto()` is the correct order.
     #[cfg(feature = "geo")]
     #[must_use]
     pub fn geo_auto(mut self) -> Self {
-        let server = self.proxy.as_ref().map(|p| p.server.clone());
-        let auth = self.proxy.as_ref().and_then(|p| p.credentials.clone());
+        // Reads whatever proxy is configured *at this point* — see the
+        // ordering note above; a proxy set later is not mirrored.
+        //
+        // The `.ok()` covers only a URL that doesn't parse, and that case is
+        // unreachable as a direct probe: `launch` / `connect` reject such a
+        // URL before this resolver is ever asked to probe.
+        let parsed = self.resolved_proxy().ok().flatten();
+        let server = parsed.as_ref().map(|p| p.server.clone());
+        let auth = parsed.as_ref().and_then(|p| p.credentials.clone());
         self.geo_resolver = Some(Arc::new(
             crate::IpApiResolver::new().with_proxy(server, auth),
         ));
@@ -1648,7 +1768,15 @@ impl BrowserBuilder {
 
     /// Compute the full argv that would be passed to Chrome. Exposed to
     /// tests + snapshots; called internally by `launch`.
-    pub(crate) fn build_flags(&self, user_data_dir: &Path) -> Vec<String> {
+    ///
+    /// `proxy` is the already-resolved [`resolved_proxy`](Self::resolved_proxy)
+    /// value rather than a re-parse of the raw string, so the only place a
+    /// malformed URL can be handled is the one that fails the launch.
+    pub(crate) fn build_flags(
+        &self,
+        user_data_dir: &Path,
+        proxy: Option<&crate::proxy::ParsedProxy>,
+    ) -> Vec<String> {
         let mut v = Vec::with_capacity(10 + self.extra_args.len());
         v.push("--remote-debugging-port=0".to_string());
         v.push(format!("--user-data-dir={}", user_data_dir.display()));
@@ -1734,7 +1862,7 @@ impl BrowserBuilder {
         // Emits the userinfo-stripped `--proxy-server=` flag unless the
         // caller already supplied their own via `.arg`/`.args` — an explicit
         // flag wins over the structured form.
-        if let Some(parsed) = self.proxy.as_ref() {
+        if let Some(parsed) = proxy {
             let explicit = self
                 .extra_args
                 .iter()
@@ -1764,6 +1892,69 @@ impl BrowserBuilder {
             v.push("about:blank".to_string());
         }
         v
+    }
+
+    /// Resolve the Chrome binary to spawn.
+    ///
+    /// Precedence: explicit [`executable`](Self::executable) > `CHROME_BIN`
+    /// (only under [`Channel::Auto`]) > per-channel platform discovery.
+    /// `chrome_bin` is the environment value, read by the caller and passed
+    /// in so this is testable without mutating process-wide state.
+    ///
+    /// The channel gate is the whole point of the middle step: `CHROME_BIN`
+    /// answers "which Chrome, when nobody said", so it fills the gap
+    /// [`Channel::Auto`] leaves and stays out of the way of a caller who
+    /// named [`Channel::Brave`] or [`Channel::Edge`].
+    fn resolve_executable(&self, chrome_bin: Option<PathBuf>) -> Result<PathBuf, ZendriverError> {
+        if let Some(p) = self.executable.clone() {
+            return Ok(p);
+        }
+        if let Some(p) = chrome_bin {
+            if self.channel == Channel::Auto {
+                info!(path = %p.display(), "using the CHROME_BIN executable override");
+                return Ok(p);
+            }
+            info!(
+                channel = ?self.channel,
+                ignored = %p.display(),
+                "CHROME_BIN ignored: an explicit channel was selected",
+            );
+        }
+        Ok(find_chrome_executable_for_channel(self.channel)?)
+    }
+
+    /// Append the container-friendly launch defaults to `flags`
+    /// (see [`ci_defaults`](Self::ci_defaults)).
+    ///
+    /// `ci_env` is the presence of the `CI` environment variable, read by the
+    /// caller and passed in — both so this is testable without mutating
+    /// process-wide state, and so the environment is consulted in exactly one
+    /// place.
+    fn apply_ci_defaults(&self, flags: &mut Vec<String>, ci_env: bool) {
+        match self.ci_defaults {
+            Some(false) => return,
+            // Detecting an environment and adjusting the argv for it is the
+            // kind of thing that should at least be audible, so the fallback
+            // announces itself and names the switch that turns it off.
+            None if ci_env => info!(
+                "CI env var set: adding --no-sandbox + --disable-dev-shm-usage; \
+                 pass .ci_defaults(false) to keep them out"
+            ),
+            None => return,
+            Some(true) => {}
+        }
+        for needed in ["--no-sandbox", "--disable-dev-shm-usage"] {
+            // A caller who explicitly asked for the sandbox keeps it. These
+            // defaults are here to make a container work, not to overrule
+            // someone who said what they wanted.
+            if needed == "--no-sandbox" && self.sandbox == Some(true) {
+                info!("sandbox(true) is set: leaving --no-sandbox out of the CI defaults");
+                continue;
+            }
+            if !flags.iter().any(|f| f == needed) {
+                flags.push(needed.into());
+            }
+        }
     }
 
     /// Build the combined [`HostMatcher`] from all configured sources, or
@@ -3207,6 +3398,9 @@ impl BrowserBuilder {
     /// fails, [`ZendriverError::Transport`] when the WebSocket attach times
     /// out.
     ///
+    /// A [`proxy`](Self::proxy) URL that cannot be parsed fails here too,
+    /// before anything is spawned — see that method.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -3216,19 +3410,16 @@ impl BrowserBuilder {
     /// # Ok(()) }
     /// ```
     pub async fn launch(mut self) -> Result<Browser, ZendriverError> {
+        // 0. Resolve the proxy URL FIRST, before anything is spawned.
+        // `proxy()` keeps the caller's string verbatim because a builder
+        // setter has no way to report an error, which makes this the point
+        // where a bad one is caught — and it has to be caught here: a Chrome
+        // that is already running would issue its first requests DIRECT while
+        // its operator believed they were proxied.
+        let proxy = self.resolved_proxy()?;
+
         // 1. Resolve Chrome executable.
-        // Precedence: explicit `.executable(...)` > `CHROME_BIN` env var >
-        // per-channel platform discovery. The env-var hop lets CI (and local
-        // devs pointing at Canary / a downloaded Chrome-for-Testing build)
-        // override the discovery path without code changes. The configured
-        // `channel` (default `Auto`) only steers the final discovery step.
-        let exe = match self.executable.clone() {
-            Some(p) => p,
-            None => match std::env::var("CHROME_BIN").ok().filter(|s| !s.is_empty()) {
-                Some(p) => PathBuf::from(p),
-                None => find_chrome_executable_for_channel(self.channel)?,
-            },
-        };
+        let exe = self.resolve_executable(chrome_bin_from_env())?;
 
         // 1b. Resolve extensions: unzip any `.crx` into a tempdir and rewrite
         // `self.extensions` to the resolved unpacked-directory paths so
@@ -3319,24 +3510,11 @@ impl BrowserBuilder {
         // stealth profile shares with `build_flags`, like `--no-first-run`)
         // appended unconditionally, matching today's behavior.
         let mut flags = merge_launch_flags(
-            self.build_flags(&user_data_path),
+            self.build_flags(&user_data_path, proxy.as_ref()),
             extra_flags,
             self.effective_gpu_backend(),
         );
-        // CI-friendly defaults: when running under CI (the runner sets
-        // `CI=true`), Chrome's user-namespace sandbox refuses to start
-        // because the GitHub-Actions / Docker container runs as root,
-        // and the small /dev/shm in the container OOMs the renderer on
-        // real workloads. Auto-add `--no-sandbox` and
-        // `--disable-dev-shm-usage` unless the caller already supplied
-        // them (so explicit user opt-in still wins).
-        if std::env::var("CI").is_ok() {
-            for needed in ["--no-sandbox", "--disable-dev-shm-usage"] {
-                if !flags.iter().any(|f| f == needed) {
-                    flags.push(needed.into());
-                }
-            }
-        }
+        self.apply_ci_defaults(&mut flags, std::env::var_os("CI").is_some());
         info!(executable = %exe.display(), "launching chrome");
 
         // Drop any `DevToolsActivePort` left behind by a previous run before we
@@ -3524,7 +3702,7 @@ impl BrowserBuilder {
             let main_session = inner.main_tab.session().clone();
             let mut builder = zendriver_interception::InterceptBuilder::new(&main_session);
             let mut needs_actor = false;
-            if let Some((user, pass)) = self.proxy_auth.clone() {
+            if let Some((user, pass)) = self.resolved_proxy_auth(proxy.as_ref()) {
                 builder = builder.handle_auth(user, pass);
                 needs_actor = true;
             }
@@ -3568,14 +3746,18 @@ impl BrowserBuilder {
     /// The spawn-only builder fields — [`BrowserBuilder::executable`],
     /// [`BrowserBuilder::user_data_dir`], [`BrowserBuilder::downloads_dir`],
     /// and any launch flags ([`BrowserBuilder::arg`] / headless / sandbox /
-    /// channel / lang / user-agent) — are **ignored** on the connect path,
-    /// since no process is launched.
+    /// channel / lang / user-agent / [`ci_defaults`](Self::ci_defaults)) —
+    /// are **ignored** on the connect path, since no process is launched.
     ///
     /// # Errors
     ///
     /// Returns [`ZendriverError::Browser`] when an `http(s)://` endpoint
     /// cannot be resolved to a `webSocketDebuggerUrl`, and
     /// [`ZendriverError::Transport`] when the WebSocket attach fails.
+    ///
+    /// A [`proxy`](Self::proxy) URL that cannot be parsed also fails here,
+    /// before the endpoint is dialled. The proxy itself is spawn-only, but a
+    /// URL that was never going to work is worth saying so about.
     ///
     /// # Examples
     ///
@@ -3595,6 +3777,13 @@ impl BrowserBuilder {
     #[cfg_attr(not(feature = "geo"), allow(unused_mut))]
     pub async fn connect(mut self, endpoint: impl Into<String>) -> Result<Browser, ZendriverError> {
         let endpoint = endpoint.into();
+
+        // `connect` ignores the spawn-only fields, but an unparseable proxy
+        // URL is not a spawn-only field — it is a mistake in what the caller
+        // asked for, and telling them here beats letting them find out from a
+        // session that was never proxied. Checked before the dial so the
+        // answer doesn't depend on the endpoint being reachable.
+        let _ = self.resolved_proxy()?;
 
         // Resolve the browser WebSocket URL from the endpoint scheme.
         let ws_url = if endpoint.starts_with("ws://") || endpoint.starts_with("wss://") {
@@ -5473,7 +5662,7 @@ mod tests {
     #[test]
     fn build_flags_default_is_headless() {
         let b = BrowserBuilder::new();
-        let flags = b.build_flags(Path::new("/tmp/x"));
+        let flags = b.build_flags(Path::new("/tmp/x"), None);
         assert!(flags.contains(&"--headless=new".to_string()));
         assert!(flags.contains(&"--disable-gpu".to_string()));
         assert!(flags.contains(&"--user-data-dir=/tmp/x".to_string()));
@@ -5483,14 +5672,14 @@ mod tests {
     #[test]
     fn build_flags_default_still_emits_disable_gpu() {
         let b = Browser::builder();
-        let flags = b.build_flags(Path::new("/tmp/zd-test"));
+        let flags = b.build_flags(Path::new("/tmp/zd-test"), None);
         assert!(flags.contains(&"--disable-gpu".to_string()));
     }
 
     #[test]
     fn build_flags_native_gpu_backend_omits_disable_gpu() {
         let b = Browser::builder().gpu_backend(GpuBackend::Native);
-        let flags = b.build_flags(Path::new("/tmp/zd-test"));
+        let flags = b.build_flags(Path::new("/tmp/zd-test"), None);
         assert!(
             !flags.contains(&"--disable-gpu".to_string()),
             "Native backend must not disable the GPU, got: {flags:?}"
@@ -5504,7 +5693,7 @@ mod tests {
     #[test]
     fn build_flags_native_gpu_backend_emits_angle_flags() {
         let b = Browser::builder().gpu_backend(GpuBackend::Native);
-        let flags = b.build_flags(Path::new("/tmp/zd-test"));
+        let flags = b.build_flags(Path::new("/tmp/zd-test"), None);
         assert!(
             flags.iter().any(|f| f == "--use-gl=angle"),
             "got: {flags:?}"
@@ -5518,7 +5707,7 @@ mod tests {
     #[test]
     fn build_flags_swiftshader_backend_keeps_disable_gpu() {
         let b = Browser::builder().gpu_backend(GpuBackend::SwiftShader);
-        let flags = b.build_flags(Path::new("/tmp/zd-test"));
+        let flags = b.build_flags(Path::new("/tmp/zd-test"), None);
         assert!(flags.contains(&"--disable-gpu".to_string()));
     }
 
@@ -5531,7 +5720,7 @@ mod tests {
         // profile's own `--use-angle=` flags.
         let b =
             Browser::builder().stealth(StealthProfile::native().gpu_backend(GpuBackend::Native));
-        let flags = b.build_flags(Path::new("/tmp/zd-test"));
+        let flags = b.build_flags(Path::new("/tmp/zd-test"), None);
         assert!(
             !flags.contains(&"--disable-gpu".to_string()),
             "profile-only Native backend must not disable the GPU, got: {flags:?}"
@@ -5547,7 +5736,7 @@ mod tests {
         let b = Browser::builder()
             .stealth(StealthProfile::native().gpu_backend(GpuBackend::Native))
             .gpu_backend(GpuBackend::SwiftShader);
-        let flags = b.build_flags(Path::new("/tmp/zd-test"));
+        let flags = b.build_flags(Path::new("/tmp/zd-test"), None);
         assert!(
             flags.contains(&"--disable-gpu".to_string()),
             "builder's SwiftShader must win and keep --disable-gpu, got: {flags:?}"
@@ -5569,7 +5758,7 @@ mod tests {
         // Profile carries the default `GpuBackend::Disabled` — today's argv
         // must be byte-for-byte identical.
         let b = Browser::builder().stealth(StealthProfile::native());
-        let flags = b.build_flags(Path::new("/tmp/zd-test"));
+        let flags = b.build_flags(Path::new("/tmp/zd-test"), None);
         assert!(flags.contains(&"--disable-gpu".to_string()));
     }
 
@@ -5585,7 +5774,7 @@ mod tests {
         // "byte-for-byte today's behavior" guarantee for `Disabled` holds.
         let base = Browser::builder()
             .stealth(StealthProfile::native())
-            .build_flags(Path::new("/tmp/zd-test"));
+            .build_flags(Path::new("/tmp/zd-test"), None);
         let extra = StealthProfile::native().build_flags();
         let merged = super::merge_launch_flags(base, extra, GpuBackend::Disabled);
 
@@ -5611,7 +5800,7 @@ mod tests {
             GpuBackend::Native,
         ] {
             let b = Browser::builder().headless(false).gpu_backend(backend);
-            let flags = b.build_flags(Path::new("/tmp/zd-test"));
+            let flags = b.build_flags(Path::new("/tmp/zd-test"), None);
             assert!(
                 !flags.contains(&"--disable-gpu".to_string()),
                 "headful must never disable the GPU, backend={backend:?}"
@@ -5701,7 +5890,7 @@ mod tests {
     #[test]
     fn build_flags_suppresses_password_popups() {
         let b = BrowserBuilder::new();
-        let flags = b.build_flags(Path::new("/tmp/x"));
+        let flags = b.build_flags(Path::new("/tmp/x"), None);
         assert!(flags.contains(&"--password-store=basic".to_string()));
         assert!(flags.contains(&"--disable-save-password-bubble".to_string()));
         assert!(
@@ -5714,7 +5903,7 @@ mod tests {
     #[test]
     fn build_flags_no_headless_when_disabled() {
         let b = BrowserBuilder::new().headless(false);
-        let flags = b.build_flags(Path::new("/tmp/x"));
+        let flags = b.build_flags(Path::new("/tmp/x"), None);
         assert!(!flags.iter().any(|f| f.starts_with("--headless")));
         assert!(!flags.contains(&"--disable-gpu".to_string()));
     }
@@ -5724,7 +5913,7 @@ mod tests {
         let b = BrowserBuilder::new()
             .arg("--proxy-server=http://x")
             .arg("--lang=en-US");
-        let flags = b.build_flags(Path::new("/tmp/x"));
+        let flags = b.build_flags(Path::new("/tmp/x"), None);
         let proxy = flags
             .iter()
             .position(|f| f == "--proxy-server=http://x")
@@ -5734,19 +5923,398 @@ mod tests {
     }
 
     #[test]
-    fn proxy_stores_parsed_and_strips_userinfo_arg() {
+    fn proxy_resolves_to_a_userinfo_stripped_server_and_arg() {
         let b = Browser::builder().proxy("http://bob:pw@host:3128");
-        let p = b.proxy.as_ref().unwrap();
+        let p = b.resolved_proxy().unwrap().unwrap();
         assert_eq!(p.server, "http://host:3128");
         assert_eq!(p.credentials, Some(("bob".into(), "pw".into())));
-        // proxy_auth auto-wired from userinfo (field only exists under the
-        // `interception` feature, which drives the auth-reply actor).
-        #[cfg(feature = "interception")]
-        assert_eq!(b.proxy_auth, Some(("bob".into(), "pw".into())));
 
         // At launch, the userinfo-stripped `--proxy-server=` flag is emitted.
-        let flags = b.build_flags(Path::new("/tmp/x"));
+        let flags = b.build_flags(Path::new("/tmp/x"), Some(&p));
         assert!(flags.contains(&"--proxy-server=http://host:3128".to_string()));
+    }
+
+    /// Userinfo still reaches the `Fetch.authRequired` auto-reply actor now
+    /// that the parse happens at launch instead of in the setter — and an
+    /// explicit `.proxy_auth(..)` still wins in EITHER call order, which is
+    /// the property the old setter-side wiring had and this must not lose.
+    #[cfg(feature = "interception")]
+    #[test]
+    fn proxy_userinfo_fills_proxy_auth_but_never_overwrites_it() {
+        let b = Browser::builder().proxy("http://bob:pw@host:3128");
+        let p = b.resolved_proxy().unwrap();
+        assert_eq!(
+            b.resolved_proxy_auth(p.as_ref()),
+            Some(("bob".into(), "pw".into()))
+        );
+
+        for b in [
+            Browser::builder()
+                .proxy("http://bob:pw@host:3128")
+                .proxy_auth("alice", "s3cret"),
+            Browser::builder()
+                .proxy_auth("alice", "s3cret")
+                .proxy("http://bob:pw@host:3128"),
+        ] {
+            let p = b.resolved_proxy().unwrap();
+            assert_eq!(
+                b.resolved_proxy_auth(p.as_ref()),
+                Some(("alice".into(), "s3cret".into())),
+                "an explicit proxy_auth must outrank the URL's userinfo"
+            );
+        }
+    }
+
+    // ----- 2b: CHROME_BIN vs an explicit channel --------------------------
+
+    /// `CHROME_BIN` is a convenience for the *unspecified* case. Naming a
+    /// channel is a caller stating which browser they want, and an
+    /// environment variable inherited from a shell must not quietly swap it
+    /// for another binary — least of all in a stealth library, where the
+    /// browser's identity is half the fingerprint.
+    #[test]
+    fn chrome_bin_loses_to_an_explicitly_chosen_channel() {
+        let env_chrome = PathBuf::from("/nonexistent/zendriver-env-chrome");
+        let picked = Browser::builder()
+            .channel(Channel::Brave)
+            .resolve_executable(Some(env_chrome.clone()));
+        match picked {
+            Ok(p) => assert_ne!(
+                p, env_chrome,
+                "an explicit channel must send discovery to Brave, not to CHROME_BIN"
+            ),
+            // No Brave on this host: discovery failing is itself proof that
+            // CHROME_BIN did not stand in for the channel that was asked for.
+            Err(e) => assert!(
+                e.to_string().contains("chrome executable not found"),
+                "unexpected error: {e}"
+            ),
+        }
+    }
+
+    /// The historical behaviour survives where it was always meant to apply:
+    /// no channel named, so the environment picks the binary — and says so,
+    /// because "which Chrome did this actually launch" should not require
+    /// guessing.
+    #[test]
+    fn chrome_bin_wins_under_channel_auto_and_is_logged() {
+        let env_chrome = PathBuf::from("/nonexistent/zendriver-env-chrome");
+        let (picked, logs) = crate::log_capture::capture_logs(|| {
+            Browser::builder().resolve_executable(Some(env_chrome.clone()))
+        });
+        assert_eq!(picked.unwrap(), env_chrome);
+        assert!(
+            logs.iter().any(|(_, m)| m.contains("CHROME_BIN")),
+            "the env override must name itself in the log: {logs:?}"
+        );
+    }
+
+    /// An explicit `.executable(..)` outranks everything, unchanged.
+    #[test]
+    fn explicit_executable_outranks_chrome_bin() {
+        let explicit = PathBuf::from("/nonexistent/zendriver-explicit-chrome");
+        let picked = Browser::builder()
+            .executable(explicit.clone())
+            .channel(Channel::Brave)
+            .resolve_executable(Some(PathBuf::from("/nonexistent/zendriver-env-chrome")))
+            .unwrap();
+        assert_eq!(picked, explicit);
+    }
+
+    // ----- 2b: CI launch defaults ----------------------------------------
+
+    /// Asking for the sandbox and getting `--no-sandbox` anyway is the bug:
+    /// the CI defaults exist to make a container work, not to overrule a
+    /// caller who said what they wanted. `--disable-dev-shm-usage` is
+    /// untouched by that — it weakens nothing and `sandbox` says nothing
+    /// about it.
+    #[test]
+    fn an_explicit_sandbox_survives_the_ci_defaults() {
+        let mut flags = Vec::new();
+        Browser::builder()
+            .sandbox(true)
+            .apply_ci_defaults(&mut flags, true);
+        assert!(
+            !flags.contains(&"--no-sandbox".to_string()),
+            "sandbox(true) must suppress the --no-sandbox half: {flags:?}"
+        );
+        assert!(
+            flags.contains(&"--disable-dev-shm-usage".to_string()),
+            "the /dev/shm half is unrelated to the sandbox: {flags:?}"
+        );
+    }
+
+    /// `ci_defaults(true)` is the way to get container defaults off a CI
+    /// runner — in a Docker image, a systemd unit, anywhere the `CI` variable
+    /// is not set but the constraint is identical.
+    #[test]
+    fn ci_defaults_true_applies_them_without_the_env_var() {
+        let mut flags = Vec::new();
+        Browser::builder()
+            .ci_defaults(true)
+            .apply_ci_defaults(&mut flags, false);
+        assert_eq!(
+            flags,
+            vec!["--no-sandbox".to_string(), "--disable-dev-shm-usage".into()],
+            "ci_defaults(true) must apply both flags with no CI env var"
+        );
+    }
+
+    /// And the other direction: an environment that happens to set `CI` must
+    /// not silently re-flag a launch the caller opted out of. This is the
+    /// half that could not be expressed at all before.
+    #[test]
+    fn ci_defaults_false_beats_the_env_var() {
+        let mut flags = Vec::new();
+        Browser::builder()
+            .ci_defaults(false)
+            .apply_ci_defaults(&mut flags, true);
+        assert!(
+            flags.is_empty(),
+            "ci_defaults(false) must suppress the env-driven defaults: {flags:?}"
+        );
+    }
+
+    /// Unset keeps the historical `CI` fallback, so nothing that works today
+    /// stops working — but it is now announced, because a launch quietly
+    /// dropping Chrome's sandbox is worth a line in the log.
+    #[test]
+    fn unset_ci_defaults_still_follow_the_env_and_say_so() {
+        let mut flags = Vec::new();
+        let ((), logs) = crate::log_capture::capture_logs(|| {
+            Browser::builder().apply_ci_defaults(&mut flags, true);
+        });
+        assert!(
+            flags.contains(&"--no-sandbox".to_string())
+                && flags.contains(&"--disable-dev-shm-usage".to_string()),
+            "the CI env var still drives the defaults when unset: {flags:?}"
+        );
+        assert!(
+            logs.iter().any(|(_, m)| m.contains("ci_defaults")),
+            "the env-driven case must name the opt-out: {logs:?}"
+        );
+    }
+
+    /// The raw URL is what the builder now holds, so `Debug` is the one place
+    /// a password could escape. It must not — including for the URLs that
+    /// *fail* to parse, which is where a mistyped proxy string ends up and the
+    /// only reason the raw form is retained at all. A well-formed fixture
+    /// alone would pass against redaction that gives up without a `://`.
+    #[test]
+    fn debug_redacts_the_proxy_password() {
+        for url in [
+            "http://bob:hunter2@host:3128",
+            // Scheme-less `user:pass@host:port` — the other shape proxy
+            // vendors hand out, and unparseable, so it stays raw in the field.
+            "bob:hunter2@host:3128",
+        ] {
+            let dbg = format!("{:?}", Browser::builder().proxy(url));
+            assert!(
+                !dbg.contains("hunter2"),
+                "password leaked into Debug for {url:?}: {dbg}"
+            );
+            assert!(
+                dbg.contains("host:3128"),
+                "host should stay visible for {url:?}: {dbg}"
+            );
+        }
+    }
+
+    /// A caller who asked to be behind a proxy and is not has a privacy
+    /// failure, not a convenience one. An unparseable URL must therefore abort
+    /// the launch rather than log a warning and go DIRECT.
+    ///
+    /// The executable is deliberately bogus: the proxy has to be rejected
+    /// *before* anything is spawned, so the error names the proxy and not the
+    /// missing binary. That ordering is the assertion — a fix that validated
+    /// after the spawn would still leak a request through a live Chrome.
+    #[tokio::test]
+    async fn launch_fails_closed_on_an_unparseable_proxy_url() {
+        let err = Browser::builder()
+            .executable("/nonexistent/zendriver-no-such-chrome")
+            .proxy("http://:3128") // no host
+            .launch()
+            .await
+            .expect_err("an unparseable proxy URL must fail the launch");
+        let msg = err.to_string();
+        assert!(msg.contains("proxy"), "error must name the proxy: {msg}");
+        assert!(
+            !msg.contains("chrome failed to start"),
+            "the proxy must be rejected before Chrome is spawned: {msg}"
+        );
+    }
+
+    /// Failing closed must not turn a bad proxy URL into a credential leak:
+    /// the error is logged, printed and often reported upward, so the password
+    /// stays redacted.
+    #[tokio::test]
+    async fn launch_proxy_failure_redacts_the_password() {
+        for url in [
+            "http://bob:hunter2@", // credentials, no host
+            // No scheme at all: the shape a vendor's `user:pass@host:port`
+            // takes when the caller forgets the `http://`, and the one that
+            // reaches the error path *because* it cannot be parsed.
+            "bob:hunter2@host:3128",
+        ] {
+            let err = Browser::builder()
+                .executable("/nonexistent/zendriver-no-such-chrome")
+                .proxy(url)
+                .launch()
+                .await
+                .expect_err("an unparseable proxy URL must fail the launch");
+            let msg = err.to_string();
+            assert!(msg.contains("proxy"), "error must name the proxy: {msg}");
+            assert!(
+                !msg.contains("hunter2"),
+                "password must be redacted for {url:?}: {msg}"
+            );
+        }
+    }
+
+    /// Drive a real [`BrowserBuilder::launch`] against a shim that records the
+    /// argv it was spawned with, and return those arguments.
+    ///
+    /// `launch` reaches Chrome's command line through a chain of ordinary call
+    /// sites — `build_flags(.., proxy)`, `merge_launch_flags`,
+    /// `apply_ci_defaults`. Calling those helpers directly proves what each
+    /// one computes and nothing at all about whether `launch` still asks them:
+    /// passing `None` for the proxy at the call site launches a perfectly
+    /// direct Chrome while every helper-level test stays green. The real argv
+    /// is the only thing that closes that gap.
+    ///
+    /// Unix-only: the shim is a shell script. The wiring under test is
+    /// platform-independent, so a POSIX-only witness still covers it.
+    #[cfg(unix)]
+    async fn recorded_launch_argv(
+        configure: impl FnOnce(BrowserBuilder) -> BrowserBuilder,
+    ) -> Vec<String> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let record = dir.path().join("argv");
+        let shim = dir.path().join("chrome-shim");
+        // Appends, because the stealth fingerprint probe runs the same binary
+        // with `--version` before the launch does; the caller filters on the
+        // launch's own flags.
+        std::fs::write(
+            &shim,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$@\" >> '{}'\nexit 1\n",
+                record.display()
+            ),
+        )
+        .expect("write shim");
+        std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        configure(Browser::builder().executable(&shim))
+            .launch()
+            .await
+            .expect_err("a shell script is not a browser; the launch cannot succeed");
+
+        let argv: Vec<String> = std::fs::read_to_string(&record)
+            .expect("the shim records every invocation")
+            .lines()
+            .map(str::to_string)
+            .collect();
+        assert!(
+            argv.iter().any(|a| a.starts_with("--user-data-dir=")),
+            "recorded the launch, not just the --version probe: {argv:?}"
+        );
+        argv
+    }
+
+    /// The proxy has to survive all the way to Chrome's command line. It is
+    /// now resolved in `launch` and handed to `build_flags` as an argument,
+    /// which is a wire that can be left unconnected — and an unconnected one
+    /// produces a Chrome browsing DIRECT with a valid proxy configured and
+    /// nothing anywhere saying so.
+    ///
+    /// The no-proxy launch is the control: it proves the recorder reports what
+    /// was actually passed rather than always containing the flag.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_launch_carries_the_resolved_proxy_into_chromes_argv() {
+        let argv = recorded_launch_argv(|b| b.proxy("http://bob:pw@recorded.example:3128")).await;
+        assert!(
+            argv.contains(&"--proxy-server=http://recorded.example:3128".to_string()),
+            "the launch must actually spawn Chrome behind the proxy: {argv:?}"
+        );
+
+        let direct = recorded_launch_argv(|b| b).await;
+        assert!(
+            !direct.iter().any(|a| a.starts_with("--proxy-server=")),
+            "no proxy was configured, so none may appear: {direct:?}"
+        );
+    }
+
+    /// Same wire, the CI-defaults end: `apply_ci_defaults` is another call
+    /// site in `launch`, running *after* `merge_launch_flags` has folded in
+    /// the stealth profile's own flags. Both directions are asserted, because
+    /// only the first kills a deleted call site — a launch that never applies
+    /// the defaults also never emits `--no-sandbox`, so the suppression case
+    /// alone would stay green against a `launch` that dropped the call.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_launch_applies_the_ci_defaults_but_not_over_an_explicit_sandbox() {
+        let argv = recorded_launch_argv(|b| b.ci_defaults(true)).await;
+        assert!(
+            argv.contains(&"--no-sandbox".to_string()),
+            "ci_defaults(true) must reach the real argv: {argv:?}"
+        );
+
+        let kept = recorded_launch_argv(|b| b.sandbox(true).ci_defaults(true)).await;
+        assert!(
+            !kept.contains(&"--no-sandbox".to_string()),
+            "sandbox(true) must survive the CI defaults in the real argv: {kept:?}"
+        );
+    }
+
+    /// The limit of `ci_defaults(false)`, pinned because the docs now state
+    /// it: the default `native` profile emits `--disable-dev-shm-usage` of its
+    /// own accord, so opting out removes the `--no-sandbox` half and leaves
+    /// the `/dev/shm` half in place. Harmless — it weakens nothing — but a
+    /// promise to "keep them out" would be false.
+    ///
+    /// `StealthProfile::off()` contributes no flags at all, and is the case
+    /// that proves the limit is the profile's doing rather than
+    /// `ci_defaults(false)` failing to work.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn ci_defaults_false_cannot_remove_the_stealth_profiles_own_dev_shm_flag() {
+        let argv = recorded_launch_argv(|b| b.ci_defaults(false)).await;
+        assert!(
+            !argv.contains(&"--no-sandbox".to_string()),
+            "ci_defaults(false) must keep --no-sandbox out: {argv:?}"
+        );
+        assert!(
+            argv.contains(&"--disable-dev-shm-usage".to_string()),
+            "the native profile emits this one regardless: {argv:?}"
+        );
+
+        let stock = recorded_launch_argv(|b| {
+            b.ci_defaults(false)
+                .stealth(zendriver_stealth::StealthProfile::off())
+        })
+        .await;
+        assert!(
+            !stock.contains(&"--disable-dev-shm-usage".to_string()),
+            "with no profile flags, ci_defaults(false) controls both: {stock:?}"
+        );
+    }
+
+    /// `connect` ignores the spawn-only launch flags, but it must not ignore a
+    /// proxy URL it cannot parse: the endpoint is never dialled.
+    #[tokio::test]
+    async fn connect_fails_closed_on_an_unparseable_proxy_url() {
+        let err = Browser::builder()
+            .proxy("http://:3128")
+            // Nothing listens on port 1; reaching the dial at all is a failure
+            // of the ordering this test exists to pin.
+            .connect("ws://127.0.0.1:1")
+            .await
+            .expect_err("an unparseable proxy URL must fail the connect");
+        let msg = err.to_string();
+        assert!(msg.contains("proxy"), "error must name the proxy: {msg}");
     }
 
     #[test]
@@ -5754,7 +6322,7 @@ mod tests {
         // Default launch must open the initial tab on about:blank (the final
         // positional argument), not Chrome's New Tab Page — the NTP's own
         // requests would otherwise pollute `wait_for_idle`'s in-flight set.
-        let flags = BrowserBuilder::new().build_flags(Path::new("/tmp/x"));
+        let flags = BrowserBuilder::new().build_flags(Path::new("/tmp/x"), None);
         assert_eq!(
             flags.last().map(String::as_str),
             Some("about:blank"),
@@ -5773,7 +6341,7 @@ mod tests {
         // about:blank (which would open a second, blank tab).
         let flags = BrowserBuilder::new()
             .arg("https://example.com")
-            .build_flags(Path::new("/tmp/x"));
+            .build_flags(Path::new("/tmp/x"), None);
         assert!(
             !flags.contains(&"about:blank".to_string()),
             "explicit positional URL should suppress about:blank in {flags:?}"
@@ -5790,21 +6358,21 @@ mod tests {
     #[test]
     fn lang_flag_present() {
         let b = BrowserBuilder::new().lang("en-US");
-        let flags = b.build_flags(Path::new("/tmp/x"));
+        let flags = b.build_flags(Path::new("/tmp/x"), None);
         assert!(flags.contains(&"--lang=en-US".to_string()));
     }
 
     #[test]
     fn user_agent_flag_present() {
         let b = BrowserBuilder::new().user_agent("MyAgent/1.0");
-        let flags = b.build_flags(Path::new("/tmp/x"));
+        let flags = b.build_flags(Path::new("/tmp/x"), None);
         assert!(flags.contains(&"--user-agent=MyAgent/1.0".to_string()));
     }
 
     #[test]
     fn sandbox_false_adds_no_sandbox() {
         let b = BrowserBuilder::new().sandbox(false);
-        let flags = b.build_flags(Path::new("/tmp/x"));
+        let flags = b.build_flags(Path::new("/tmp/x"), None);
         assert!(flags.contains(&"--no-sandbox".to_string()));
     }
 
@@ -5814,7 +6382,7 @@ mod tests {
         // build_flags. The CI auto-add lives in `launch`, not build_flags,
         // so this is unaffected by the CI env var.
         let b = BrowserBuilder::new();
-        let flags = b.build_flags(Path::new("/tmp/x"));
+        let flags = b.build_flags(Path::new("/tmp/x"), None);
         assert!(!flags.contains(&"--no-sandbox".to_string()));
     }
 
@@ -5823,7 +6391,7 @@ mod tests {
     #[test]
     fn expert_adds_web_security_and_site_isolation_flags() {
         let b = BrowserBuilder::new().expert(true);
-        let flags = b.build_flags(Path::new("/tmp/x"));
+        let flags = b.build_flags(Path::new("/tmp/x"), None);
         assert!(
             flags.contains(&"--disable-web-security".to_string()),
             "expected --disable-web-security in {flags:?}"
@@ -5836,7 +6404,7 @@ mod tests {
 
     #[test]
     fn expert_off_omits_expert_flags() {
-        let flags = BrowserBuilder::new().build_flags(Path::new("/tmp/x"));
+        let flags = BrowserBuilder::new().build_flags(Path::new("/tmp/x"), None);
         assert!(!flags.contains(&"--disable-web-security".to_string()));
         assert!(!flags.contains(&"--disable-site-isolation-trials".to_string()));
     }
@@ -5846,7 +6414,7 @@ mod tests {
     #[test]
     fn extensions_add_load_and_disable_except_flags() {
         let b = BrowserBuilder::new().add_extension("a").add_extension("b");
-        let flags = b.build_flags(Path::new("/tmp/x"));
+        let flags = b.build_flags(Path::new("/tmp/x"), None);
         assert!(
             flags.contains(&"--load-extension=a,b".to_string()),
             "expected --load-extension=a,b in {flags:?}"
@@ -5870,7 +6438,7 @@ mod tests {
         let b = BrowserBuilder::new()
             .stealth(StealthProfile::off())
             .add_extension("ext");
-        let flags = b.build_flags(Path::new("/tmp/x"));
+        let flags = b.build_flags(Path::new("/tmp/x"), None);
         assert!(
             flags.iter().any(|f| f.starts_with("--disable-features=")
                 && f.contains("DisableLoadExtensionCommandLineSwitch")),
@@ -5882,7 +6450,7 @@ mod tests {
     fn no_extensions_omits_extension_flags() {
         // Default builder must not emit any extension flags (keeps the default
         // argv + snapshots unchanged).
-        let flags = BrowserBuilder::new().build_flags(Path::new("/tmp/x"));
+        let flags = BrowserBuilder::new().build_flags(Path::new("/tmp/x"), None);
         assert!(!flags.iter().any(|f| f.starts_with("--load-extension")));
         assert!(
             !flags
@@ -6052,7 +6620,7 @@ mod tests {
     #[test]
     fn default_launch_flags_snapshot() {
         let b = BrowserBuilder::new();
-        let flags = b.build_flags(std::path::Path::new("/tmp/test-user-data"));
+        let flags = b.build_flags(std::path::Path::new("/tmp/test-user-data"), None);
         insta::assert_yaml_snapshot!("default_launch_flags", flags);
     }
 
@@ -6075,7 +6643,7 @@ mod tests {
     #[test]
     fn non_headless_launch_flags_snapshot() {
         let b = BrowserBuilder::new().headless(false);
-        let flags = b.build_flags(std::path::Path::new("/tmp/test-user-data"));
+        let flags = b.build_flags(std::path::Path::new("/tmp/test-user-data"), None);
         insta::assert_yaml_snapshot!("non_headless_launch_flags", flags);
     }
 

--- a/crates/zendriver/src/log_capture.rs
+++ b/crates/zendriver/src/log_capture.rs
@@ -71,6 +71,26 @@ pub(crate) async fn with_captured_logs<T>(fut: impl Future<Output = T>) -> (T, V
     (out, logs)
 }
 
+/// Synchronous sibling of [`with_captured_logs`], for code under test that
+/// is not a future. Installed as the thread-local default subscriber for the
+/// duration of `f`.
+pub(crate) fn capture_logs<T>(f: impl FnOnce() -> T) -> (T, Vec<CapturedLog>) {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    let capture = LogCapture::default();
+    let subscriber = tracing_subscriber::registry().with(capture.clone());
+    let out = tracing::subscriber::with_default(subscriber, || {
+        // `tracing` caches each callsite's interest globally the first time it
+        // is evaluated, and a site first reached with no subscriber installed
+        // caches "never" — which is every other test in this binary. Without
+        // this rebuild a capture test passes alone and fails in a full run.
+        tracing::callsite::rebuild_interest_cache();
+        f()
+    });
+    let logs = capture.0.lock().expect("log buffer poisoned").clone();
+    (out, logs)
+}
+
 /// Just the `WARN` messages.
 ///
 /// Capture is deliberately unfiltered — a caller may want to assert on any

--- a/crates/zendriver/src/proxy.rs
+++ b/crates/zendriver/src/proxy.rs
@@ -77,11 +77,13 @@ pub(crate) fn split_proxy_url(url: &str) -> Result<ParsedProxy, ZendriverError> 
 /// in an error message, so a rejected/malformed proxy URL never leaks its
 /// password. Deliberately string surgery rather than `url::Url`-based —
 /// this must also work on URLs that failed to parse in the first place.
-fn redact_userinfo(raw: &str) -> String {
-    let Some(scheme_end) = raw.find("://") else {
-        return raw.to_string();
-    };
-    let after_scheme = scheme_end + 3;
+///
+/// A missing `://` is not a reason to give up: `user:pass@host:port` with no
+/// scheme is a shape proxy vendors hand out, it is exactly the shape that
+/// *fails* to parse, and the failure path is what carries the string into a
+/// log or an error. Treat the whole string as the authority in that case.
+pub(crate) fn redact_userinfo(raw: &str) -> String {
+    let after_scheme = raw.find("://").map_or(0, |i| i + 3);
     // The authority (userinfo + host + port) ends at the first `/`, `?`, or
     // `#` — don't let an `@` in the path/query masquerade as userinfo.
     let authority_end = raw[after_scheme..]
@@ -188,5 +190,33 @@ mod tests {
             "http://proxy.example:8080"
         );
         assert_eq!(redact_userinfo("not a url"), "not a url");
+    }
+
+    /// `user:pass@host:port` with no scheme is one of the two shapes proxy
+    /// vendors hand out, and it is *unparseable* — so it reaches redaction
+    /// only along the failure path, which is exactly the path that logs and
+    /// returns the string. Redaction that only works on well-formed URLs
+    /// protects the case that never needed it.
+    #[test]
+    fn redact_userinfo_masks_credentials_on_a_scheme_less_url() {
+        assert_eq!(
+            redact_userinfo("bob:s3cret@localhost:8080"),
+            "***@localhost:8080"
+        );
+        assert_eq!(
+            redact_userinfo("bob:s3cret@10.0.0.1:1080/path"),
+            "***@10.0.0.1:1080/path"
+        );
+        // No userinfo, no scheme: untouched.
+        assert_eq!(redact_userinfo("localhost:8080"), "localhost:8080");
+    }
+
+    /// The parse failure for a scheme-less URL carries the string back to the
+    /// caller as an error. It must arrive redacted.
+    #[test]
+    fn a_scheme_less_url_fails_without_leaking_its_password() {
+        let err = split_proxy_url("bob:s3cret@localhost:8080").unwrap_err();
+        let msg = err.to_string();
+        assert!(!msg.contains("s3cret"), "error leaked password: {msg}");
     }
 }

--- a/docs/book/src/error-reference.md
+++ b/docs/book/src/error-reference.md
@@ -83,7 +83,7 @@ Sub-error returned wrapped in `ZendriverError::Stealth`.
 | `PatchFailed { patch, source }` | A specific stealth patch CDP call failed. | Read the source `CallError`; usually means the target page navigated mid-patch. Retry the launch. |
 | `ChromeVersionDetect(String)` | The Chrome version probe failed — reading the binary's PE version resource on Windows, or running `chrome --version` on Unix. Non-fatal on its own: the probe falls back to a baked-in version. | Confirm the binary path; pass `.chrome_version(N)` to the stealth profile to skip the probe. |
 | `SystemInfo(String)` | `sysinfo` couldn't read RAM / CPU count. | Pass `.memory_gb(N).cpu_count(N)` overrides to skip the auto-detect. |
-| `InvalidOverride(String)` | A fingerprint override value was outside the validated range (e.g. `memory_gb = 0`). | Read the message; fix the override. |
+| `InvalidOverride(String)` | Nothing constructs this today. An explicit fingerprint override is reported exactly as you set it, and an implausible value (`memory_gb` outside `{1, 2, 4, 8}`, `cpu_count` outside `2..=32`) is a `tracing::warn!` naming the field rather than an error. | Read the warning; the value is yours to keep or change. |
 
 ## `InterceptionError` variants
 

--- a/docs/book/src/fingerprint.md
+++ b/docs/book/src/fingerprint.md
@@ -813,6 +813,11 @@ let browser = Browser::builder()
 authenticated proxy like the one above is probed authenticated — the probe
 would otherwise 407 silently and fail soft with no overlay.
 
+**Order matters here.** `geo_auto()` reads the proxy configured at the moment
+you call it, so it has to come *after* `.proxy(..)` — as above. Reversed,
+there is nothing to mirror: the probe leaves over your own connection, which
+hands `ip-api.com` your real IP and derives a locale for the wrong country.
+
 **Privacy:** the bundled `ip-api.com` probe fires ONLY when `.geo_auto()` (or
 `.geo_resolver()`) is called — it is fully opt-in, never implicit. Failure
 (no network, proxy down, unrecognized country) is fail-soft: a
@@ -831,6 +836,15 @@ credentials there), and auto-wires `proxy_auth` from the userinfo when set
 `Fetch.authRequired` challenge). It also makes `geo_auto()`'s probe traffic
 mirror the same upstream proxy the browser itself will use, so the resolved
 country matches the exit IP Chrome actually sees.
+
+**It fails closed.** The URL is parsed by `launch()` / `connect()` rather
+than by the setter, and one that can't be parsed fails that call — before
+Chrome is spawned or an endpoint is dialled. Unlike geo resolution, which
+degrades to a less coherent persona, a dropped proxy means requests leave
+from your own IP while you believe otherwise. Error messages redact any
+userinfo the URL carried, so a typo in a proxy password does not end up in
+a log. (`browser_context().proxy(..)` has always behaved this way — its
+`build()` returns the same parse error.)
 
 ### Custom resolver (`geo_resolver`)
 

--- a/docs/book/src/install.md
+++ b/docs/book/src/install.md
@@ -102,9 +102,52 @@ platform — not that a binary merely compiles for it.
 | Windows          | yes       | Real-Chrome integration tests run in CI on `windows-latest`; fmt/clippy/unit/doc jobs are Linux-only. Path semantics differ slightly.         |
 
 Chrome (or Chromium / Edge / any Chromium-derived browser) must be on
-`$PATH`, or you must pass an explicit `chrome_path` to the builder, or
-you must enable the `fetcher` feature and let zendriver download Chrome
+`$PATH`, or you must pass an explicit `.executable(path)` to the builder,
+or you must enable the `fetcher` feature and let zendriver download Chrome
 for Testing at startup.
+
+### Picking the binary
+
+Three things can decide it, in order:
+
+1. `.executable(path)` — always wins.
+2. The `CHROME_BIN` environment variable, **only** under the default
+   `Channel::Auto`. It answers "which Chrome, when nobody said", so naming
+   `.channel(Channel::Brave)` or `.channel(Channel::Edge)` sends discovery
+   to that browser instead and the variable is ignored (with a log line
+   saying so). An inherited shell variable should not silently swap the
+   browser you asked for — in a stealth library the binary's identity is
+   half the fingerprint.
+3. Per-channel discovery of the conventional install locations.
+
+Whichever wins, `launch()` logs the path it is spawning.
+
+### Running in a container
+
+Chrome's user-namespace sandbox refuses to start as root, and a container's
+small `/dev/shm` starves the renderer on real pages. Both are fixed by
+`--no-sandbox` and `--disable-dev-shm-usage`, which
+[`BrowserBuilder::ci_defaults`] adds:
+
+```rust,no_run
+let builder = zendriver::Browser::builder().ci_defaults(true);
+```
+
+Left unset, it follows the `CI` environment variable — historical
+behaviour, and now announced in the log when it fires. Pass `false` to keep
+them out of a launch whose environment happens to set `CI`. An explicit
+`.sandbox(true)` also keeps the `--no-sandbox` half out. Only disable the
+sandbox on a throwaway browser: it removes Chrome's process isolation, so a
+compromised renderer is a compromised host process.
+
+`false` reliably controls the `--no-sandbox` half only. The `native` and
+`spoofed` stealth profiles emit `--disable-dev-shm-usage` themselves, so
+with either attached — `native` is the default — that flag is in the argv
+either way; only `StealthProfile::off()` leaves `ci_defaults(false)` in
+sole control of both. The `/dev/shm` flag trades shared memory for disk and
+weakens nothing, so it gets no second knob.
+
+[`BrowserBuilder::ci_defaults`]: https://docs.rs/zendriver/latest/zendriver/struct.BrowserBuilder.html#method.ci_defaults
 
 ## Verifying the install
 

--- a/docs/book/src/mcp.md
+++ b/docs/book/src/mcp.md
@@ -143,7 +143,17 @@ present in the schema but only takes effect when the `geo` feature is enabled.
 - `proxy: string` — route the browser through an upstream proxy
   (`scheme://[user:pass@]host:port`); userinfo is auto-split into proxy-auth
   credentials (requires the default `interception` feature to actually answer
-  the `Fetch.authRequired` challenge). Always present in the schema.
+  the `Fetch.authRequired` challenge). Always present in the schema. A URL
+  that can't be parsed **fails** `browser_open` rather than opening a browser
+  that goes direct; the error redacts any userinfo the URL carried.
+- `ci_defaults: bool` — add the container launch flags `--no-sandbox` and
+  `--disable-dev-shm-usage`. Unset follows the `CI` environment variable
+  (what the server has always done); pass `true` for a root container that
+  sets no `CI`, or `false` to keep them out of one that does. `--no-sandbox`
+  drops Chrome's process isolation, so only use it on a throwaway browser.
+  `false` reliably controls that half only — the `native` and `spoofed`
+  stealth profiles emit `--disable-dev-shm-usage` themselves, and it
+  weakens nothing.
 - `geo_auto: bool` — auto-derive `locale`/`languages` from the exit IP's
   country via a proxied probe to `ip-api.com` (mirrors `proxy` above), instead
   of naming a country explicitly via `geo_country`. Makes at most one outbound

--- a/docs/book/src/quickstart.md
+++ b/docs/book/src/quickstart.md
@@ -42,8 +42,12 @@ defaults. The chain pattern lets you customize before launch:
   cookies and localStorage persist across runs.
 - `.stealth(StealthProfile::native())` — opt into the anti-detection
   patches (covered in [Stealth](./stealth.md)).
-- `.chrome_path(path)` — bypass the `$PATH` lookup when you want a
-  specific Chrome binary.
+- `.executable(path)` — bypass the `$PATH` lookup when you want a
+  specific Chrome binary (see [Install](./install.md#picking-the-binary)
+  for how `CHROME_BIN` and `.channel(..)` interact with it).
+- `.ci_defaults(true)` — add the container launch flags `--no-sandbox`
+  and `--disable-dev-shm-usage` (see
+  [Install](./install.md#running-in-a-container)).
 
 `.launch()` is async because it has to spin up the Chrome subprocess,
 wait for the CDP WebSocket endpoint to come up, perform the initial

--- a/docs/book/src/stealth.md
+++ b/docs/book/src/stealth.md
@@ -119,9 +119,11 @@ document).
 ## Customizing the fingerprint
 
 All three profiles return a builder that lets you override individual
-fingerprint fields. The values are validated and clamped at resolve
-time (e.g. `memory_gb` is clamped to a plausible W3C-rounded value;
-`cpu_count` is clamped to `2..=32`).
+fingerprint fields. **What you set is what gets reported.** Values that
+real browsers don't produce — a `memory_gb` outside `{1, 2, 4, 8}`, a
+`cpu_count` outside `2..=32` — are logged as warnings naming the field,
+and then used as given. The host probe behind the *defaults* still rounds,
+because there the input is a measurement rather than something you stated.
 
 ```rust,no_run
 use zendriver::{Browser, StealthProfile};
@@ -151,6 +153,22 @@ differently-weighted list. Its first entry then becomes
 `navigator.language` as well, because Chrome always reports that as
 `navigator.languages[0]`, and a locale sitting outside the advertised
 list is a mismatch no real browser produces.
+
+`chrome_version(126)` pins only the major, and a UA needs four digits — so
+the other three get invented, and the resolver logs a warning telling you
+it did. When the exact build matters, state it:
+
+```rust,no_run
+use zendriver::StealthProfile;
+
+let profile = StealthProfile::spoofed().chrome_full_version("125.0.6422.113");
+```
+
+That drives the UA-CH `fullVersionList` (the UA string itself only ever
+carries Chrome's reduced `125.0.0.0` form), and its leading component
+becomes the reported major, so it wins over `chrome_version` when both are
+set. Take the value from a real Chrome release; a build number nobody
+shipped is its own tell.
 
 A [`Persona`](https://docs.rs/zendriver-stealth/latest/zendriver_stealth/struct.Persona.html)
 carries the same `timezone` / `locale` / `languages` / `screen` fields,


### PR DESCRIPTION
Four places where the launch path took a caller's value and quietly substituted its own judgement. None of them were visible from outside, which is why they lasted.

- **`proxy()` failed open.** An unparseable URL was logged as a warning and the browser launched **direct**. A caller who asked to be behind a proxy and isn't has a privacy failure, not a convenience one. It now stores the raw string and resolves at `launch()`/`connect()`, erroring *before* the browser spawns — the deferred-work pattern `BrowserContextBuilder` already used for exactly this. `Debug` redacts the userinfo.
- **`.sandbox(true)` could not defeat the `CI` sniff** — the flag was emitted only for `Some(false)`. `ci_defaults(bool)` now decides in both directions, and an explicit sandbox choice wins.
- **Clamps and fabrication applied to values the caller stated.** `cpu_count` was clamped to 2..32, `memory_gb` snapped with a floor of 4, and a major-only `chrome_version` had build digits invented. Explicit values now pass through verbatim with a warning naming the field.
- **`CHROME_BIN` overrode an explicitly chosen channel.** It is consulted only when the channel is `Auto`, and logs both when it wins and when a chosen channel makes it lose.

Host probes **keep** their clamps. Those are sanity bounds on measured data, not overrides of stated intent, and the asymmetry is the whole point — a reviewer tested both directions to confirm it.

## Two decisions, both yours

**The `CI` sniff is overridden, not deleted.** `ci_defaults(true/false)` is authoritative and the fallback logs when it fires, so nothing is silent — but an unset builder still follows `$CI`. Deleting it outright would need ~425 `Browser::builder()` sites to opt in, including this repo's own live-Chrome tier, which genuinely needs `--no-sandbox` on Ubuntu runners. You chose the audible fallback.

**`StealthProfile::chrome_full_version` is new API the row doesn't name.** UA-CH's `fullVersionList` needs four components, so the fabrication can't simply be deleted without leaving a probed 148 beside an invented 125. You chose to keep it here rather than split it, since 2b otherwise ships a warning naming an option that doesn't exist yet.

## Verification

**461 tests** in `zendriver`, 321 in `zendriver-stealth`. 29 mutations applied across the review rounds, **27 killed** — the two survivors are disclosed: one needs network I/O to close, the other is a duplicate interest-cache rebuild.

`fmt` clean · clippy clean workspace-wide and on `zendriver-mcp --all-features` · schema snapshots 150, none pending · `mdbook build` clean · ledger gate green.

Book updated across `install.md` (new "Picking the binary" / "Running in a container"), `quickstart.md`, `stealth.md`, `fingerprint.md`, `mcp.md`, `error-reference.md`. MCP gained `browser_open.ci_defaults` and `browser_stealth_set.overrides.chrome_full_version`.

## Two riders worth calling out

The branch carries **your own unpushed `Update CLAUDE.md` commit** from the 17th. It was cut onto this branch and exists nowhere else, so dropping it would have lost it. Authorship is intact.

It also carries a one-line docs fix I earned the hard way: the documented local coverage-check command omits `PUBLIC_API_TOOLCHAIN`, so it runs against whatever nightly is default. Anything newer than the pin renders `std::io::error::Error` as `core::io::error::Error` and reports six phantom missing ledger entries that never reproduce in CI. The baseline was correct throughout.

---
PR 2b of [pr-plan.md](docs/api-audit/pr-plan.md). 🤖 Generated with [Claude Code](https://claude.com/claude-code)